### PR TITLE
test: isolate local validation from machine-only dependencies

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -66,10 +66,18 @@ logger.info(
 
 # --- Hard fail if not running under the project venv interpreter
 if os.name == "nt":
-    expected = (Path(LOG_DIR).parent / "venv" / "Scripts" / "python.exe").resolve()
+    expected_paths = {
+        (Path(LOG_DIR).parent / name / "Scripts" / "python.exe").resolve()
+        for name in ("venv", ".venv")
+    }
     actual = Path(sys.executable).resolve()
-    if actual != expected:
-        logger.critical("❌ Wrong interpreter: %s (expected %s). Exiting.", actual, expected)
+    if actual not in expected_paths:
+        expected_display = ", ".join(str(p) for p in sorted(expected_paths))
+        logger.critical(
+            "❌ Wrong interpreter: %s (expected one of: %s). Exiting.",
+            actual,
+            expected_display,
+        )
         flush_logs()
         sys.exit(1)
 

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -1,0 +1,17 @@
+### Deferred Optimisation
+- Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
+- Type: consistency
+- Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.
+- Suggested Fix: Add subsystem-specific DAL/service boundary patches or explicit integration markers, then gate live DB coverage behind RUN_DB_TESTS=1.
+- Impact: high
+- Risk: medium
+- Dependencies: Agreement on which non-Ark tests should remain live DB integration coverage.
+
+### Deferred Optimisation
+- Area: tests/test_dl_bot_mge_auto_import.py, tests/test_integration_end_to_end_fake_worker.py, tests/test_maintenance_suite.py
+- Type: consistency
+- Description: Full-suite validation in the Codex/local PR environment has non-DB environment blockers: DL_bot expects venv/Scripts/python.exe while the documented command uses .venv, and subprocess worker tests fail with WinError 5 in the sandbox.
+- Suggested Fix: Make startup interpreter validation configurable for tests and mark subprocess worker tests with an environment capability gate when process spawning is unavailable.
+- Impact: medium
+- Risk: medium
+- Dependencies: Local validation environment contract for venv naming and subprocess permissions.

--- a/file_utils.py
+++ b/file_utils.py
@@ -2307,6 +2307,28 @@ def _terminate_pid_with_escalation(pid: int, grace_period: float = 5.0) -> tuple
                 return True, "Killed after terminate"
             else:
                 return True, "Terminated gracefully"
+        elif os.name == "nt":
+            try:
+                completed = subprocess.run(
+                    ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+                    capture_output=True,
+                    text=True,
+                    timeout=max(float(grace_period), 1.0),
+                    check=False,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                )
+            except subprocess.TimeoutExpired:
+                return False, "taskkill timed out"
+            except Exception as exc:
+                return False, f"taskkill failed: {exc}"
+
+            if completed.returncode == 0 or not _pid_exists(pid):
+                return True, "Killed with taskkill"
+
+            details = (completed.stderr or completed.stdout or "").strip()
+            if details:
+                return False, f"taskkill failed: {details[:500]}"
+            return False, f"taskkill failed with returncode={completed.returncode}"
         else:
             try:
                 os.kill(pid, signal.SIGTERM)

--- a/stats_service.py
+++ b/stats_service.py
@@ -144,17 +144,27 @@ async def _fetch_proc(gov_ids: list[int], slices_csv: str, include_aggregate: bo
     except Exception:
         run_blocking_in_thread = None
 
-    if run_blocking_in_thread is not None:
-        result = await run_blocking_in_thread(
-            _fetch_proc_sync,
+    try:
+        if run_blocking_in_thread is not None:
+            result = await run_blocking_in_thread(
+                _fetch_proc_sync,
+                gov_ids,
+                slices_csv,
+                include_aggregate,
+                name="fetch_proc",
+                meta={"gov_ids": gov_ids, "slice": slices_csv},
+            )
+        else:
+            result = await asyncio.to_thread(
+                _fetch_proc_sync, gov_ids, slices_csv, include_aggregate
+            )
+    except Exception:
+        logger.exception(
+            "fetch_proc failed; returning empty rows. gov_ids=%s slice=%s",
             gov_ids,
             slices_csv,
-            include_aggregate,
-            name="fetch_proc",
-            meta={"gov_ids": gov_ids, "slice": slices_csv},
         )
-    else:
-        result = await asyncio.to_thread(_fetch_proc_sync, gov_ids, slices_csv, include_aggregate)
+        return []
 
     # Normalize result (run_blocking_in_thread may return tuple with worker metadata)
     if isinstance(result, tuple) and len(result) == 2:
@@ -556,26 +566,10 @@ async def get_stats_payload(
                 latest_utc = latest
             return {"daily": latest_utc}
 
-        # Prefer start_callable_offload for freshness/readers for process-level visibility,
-        # fall back to run_blocking_in_thread or asyncio.to_thread
         try:
-            from file_utils import start_callable_offload  # type: ignore
-        except Exception:
-            start_callable_offload = None
+            from file_utils import run_blocking_in_thread
 
-        try:
-            if start_callable_offload is not None:
-                res = await start_callable_offload(
-                    _fresh, name="fetch_freshness", prefer_process=True
-                )
-                if isinstance(res, tuple) and len(res) == 2 and isinstance(res[1], dict):
-                    freshness = res[0]
-                else:
-                    freshness = res
-            else:
-                from file_utils import run_blocking_in_thread
-
-                freshness = await run_blocking_in_thread(_fresh, name="fetch_freshness")
+            freshness = await run_blocking_in_thread(_fresh, name="fetch_freshness")
         except Exception:
             # fallback to to_thread
             freshness = await asyncio.to_thread(_fresh)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,3 +94,36 @@ def _reset_registry_cache():
     except Exception:
         pass
     yield
+
+
+@pytest.fixture(autouse=True)
+def _block_live_ark_db_access_in_unit_tests(monkeypatch):
+    """Fail fast if a normal Ark unit test accidentally reaches the live SQL DB."""
+    if os.getenv("RUN_DB_TESTS", "0") == "1":
+        yield
+        return
+
+    def _raise_live_db_access(*_args, **_kwargs):
+        raise AssertionError(
+            "Unit test attempted live DB access. Patch the DAL/service boundary "
+            "or run with RUN_DB_TESTS=1 for explicit integration coverage."
+        )
+
+    async def _raise_live_db_access_async(*_args, **_kwargs):
+        _raise_live_db_access()
+
+    try:
+        import ark.dal.ark_dal as ark_dal
+
+        for name in (
+            "run_query_async",
+            "run_query_strict_async",
+            "run_one_async",
+            "run_one_strict_async",
+            "execute_async",
+        ):
+            monkeypatch.setattr(ark_dal, name, _raise_live_db_access_async, raising=False)
+    except Exception:
+        pass
+
+    yield

--- a/tests/test_ark_bans_enforcement.py
+++ b/tests/test_ark_bans_enforcement.py
@@ -56,9 +56,21 @@ async def test_admin_add_blocked_by_ban_when_override_off(monkeypatch):
     async def _active_ban(**_kwargs):
         return {"BanId": 900, "Reason": "Test reason"}
 
+    async def _empty_roster(*_a, **_k):
+        return []
+
+    async def _no_conflict(*_a, **_k):
+        return None
+
+    async def _noop(*_a, **_k):
+        return True
+
     monkeypatch.setattr(controller, "_is_admin_or_leadership", lambda *_a, **_k: True)
     monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
+    monkeypatch.setattr("ark.registration_flow.get_roster", _empty_roster)
     monkeypatch.setattr("ark.registration_flow.get_active_ban_for", _active_ban)
+    monkeypatch.setattr("ark.registration_flow.find_active_signup_for_weekend", _no_conflict)
+    monkeypatch.setattr("ark.registration_flow.insert_audit_log", _noop)
 
     await controller._apply_admin_add(interaction, "12345", "Gov Name", slot_type="Player")
 
@@ -88,9 +100,17 @@ async def test_admin_add_allows_when_override_on(monkeypatch):
     async def _noop(*_a, **_k):
         return True
 
+    async def _empty_roster(*_a, **_k):
+        return []
+
+    async def _no_conflict(*_a, **_k):
+        return None
+
     monkeypatch.setattr(controller, "_is_admin_or_leadership", lambda *_a, **_k: True)
     monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
+    monkeypatch.setattr("ark.registration_flow.get_roster", _empty_roster)
     monkeypatch.setattr("ark.registration_flow.get_active_ban_for", _active_ban)
+    monkeypatch.setattr("ark.registration_flow.find_active_signup_for_weekend", _no_conflict)
     monkeypatch.setattr("ark.registration_flow.add_signup", _noop)
     monkeypatch.setattr("ark.registration_flow.insert_audit_log", _noop)
     monkeypatch.setattr(controller, "refresh_registration_message", _noop)

--- a/tests/test_ark_registration_flow.py
+++ b/tests/test_ark_registration_flow.py
@@ -188,6 +188,9 @@ async def test_join_player_adds_signup(monkeypatch):
     async def _get_roster(match_id):
         return []
 
+    async def _no_conflict(*_a, **_k):
+        return None
+
     called = {"add": False, "audit": False, "refresh": False}
 
     async def _add_signup(**kwargs):
@@ -203,8 +206,11 @@ async def test_join_player_adds_signup(monkeypatch):
 
     monkeypatch.setattr(controller, "_prompt_governor_selection", _prompt)
     monkeypatch.setattr(controller, "_validate_governor", _validate)
+    monkeypatch.setattr(controller, "_check_active_ban", _no_conflict)
     monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
     monkeypatch.setattr("ark.registration_flow.get_roster", _get_roster)
+    monkeypatch.setattr("ark.registration_flow.find_active_signup_for_weekend", _no_conflict)
+    monkeypatch.setattr("ark.registration_flow.get_signup", _no_conflict)
     monkeypatch.setattr("ark.registration_flow.add_signup", _add_signup)
     monkeypatch.setattr("ark.registration_flow.insert_audit_log", _audit)
     monkeypatch.setattr(controller, "refresh_registration_message", _refresh)
@@ -322,6 +328,9 @@ async def test_switch_updates_governor(monkeypatch):
     async def _no_conflict(*_a, **_k):
         return None
 
+    async def _get_signup_none(*_a, **_k):
+        return None
+
     called = {"switch": None, "audit": False, "refresh": False}
 
     async def _switch(
@@ -348,6 +357,7 @@ async def test_switch_updates_governor(monkeypatch):
     monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
     monkeypatch.setattr("ark.registration_flow.get_roster", _get_roster)
     monkeypatch.setattr("ark.registration_flow.find_active_signup_for_weekend", _no_conflict)
+    monkeypatch.setattr("ark.registration_flow.get_signup", _get_signup_none)
     monkeypatch.setattr("ark.registration_flow.switch_signup_governor", _switch)
     monkeypatch.setattr("ark.registration_flow.insert_audit_log", _audit)
     monkeypatch.setattr(controller, "refresh_registration_message", _refresh)

--- a/tests/test_ark_registration_messages.py
+++ b/tests/test_ark_registration_messages.py
@@ -32,7 +32,12 @@ class _Client:
 
 
 @pytest.mark.asyncio
-async def test_upsert_registration_no_everyone_by_default():
+async def test_upsert_registration_no_everyone_by_default(monkeypatch):
+    async def _get_match(_match_id):
+        return None
+
+    monkeypatch.setattr("ark.registration_messages.get_match", _get_match)
+
     state = ArkJsonState()
     client = _Client()
     moved, changed = await upsert_registration_message(
@@ -48,7 +53,12 @@ async def test_upsert_registration_no_everyone_by_default():
 
 
 @pytest.mark.asyncio
-async def test_upsert_registration_with_announce_sets_everyone():
+async def test_upsert_registration_with_announce_sets_everyone(monkeypatch):
+    async def _get_match(_match_id):
+        return None
+
+    monkeypatch.setattr("ark.registration_messages.get_match", _get_match)
+
     state = ArkJsonState()
     channel = _Chan()
 

--- a/tests/test_ark_reminder_phase_bd.py
+++ b/tests/test_ark_reminder_phase_bd.py
@@ -94,6 +94,7 @@ async def test_close_1h_reminder_fires_in_window() -> None:
             new=AsyncMock(return_value={"PlayersCap": 15, "SubsCap": 5}),
         ),
         patch("ark.ark_scheduler.get_roster", new=AsyncMock(return_value=[])),
+        patch("ark.ark_scheduler.list_match_team_rows", new=AsyncMock(return_value=[])),
         patch("ark.ark_scheduler._utcnow", return_value=now),
     ):
         from ark.ark_scheduler import _run_match_reminder_dispatch
@@ -138,6 +139,7 @@ async def test_close_1h_reminder_does_not_fire_before_window() -> None:
         patch("ark.ark_scheduler.get_alliance", new=AsyncMock(return_value=_make_alliance_row())),
         patch("ark.ark_scheduler.get_config", new=AsyncMock(return_value={})),
         patch("ark.ark_scheduler.get_roster", new=AsyncMock(return_value=[])),
+        patch("ark.ark_scheduler.list_match_team_rows", new=AsyncMock(return_value=[])),
         patch("ark.ark_scheduler._utcnow", return_value=now),
     ):
         from ark.ark_scheduler import _run_match_reminder_dispatch
@@ -166,6 +168,7 @@ async def test_close_1h_reminder_does_not_fire_after_close() -> None:
         patch("ark.ark_scheduler.get_alliance", new=AsyncMock(return_value=_make_alliance_row())),
         patch("ark.ark_scheduler.get_config", new=AsyncMock(return_value={})),
         patch("ark.ark_scheduler.get_roster", new=AsyncMock(return_value=[])),
+        patch("ark.ark_scheduler.list_match_team_rows", new=AsyncMock(return_value=[])),
         patch("ark.ark_scheduler._utcnow", return_value=now),
     ):
         from ark.ark_scheduler import _run_match_reminder_dispatch
@@ -198,6 +201,7 @@ async def test_close_1h_includes_jump_link_when_ref_available() -> None:
         patch("ark.ark_scheduler.get_alliance", new=AsyncMock(return_value=_make_alliance_row())),
         patch("ark.ark_scheduler.get_config", new=AsyncMock(return_value={})),
         patch("ark.ark_scheduler.get_roster", new=AsyncMock(return_value=[])),
+        patch("ark.ark_scheduler.list_match_team_rows", new=AsyncMock(return_value=[])),
         patch("ark.ark_scheduler._utcnow", return_value=now),
     ):
         from ark.ark_scheduler import _run_match_reminder_dispatch
@@ -234,6 +238,7 @@ async def test_close_1h_omits_link_when_no_ref() -> None:
         patch("ark.ark_scheduler.get_alliance", new=AsyncMock(return_value=_make_alliance_row())),
         patch("ark.ark_scheduler.get_config", new=AsyncMock(return_value={})),
         patch("ark.ark_scheduler.get_roster", new=AsyncMock(return_value=[])),
+        patch("ark.ark_scheduler.list_match_team_rows", new=AsyncMock(return_value=[])),
         patch("ark.ark_scheduler._utcnow", return_value=now),
     ):
         from ark.ark_scheduler import _run_match_reminder_dispatch

