### PR TITLE
chore: add workflow promotion tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,14 @@
 Before beginning repo work, read the current versions of:
 
 - `README-DEV.md`
-- `K98 Bot — Coding Execution Guidelines.md`
-- `k98 Bot — Deferred Optimisation Framework.md`
-- `K98 Bot — Project Engineering Standards.md`
-- `K98 Bot — Skills & Refactor Triggers.md`
-- `K98 Bot — Standard Development Initiation Statement.md`
-- `K98 Bot — Testing Standards.md`
-- `K98 Bot Deferred Optimisation Scoring Model.md`
-- `K98 Bot Codex Task Pack Generator.md`
+- `docs/K98 Bot — Coding Execution Guidelines.md`
+- `docs/k98 Bot — Deferred Optimisation Framework.md`
+- `docs/K98 Bot — Project Engineering Standards.md`
+- `docs/K98 Bot — Skills & Refactor Triggers.md`
+- `docs/K98 Bot — Standard Development Initiation Statement.md`
+- `docs/K98 Bot — Testing Standards.md`
+- `docs/K98 Bot Deferred Optimisation Scoring Model.md`
+- `docs/K98 Bot Codex Task Pack Generator.md`
 
 ## Working Rules
 
@@ -23,3 +23,12 @@ Before beginning repo work, read the current versions of:
 - Preserve existing behaviour unless explicitly changing it.
 - Run targeted tests and lint where practical.
 - Capture deferred optimisation items clearly.
+
+## Repository / Promotion Model
+
+- `origin` is the scrubbed Codex mirror: `K98-bot-mirror`.
+- `production` is the private production repository: `K98-bot`.
+- Codex should create branches and PRs against `K98-bot-mirror`.
+- Production promotion happens only after local validation.
+- Production changes are promoted by pushing the same branch to the `production` remote and opening a PR into `K98-bot/main`.
+- The bot machine must deploy only from `K98-bot/main`, never from `K98-bot-mirror`.

