### PR TITLE
[codex] add inventory phase 1c export and audit

### DIFF
--- a/commands/inventory_cmds.py
+++ b/commands/inventory_cmds.py
@@ -7,9 +7,9 @@ from discord.ext import commands as ext_commands
 
 from bot_config import ADMIN_USER_ID, GUILD_ID, INVENTORY_UPLOAD_CHANNEL_ID
 from core.interaction_safety import safe_command, safe_defer
-from decoraters import track_usage
-from inventory import reporting_service
-from inventory.models import InventoryReportVisibility
+from decoraters import _is_admin, track_usage
+from inventory import audit_service, export_service, reporting_service
+from inventory.models import InventoryAuditRecord, InventoryReportVisibility
 from ui.views.inventory_report_views import start_myinventory_command
 from ui.views.inventory_views import start_import_command
 from versioning import versioned
@@ -147,3 +147,202 @@ def register_inventory(bot: ext_commands.Bot) -> None:
                 "Inventory report generation failed. Please try again or contact an admin.",
                 ephemeral=True,
             )
+
+    @bot.slash_command(
+        name="export_inventory",
+        description="Export your approved resources and speedups inventory records",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def export_inventory(
+        ctx: discord.ApplicationContext,
+        format: str = discord.Option(
+            str,
+            "Choose export format",
+            choices=["Excel", "CSV", "GoogleSheets"],
+            required=False,
+            default="Excel",
+        ),
+        view: str = discord.Option(
+            str,
+            "Inventory records to export",
+            choices=["Resources", "Speedups", "All"],
+            required=False,
+            default="All",
+        ),
+        governor: int | None = discord.Option(
+            int,
+            "Governor ID to export (optional; defaults to all registered governors)",
+            required=False,
+            default=None,
+        ),
+        days: int = discord.Option(
+            int,
+            "Number of days to include",
+            min_value=1,
+            max_value=366,
+            required=False,
+            default=366,
+        ),
+    ) -> None:
+        await safe_defer(ctx, ephemeral=True)
+        export_file = None
+        try:
+            export_format = export_service.parse_export_format(format)
+            export_view = export_service.parse_export_view(view)
+            export_file = await export_service.build_inventory_export_file(
+                discord_user_id=int(ctx.user.id),
+                username=getattr(ctx.user, "display_name", None)
+                or getattr(ctx.user, "name", "user"),
+                export_format=export_format,
+                view=export_view,
+                governor_id=governor,
+                lookback_days=int(days),
+                is_admin=_is_admin(ctx.user),
+                discord_user=ctx.user,
+            )
+            file_obj = discord.File(str(export_file.path), filename=export_file.filename)
+            await ctx.followup.send(
+                content=(
+                    "Inventory export ready. "
+                    f"`{export_file.row_count}` raw approved row(s), "
+                    f"`{len(export_file.governor_ids)}` governor(s)."
+                ),
+                file=file_obj,
+                ephemeral=True,
+            )
+        except PermissionError as exc:
+            await ctx.followup.send(str(exc), ephemeral=True)
+        except ValueError as exc:
+            await ctx.followup.send(str(exc), ephemeral=True)
+        except Exception:
+            logger.exception("export_inventory_command_failed actor=%s", ctx.user.id)
+            await ctx.followup.send(
+                "Inventory export failed. Please try again or contact an admin.",
+                ephemeral=True,
+            )
+        finally:
+            if export_file is not None:
+                export_service.cleanup_export_file(export_file)
+
+    @bot.slash_command(
+        name="inventory_import_audit",
+        description="Admin: review inventory import batches and retained debug references",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def inventory_import_audit(
+        ctx: discord.ApplicationContext,
+        status: str = discord.Option(
+            str,
+            "Import status filter",
+            choices=[
+                "All",
+                "Awaiting Upload",
+                "Analysed",
+                "Approved",
+                "Rejected",
+                "Cancelled",
+                "Failed",
+            ],
+            required=False,
+            default="All",
+        ),
+        import_type: str = discord.Option(
+            str,
+            "Import type filter",
+            choices=["All", "Resources", "Speedups", "Materials", "Unknown"],
+            required=False,
+            default="All",
+        ),
+        governor: int | None = discord.Option(
+            int,
+            "Governor ID filter",
+            required=False,
+            default=None,
+        ),
+        discord_user_id: int | None = discord.Option(
+            int,
+            "Discord user ID filter",
+            required=False,
+            default=None,
+        ),
+        days: int = discord.Option(
+            int,
+            "Lookback days",
+            min_value=1,
+            max_value=366,
+            required=False,
+            default=30,
+        ),
+        limit: int = discord.Option(
+            int,
+            "Rows to show",
+            min_value=1,
+            max_value=25,
+            required=False,
+            default=10,
+        ),
+    ) -> None:
+        await safe_defer(ctx, ephemeral=True)
+        if not _is_admin(ctx.user):
+            await ctx.followup.send("You do not have permission to use this command.", ephemeral=True)
+            return
+        try:
+            parsed_status = audit_service.parse_audit_status(
+                status.strip().lower().replace(" ", "_")
+            )
+            parsed_type = audit_service.parse_audit_import_type(import_type)
+            records = await audit_service.fetch_inventory_audit(
+                status=parsed_status,
+                import_type=parsed_type,
+                governor_id=governor,
+                discord_user_id=discord_user_id,
+                lookback_days=int(days),
+                limit=int(limit),
+            )
+            embed = _build_inventory_audit_embed(records, days=int(days))
+            await ctx.followup.send(embed=embed, ephemeral=True)
+        except ValueError as exc:
+            await ctx.followup.send(str(exc), ephemeral=True)
+        except Exception:
+            logger.exception("inventory_import_audit_failed actor=%s", ctx.user.id)
+            await ctx.followup.send(
+                "Inventory import audit failed. Please try again or contact an admin.",
+                ephemeral=True,
+            )
+
+
+def _build_inventory_audit_embed(
+    records: list[InventoryAuditRecord], *, days: int
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="Inventory Import Audit",
+        description=f"Recent inventory import batches from the last {days} day(s).",
+        color=discord.Color.blurple(),
+    )
+    if not records:
+        embed.add_field(name="Results", value="No matching inventory import batches.", inline=False)
+        return embed
+
+    for record in records[:25]:
+        confidence = (
+            f"{record.confidence_score:.2f}" if record.confidence_score is not None else "n/a"
+        )
+        json_parts = audit_service.summarize_json_comparison(record)
+        value = (
+            f"Governor `{record.governor_id}` | User `{record.discord_user_id}`\n"
+            f"type `{record.import_type or 'unknown'}` | flow `{record.flow_type}` | "
+            f"confidence `{confidence}`\n"
+            f"debug {record.debug_reference} | json `{json_parts}`"
+        )
+        embed.add_field(
+            name=f"Batch {record.import_batch_id} - {record.status}",
+            value=value[:1024],
+            inline=False,
+        )
+    return embed

--- a/commands/inventory_cmds.py
+++ b/commands/inventory_cmds.py
@@ -290,7 +290,9 @@ def register_inventory(bot: ext_commands.Bot) -> None:
     ) -> None:
         await safe_defer(ctx, ephemeral=True)
         if not _is_admin(ctx.user):
-            await ctx.followup.send("You do not have permission to use this command.", ephemeral=True)
+            await ctx.followup.send(
+                "You do not have permission to use this command.", ephemeral=True
+            )
             return
         try:
             parsed_status = audit_service.parse_audit_status(

--- a/docs/Codex Task Pack — Inventory Image Import Module.md
+++ b/docs/Codex Task Pack — Inventory Image Import Module.md
@@ -6,6 +6,8 @@ Phase 0 is complete and deployed.
 
 Phase 1A is complete, tested, and deployed.
 
+Phase 1B is complete, tested, and deployed.
+
 Phase 0 delivered:
 
 - OpenAI Vision API setup documented in `docs/inventory_image_import_setup.md`.
@@ -62,6 +64,33 @@ Phase 1A validation:
 - Full test suite passed during promotion validation: `1056 passed, 8 skipped`.
 - Production deployment completed.
 
+Phase 1B delivered:
+
+- Canonical `/myinventory` command.
+- Latest Resources and Speedups inventory summary image.
+- Generated mobile/desktop-suitable report images using SQL-backed inventory data.
+- Range controls for 1M / 3M / 6M / 12M.
+- Summary-only output when only one approved record exists.
+- Summary plus trend graph when at least two approved records exist.
+- Persistent reporting visibility preference.
+- Materials kept disabled until Phase 2.
+
+Phase 1B implementation files:
+
+- `commands/inventory_cmds.py`
+- `inventory/reporting_service.py`
+- `inventory/report_image_renderer.py`
+- `inventory/dal/inventory_reporting_dal.py`
+- `ui/views/inventory_report_views.py`
+- `tests/test_inventory_reporting_service.py`
+- `tests/test_inventory_report_image_renderer.py`
+- `tests/test_inventory_report_views.py`
+
+Phase 1B validation:
+
+- Phase 1B has been tested and deployed.
+- Reporting service, image renderer, and report view test coverage added.
+
 Phase 0 sample validation:
 
 - `python scripts\test_inventory_vision.py C:\rok\rss_sample.png --type resources`
@@ -106,8 +135,9 @@ Development is split into:
 
 - Phase 0 - OpenAI Vision Integration Setup: complete and deployed.
 - Phase 1A - Foundation + Resources/Speedups Import: complete, tested, and deployed.
-- Phase 1B - Inventory reporting images and visibility preferences: next phase.
-- Phase 1C - Inventory export, admin audit, and interaction boundary hardening: planned follow-on.
+- Phase 1B - Inventory reporting images and visibility preferences: complete, tested, and deployed.
+- Phase 1C - Inventory export, admin audit, and interaction boundary hardening: next phase.
+- Phase 1D - Final Resources/Speedups completion polish: planned follow-on.
 - Phase 2 - Materials Import: later phase.
 
 Work must proceed phase by phase. The next phase should begin with review/scope only per repository rules.
@@ -244,7 +274,7 @@ Do not use `/inventory_import` for the user-facing command name.
 Add:
 
 - `/import_inventory` - complete in Phase 1A.
-- `/myinventory` - Phase 1B.
+- `/myinventory` - complete in Phase 1B.
 - `/export_inventory` - Phase 1C.
 - `/inventory_import_audit` - Phase 1C.
 
@@ -533,7 +563,7 @@ SQL schema changes belong in the SQL Server repository, not only in Python.
 
 ### `/myinventory`
 
-Status: Phase 1B.
+Status: complete in Phase 1B.
 
 Purpose:
 
@@ -591,7 +621,7 @@ Architecture note:
 
 ### Phase 1 Output Images
 
-Status: Phase 1B.
+Status: Resources and Speedups output images complete in Phase 1B.
 
 Shared output-image direction:
 
@@ -734,6 +764,37 @@ Boundary hardening goals:
 - Reassess whether same-session retry after reject needs richer UX or whether upload-first replacement is sufficient.
 
 Phase 1C should remain Materials-free. Materials belong to Phase 2.
+
+## Phase 1D - Final Resources/Speedups Completion Polish
+
+Phase 1D should be a small follow-on phase after Phase 1C to finish the remaining
+Resources and Speedups user-experience surface before declaring Phase 1 complete.
+
+Recommended scope:
+
+- Add export buttons under `/myinventory` report output where appropriate.
+- Reuse the `/export_inventory` service/DAL path rather than adding export SQL or file generation to views.
+- Perform targeted OCR/prompt tuning for Resources and Speedups only, based on production smoke-test failures or recurring admin-audit findings.
+- Review the Phase 1A/1B/1C scenario matrix end to end for Resources and Speedups:
+  - no registered governors
+  - governor selector timeout/no approval
+  - reject then repeat import
+  - same-day duplicate approved import
+  - random/unknown image
+  - Materials-disabled image
+  - export/audit access and empty-data handling
+- Confirm documentation and user-facing guidance are aligned with final Phase 1 behaviour.
+
+Out of scope for Phase 1D:
+
+- Materials processing or reporting.
+- `/my_stats` integration.
+- The stats export SQL refactor tracked by GitHub issue #46.
+- Broad OCR redesign beyond targeted Resources/Speedups tuning.
+
+Phase 1 for Resources and Speedups should be considered complete only after Phase 1D
+validates import, report, export, audit, retry/repeat, and targeted OCR/prompt behaviour
+against the documented scenario matrix.
 
 ## Phase 2 - Materials
 
@@ -893,18 +954,18 @@ Test:
 - correction workflow - Phase 1A complete
 - large correction warning - review/extend in Phase 1C if additional comparison/audit UX is needed
 - admin debug channel logging - Phase 1A complete
-- image output generation - Phase 1B
-- visibility preference persistence - Phase 1B
+- image output generation - Phase 1B complete for Resources and Speedups
+- visibility preference persistence - Phase 1B complete
 - `/export_inventory` - Phase 1C
 - `/inventory_import_audit` - Phase 1C
-- restart/persistence behaviour for active/imported state - Phase 1A complete for import batches; Phase 1B should cover reporting preferences
-- cache safety where applicable - continue in Phase 1B and Phase 1C
+- restart/persistence behaviour for active/imported state - Phase 1A complete for import batches; Phase 1B complete for reporting preferences
+- cache safety where applicable - continue in Phase 1C
 
 ### Phase 1B
 
-Next phase.
+Complete, tested, and deployed.
 
-Recommended scope:
+Delivered scope:
 
 - `/myinventory`
 - latest inventory summary view
@@ -914,7 +975,7 @@ Recommended scope:
 - trend graph when at least two approved records exist
 - persistent visibility preference
 
-Recommended Phase 1B audit points:
+Completed Phase 1B audit points:
 
 - Confirm live Phase 1A SQL schema is the source of truth before building read/report queries.
 - Verify command name remains canonical: `/myinventory`.
@@ -924,7 +985,7 @@ Recommended Phase 1B audit points:
 
 ### Phase 1C
 
-Planned follow-on phase.
+Next phase.
 
 Recommended scope:
 
@@ -941,6 +1002,22 @@ Recommended Phase 1C audit points:
 - Confirm GitHub issue #46 remains the tracking item for the existing stats export direct-SQL refactor.
 - Do not expand into `/my_stats` integration.
 - Do not add Materials support before Phase 2.
+
+### Phase 1D
+
+Planned follow-on phase.
+
+Recommended scope:
+
+- `/myinventory` export buttons wired to the Phase 1C export service/DAL path.
+- Targeted Resources/Speedups OCR and prompt tuning based on smoke-test/audit evidence.
+- Final Phase 1 Resources/Speedups scenario validation and documentation alignment.
+
+Do not include:
+
+- Materials processing.
+- `/my_stats` integration.
+- Stats export SQL refactor work tracked by GitHub issue #46.
 
 ### Phase 2
 
@@ -1005,5 +1082,5 @@ Do not create a duplicate issue for this item. Reference issue #46 whenever Phas
 ## Suggested Next Chat Opening Prompt
 
 ```text
-Start Phase 1B review/scope for the Inventory Image Import Module. Phase 0 and Phase 1A are complete, tested, and deployed. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 1A delivered /import_inventory, upload-first import in INVENTORY_UPLOAD_CHANNEL_ID, Vision-derived image type, Resources/Speedups SQL-backed imports, correction/reject/cancel flow, and admin debug channel retention. For Phase 1B, assess and scope /myinventory, generated Resources/Speedups output images, range buttons, and persistent visibility preference. Keep /export_inventory, /inventory_import_audit, export files, admin audit access, and Phase 1A inventory view/service boundary hardening for linked Phase 1C. Keep commands thin, use service/DAL boundaries, do not copy the direct SQL pattern from /my_stats_export, reference GitHub issue #46 for the existing stats export SQL refactor, keep Materials out of scope until Phase 2, and begin with audit/scope only per repo rules.
+Start Phase 1C review/scope for the Inventory Image Import Module. Phase 0, Phase 1A, and Phase 1B are complete, tested, and deployed. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 1A delivered /import_inventory, upload-first import in INVENTORY_UPLOAD_CHANNEL_ID, Vision-derived image type, Resources/Speedups SQL-backed imports, correction/reject/cancel flow, and admin debug channel retention. Phase 1B delivered /myinventory, generated Resources/Speedups report images, 1M/3M/6M/12M range controls, summary-only output for one approved record, trend graphs for two or more approved records, and persistent visibility preference. For Phase 1C, assess and scope /export_inventory, /inventory_import_audit, raw inventory export files, admin audit filtering/debug-message reference access, and targeted cleanup of Phase 1A inventory view/service boundaries. Keep commands thin, use service/DAL boundaries, do not copy the direct SQL pattern from /my_stats_export, reference GitHub issue #46 for the existing stats export SQL refactor, keep Materials out of scope until Phase 2, and begin with audit/scope only per repo rules.
 ```

--- a/inventory/audit_service.py
+++ b/inventory/audit_service.py
@@ -15,7 +15,9 @@ def parse_audit_status(value: str | None) -> InventoryAuditStatus:
     try:
         return InventoryAuditStatus(normalized)
     except ValueError as exc:
-        raise ValueError("Audit status must be All, Awaiting Upload, Analysed, Approved, Rejected, Cancelled, or Failed.") from exc
+        raise ValueError(
+            "Audit status must be All, Awaiting Upload, Analysed, Approved, Rejected, Cancelled, or Failed."
+        ) from exc
 
 
 def parse_audit_import_type(value: str | None) -> InventoryImportType | None:
@@ -25,7 +27,9 @@ def parse_audit_import_type(value: str | None) -> InventoryImportType | None:
     try:
         return InventoryImportType(normalized)
     except ValueError as exc:
-        raise ValueError("Audit import type must be All, Resources, Speedups, Materials, or Unknown.") from exc
+        raise ValueError(
+            "Audit import type must be All, Resources, Speedups, Materials, or Unknown."
+        ) from exc
 
 
 def _json_dict(value: Any) -> dict[str, Any] | None:

--- a/inventory/audit_service.py
+++ b/inventory/audit_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from inventory.dal import inventory_audit_dal
+from inventory.models import InventoryAuditRecord, InventoryAuditStatus, InventoryImportType
+
+logger = logging.getLogger(__name__)
+
+
+def parse_audit_status(value: str | None) -> InventoryAuditStatus:
+    normalized = (value or InventoryAuditStatus.ALL.value).strip().lower()
+    try:
+        return InventoryAuditStatus(normalized)
+    except ValueError as exc:
+        raise ValueError("Audit status must be All, Awaiting Upload, Analysed, Approved, Rejected, Cancelled, or Failed.") from exc
+
+
+def parse_audit_import_type(value: str | None) -> InventoryImportType | None:
+    normalized = (value or "all").strip().lower()
+    if normalized == "all":
+        return None
+    try:
+        return InventoryImportType(normalized)
+    except ValueError as exc:
+        raise ValueError("Audit import type must be All, Resources, Speedups, Materials, or Unknown.") from exc
+
+
+def _json_dict(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _warnings(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _record_from_row(row: dict[str, Any]) -> InventoryAuditRecord:
+    return InventoryAuditRecord(
+        import_batch_id=int(row["ImportBatchID"]),
+        governor_id=int(row["GovernorID"]),
+        discord_user_id=int(row["DiscordUserID"]),
+        import_type=row.get("ImportType"),
+        flow_type=str(row.get("FlowType") or ""),
+        status=str(row.get("Status") or ""),
+        created_at_utc=row.get("CreatedAtUtc"),
+        approved_at_utc=row.get("ApprovedAtUtc"),
+        rejected_at_utc=row.get("RejectedAtUtc"),
+        confidence_score=(
+            float(row["ConfidenceScore"]) if row.get("ConfidenceScore") is not None else None
+        ),
+        vision_model=row.get("VisionModel"),
+        fallback_used=bool(row.get("FallbackUsed")),
+        admin_debug_channel_id=(
+            int(row["AdminDebugChannelID"]) if row.get("AdminDebugChannelID") else None
+        ),
+        admin_debug_message_id=(
+            int(row["AdminDebugMessageID"]) if row.get("AdminDebugMessageID") else None
+        ),
+        warnings=_warnings(row.get("WarningJson")),
+        detected_json=_json_dict(row.get("DetectedJson")),
+        corrected_json=_json_dict(row.get("CorrectedJson")),
+        final_json=_json_dict(row.get("FinalJson")),
+        error_json=_json_dict(row.get("ErrorJson")),
+    )
+
+
+async def fetch_inventory_audit(
+    *,
+    status: InventoryAuditStatus,
+    import_type: InventoryImportType | None = None,
+    governor_id: int | None = None,
+    discord_user_id: int | None = None,
+    lookback_days: int = 30,
+    limit: int = 10,
+) -> list[InventoryAuditRecord]:
+    rows = await asyncio.to_thread(
+        inventory_audit_dal.fetch_import_audit_rows,
+        status=status.value,
+        import_type=import_type.value if import_type else None,
+        governor_id=governor_id,
+        discord_user_id=discord_user_id,
+        lookback_days=lookback_days,
+        limit=limit,
+    )
+    records = [_record_from_row(row) for row in rows]
+    logger.info(
+        "inventory_audit_fetched status=%s import_type=%s governor=%s user=%s rows=%s",
+        status.value,
+        import_type.value if import_type else "all",
+        governor_id,
+        discord_user_id,
+        len(records),
+    )
+    return records
+
+
+def summarize_json_comparison(record: InventoryAuditRecord) -> str:
+    parts = []
+    if record.detected_json is not None:
+        parts.append("detected")
+    if record.corrected_json is not None:
+        parts.append("corrected")
+    if record.final_json is not None:
+        parts.append("final")
+    if record.error_json is not None:
+        parts.append("error")
+    return ", ".join(parts) if parts else "none"

--- a/inventory/audit_service.py
+++ b/inventory/audit_service.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_audit_status(value: str | None) -> InventoryAuditStatus:
-    normalized = (value or InventoryAuditStatus.ALL.value).strip().lower()
+    normalized = (value or InventoryAuditStatus.ALL.value).strip().lower().replace(" ", "_")
     try:
         return InventoryAuditStatus(normalized)
     except ValueError as exc:

--- a/inventory/dal/inventory_audit_dal.py
+++ b/inventory/dal/inventory_audit_dal.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _get_conn():
+    from file_utils import get_conn_with_retries
+
+    return get_conn_with_retries()
+
+
+def _loads_json(value: Any) -> Any:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(str(value))
+    except Exception:
+        return None
+
+
+def _rows_to_dicts(cursor) -> list[dict[str, Any]]:
+    rows = cursor.fetchall()
+    if not rows:
+        return []
+    cols = [item[0] for item in cursor.description]
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(zip(cols, row, strict=True))
+        for key in ("DetectedJson", "CorrectedJson", "FinalJson", "WarningJson", "ErrorJson"):
+            item[key] = _loads_json(item.get(key))
+        out.append(item)
+    return out
+
+
+def fetch_import_audit_rows(
+    *,
+    status: str | None = None,
+    import_type: str | None = None,
+    governor_id: int | None = None,
+    discord_user_id: int | None = None,
+    lookback_days: int = 30,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    clauses = ["CreatedAtUtc >= ?"]
+    params: list[Any] = [datetime.now(UTC) - timedelta(days=max(1, int(lookback_days)))]
+
+    if status and status != "all":
+        clauses.append("Status = ?")
+        params.append(status)
+    if import_type and import_type != "all":
+        clauses.append("ImportType = ?")
+        params.append(import_type)
+    if governor_id is not None:
+        clauses.append("GovernorID = ?")
+        params.append(int(governor_id))
+    if discord_user_id is not None:
+        clauses.append("DiscordUserID = ?")
+        params.append(int(discord_user_id))
+
+    where = " AND ".join(clauses)
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT TOP (?)
+                   ImportBatchID,
+                   GovernorID,
+                   DiscordUserID,
+                   ImportType,
+                   FlowType,
+                   Status,
+                   CreatedAtUtc,
+                   ApprovedAtUtc,
+                   RejectedAtUtc,
+                   ConfidenceScore,
+                   VisionModel,
+                   FallbackUsed,
+                   AdminDebugChannelID,
+                   AdminDebugMessageID,
+                   DetectedJson,
+                   CorrectedJson,
+                   FinalJson,
+                   WarningJson,
+                   ErrorJson
+            FROM dbo.InventoryImportBatch
+            WHERE {where}
+            ORDER BY CreatedAtUtc DESC, ImportBatchID DESC
+            """,
+            (max(1, min(int(limit), 25)), *params),
+        )
+        return _rows_to_dicts(cur)
+    finally:
+        conn.close()

--- a/inventory/dal/inventory_dal.py
+++ b/inventory/dal/inventory_dal.py
@@ -55,8 +55,8 @@ def create_import_batch(
                 ImageAttachmentURL, Status, CreatedAtUtc, RetryCount, IsAdminImport,
                 ExpiresAtUtc
             )
+            OUTPUT INSERTED.ImportBatchID
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?);
-            SELECT CAST(SCOPE_IDENTITY() AS BIGINT) AS ImportBatchID;
             """,
             (
                 int(governor_id),

--- a/inventory/dal/inventory_export_dal.py
+++ b/inventory/dal/inventory_export_dal.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _get_conn():
+    from file_utils import get_conn_with_retries
+
+    return get_conn_with_retries()
+
+
+def _rows_to_dicts(cursor) -> list[dict[str, Any]]:
+    rows = cursor.fetchall()
+    if not rows:
+        return []
+    cols = [item[0] for item in cursor.description]
+    return [dict(zip(cols, row, strict=True)) for row in rows]
+
+
+def fetch_resource_export_rows(
+    governor_ids: list[int], *, lookback_days: int = 366
+) -> list[dict[str, Any]]:
+    if not governor_ids:
+        return []
+    since_utc = datetime.now(UTC) - timedelta(days=int(lookback_days))
+    placeholders = ",".join("?" for _ in governor_ids)
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT b.ImportBatchID,
+                   b.GovernorID,
+                   b.DiscordUserID,
+                   b.FlowType,
+                   b.ApprovedAtUtc,
+                   b.CreatedAtUtc,
+                   r.ScanUtc,
+                   r.ResourceType,
+                   r.FromItemsValue,
+                   r.TotalResourcesValue
+            FROM dbo.GovernorResourceInventory AS r
+            INNER JOIN dbo.InventoryImportBatch AS b
+                ON b.ImportBatchID = r.ImportBatchID
+            WHERE r.GovernorID IN ({placeholders})
+              AND b.Status = N'approved'
+              AND b.ImportType = N'resources'
+              AND r.ScanUtc >= ?
+            ORDER BY r.GovernorID ASC, r.ScanUtc DESC, r.ResourceType ASC
+            """,
+            (*[int(item) for item in governor_ids], since_utc),
+        )
+        return _rows_to_dicts(cur)
+    finally:
+        conn.close()
+
+
+def fetch_speedup_export_rows(
+    governor_ids: list[int], *, lookback_days: int = 366
+) -> list[dict[str, Any]]:
+    if not governor_ids:
+        return []
+    since_utc = datetime.now(UTC) - timedelta(days=int(lookback_days))
+    placeholders = ",".join("?" for _ in governor_ids)
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT b.ImportBatchID,
+                   b.GovernorID,
+                   b.DiscordUserID,
+                   b.FlowType,
+                   b.ApprovedAtUtc,
+                   b.CreatedAtUtc,
+                   s.ScanUtc,
+                   s.SpeedupType,
+                   s.TotalMinutes,
+                   s.TotalHours,
+                   s.TotalDaysDecimal
+            FROM dbo.GovernorSpeedupInventory AS s
+            INNER JOIN dbo.InventoryImportBatch AS b
+                ON b.ImportBatchID = s.ImportBatchID
+            WHERE s.GovernorID IN ({placeholders})
+              AND b.Status = N'approved'
+              AND b.ImportType = N'speedups'
+              AND s.ScanUtc >= ?
+            ORDER BY s.GovernorID ASC, s.ScanUtc DESC, s.SpeedupType ASC
+            """,
+            (*[int(item) for item in governor_ids], since_utc),
+        )
+        return _rows_to_dicts(cur)
+    finally:
+        conn.close()

--- a/inventory/export_service.py
+++ b/inventory/export_service.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+from datetime import UTC, datetime
+import logging
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from decoraters import _is_admin
+from inventory.dal import inventory_export_dal
+from inventory.inventory_service import (
+    get_registered_governors_for_user,
+    user_can_import_for_governor,
+)
+from inventory.models import InventoryExportFile, InventoryExportFormat, InventoryReportView
+
+logger = logging.getLogger(__name__)
+
+EXPORT_COLUMNS = [
+    "RecordKind",
+    "ImportBatchID",
+    "GovernorID",
+    "DiscordUserID",
+    "FlowType",
+    "ApprovedAtUtc",
+    "ScanUtc",
+    "ItemType",
+    "FromItemsValue",
+    "TotalResourcesValue",
+    "TotalMinutes",
+    "TotalHours",
+    "TotalDaysDecimal",
+]
+
+
+def parse_export_format(value: str | None) -> InventoryExportFormat:
+    normalized = (value or "Excel").strip().lower().replace(" ", "_")
+    aliases = {
+        "excel": InventoryExportFormat.EXCEL,
+        "xlsx": InventoryExportFormat.EXCEL,
+        "csv": InventoryExportFormat.CSV,
+        "google": InventoryExportFormat.GOOGLE_SHEETS,
+        "googlesheets": InventoryExportFormat.GOOGLE_SHEETS,
+        "google_sheets": InventoryExportFormat.GOOGLE_SHEETS,
+    }
+    if normalized not in aliases:
+        raise ValueError("Export format must be Excel, CSV, or GoogleSheets.")
+    return aliases[normalized]
+
+
+def _parse_export_view(value: str | None) -> InventoryReportView:
+    normalized = (value or InventoryReportView.ALL.value).strip().lower()
+    try:
+        return InventoryReportView(normalized)
+    except ValueError as exc:
+        raise ValueError("Inventory export view must be Resources, Speedups, or All.") from exc
+
+
+async def resolve_export_governor_ids(
+    *,
+    discord_user_id: int,
+    governor_id: int | None,
+    is_admin: bool = False,
+    discord_user: Any | None = None,
+) -> list[int]:
+    admin = bool(is_admin or (discord_user is not None and _is_admin(discord_user)))
+    if governor_id is not None:
+        if not admin and not await user_can_import_for_governor(
+            discord_user_id=int(discord_user_id),
+            governor_id=int(governor_id),
+            is_admin=False,
+        ):
+            raise PermissionError("You can only export inventory for governors registered to you.")
+        return [int(governor_id)]
+
+    governors = await get_registered_governors_for_user(int(discord_user_id))
+    if not governors:
+        raise ValueError("You have no registered governors. Use `/register_governor` first.")
+    return [int(item.governor_id) for item in governors]
+
+
+def _dt(value: Any) -> str:
+    if value is None:
+        return ""
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _resource_export_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "RecordKind": "resource",
+            "ImportBatchID": row.get("ImportBatchID"),
+            "GovernorID": row.get("GovernorID"),
+            "DiscordUserID": row.get("DiscordUserID"),
+            "FlowType": row.get("FlowType"),
+            "ApprovedAtUtc": _dt(row.get("ApprovedAtUtc")),
+            "ScanUtc": _dt(row.get("ScanUtc")),
+            "ItemType": row.get("ResourceType"),
+            "FromItemsValue": row.get("FromItemsValue"),
+            "TotalResourcesValue": row.get("TotalResourcesValue"),
+            "TotalMinutes": "",
+            "TotalHours": "",
+            "TotalDaysDecimal": "",
+        }
+        for row in rows
+    ]
+
+
+def _speedup_export_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "RecordKind": "speedup",
+            "ImportBatchID": row.get("ImportBatchID"),
+            "GovernorID": row.get("GovernorID"),
+            "DiscordUserID": row.get("DiscordUserID"),
+            "FlowType": row.get("FlowType"),
+            "ApprovedAtUtc": _dt(row.get("ApprovedAtUtc")),
+            "ScanUtc": _dt(row.get("ScanUtc")),
+            "ItemType": row.get("SpeedupType"),
+            "FromItemsValue": "",
+            "TotalResourcesValue": "",
+            "TotalMinutes": row.get("TotalMinutes"),
+            "TotalHours": row.get("TotalHours"),
+            "TotalDaysDecimal": row.get("TotalDaysDecimal"),
+        }
+        for row in rows
+    ]
+
+
+def _write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=EXPORT_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_xlsx(rows: list[dict[str, Any]], path: Path) -> None:
+    import pandas as pd
+
+    df = pd.DataFrame(rows, columns=EXPORT_COLUMNS)
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame(
+            {
+                "Info": [
+                    "Inventory Export",
+                    "Approved Resources and Speedups only.",
+                    "Materials are not included in Phase 1C.",
+                ]
+            }
+        ).to_excel(writer, index=False, sheet_name="README")
+        df.to_excel(writer, index=False, sheet_name="RAW_INVENTORY")
+
+
+async def build_inventory_export_file(
+    *,
+    discord_user_id: int,
+    username: str,
+    export_format: InventoryExportFormat,
+    view: InventoryReportView,
+    governor_id: int | None = None,
+    lookback_days: int = 366,
+    is_admin: bool = False,
+    discord_user: Any | None = None,
+) -> InventoryExportFile:
+    governor_ids = await resolve_export_governor_ids(
+        discord_user_id=int(discord_user_id),
+        governor_id=governor_id,
+        is_admin=is_admin,
+        discord_user=discord_user,
+    )
+
+    resources: list[dict[str, Any]] = []
+    speedups: list[dict[str, Any]] = []
+    if view in {InventoryReportView.RESOURCES, InventoryReportView.ALL}:
+        resources = await asyncio.to_thread(
+            inventory_export_dal.fetch_resource_export_rows,
+            governor_ids,
+            lookback_days=lookback_days,
+        )
+    if view in {InventoryReportView.SPEEDUPS, InventoryReportView.ALL}:
+        speedups = await asyncio.to_thread(
+            inventory_export_dal.fetch_speedup_export_rows,
+            governor_ids,
+            lookback_days=lookback_days,
+        )
+
+    export_rows = _resource_export_rows(resources) + _speedup_export_rows(speedups)
+    if not export_rows:
+        raise ValueError("No approved inventory records found for the selected export.")
+
+    safe_username = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in username)
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    suffix = ".csv" if export_format == InventoryExportFormat.CSV else ".xlsx"
+    temp_dir = Path(tempfile.mkdtemp(prefix="inventory_export_"))
+    path = temp_dir / f"inventory_{safe_username}_{timestamp}{suffix}"
+
+    if export_format == InventoryExportFormat.CSV:
+        await asyncio.to_thread(_write_csv, export_rows, path)
+    else:
+        await asyncio.to_thread(_write_xlsx, export_rows, path)
+
+    logger.info(
+        "inventory_export_built user_id=%s governors=%s format=%s rows=%s",
+        discord_user_id,
+        governor_ids,
+        export_format.value,
+        len(export_rows),
+    )
+    return InventoryExportFile(
+        path=path,
+        filename=path.name,
+        format=export_format,
+        row_count=len(export_rows),
+        governor_ids=tuple(governor_ids),
+    )
+
+
+def cleanup_export_file(export_file: InventoryExportFile | None) -> None:
+    if export_file is None:
+        return
+    try:
+        export_file.path.unlink(missing_ok=True)
+    except Exception:
+        logger.warning("inventory_export_file_cleanup_failed path=%s", export_file.path)
+    try:
+        export_file.path.parent.rmdir()
+    except Exception:
+        logger.debug("inventory_export_dir_cleanup_skipped path=%s", export_file.path.parent)
+
+
+def parse_export_view(value: str | None) -> InventoryReportView:
+    return _parse_export_view(value)