--- a/tests/test_ark_scheduler.py
+++ b/tests/test_ark_scheduler.py
@@ -141,6 +141,9 @@ async def test_scheduler_does_not_relock_locked_matches(monkeypatch):
     async def _open_pending(*_a, **_k):
         return None
 
+    async def _list_completed():
+        return []
+
     async def _auto_create(**_kwargs):
         called["auto_create"] = True
         return type(
@@ -164,6 +167,9 @@ async def test_scheduler_does_not_relock_locked_matches(monkeypatch):
     monkeypatch.setattr("ark.ark_scheduler.lock_match_and_post_confirmation", _lock)
     monkeypatch.setattr("ark.ark_scheduler.ensure_confirmation_message", _ensure)
     monkeypatch.setattr("ark.ark_scheduler.sync_ark_matches_from_calendar", _auto_create)
+    monkeypatch.setattr(
+        "ark.ark_scheduler.list_completed_matches_pending_completion", _list_completed
+    )
     monkeypatch.setattr("ark.ark_scheduler._open_pending_registrations", _open_pending)
     monkeypatch.setattr("ark.ark_scheduler._run_match_reminder_dispatch", _run_match_dispatch)
     monkeypatch.setattr("ark.ark_scheduler.asyncio.sleep", _sleep)
@@ -215,12 +221,31 @@ async def test_scheduler_updates_match_complete_immediately(monkeypatch):
     async def _open_pending(*_a, **_k):
         return None
 
+    async def _auto_create(**_kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "scanned": 0,
+                "created": 0,
+                "existing": 0,
+                "skipped_cancelled_match": 0,
+                "invalid_title": 0,
+                "errors": 0,
+            },
+        )()
+
+    async def _get_match(_match_id):
+        return {"Status": "Completed"}
+
     monkeypatch.setattr("ark.ark_scheduler._utcnow", lambda: now)
     monkeypatch.setattr("ark.ark_scheduler.get_config", _get_config)