--- a/docs/templates/Codex Task Pack Template.md
+++ b/docs/templates/Codex Task Pack Template.md
@@ -1,0 +1,198 @@
+# Codex Task Pack - <Task Name>
+
+> Task pack version: 1.0
+> Date: <YYYY-MM-DD>
+> Owner/context: <requester, issue, or source>
+
+## Required Reading
+
+Read and follow the current versions of:
+
+- `README-DEV.md`
+- `docs/K98 Bot — Project Engineering Standards.md`
+- `docs/K98 Bot — Coding Execution Guidelines.md`
+- `docs/K98 Bot — Standard Development Initiation Statement.md`
+- `docs/K98 Bot — Testing Standards.md`
+- `docs/K98 Bot — Skills & Refactor Triggers.md`
+- `docs/k98 Bot — Deferred Optimisation Framework.md`
+- `docs/K98 Bot Deferred Optimisation Scoring Model.md`
+- `docs/K98 Bot Codex Task Pack Generator.md`
+- `docs/K98 Code Prompt.md`
+
+## Objective
+
+<Describe the outcome in 2-4 lines. State the user-visible or engineering result, not the implementation first.>
+
+## Background
+
+<Summarise relevant context, links, prior PRs, deferred items, incidents, or current behaviour.>
+
+## Scope
+
+### In Scope
+
+- <Specific file, module, behaviour, or workflow to change>
+- <Specific validation or docs work to include>
+
+### Out of Scope
+
+- <Explicitly excluded work>
+- <Related optimisation that should be deferred unless separately approved>
+
+## Source Deferred Items
+
+Use this section when the task pack comes from deferred optimisation capture. Delete if not applicable.
+
+```md
+### Deferred Optimisation
+- Area:
+- Type: performance | architecture | cleanup | refactor | consistency
+- Description:
+- Suggested Fix:
+- Impact: low | medium | high
+- Risk: low | medium | high
+- Dependencies:
+```
+
+## Mandatory Workflow
+
+Follow `docs/K98 Code Prompt.md`.
+
+Stop for approval after:
+
+1. Audit / scope review
+2. Architecture validation
+3. Implementation plan
+
+Do not code until approval unless the user explicitly requests a one-pass implementation.
+
+## Audit Requirements
+
+Review the touched area for:
+
+- direct SQL in commands/views
+- business logic in interaction layers
+- duplicate helpers or near-duplicates
+- dead code from prior iterations
+- weak validation or logging
+- cache and persistence safety
+- restart safety
+- test coverage gaps
+
+Map the likely:
+
+- commands
+- services
+- repositories / DAL modules
+- SQL objects or contracts
+- views/modals
+- caches or persisted state
+- restart implications
+
+## Target Architecture
+
+| Concern | Target |
+|---|---|
+| Slash commands | `commands/<domain>_cmds.py` |
+| Views / modals | `ui/views/` |
+| Services / business logic | subsystem package or `<domain>_service.py` |
+| Repository / DAL | subsystem package or repository module |
+| Shared helpers | `core/` or existing helper modules |
+| Operational tooling | `scripts/` |
+| Documentation | `docs/` |
+| SQL schema | SQL repo `sql_schema/<schema>.<Object>.<Type>.sql` |
+| Tests | `tests/` |
+
+## Likely Files To Review
+
+- `<path>`
+
+## Likely Files To Modify
+
+- `<path>`
+
+## Implementation Requirements
+
+- Keep commands and views thin.
+- Move business logic into services.
+- Move data access into repository/DAL code.
+- Avoid new direct SQL in commands or views.
+- Reuse existing helpers where practical.
+- Preserve restart safety.
+- Add or improve meaningful logging where the task touches operational paths.
+- Add or update tests unless the change is documentation-only or tooling-only.
+- Capture new out-of-scope findings as deferred optimisations.
+
+## Testing Requirements
+
+Consider each category and either cover it or explain why it does not apply:
+
+- happy path
+- negative path
+- regression
+- permission boundary
+- restart/persistence
+- cache safety
+- format/output shape
+
+Suggested commands:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+Add focused pytest commands for the subsystem under change.
+
+## Acceptance Criteria
+
+- [ ] Scope is complete and no out-of-scope work was mixed in.
+- [ ] Correct architecture/layer ownership is preserved.
+- [ ] No new direct SQL exists in commands/views.
+- [ ] Helper reuse was checked and documented.
+- [ ] Logging is adequate for changed operational paths.
+- [ ] Restart safety is preserved or explicitly not applicable.
+- [ ] Tests were added/updated or a clear testing exception is documented.
+- [ ] Quality gates were run or documented.
+- [ ] Deferred optimisations are captured structurally.
+
+## Required Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. New Files
+4. Modified Files
+5. SQL Changes
+6. Helpers Reused
+7. Refactor Findings
+8. Test Plan
+9. Deployment Steps
+10. Deferred Optimisations
+
+## PR Summary Template
+
+```md
+## Summary
+
+- <summary item>
+
+## Changes
+
+- <change item>
+
+## Tests
+
+- <test command or verification>
+
+## Deferred Optimisations
+
+- None, or structured deferred items.
+
+## Risk / Rollback
+
+- <risk and rollback note>
+```

--- a/scripts/promote-to-production.ps1
+++ b/scripts/promote-to-production.ps1
@@ -121,7 +121,7 @@ Write-Host "Pushing branch to mirror..."
 Invoke-Native -FilePath "git" -Arguments @("push", "-u", "origin", $BranchName)
 
 Write-Host "Pushing branch to production..."
-Invoke-Native -FilePath "git" -Arguments @("push", "-u", "production", $BranchName)
+Invoke-Native -FilePath "git" -Arguments @("push", "production", $BranchName)
 
 Write-Host ""
 Write-Host "Done. Now open PRs:"

--- a/scripts/promote-to-production.ps1
+++ b/scripts/promote-to-production.ps1
@@ -115,7 +115,7 @@ if ($dirtyAfterPreCommit) {
 }
 
 Write-Host "Running pytest..."
-Invoke-Native -FilePath $resolvedPython -Arguments @("-m", "pytest", "-q")
+Invoke-Native -FilePath $resolvedPython -Arguments @("-m", "pytest tests", "-q")
 
 Write-Host "Pushing branch to mirror..."
 Invoke-Native -FilePath "git" -Arguments @("push", "-u", "origin", $BranchName)

