### PR TITLE
[codex] Fix inventory vision strict schema

### DIFF
--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -57,6 +57,49 @@ def default_config() -> InventoryVisionConfig:
 
 
 def build_inventory_vision_schema() -> dict[str, Any]:
+    nullable_number = {"type": ["number", "null"]}
+    nullable_integer = {"type": ["integer", "null"]}
+
+    resource_row = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["from_items_value", "total_resources_value"],
+        "properties": {
+            "from_items_value": nullable_integer,
+            "total_resources_value": nullable_integer,
+        },
+    }
+    speedup_row = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["total_minutes", "total_hours", "total_days_decimal"],
+        "properties": {
+            "total_minutes": nullable_integer,
+            "total_hours": nullable_number,
+            "total_days_decimal": nullable_number,
+        },
+    }
+    material_row = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "normal",
+            "advanced",
+            "elite",
+            "epic",
+            "legendary",
+            "legendary_equivalent",
+        ],
+        "properties": {
+            "normal": nullable_integer,
+            "advanced": nullable_integer,
+            "elite": nullable_integer,
+            "epic": nullable_integer,
+            "legendary": nullable_integer,
+            "legendary_equivalent": nullable_number,
+        },
+    }
+
     return {
         "type": "object",
         "additionalProperties": False,
@@ -70,7 +113,57 @@ def build_inventory_vision_schema() -> dict[str, Any]:
             "warnings": {"type": "array", "items": {"type": "string"}},
             "values": {
                 "type": "object",
-                "additionalProperties": True,
+                "additionalProperties": False,
+                "required": ["resources", "speedups", "materials"],
+                "properties": {
+                    "resources": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["food", "wood", "stone", "gold"],
+                        "properties": {
+                            "food": resource_row,
+                            "wood": resource_row,
+                            "stone": resource_row,
+                            "gold": resource_row,
+                        },
+                    },
+                    "speedups": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": [
+                            "building",
+                            "research",
+                            "training",
+                            "healing",
+                            "universal",
+                        ],
+                        "properties": {
+                            "building": speedup_row,
+                            "research": speedup_row,
+                            "training": speedup_row,
+                            "healing": speedup_row,
+                            "universal": speedup_row,
+                        },
+                    },
+                    "materials": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": [
+                            "choice_chests",
+                            "leather",
+                            "iron_ore",
+                            "ebony",
+                            "animal_bone",
+                        ],
+                        "properties": {
+                            "choice_chests": material_row,
+                            "leather": material_row,
+                            "iron_ore": material_row,
+                            "ebony": material_row,
+                            "animal_bone": material_row,
+                        },
+                    },
+                },
             },
         },
     }
@@ -84,10 +177,12 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         f"Expected import type hint: {hint}. "
         "Return only structured JSON matching the supplied schema. "
         "Classify the image as resources, speedups, materials, or unknown. "
-        "For resources, extract Food, Wood, Stone, Gold, From Items, and Total Resources "
-        "as integer quantities after expanding K/M/B suffixes. "
+        "Always include the resources, speedups, and materials objects required by the "
+        "schema. Use null for fields that do not apply to the detected image type or "
+        "cannot be read. For resources, extract food, wood, stone, and gold from-items "
+        "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, extract Building, Research, Training, Healing, and Universal "
-        "speedups as total_minutes where possible. "
+        "speedups as total_minutes, total_hours, and total_days_decimal where possible. "
         "Use warnings for missing rows, unreadable values, low confidence, or mismatched "
         "image type. If the image is not readable, use detected_image_type unknown and "
         "a confidence_score below 0.70."
@@ -159,10 +254,7 @@ def _parse_result_payload(
             model=model,
             prompt_version=prompt_version,
             fallback_used=fallback_used,
-            error=(
-                "Vision response JSON missing required field(s): "
-                + ", ".join(missing_keys)
-            ),
+            error=("Vision response JSON missing required field(s): " + ", ".join(missing_keys)),
         )
 
     detected_raw = payload.get("detected_image_type")