+    monkeypatch.setattr("ark.ark_scheduler.get_match", _get_match)
     monkeypatch.setattr("ark.ark_scheduler.list_open_matches", _list_open_matches)
     monkeypatch.setattr(
         "ark.ark_scheduler.list_completed_matches_pending_completion", _list_completed
     )
+    monkeypatch.setattr("ark.ark_scheduler.sync_ark_matches_from_calendar", _auto_create)
     monkeypatch.setattr("ark.ark_scheduler._open_pending_registrations", _open_pending)
     monkeypatch.setattr("ark.ark_scheduler.ensure_confirmation_message", _ensure)
     monkeypatch.setattr("ark.ark_scheduler.mark_match_completion_posted", _mark)
@@ -269,12 +294,27 @@ async def test_scheduler_schedules_match_complete(monkeypatch):
     async def _open_pending(*_a, **_k):
         return None
 
+    async def _auto_create(**_kwargs):
+        return type(
+            "R",
+            (),
+            {
+                "scanned": 0,
+                "created": 0,
+                "existing": 0,
+                "skipped_cancelled_match": 0,
+                "invalid_title": 0,
+                "errors": 0,
+            },
+        )()
+
     monkeypatch.setattr("ark.ark_scheduler._utcnow", lambda: now)
     monkeypatch.setattr("ark.ark_scheduler.get_config", _get_config)
     monkeypatch.setattr("ark.ark_scheduler.list_open_matches", _list_open_matches)
     monkeypatch.setattr(
         "ark.ark_scheduler.list_completed_matches_pending_completion", _list_completed
     )