--- a/scripts/promote-to-production.ps1
+++ b/scripts/promote-to-production.ps1
@@ -1,0 +1,129 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$BranchName,
+
+  [string]$PythonExe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [Parameter()]
+    [string[]]$Arguments = @()
+  )
+
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+  }
+}
+
+function Get-RequiredRemoteUrl {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RemoteName
+  )
+
+  $url = git remote get-url $RemoteName 2>$null
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($url)) {
+    throw "Required git remote '$RemoteName' is not configured."
+  }
+  return $url.Trim()
+}
+
+function Resolve-PythonExecutable {
+  param(
+    [string]$RequestedPythonExe,
+    [string]$RepoRoot
+  )
+
+  $candidates = @()
+  if (-not [string]::IsNullOrWhiteSpace($RequestedPythonExe)) {
+    $candidates += $RequestedPythonExe
+  }
+  $candidates += @(
+    (Join-Path $RepoRoot ".venv\Scripts\python.exe"),
+    (Join-Path $RepoRoot "venv\Scripts\python.exe")
+  )
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+
+  $python = Get-Command python -ErrorAction SilentlyContinue
+  if ($python) {
+    return $python.Source
+  }
+
+  throw "Could not find Python. Pass -PythonExe or create .venv/venv."
+}
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$repoRoot = Split-Path -Parent $scriptDir
+$repoRoot = (Resolve-Path -LiteralPath $repoRoot).Path
+
+Set-Location -LiteralPath $repoRoot
+
+Write-Host "Repository: $repoRoot"
+
+Write-Host "Checking git remotes..."
+$originUrl = Get-RequiredRemoteUrl -RemoteName "origin"
+$productionUrl = Get-RequiredRemoteUrl -RemoteName "production"
+Write-Host "origin:     $originUrl"
+Write-Host "production: $productionUrl"
+
+Write-Host "Checking current branch..."
+$currentBranch = (git branch --show-current).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($currentBranch)) {
+  throw "Could not determine the current git branch."
+}
+if ($currentBranch -ne $BranchName) {
+  throw "Current branch is '$currentBranch'. Expected '$BranchName'. Switch branches first."
+}
+
+Write-Host "Checking working tree..."
+$dirty = git status --porcelain
+if ($LASTEXITCODE -ne 0) {
+  throw "Could not read git status."
+}
+if ($dirty) {
+  throw "Working tree is not clean. Commit or stash changes before promotion."
+}
+
+$resolvedPython = Resolve-PythonExecutable -RequestedPythonExe $PythonExe -RepoRoot $repoRoot
+Write-Host "Python: $resolvedPython"
+
+Write-Host "Running pre-commit validation..."
+Invoke-Native -FilePath $resolvedPython -Arguments @("-m", "pre_commit", "run", "-a")
+
+Write-Host "Re-checking working tree after pre-commit..."
+$dirtyAfterPreCommit = git status --porcelain
+if ($LASTEXITCODE -ne 0) {
+  throw "Could not read git status after pre-commit."
+}
+if ($dirtyAfterPreCommit) {
+  throw "pre-commit modified files. Review, commit, and rerun promotion."
+}
+
+Write-Host "Running pytest..."
+Invoke-Native -FilePath $resolvedPython -Arguments @("-m", "pytest", "-q")
+
+Write-Host "Pushing branch to mirror..."
+Invoke-Native -FilePath "git" -Arguments @("push", "-u", "origin", $BranchName)
+
+Write-Host "Pushing branch to production..."
+Invoke-Native -FilePath "git" -Arguments @("push", "-u", "production", $BranchName)
+
+Write-Host ""
+Write-Host "Done. Now open PRs:"
+Write-Host "1. K98-bot-mirror: $BranchName -> main"
+Write-Host "2. K98-bot:        $BranchName -> main"


### PR DESCRIPTION
## Summary
- Document the mirror/production repository promotion model in AGENTS.md.
- Add a reusable Codex task pack template under docs/templates.
- Add a PowerShell promotion helper that validates locally before pushing to origin and production.

## Tests
- Parsed scripts/promote-to-production.ps1 with the PowerShell AST parser.
- Ran pre-commit on the changed workflow files: `python -m pre_commit run --files AGENTS.md docs/templates/Codex Task Pack Template.md scripts/promote-to-production.ps1`.
- Ran `git diff --check`.

## Notes
- No production bot code modified.
- No SQL changes.