@@ -172,13 +264,11 @@ def _parse_result_payload(
             model=model,
             prompt_version=prompt_version,
             fallback_used=fallback_used,
-            error=(
-                "Vision response field 'detected_image_type' must be a non-empty string."
-            ),
+            error=("Vision response field 'detected_image_type' must be a non-empty string."),
         )
 
     detected = detected_raw.strip().lower()
-    allowed_detected_types = {"unknown", "photo", "screenshot"}
+    allowed_detected_types = {"resources", "speedups", "materials", "unknown"}
     if detected not in allowed_detected_types:
         return InventoryVisionResult(
             ok=False,
@@ -215,8 +305,7 @@ def _parse_result_payload(
             prompt_version=prompt_version,
             fallback_used=fallback_used,
             error=(
-                "Vision response field 'values' must be a dict "
-                f"(got {type(values).__name__})."
+                "Vision response field 'values' must be a dict " f"(got {type(values).__name__})."
             ),
         )
 

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -6,7 +6,11 @@ import sys
 
 import pytest
 
-from services.vision_client import InventoryVisionClient, InventoryVisionConfig
+from services.vision_client import (
+    InventoryVisionClient,
+    InventoryVisionConfig,
+    build_inventory_vision_schema,
+)
 
 
 class FakeResponses:
@@ -36,6 +40,28 @@ def _config(**overrides):
     }
     values.update(overrides)
     return InventoryVisionConfig(**values)
+
+
+def _walk_schema_objects(schema):
+    if isinstance(schema, dict):
+        schema_type = schema.get("type")
+        if schema_type == "object" or (isinstance(schema_type, list) and "object" in schema_type):
+            yield schema
+        for value in schema.values():
+            yield from _walk_schema_objects(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            yield from _walk_schema_objects(item)
+
+
+def test_schema_is_strict_for_openai_structured_outputs():
+    schema = build_inventory_vision_schema()
+
+    object_schemas = list(_walk_schema_objects(schema))
+
+    assert object_schemas
+    assert all(item.get("additionalProperties") is False for item in object_schemas)
+    assert schema["properties"]["values"]["additionalProperties"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the deployed Phase 0 OpenAI structured-output failure where the Responses API rejected the `values` schema because it allowed arbitrary nested keys.

## Changes

- Replaced the dynamic `values` object schema with explicit `resources`, `speedups`, and `materials` shapes.
- Ensured every object schema declares `additionalProperties: false`, including nested resource/speedup/material rows.
- Updated the prompt to tell the model to include all schema-required sections and use `null` for fields that do not apply.
- Aligned parser validation with the schema enum values: `resources`, `speedups`, `materials`, `unknown`.
- Added a regression test that recursively checks all object schemas are strict for OpenAI structured outputs.

## Validation

- `./.venv/Scripts/python.exe -m pytest tests/test_inventory_vision_client.py tests/test_inventory_vision_script.py tests/test_inventory_vision_config.py -q` -> 10 passed
- `./.venv/Scripts/python.exe -m ruff check services/vision_client.py tests/test_inventory_vision_client.py` -> passed
- `./.venv/Scripts/python.exe -m black --check services/vision_client.py tests/test_inventory_vision_client.py` -> passed
- `git diff --check` -> passed
- Live smoke: `./.venv/Scripts/python.exe scripts/test_inventory_vision.py C:\rok\rss_sample.png --type resources` -> `ok: true`, `model: gpt-4.1-mini`, `confidence_score: 0.98`
- Live smoke: `./.venv/Scripts/python.exe scripts/test_inventory_vision.py C:\rok\speedup_sample.png --type speedups` -> `ok: true`, `model: gpt-4.1-mini`, `confidence_score: 0.98`

## Risk / Rollback

Low risk. This only tightens the Phase 0 vision response schema and parser validation. No SQL or Discord workflow changes are included. Rollback is reverting this PR.