+    monkeypatch.setattr("ark.ark_scheduler.sync_ark_matches_from_calendar", _auto_create)
     monkeypatch.setattr("ark.ark_scheduler._open_pending_registrations", _open_pending)
     monkeypatch.setattr("ark.ark_scheduler._schedule_once", _schedule_once)
     monkeypatch.setattr("ark.ark_scheduler.asyncio.sleep", _sleep)

--- a/tests/test_cancel_offload.py
+++ b/tests/test_cancel_offload.py
@@ -32,27 +32,32 @@ def test_cancel_offload_by_pid(tmp_path):
     pid = proc.pid
     assert pid is not None
 
-    # Register offload in registry
-    off_id = start_offload(meta={"test": True, "tag": "cancel_test"})
-    record_process_offload(off_id, pid, cmd)
+    try:
+        # Register offload in registry
+        off_id = start_offload(meta={"test": True, "tag": "cancel_test"})
+        record_process_offload(off_id, pid, cmd)
 
-    # Ensure registry persisted
-    offs = list_offloads()
-    assert any(o.get("offload_id") == off_id for o in offs)
+        # Ensure registry persisted
+        offs = list_offloads()
+        assert any(o.get("offload_id") == off_id for o in offs)
 
-    # Cancel by pid
-    res = cancel_offload(pid=pid, actor="test_suite", grace_period=2.0)
-    assert isinstance(res, dict)
-    # process should be gone after cancellation attempt
-    time.sleep(0.2)
-    ret = proc.poll()
-    assert ret is not None
+        # Cancel by pid
+        res = cancel_offload(pid=pid, actor="test_suite", grace_period=2.0)
+        assert isinstance(res, dict)
+        # process should be gone after cancellation attempt
+        time.sleep(0.2)
+        ret = proc.poll()
+        assert ret is not None
 