--- a/inventory/inventory_service.py
+++ b/inventory/inventory_service.py
@@ -57,9 +57,13 @@ async def get_registered_governors_for_user(discord_user_id: int) -> list[Regist
 
 
 async def user_can_import_for_governor(
-    *, discord_user_id: int, governor_id: int, discord_user: Any | None = None
+    *,
+    discord_user_id: int,
+    governor_id: int,
+    discord_user: Any | None = None,
+    is_admin: bool = False,
 ) -> bool:
-    if discord_user is not None and _is_admin(discord_user):
+    if is_admin or (discord_user is not None and _is_admin(discord_user)):
         return True
     governors = await get_registered_governors_for_user(discord_user_id)
     return any(item.governor_id == int(governor_id) for item in governors)
@@ -70,12 +74,15 @@ async def create_pending_command_session(
     governor_id: int,
     discord_user_id: int,
     discord_user: Any | None = None,
+    is_admin: bool = False,
     timeout_minutes: int = 10,
 ) -> int:
+    admin = bool(is_admin or (discord_user is not None and _is_admin(discord_user)))
     if not await user_can_import_for_governor(
         discord_user_id=discord_user_id,
         governor_id=governor_id,
         discord_user=discord_user,
+        is_admin=admin,
     ):
         raise PermissionError("You can only import inventory for governors registered to you.")
 
@@ -85,14 +92,13 @@ async def create_pending_command_session(
         raise ValueError("This governor already has an active inventory import session.")
 
     expires = datetime.now(UTC) + timedelta(minutes=timeout_minutes)
-    is_admin = bool(discord_user is not None and _is_admin(discord_user))
     return await asyncio.to_thread(
         inventory_dal.create_import_batch,
         governor_id=int(governor_id),
         discord_user_id=int(discord_user_id),
         flow_type=InventoryFlowType.COMMAND,
         status=InventoryImportStatus.AWAITING_UPLOAD,
-        is_admin_import=is_admin,
+        is_admin_import=admin,
         expires_at_utc=expires,
     )
 
@@ -107,11 +113,14 @@ async def create_upload_first_batch(
     discord_user_id: int,
     payload: InventoryImagePayload,
     discord_user: Any | None = None,
+    is_admin: bool = False,
 ) -> int:
+    admin = bool(is_admin or (discord_user is not None and _is_admin(discord_user)))
     if not await user_can_import_for_governor(
         discord_user_id=discord_user_id,
         governor_id=governor_id,
         discord_user=discord_user,
+        is_admin=admin,
     ):
         raise PermissionError("You can only import inventory for governors registered to you.")
 
@@ -128,7 +137,7 @@ async def create_upload_first_batch(
         source_message_id=payload.source_message_id,
         source_channel_id=payload.source_channel_id,
         image_attachment_url=payload.image_attachment_url,
-        is_admin_import=bool(discord_user is not None and _is_admin(discord_user)),
+        is_admin_import=admin,
     )
 
 
@@ -206,7 +215,7 @@ async def approve_import(
 ) -> dict[str, Any]:
     if summary.import_type in {InventoryImportType.MATERIALS, InventoryImportType.UNKNOWN}:
         raise ValueError(
-            f"{summary.import_type.value.title()} imports are not available in Phase 1A."
+            f"{summary.import_type.value.title()} imports are not available in Phase 1."
         )
     if summary.confidence_score < LOW_CONFIDENCE_REJECT_THRESHOLD:
         raise ValueError("Image confidence is too low to approve.")
@@ -279,3 +288,18 @@ async def update_debug_reference(
         admin_debug_channel_id=int(admin_debug_channel_id),
         admin_debug_message_id=int(admin_debug_message_id),
     )
+
+
+def build_admin_debug_payload(
+    *,
+    summary: InventoryAnalysisSummary | None,
+    corrected_json: dict[str, Any] | None = None,
+    final_json: dict[str, Any] | None = None,
+    error_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "detected": summary.raw_json if summary else None,
+        "corrected": corrected_json,
+        "final": final_json,
+        "error": error_json,
+    }

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 
@@ -42,6 +43,22 @@ class InventoryReportRange(StrEnum):
 class InventoryReportVisibility(StrEnum):
     ONLY_ME = "only_me"
     PUBLIC = "public"
+
+
+class InventoryExportFormat(StrEnum):
+    EXCEL = "excel"
+    CSV = "csv"
+    GOOGLE_SHEETS = "google_sheets"
+
+
+class InventoryAuditStatus(StrEnum):
+    ALL = "all"
+    AWAITING_UPLOAD = "awaiting_upload"
+    ANALYSED = "analysed"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
 
 
 @dataclass(frozen=True)
@@ -115,3 +132,41 @@ class InventoryReportPayload:
     resources: list[InventoryResourcePoint] = field(default_factory=list)
     speedups: list[InventorySpeedupPoint] = field(default_factory=list)
     generated_at_utc: Any | None = None
+
+
+@dataclass(frozen=True)
+class InventoryExportFile:
+    path: Path
+    filename: str
+    format: InventoryExportFormat
+    row_count: int
+    governor_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class InventoryAuditRecord:
+    import_batch_id: int
+    governor_id: int
+    discord_user_id: int
+    import_type: str | None
+    flow_type: str
+    status: str
+    created_at_utc: Any
+    approved_at_utc: Any | None = None
+    rejected_at_utc: Any | None = None
+    confidence_score: float | None = None
+    vision_model: str | None = None
+    fallback_used: bool = False
+    admin_debug_channel_id: int | None = None
+    admin_debug_message_id: int | None = None
+    warnings: list[str] = field(default_factory=list)
+    detected_json: dict[str, Any] | None = None
+    corrected_json: dict[str, Any] | None = None
+    final_json: dict[str, Any] | None = None
+    error_json: dict[str, Any] | None = None
+
+    @property
+    def debug_reference(self) -> str:
+        if self.admin_debug_channel_id and self.admin_debug_message_id:
+            return f"<#{self.admin_debug_channel_id}> / `{self.admin_debug_message_id}`"
+        return "none"

--- a/tests/test_inventory_audit_service.py
+++ b/tests/test_inventory_audit_service.py
@@ -1,0 +1,48 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from inventory import audit_service
+from inventory.models import InventoryAuditStatus, InventoryImportType
+
+
+def test_parse_audit_filters():
+    assert audit_service.parse_audit_status("rejected") == InventoryAuditStatus.REJECTED
+    assert audit_service.parse_audit_import_type("Resources") == InventoryImportType.RESOURCES
+    assert audit_service.parse_audit_import_type("All") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_audit_maps_debug_reference(monkeypatch):
+    def _rows(**kwargs):
+        assert kwargs["status"] == "failed"
+        return [
+            {
+                "ImportBatchID": 9,
+                "GovernorID": 111,
+                "DiscordUserID": 42,
+                "ImportType": "unknown",
+                "FlowType": "upload_first",
+                "Status": "failed",
+                "CreatedAtUtc": datetime.now(UTC),
+                "ApprovedAtUtc": None,
+                "RejectedAtUtc": None,
+                "ConfidenceScore": 0.12,
+                "VisionModel": "test-model",
+                "FallbackUsed": False,
+                "AdminDebugChannelID": 555,
+                "AdminDebugMessageID": 777,
+                "WarningJson": ["low confidence"],
+                "DetectedJson": {"detected_image_type": "unknown"},
+                "CorrectedJson": None,
+                "FinalJson": None,
+                "ErrorJson": {"error": "Analysis failed."},
+            }
+        ]
+
+    monkeypatch.setattr(audit_service.inventory_audit_dal, "fetch_import_audit_rows", _rows)
+
+    records = await audit_service.fetch_inventory_audit(status=InventoryAuditStatus.FAILED)
+
+    assert records[0].debug_reference == "<#555> / `777`"
+    assert audit_service.summarize_json_comparison(records[0]) == "detected, error"

--- a/tests/test_inventory_command_registration.py
+++ b/tests/test_inventory_command_registration.py
@@ -19,3 +19,5 @@ def test_register_inventory_command_registers_import_inventory():
 
     assert "import_inventory" in fake_bot.registered
     assert "myinventory" in fake_bot.registered
+    assert "export_inventory" in fake_bot.registered
+    assert "inventory_import_audit" in fake_bot.registered

--- a/tests/test_inventory_dal.py
+++ b/tests/test_inventory_dal.py
@@ -1,0 +1,53 @@
+from datetime import UTC, datetime
+
+from inventory.dal import inventory_dal
+from inventory.models import InventoryFlowType, InventoryImportStatus
+
+
+class _Cursor:
+    def __init__(self):
+        self.sql = ""
+        self.params = ()
+
+    def execute(self, sql, params):
+        self.sql = sql
+        self.params = params
+
+    def fetchone(self):
+        return (12345,)
+
+
+class _Conn:
+    def __init__(self):
+        self.cursor_obj = _Cursor()
+        self.committed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_create_import_batch_uses_output_inserted_identity(monkeypatch):
+    conn = _Conn()
+    monkeypatch.setattr(inventory_dal, "_get_conn", lambda: conn)
+
+    batch_id = inventory_dal.create_import_batch(
+        governor_id=111,
+        discord_user_id=222,
+        flow_type=InventoryFlowType.COMMAND,
+        status=InventoryImportStatus.AWAITING_UPLOAD,
+        expires_at_utc=datetime.now(UTC),
+    )
+
+    assert batch_id == 12345
+    assert "OUTPUT INSERTED.ImportBatchID" in conn.cursor_obj.sql
+    assert "SCOPE_IDENTITY" not in conn.cursor_obj.sql
+    assert conn.committed is True

--- a/tests/test_inventory_export_service.py
+++ b/tests/test_inventory_export_service.py
@@ -1,0 +1,98 @@
+import csv
+from datetime import UTC, datetime
+
+import pytest
+
+from inventory import export_service
+from inventory.models import InventoryExportFormat, InventoryReportView, RegisteredGovernor
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_resolve_export_governor_ids_defaults_to_registered(monkeypatch):
+    async def _governors(user_id):
+        assert user_id == 42
+        return [RegisteredGovernor(111, "Gov 1", "Main"), RegisteredGovernor(222, "Gov 2", "Alt")]
+
+    monkeypatch.setattr(export_service, "get_registered_governors_for_user", _governors)
+
+    governor_ids = await export_service.resolve_export_governor_ids(
+        discord_user_id=42,
+        governor_id=None,
+    )
+
+    assert governor_ids == [111, 222]
+
+
+async def test_build_inventory_export_file_writes_csv_and_cleans_up(monkeypatch):
+    async def _governors(_user_id):
+        return [RegisteredGovernor(111, "Gov", "Main")]
+
+    def _resources(governor_ids, *, lookback_days):
+        assert governor_ids == [111]
+        assert lookback_days == 30
+        return [
+            {
+                "ImportBatchID": 1,
+                "GovernorID": 111,
+                "DiscordUserID": 42,
+                "FlowType": "upload_first",
+                "ApprovedAtUtc": datetime.now(UTC),
+                "ScanUtc": datetime.now(UTC),
+                "ResourceType": "food",
+                "FromItemsValue": 100,
+                "TotalResourcesValue": 200,
+            }
+        ]
+
+    monkeypatch.setattr(export_service, "get_registered_governors_for_user", _governors)
+    monkeypatch.setattr(
+        export_service.inventory_export_dal,
+        "fetch_resource_export_rows",
+        _resources,
+    )
+
+    export_file = await export_service.build_inventory_export_file(
+        discord_user_id=42,
+        username="Tester",
+        export_format=InventoryExportFormat.CSV,
+        view=InventoryReportView.RESOURCES,
+        lookback_days=30,
+    )
+
+    try:
+        with export_file.path.open(encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        assert rows[0]["RecordKind"] == "resource"
+        assert rows[0]["TotalResourcesValue"] == "200"
+        assert export_file.row_count == 1
+    finally:
+        parent = export_file.path.parent
+        export_service.cleanup_export_file(export_file)
+    assert not export_file.path.exists()
+    assert not parent.exists()
+
+
+async def test_build_inventory_export_file_rejects_no_records(monkeypatch):
+    async def _governors(_user_id):
+        return [RegisteredGovernor(111, "Gov", "Main")]
+
+    monkeypatch.setattr(export_service, "get_registered_governors_for_user", _governors)
+    monkeypatch.setattr(
+        export_service.inventory_export_dal,
+        "fetch_resource_export_rows",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        export_service.inventory_export_dal,
+        "fetch_speedup_export_rows",
+        lambda *_args, **_kwargs: [],
+    )
+
+    with pytest.raises(ValueError, match="No approved inventory records"):
+        await export_service.build_inventory_export_file(
+            discord_user_id=42,
+            username="Tester",
+            export_format=InventoryExportFormat.CSV,
+            view=InventoryReportView.ALL,
+        )

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -45,6 +45,18 @@ class _VisionClient:
         return _VisionResult()
 
 
+class _LowConfidenceVisionClient(_VisionClient):
+    async def analyse_image(
+        self, image_bytes, *, filename=None, content_type=None, import_type_hint=None
+    ):
+        result = _VisionResult()
+        result.ok = True
+        result.detected_image_type = "unknown"
+        result.confidence_score = 0.12
+        result.error = "not an inventory screenshot"
+        return result
+
+
 async def test_analyse_inventory_image_does_not_send_type_hint(monkeypatch):
     captured = {}
 
@@ -92,3 +104,41 @@ async def test_get_registered_governors_for_user_maps_registry(monkeypatch):
 
     assert [item.governor_id for item in governors] == [111, 222]
     assert governors[0].account_type == "Main"
+
+
+async def test_analyse_inventory_image_marks_random_image_failed(monkeypatch):
+    captured = {}
+
+    def _update(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(inventory_service.inventory_dal, "update_batch_analysis", _update)
+
+    summary = await inventory_service.analyse_inventory_image(
+        import_batch_id=42,
+        payload=InventoryImagePayload(
+            image_bytes=b"cat",
+            filename="cat.png",
+            content_type="image/png",
+        ),
+        vision_client=_LowConfidenceVisionClient(),
+    )
+
+    assert summary.import_type == InventoryImportType.UNKNOWN
+    assert captured["status"] == InventoryImportStatus.FAILED
+
+
+async def test_approve_import_blocks_duplicate_same_day_for_non_admin(monkeypatch):
+    monkeypatch.setattr(
+        inventory_service.inventory_dal,
+        "has_approved_import_today",
+        lambda governor_id, import_type: True,
+    )
+
+    summary = inventory_service._summary_from_vision_result(_VisionResult())
+    with pytest.raises(ValueError, match="already has an approved import"):
+        await inventory_service.approve_import(
+            import_batch_id=42,
+            governor_id=111,
+            summary=summary,
+        )

--- a/tests/test_inventory_upload_flow.py
+++ b/tests/test_inventory_upload_flow.py
@@ -2,7 +2,12 @@ import types
 
 import pytest
 
-from inventory.models import RegisteredGovernor
+from inventory.models import (
+    InventoryAnalysisSummary,
+    InventoryImagePayload,
+    InventoryImportType,
+    RegisteredGovernor,
+)
 from ui.views import inventory_views
 
 pytestmark = pytest.mark.asyncio
@@ -84,3 +89,29 @@ async def test_upload_first_without_governors_sends_guidance(monkeypatch):
 
     assert handled is True
     assert "registered governor" in message.channel.sent[0][0][0]
+
+
+async def test_confirmation_view_timeout_cancels_active_batch(monkeypatch):
+    cancelled = []
+
+    async def _cancel(batch_id):
+        cancelled.append(batch_id)
+
+    monkeypatch.setattr(inventory_views.inventory_service, "cancel_import", _cancel)
+    view = inventory_views.InventoryConfirmationView(
+        bot=object(),
+        actor_discord_id=42,
+        governor_id=111,
+        batch_id=99,
+        payload=InventoryImagePayload(image_bytes=b"img", filename="inventory.png"),
+        summary=InventoryAnalysisSummary(
+            ok=True,
+            import_type=InventoryImportType.RESOURCES,
+            values={"resources": {}},
+            confidence_score=0.95,
+        ),
+    )
+
+    await view.on_timeout()
+
+    assert cancelled == [99]

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -146,12 +146,12 @@ async def _post_admin_debug(
         )
         if summary.warnings:
             embed.add_field(name="Warnings", value="\n".join(summary.warnings)[:1024], inline=False)
-    debug_payload = {
-        "detected": summary.raw_json if summary else None,
-        "corrected": corrected_json,
-        "final": final_json,
-        "error": error_json,
-    }
+    debug_payload = inventory_service.build_admin_debug_payload(
+        summary=summary,
+        corrected_json=corrected_json,
+        final_json=final_json,
+        error_json=error_json,
+    )
     embed.add_field(
         name="JSON",
         value=f"```json\n{json.dumps(debug_payload, ensure_ascii=False, sort_keys=True)[:900]}\n```",
@@ -231,6 +231,7 @@ class InventoryConfirmationView(discord.ui.View):
                     final_json=normalized,
                 )
             self.disable_all_items()
+            self.stop()
             await interaction.followup.send("Inventory import approved.", ephemeral=True)
             try:
                 await interaction.message.edit(view=self)
@@ -274,6 +275,7 @@ class InventoryConfirmationView(discord.ui.View):
             error_json={"error": "Rejected by user."},
         )
         self.disable_all_items()
+        self.stop()
         await interaction.followup.send(
             "Import rejected. You can upload one replacement screenshot if needed.\n\n"
             + SCREENSHOT_GUIDELINES,
@@ -294,11 +296,23 @@ class InventoryConfirmationView(discord.ui.View):
             return
         await inventory_service.cancel_import(self.batch_id)
         self.disable_all_items()
+        self.stop()
         await interaction.response.send_message("Import cancelled.", ephemeral=True)
         try:
             await interaction.message.edit(view=self)
         except Exception:
             logger.debug("inventory_cancel_message_edit_failed", exc_info=True)
+
+    async def on_timeout(self) -> None:
+        try:
+            await inventory_service.cancel_import(self.batch_id)
+        except Exception:
+            logger.debug(
+                "inventory_confirmation_timeout_cancel_failed batch_id=%s",
+                self.batch_id,
+                exc_info=True,
+            )
+        self.disable_all_items()
 
 
 class InventoryCorrectionModal(discord.ui.Modal):
@@ -432,7 +446,7 @@ async def _process_payload_for_governor(
                 governor_id=governor_id,
                 discord_user_id=actor_discord_id,
                 payload=payload,
-                discord_user=getattr(interaction, "user", None) if interaction else None,
+                is_admin=_is_admin(getattr(interaction, "user", None)) if interaction else False,
             )
         await _delete_original_upload(original_message=original_message, batch_id=batch_id)
         summary = await inventory_service.analyse_inventory_image(
@@ -469,7 +483,7 @@ async def _process_payload_for_governor(
 
         embed = _analysis_embed(governor_id=governor_id, summary=summary)
         if summary.import_type == InventoryImportType.MATERIALS:
-            await inventory_service.reject_import(batch_id, error="Materials disabled in Phase 1A.")
+            await inventory_service.reject_import(batch_id, error="Materials disabled in Phase 1.")
             await _post_admin_debug(
                 bot=bot,
                 batch_id=batch_id,
@@ -478,7 +492,7 @@ async def _process_payload_for_governor(
                 status="materials_disabled",
                 payload=payload,
                 summary=summary,
-                error_json={"error": "Materials disabled in Phase 1A."},
+                error_json={"error": "Materials disabled in Phase 1."},
             )
             content = "Materials import is not available yet. No values were saved."
             if interaction is not None:
@@ -537,6 +551,7 @@ async def start_import_command(ctx: discord.ApplicationContext, bot: Any) -> Non
             governor_id=governor_id,
             discord_user_id=int(ctx.user.id),
             discord_user=ctx.user,
+            is_admin=_is_admin(ctx.user),
         )
         await ctx.followup.send(
             (
@@ -568,6 +583,7 @@ async def start_import_command(ctx: discord.ApplicationContext, bot: Any) -> Non
             governor_id=int(governor_id),
             discord_user_id=int(ctx.user.id),
             discord_user=ctx.user,
+            is_admin=_is_admin(ctx.user),
         )
         await interaction.followup.send(
             (

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -243,9 +243,7 @@ class InventoryConfirmationView(discord.ui.View):
                     final_json=normalized,
                 )
             except Exception:
-                logger.exception(
-                    "inventory_approve_debug_post_failed batch_id=%s", self.batch_id
-                )
+                logger.exception("inventory_approve_debug_post_failed batch_id=%s", self.batch_id)
         await interaction.followup.send("Inventory import approved.", ephemeral=True)
         try:
             await interaction.message.edit(view=self)

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -185,6 +185,7 @@ class InventoryConfirmationView(discord.ui.View):
         self.payload = payload
         self.summary = summary
         self.corrected_values: dict[str, Any] | None = None
+        self._terminal = False
 
         if summary.import_type in {InventoryImportType.MATERIALS, InventoryImportType.UNKNOWN}:
             for child in self.children:
@@ -218,7 +219,18 @@ class InventoryConfirmationView(discord.ui.View):
                 corrected_values=self.corrected_values,
                 is_admin=_is_admin(interaction.user),
             )
-            if self.corrected_values:
+        except Exception:
+            logger.exception("inventory_import_approve_failed batch_id=%s", self.batch_id)
+            await interaction.followup.send(
+                f"Approval failed due to an internal error. Please try again or contact an admin with batch ID {self.batch_id}.",
+                ephemeral=True,
+            )
+            return
+        self._terminal = True
+        self.disable_all_items()
+        self.stop()
+        if self.corrected_values:
+            try:
                 await _post_admin_debug(
                     bot=self.bot,
                     batch_id=self.batch_id,
@@ -230,19 +242,15 @@ class InventoryConfirmationView(discord.ui.View):
                     corrected_json=self.corrected_values,
                     final_json=normalized,
                 )
-            self.disable_all_items()
-            self.stop()
-            await interaction.followup.send("Inventory import approved.", ephemeral=True)
-            try:
-                await interaction.message.edit(view=self)
             except Exception:
-                logger.debug("inventory_approve_message_edit_failed", exc_info=True)
+                logger.exception(
+                    "inventory_approve_debug_post_failed batch_id=%s", self.batch_id
+                )
+        await interaction.followup.send("Inventory import approved.", ephemeral=True)
+        try:
+            await interaction.message.edit(view=self)
         except Exception:
-            logger.exception("inventory_import_approve_failed batch_id=%s", self.batch_id)
-            await interaction.followup.send(
-                f"Approval failed due to an internal error. Please try again or contact an admin with batch ID {self.batch_id}.",
-                ephemeral=True,
-            )
+            logger.debug("inventory_approve_message_edit_failed", exc_info=True)
 
     @discord.ui.button(
         label="Correct Data",
@@ -263,19 +271,31 @@ class InventoryConfirmationView(discord.ui.View):
         if await self._deny_if_not_actor(interaction):
             return
         await interaction.response.defer(ephemeral=True)
-        await inventory_service.reject_import(self.batch_id, error="Rejected by user.")
-        await _post_admin_debug(
-            bot=self.bot,
-            batch_id=self.batch_id,
-            governor_id=self.governor_id,
-            discord_user_id=self.actor_discord_id,
-            status="rejected",
-            payload=self.payload,
-            summary=self.summary,
-            error_json={"error": "Rejected by user."},
-        )
+        try:
+            await inventory_service.reject_import(self.batch_id, error="Rejected by user.")
+        except Exception:
+            logger.exception("inventory_import_reject_failed batch_id=%s", self.batch_id)
+            await interaction.followup.send(
+                f"Rejection failed due to an internal error. Please try again or contact an admin with batch ID {self.batch_id}.",
+                ephemeral=True,
+            )
+            return
+        self._terminal = True
         self.disable_all_items()
         self.stop()
+        try:
+            await _post_admin_debug(
+                bot=self.bot,
+                batch_id=self.batch_id,
+                governor_id=self.governor_id,
+                discord_user_id=self.actor_discord_id,
+                status="rejected",
+                payload=self.payload,
+                summary=self.summary,
+                error_json={"error": "Rejected by user."},
+            )
+        except Exception:
+            logger.exception("inventory_reject_debug_post_failed batch_id=%s", self.batch_id)
         await interaction.followup.send(
             "Import rejected. You can upload one replacement screenshot if needed.\n\n"
             + SCREENSHOT_GUIDELINES,
@@ -295,6 +315,7 @@ class InventoryConfirmationView(discord.ui.View):
         if await self._deny_if_not_actor(interaction):
             return
         await inventory_service.cancel_import(self.batch_id)
+        self._terminal = True
         self.disable_all_items()
         self.stop()
         await interaction.response.send_message("Import cancelled.", ephemeral=True)
@@ -304,14 +325,15 @@ class InventoryConfirmationView(discord.ui.View):
             logger.debug("inventory_cancel_message_edit_failed", exc_info=True)
 
     async def on_timeout(self) -> None:
-        try:
-            await inventory_service.cancel_import(self.batch_id)
-        except Exception:
-            logger.debug(
-                "inventory_confirmation_timeout_cancel_failed batch_id=%s",
-                self.batch_id,
-                exc_info=True,
-            )
+        if not self._terminal:
+            try:
+                await inventory_service.cancel_import(self.batch_id)
+            except Exception:
+                logger.debug(
+                    "inventory_confirmation_timeout_cancel_failed batch_id=%s",
+                    self.batch_id,
+                    exc_info=True,
+                )
         self.disable_all_items()
 
 


### PR DESCRIPTION
## Summary

Adds Phase 1C for the Inventory Image Import Module: raw inventory export, admin import audit, the smoke-test blocker fix for import batch creation, and targeted import lifecycle hardening.

## Changes

- Fixes `InventoryImportBatch` identity return by using `OUTPUT INSERTED.ImportBatchID`, avoiding the pyodbc `No results. Previous SQL was not a query` failure seen during smoke testing.
- Adds `/export_inventory` with service/DAL-based raw approved Resources/Speedups exports for Excel, CSV, and Google Sheets-compatible XLSX output.
- Adds `/inventory_import_audit` as an admin-only audit command with status, import type, governor, user, lookback, and limit filters.
- Adds inventory export/audit services and DAL modules so commands remain thin and do not copy the direct SQL pattern from `/my_stats_export`.
- Hardens import lifecycle behavior: confirmation timeout now cancels the active batch, terminal approve/reject/cancel actions stop the view, random/unknown image handling is covered, and duplicate same-day approvals remain blocked.
- Moves admin debug JSON payload shaping into the inventory service while leaving Discord send mechanics in the view layer.
- Updates the task pack to include Phase 1D as the planned final Resources/Speedups polish phase for `/myinventory` export buttons, targeted OCR/prompt tuning, and final scenario validation.

## Out of Scope

- Materials import/reporting remains Phase 2.
- `/my_stats` integration remains downstream.
- Existing stats export SQL refactor remains tracked by GitHub issue #46 and is not duplicated here.

## Tests

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_command_registration.py tests\test_inventory_dal.py tests\test_inventory_service.py tests\test_inventory_upload_flow.py tests\test_inventory_export_service.py tests\test_inventory_audit_service.py tests\test_inventory_parsing.py tests\test_inventory_reporting_service.py tests\test_inventory_report_views.py tests\test_inventory_report_image_renderer.py tests\test_inventory_schema_contract.py`
- `.\.venv\Scripts\python.exe -m ruff check commands\inventory_cmds.py inventory\inventory_service.py inventory\export_service.py inventory\audit_service.py inventory\dal\inventory_dal.py inventory\dal\inventory_export_dal.py inventory\dal\inventory_audit_dal.py ui\views\inventory_views.py tests\test_inventory_command_registration.py tests\test_inventory_dal.py tests\test_inventory_service.py tests\test_inventory_upload_flow.py tests\test_inventory_export_service.py tests\test_inventory_audit_service.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`

## Risk / Rollback

Risk is moderate because this touches live inventory import lifecycle paths and introduces new export/audit commands. Rollback is the PR revert; no SQL schema migration is included in this PR.