-    # Registry updated (entry exists)
-    info = None
-    for o in list_offloads():
-        if o.get("offload_id") == off_id:
-            info = o
-            break
-    assert info is not None
-    assert info.get("cancel_requested") in (True, None) or info.get("ok") is False
+        # Registry updated (entry exists)
+        info = None
+        for o in list_offloads():
+            if o.get("offload_id") == off_id:
+                info = o
+                break
+        assert info is not None
+        assert info.get("cancel_requested") in (True, None) or info.get("ok") is False
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tests/test_gsheet_module.py
+++ b/tests/test_gsheet_module.py
@@ -11,6 +11,12 @@ from gspread.exceptions import SpreadsheetNotFound
 import gsheet_module as gm
 
 
+class _FakeCredentials:
+    @staticmethod
+    def from_service_account_file(*_args, **_kwargs):
+        return object()
+
+
 def test_get_sheet_values_success(monkeypatch):
     """Should return the rows list when the Sheets client returns values."""
 
@@ -32,6 +38,11 @@ def test_get_sheet_values_success(monkeypatch):
     # monkeypatch the builder used by get_sheet_values
     monkeypatch.setattr(
         gm, "_build_sheets_with_timeout", lambda creds, timeout=None: FakeSheetsService()
+    )
+    monkeypatch.setattr(gm, "CREDENTIALS_FILE", "fake-creds.json")
+    monkeypatch.setattr(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        _FakeCredentials.from_service_account_file,
     )
 
     rows = gm.get_sheet_values("FAKE_ID", "Sheet1!A1:B2", timeout=5)
@@ -56,6 +67,11 @@ def test_get_sheet_values_empty_range(monkeypatch):
 
     monkeypatch.setattr(
         gm, "_build_sheets_with_timeout", lambda creds, timeout=None: FakeSheetsService()
+    )
+    monkeypatch.setattr(gm, "CREDENTIALS_FILE", "fake-creds.json")
+    monkeypatch.setattr(
+        "google.oauth2.service_account.Credentials.from_service_account_file",
+        _FakeCredentials.from_service_account_file,
     )
 
     rows = gm.get_sheet_values("FAKE_ID", "Sheet1!A1:A", timeout=2)

--- a/tests/test_prekvk_stats.py
+++ b/tests/test_prekvk_stats.py
@@ -34,7 +34,7 @@ def test_load_prekvk_top3_structured(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    monkeypatch.setattr("file_utils.get_conn_with_retries", lambda: DummyConn())
+    monkeypatch.setattr(prekvk_stats, "get_conn_with_retries", lambda: DummyConn())
 
     out = prekvk_stats.load_prekvk_top3(14, limit=3)
     assert set(out.keys()) == {"overall", "p1", "p2", "p3"}
@@ -70,7 +70,7 @@ def test_load_prekvk_top3_limit_one(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    monkeypatch.setattr("file_utils.get_conn_with_retries", lambda: DummyConn())
+    monkeypatch.setattr(prekvk_stats, "get_conn_with_retries", lambda: DummyConn())
 
     out = prekvk_stats.load_prekvk_top3(15, limit=1)
     assert len(out["overall"]) <= 1

--- a/tests/test_proc_config_import_phase2.py
+++ b/tests/test_proc_config_import_phase2.py
@@ -45,11 +45,18 @@ def make_sample_df():
     return pd.DataFrame([{"KVK_NO": 1, "SomeCol": "A"}, {"KVK_NO": 2, "SomeCol": "B"}])
 
 
+def _patch_import_credentials(monkeypatch, tmp_path):
+    creds = tmp_path / "fake-creds.json"
+    creds.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(pci, "CREDENTIALS_FILE", str(creds))
+
+
 def test_transactional_success(monkeypatch, tmp_path):
     # Prepare environment and monkeypatches
     monkeypatch.setattr(pci, "DATA_DIR", str(tmp_path))
     monkeypatch.setattr(pci, "KVK_SHEET_ID", "sheet-id")
     monkeypatch.setattr(pci, "IMPORT_TRANSACTIONAL", True)
+    _patch_import_credentials(monkeypatch, tmp_path)
 
     # Mock sheet service / read
     monkeypatch.setattr(pci, "_get_sheet_service", lambda: SimpleNamespace())
@@ -92,6 +99,7 @@ def test_transactional_upsert_failure_triggers_rollback(monkeypatch, tmp_path):
     monkeypatch.setattr(pci, "DATA_DIR", str(tmp_path))
     monkeypatch.setattr(pci, "KVK_SHEET_ID", "sheet-id")
     monkeypatch.setattr(pci, "IMPORT_TRANSACTIONAL", True)
+    _patch_import_credentials(monkeypatch, tmp_path)
 
     monkeypatch.setattr(pci, "_get_sheet_service", lambda: SimpleNamespace())
     monkeypatch.setattr(
@@ -126,6 +134,7 @@ def test_non_transactional_calls_helper_and_commits(monkeypatch, tmp_path):
     monkeypatch.setattr(pci, "KVK_SHEET_ID", "sheet-id")
     # Set non-transactional mode
     monkeypatch.setattr(pci, "IMPORT_TRANSACTIONAL", False)
+    _patch_import_credentials(monkeypatch, tmp_path)
 
     monkeypatch.setattr(pci, "_get_sheet_service", lambda: SimpleNamespace())
     monkeypatch.setattr(

--- a/tests/test_sheets_sync_flow.py
+++ b/tests/test_sheets_sync_flow.py
@@ -3,6 +3,20 @@ from __future__ import annotations
 from event_calendar import sheets_sync
 
 
+class FakeConn:
+    def cursor(self):
+        return object()
+
+    def commit(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
 def test_sync_sheets_to_sql_fetch_fail_graceful(monkeypatch):
     monkeypatch.setattr(sheets_sync, "_insert_sync_log_start", lambda _src: 123)
 
@@ -28,6 +42,7 @@ def test_sync_sheets_to_sql_fetch_fail_graceful(monkeypatch):
 def test_sync_sheets_to_sql_happy_path(monkeypatch):
     monkeypatch.setattr(sheets_sync, "_insert_sync_log_start", lambda _src: 999)
     monkeypatch.setattr(sheets_sync, "_finish_sync_log", lambda *_a, **_k: None)
+    monkeypatch.setattr(sheets_sync, "get_conn_with_retries", lambda **_kwargs: FakeConn())
 
     def _fetch(_sheet, tab):
         if tab == "recurring_rules":

--- a/tests/test_stats_service.py
+++ b/tests/test_stats_service.py
@@ -66,7 +66,7 @@ async def test_fetch_proc_handles_db_error_gracefully():
     """
     from stats_service import _fetch_proc
 
-    with patch("file_utils.get_conn_with_retries", side_effect=Exception("DB offline")):
+    with patch("stats_service.get_conn_with_retries", side_effect=Exception("DB offline")):
         # Should NOT raise; should fall back gracefully
         try:
             result = await _fetch_proc([123], "wtd", True)
@@ -220,7 +220,7 @@ async def test_get_stats_payload_basic_flow():
     with patch("stats_service._fetch_proc_sync", return_value=mock_proc_data):
         with patch("stats_service._fetch_trendlines_sync", return_value=mock_trend_rows):
             # Mock the freshness query
-            with patch("file_utils.get_conn_with_retries") as mock_conn:
+            with patch("stats_service.get_conn_with_retries") as mock_conn:
                 mock_cursor = MagicMock()
                 mock_cursor.fetchall.return_value = [("2025-02-03",)]
                 mock_cursor.description = [("AsOfDate",)]
@@ -493,7 +493,7 @@ async def test_my_stats_unchanged_after_schema_update():
 
     with patch("stats_service._fetch_proc_sync", return_value=mock_proc_data):
         with patch("stats_service._fetch_trendlines_sync", return_value=[]):
-            with patch("file_utils.get_conn_with_retries") as mock_conn:
+            with patch("stats_service.get_conn_with_retries") as mock_conn:
                 mock_cursor = MagicMock()
                 mock_cursor.fetchall.return_value = [("2026-02-05",)]
                 mock_cursor.description = [("AsOfDate",)]

--- a/tests/test_targets_sql_cache_subproc.py
+++ b/tests/test_targets_sql_cache_subproc.py
@@ -5,6 +5,19 @@
 import targets_sql_cache as tsc
 
 
+class FakeCursor:
+    def close(self):
+        return None
+
+
+class FakeConn:
+    def cursor(self):
+        return FakeCursor()
+
+    def close(self):
+        return None
+
+
 def make_sample_rows():
     # simulate two target rows returned from _fetch_targets_from_view
     return [
@@ -40,6 +53,7 @@ def test_refresh_targets_cache_returns_summary_in_subprocess(monkeypatch, tmp_pa
     monkeypatch.setattr(
         "targets_sql_cache._fetch_targets_from_view", lambda cur: make_sample_rows()
     )
+    monkeypatch.setattr("targets_sql_cache._conn", lambda: FakeConn())
     # stub _write_json to write to temp file (no exception)
     _captured_path = str(tmp_path / "targets.json")
     monkeypatch.setattr("targets_sql_cache._write_json", lambda path, data: None)
@@ -64,6 +78,7 @@ def test_refresh_targets_cache_returns_full_when_not_subprocess(monkeypatch, tmp
     monkeypatch.setattr(
         "targets_sql_cache._fetch_targets_from_view", lambda cur: make_sample_rows()
     )
+    monkeypatch.setattr("targets_sql_cache._conn", lambda: FakeConn())
     monkeypatch.setattr("targets_sql_cache._write_json", lambda path, data: None)
     res = tsc.refresh_targets_cache()
     assert "_meta" in res


### PR DESCRIPTION
## Summary
- Adds an Ark-specific pytest guard that fails fast when unit tests accidentally reach Ark DAL DB helpers without explicit integration opt-in.
- Patches Ark registration, reminder, scheduler, message, Google Sheets, Pre-KVK, proc import, calendar sync, stats, and targets cache tests at the module boundaries they actually execute.
- Makes offload cancellation deterministic on Windows without `psutil` by using a `taskkill /T /F` fallback and ensuring the test cleans up spawned workers.
- Allows the Windows startup interpreter guard to accept either project-local `venv` or `.venv`, keeping arbitrary interpreters blocked while matching local PR validation.
- Fixes `stats_service` so proc DB errors degrade to empty rows and freshness uses the thread helper instead of the incompatible callable-offload API.
- Captures remaining test-environment improvement ideas in `docs/deferred_optimisations.md`.

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/test_ark_bans_enforcement.py tests/test_ark_reminder_phase_bd.py tests/test_ark_scheduler.py -q` -> 14 passed
- `$files = Get-ChildItem tests -Filter 'test_ark_*.py' | ForEach-Object { $_.FullName }; .\.venv\Scripts\python.exe -m pytest $files -q` -> 164 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_cancel_offload.py -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_dl_bot_mge_auto_import.py -vv` -> 2 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_gsheet_module.py tests/test_prekvk_stats.py tests/test_proc_config_import_phase2.py tests/test_sheets_sync_flow.py tests/test_stats_service.py tests/test_targets_sql_cache_subproc.py -q` -> 33 passed
- `.\.venv\Scripts\python.exe -m black --check tests/conftest.py tests/test_ark_bans_enforcement.py tests/test_ark_registration_flow.py tests/test_ark_registration_messages.py tests/test_ark_reminder_phase_bd.py tests/test_ark_scheduler.py file_utils.py tests/test_cancel_offload.py DL_bot.py stats_service.py tests/test_gsheet_module.py tests/test_prekvk_stats.py tests/test_proc_config_import_phase2.py tests/test_sheets_sync_flow.py tests/test_stats_service.py tests/test_targets_sql_cache_subproc.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff check tests/conftest.py tests/test_ark_bans_enforcement.py tests/test_ark_registration_flow.py tests/test_ark_registration_messages.py tests/test_ark_reminder_phase_bd.py tests/test_ark_scheduler.py file_utils.py tests/test_cancel_offload.py DL_bot.py stats_service.py tests/test_gsheet_module.py tests/test_prekvk_stats.py tests/test_proc_config_import_phase2.py tests/test_sheets_sync_flow.py tests/test_stats_service.py tests/test_targets_sql_cache_subproc.py` -> passed
- `.\.venv\Scripts\python.exe -m pytest tests -q` -> 1018 passed, 8 skipped when run outside the Codex sandbox. Inside the sandbox, 4 subprocess tests fail with `[WinError 5] Access is denied`; the same focused subprocess set passes unsandboxed.

## Risk / Rollback
- Mostly test isolation plus small Windows-local hardening and one stats-service compatibility fix. Rollback is reverting this PR if the Ark guard, `taskkill` fallback, `.venv` interpreter allowance, or stats freshness change proves too broad.