### PR TITLE
[codex] Improve speedup duration extraction

### DIFF
--- a/inventory/parsing.py
+++ b/inventory/parsing.py
@@ -122,11 +122,12 @@ def speedup_row_from_minutes(total_minutes: int) -> dict[str, int | float]:
     }
 
 
-def speedup_row_from_days(total_days: int) -> dict[str, int | float]:
+def speedup_row_from_days(total_days: int) -> dict[str, int | float | str]:
     if total_days < 0:
         raise ValueError("Negative values are not allowed.")
     minutes = int(total_days) * 1440
     return {
+        "raw_duration_text": f"{int(total_days)}d",
         "total_minutes": minutes,
         "total_hours": int(total_days) * 24,
         "total_days_decimal": float(int(total_days)),
@@ -184,7 +185,7 @@ def apply_speedup_duration_corrections(
     if not isinstance(speedup_values, dict):
         raise ValueError("Missing speedups section.")
 
-    normalized_speedups: dict[str, dict[str, int | float]] = {}
+    normalized_speedups: dict[str, dict[str, int | float | str]] = {}
     for speedup_type in SPEEDUP_TYPES:
         row = speedup_values.get(speedup_type)
         if not isinstance(row, dict):
@@ -200,15 +201,17 @@ def apply_speedup_duration_corrections(
 
 
 def _speedup_days_from_row(row: dict[str, Any]) -> int:
-    if row.get("total_minutes") is not None:
-        minutes = parse_speedup_minutes(row.get("total_minutes"))
-        return minutes // 1440
+    if row.get("raw_duration_text") is not None:
+        return parse_speedup_days(row.get("raw_duration_text"))
     if row.get("total_days_decimal") is not None:
         return parse_speedup_days(row.get("total_days_decimal"))
     if row.get("duration") is not None:
         return parse_speedup_days(row.get("duration"))
     if row.get("value") is not None:
         return parse_speedup_days(row.get("value"))
+    if row.get("total_minutes") is not None:
+        minutes = parse_speedup_minutes(row.get("total_minutes"))
+        return minutes // 1440
     return 0
 
 
@@ -231,12 +234,12 @@ def normalize_resource_values(values: dict[str, Any]) -> dict[str, dict[str, int
     return normalized
 
 
-def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int | float]]:
+def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int | float | str]]:
     speedups = values.get("speedups") if isinstance(values, dict) else None
     if not isinstance(speedups, dict):
         raise ValueError("Missing speedups section.")
 
-    normalized: dict[str, dict[str, int | float]] = {}
+    normalized: dict[str, dict[str, int | float | str]] = {}
     for speedup_type in SPEEDUP_TYPES:
         row = speedups.get(speedup_type)
         if not isinstance(row, dict):

--- a/inventory/parsing.py
+++ b/inventory/parsing.py
@@ -242,7 +242,9 @@ def normalize_resource_values(values: dict[str, Any]) -> dict[str, dict[str, int
     return normalized
 
 
-def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int | float | str | None]]:
+def normalize_speedup_values(
+    values: dict[str, Any],
+) -> dict[str, dict[str, int | float | str | None]]:
     speedups = values.get("speedups") if isinstance(values, dict) else None
     if not isinstance(speedups, dict):
         raise ValueError("Missing speedups section.")
@@ -253,7 +255,9 @@ def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int 
         if not isinstance(row, dict):
             raise ValueError(f"Missing speedup row: {speedup_type}.")
         days = _speedup_days_from_row(row)
-        normalized[speedup_type] = speedup_row_from_days(days, raw_duration_text=row.get("raw_duration_text"))
+        normalized[speedup_type] = speedup_row_from_days(
+            days, raw_duration_text=row.get("raw_duration_text")
+        )
     return normalized
 
 

--- a/inventory/parsing.py
+++ b/inventory/parsing.py
@@ -122,12 +122,14 @@ def speedup_row_from_minutes(total_minutes: int) -> dict[str, int | float]:
     }
 
 
-def speedup_row_from_days(total_days: int) -> dict[str, int | float | str]:
+def speedup_row_from_days(
+    total_days: int, raw_duration_text: str | None = None
+) -> dict[str, int | float | str | None]:
     if total_days < 0:
         raise ValueError("Negative values are not allowed.")
     minutes = int(total_days) * 1440
     return {
-        "raw_duration_text": f"{int(total_days)}d",
+        "raw_duration_text": raw_duration_text,
         "total_minutes": minutes,
         "total_hours": int(total_days) * 24,
         "total_days_decimal": float(int(total_days)),
@@ -185,7 +187,7 @@ def apply_speedup_duration_corrections(
     if not isinstance(speedup_values, dict):
         raise ValueError("Missing speedups section.")
 
-    normalized_speedups: dict[str, dict[str, int | float | str]] = {}
+    normalized_speedups: dict[str, dict[str, int | float | str | None]] = {}
     for speedup_type in SPEEDUP_TYPES:
         row = speedup_values.get(speedup_type)
         if not isinstance(row, dict):
@@ -196,13 +198,19 @@ def apply_speedup_duration_corrections(
             if speedup_type in corrections
             else _speedup_days_from_row(row)
         )
-        normalized_speedups[speedup_type] = speedup_row_from_days(days)
+        normalized_speedups[speedup_type] = speedup_row_from_days(
+            days, raw_duration_text=row.get("raw_duration_text")
+        )
     return {"speedups": normalized_speedups}
 
 
 def _speedup_days_from_row(row: dict[str, Any]) -> int:
-    if row.get("raw_duration_text") is not None:
-        return parse_speedup_days(row.get("raw_duration_text"))
+    raw = row.get("raw_duration_text")
+    if raw:
+        try:
+            return parse_speedup_days(raw)
+        except (ValueError, TypeError):
+            pass
     if row.get("total_days_decimal") is not None:
         return parse_speedup_days(row.get("total_days_decimal"))
     if row.get("duration") is not None:
@@ -234,18 +242,18 @@ def normalize_resource_values(values: dict[str, Any]) -> dict[str, dict[str, int
     return normalized
 
 
-def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int | float | str]]:
+def normalize_speedup_values(values: dict[str, Any]) -> dict[str, dict[str, int | float | str | None]]:
     speedups = values.get("speedups") if isinstance(values, dict) else None
     if not isinstance(speedups, dict):
         raise ValueError("Missing speedups section.")
 
-    normalized: dict[str, dict[str, int | float | str]] = {}
+    normalized: dict[str, dict[str, int | float | str | None]] = {}
     for speedup_type in SPEEDUP_TYPES:
         row = speedups.get(speedup_type)
         if not isinstance(row, dict):
             raise ValueError(f"Missing speedup row: {speedup_type}.")
         days = _speedup_days_from_row(row)
-        normalized[speedup_type] = speedup_row_from_days(days)
+        normalized[speedup_type] = speedup_row_from_days(days, raw_duration_text=row.get("raw_duration_text"))
     return normalized
 
 

--- a/inventory/parsing.py
+++ b/inventory/parsing.py
@@ -123,13 +123,16 @@ def speedup_row_from_minutes(total_minutes: int) -> dict[str, int | float]:
 
 
 def speedup_row_from_days(
-    total_days: int, raw_duration_text: str | None = None
+    total_days: int,
+    raw_duration_text: str | None = None,
+    day_digits_text: str | None = None,
 ) -> dict[str, int | float | str | None]:
     if total_days < 0:
         raise ValueError("Negative values are not allowed.")
     minutes = int(total_days) * 1440
     return {
         "raw_duration_text": raw_duration_text,
+        "day_digits_text": day_digits_text,
         "total_minutes": minutes,
         "total_hours": int(total_days) * 24,
         "total_days_decimal": float(int(total_days)),
@@ -199,12 +202,20 @@ def apply_speedup_duration_corrections(
             else _speedup_days_from_row(row)
         )
         normalized_speedups[speedup_type] = speedup_row_from_days(
-            days, raw_duration_text=row.get("raw_duration_text")
+            days,
+            raw_duration_text=row.get("raw_duration_text"),
+            day_digits_text=row.get("day_digits_text"),
         )
     return {"speedups": normalized_speedups}
 
 
 def _speedup_days_from_row(row: dict[str, Any]) -> int:
+    day_digits = row.get("day_digits_text")
+    if day_digits:
+        try:
+            return parse_speedup_days(day_digits)
+        except (ValueError, TypeError):
+            pass
     raw = row.get("raw_duration_text")
     if raw:
         try:
@@ -256,7 +267,9 @@ def normalize_speedup_values(
             raise ValueError(f"Missing speedup row: {speedup_type}.")
         days = _speedup_days_from_row(row)
         normalized[speedup_type] = speedup_row_from_days(
-            days, raw_duration_text=row.get("raw_duration_text")
+            days,
+            raw_duration_text=row.get("raw_duration_text"),
+            day_digits_text=row.get("day_digits_text"),
         )
     return normalized
 

--- a/inventory/parsing.py
+++ b/inventory/parsing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 import json
 import re
 from typing import Any
@@ -126,6 +127,7 @@ def speedup_row_from_days(
     total_days: int,
     raw_duration_text: str | None = None,
     day_digits_text: str | None = None,
+    day_digits_verification_text: str | None = None,
 ) -> dict[str, int | float | str | None]:
     if total_days < 0:
         raise ValueError("Negative values are not allowed.")
@@ -133,6 +135,7 @@ def speedup_row_from_days(
     return {
         "raw_duration_text": raw_duration_text,
         "day_digits_text": day_digits_text,
+        "day_digits_verification_text": day_digits_verification_text,
         "total_minutes": minutes,
         "total_hours": int(total_days) * 24,
         "total_days_decimal": float(int(total_days)),
@@ -205,33 +208,65 @@ def apply_speedup_duration_corrections(
             days,
             raw_duration_text=row.get("raw_duration_text"),
             day_digits_text=row.get("day_digits_text"),
+            day_digits_verification_text=row.get("day_digits_verification_text"),
         )
     return {"speedups": normalized_speedups}
 
 
+def _parse_speedup_day_candidate(value: Any) -> int | None:
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    if value is not None:
+        try:
+            return parse_speedup_days(value)
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
 def _speedup_days_from_row(row: dict[str, Any]) -> int:
-    day_digits = row.get("day_digits_text")
-    if day_digits:
-        try:
-            return parse_speedup_days(day_digits)
-        except (ValueError, TypeError):
-            pass
-    raw = row.get("raw_duration_text")
-    if raw:
-        try:
-            return parse_speedup_days(raw)
-        except (ValueError, TypeError):
-            pass
-    if row.get("total_days_decimal") is not None:
-        return parse_speedup_days(row.get("total_days_decimal"))
-    if row.get("duration") is not None:
-        return parse_speedup_days(row.get("duration"))
-    if row.get("value") is not None:
-        return parse_speedup_days(row.get("value"))
+    text_candidates: list[int] = []
+    for key in (
+        "day_digits_text",
+        "day_digits_verification_text",
+        "raw_duration_text",
+    ):
+        candidate = _parse_speedup_day_candidate(row.get(key))
+        if candidate is not None:
+            text_candidates.append(candidate)
+
+    if text_candidates:
+        counts = Counter(text_candidates)
+        day, count = counts.most_common(1)[0]
+        if count > 1:
+            return day
+        return text_candidates[0]
+
+    numeric_candidates: list[int] = []
+    for key in (
+        "total_days_decimal",
+        "duration",
+        "value",
+    ):
+        candidate = _parse_speedup_day_candidate(row.get(key))
+        if candidate is not None:
+            numeric_candidates.append(candidate)
+
     if row.get("total_minutes") is not None:
-        minutes = parse_speedup_minutes(row.get("total_minutes"))
-        return minutes // 1440
-    return 0
+        try:
+            minutes = parse_speedup_minutes(row.get("total_minutes"))
+            numeric_candidates.append(minutes // 1440)
+        except (ValueError, TypeError):
+            pass
+
+    if not numeric_candidates:
+        return 0
+
+    counts = Counter(numeric_candidates)
+    day, count = counts.most_common(1)[0]
+    if count > 1:
+        return day
+    return numeric_candidates[0]
 
 
 def normalize_resource_values(values: dict[str, Any]) -> dict[str, dict[str, int]]:
@@ -270,6 +305,7 @@ def normalize_speedup_values(
             days,
             raw_duration_text=row.get("raw_duration_text"),
             day_digits_text=row.get("day_digits_text"),
+            day_digits_verification_text=row.get("day_digits_verification_text"),
         )
     return normalized
 

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -665,6 +665,17 @@ class InventoryVisionClient:
                 error="No image bytes were provided.",
             )
 
+        if _is_speedup_hint(import_type_hint):
+            speedup_model = self.config.fallback_model or self.config.model
+            return await self._analyse_with_model(
+                speedup_model,
+                image_bytes,
+                filename=filename,
+                content_type=content_type,
+                import_type_hint=import_type_hint,
+                fallback_used=speedup_model != self.config.model,
+            )
+
         primary = await self._analyse_with_model(
             self.config.model,
             image_bytes,

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -14,6 +14,25 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_FALLBACK_CONFIDENCE_THRESHOLD = 0.90
 _SPEEDUP_DAY_TEXT_RE = re.compile(r"^\s*(\d[\d,]*)(?:\s*d\b.*)?$", re.IGNORECASE)
+_SPEEDUP_DAY_LABELS = ("Building", "Research", "Training", "Healing", "Universal")
+_SPEEDUP_DAY_KEYS = ("building", "research", "training", "healing", "universal")
+_SPEEDUP_OCR_TEMPLATE_WIDTH = 8
+_SPEEDUP_OCR_TEMPLATE_HEIGHT = 12
+_SPEEDUP_OCR_MAX_DISTANCE = 24
+_SPEEDUP_OCR_TEMPLATES = {
+    "0": "3c7ee6c3c3c3c3c3c3c27e3c",
+    "1": "387818181818181818187eff",
+    "2": "7cfe060206060c1c1830feff",
+    "3": "7c7e0303063c1e030303fe7c",
+    "4": "0c0e1e1e366646ffff060606",
+    "5": "7e7e60607c7e03030303fe7c",
+    "6": "3e7e60c0c8fee3c3c3637e3c",
+    "7": "ff7f06040c08181818181010",
+    "8": "3c664343663c6ec3c3c3e63c",
+    "9": "3c7ec6c3c3c77f130306fe78",
+    "d": "0303031b7f63c3c3c3c37f3f",
+}
+_DECODED_SPEEDUP_OCR_TEMPLATES: dict[str, tuple[tuple[int, ...], ...]] | None = None
 
 
 class VisionClientError(RuntimeError):
@@ -295,15 +314,14 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
         if width < 200 or height < 200:
             return []
 
-        labels = ("Building", "Research", "Training", "Healing", "Universal")
         duration_x1 = int(width * 0.55)
         duration_x2 = int(width * 0.98)
         row_bounds = _detect_speedup_duration_row_bounds(image, duration_x1, duration_x2)
-        if len(row_bounds) < len(labels):
+        if len(row_bounds) < len(_SPEEDUP_DAY_LABELS):
             row_bounds = _fallback_speedup_duration_row_bounds(height)
         scale = 3
         row_images = []
-        for label, (row_top, row_bottom) in zip(labels, row_bounds, strict=False):
+        for label, (row_top, row_bottom) in zip(_SPEEDUP_DAY_LABELS, row_bounds, strict=False):
             row_padding = max(24, int(height * 0.03))
             crop = image.crop(
                 (
@@ -323,6 +341,23 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
             crop = _crop_first_dark_text_token(crop)
             row_images.append((label, crop))
     return row_images
+
+
+def _speedup_day_values_from_image(image_bytes: bytes) -> dict[str, int]:
+    values: dict[str, int] = {}
+    try:
+        row_images = _speedup_day_token_crop_images(image_bytes)
+    except Exception:
+        logger.debug("[inventory_vision] could not OCR speedup day values", exc_info=True)
+        return values
+
+    for key, (label, crop) in zip(_SPEEDUP_DAY_KEYS, row_images, strict=False):
+        days = _ocr_speedup_day_token(crop)
+        if days is None:
+            logger.debug("[inventory_vision] could not OCR speedup day token for %s", label)
+            continue
+        values[key] = days
+    return values
 
 
 def _detect_speedup_duration_row_bounds(
@@ -466,6 +501,164 @@ def _crop_first_dark_text_token(image: Any) -> Any:
     left = max(0, token[0] - padding)
     right = min(width, token[1] + padding)
     return image.crop((left, 0, right, height))
+
+
+def _ocr_speedup_day_token(image: Any) -> int | None:
+    characters = []
+    for box in _dark_text_character_bounds(image):
+        if box[1] - box[0] < max(12, int(image.height * 0.14)):
+            continue
+        normalized = _normalize_dark_character(image, box)
+        if normalized is None:
+            continue
+        character = _classify_speedup_ocr_character(normalized)
+        if character is None:
+            return None
+        characters.append(character)
+
+    if not characters or characters[-1].lower() != "d":
+        return None
+    digit_text = "".join(char for char in characters[:-1] if char.isdigit())
+    if not digit_text:
+        return None
+    return int(digit_text)
+
+
+def _dark_text_character_bounds(image: Any) -> list[tuple[int, int]]:
+    gray = image.convert("L")
+    width, height = gray.size
+    pixels = gray.load()
+    dark_columns = [x for x in range(width) if any(pixels[x, y] <= 80 for y in range(height))]
+    if not dark_columns:
+        return []
+
+    groups: list[list[int]] = [[dark_columns[0], dark_columns[0]]]
+    for x in dark_columns[1:]:
+        if x - groups[-1][1] <= 3:
+            groups[-1][1] = x
+        else:
+            groups.append([x, x])
+    return [(left, right) for left, right in groups]
+
+
+def _normalize_dark_character(
+    image: Any, box: tuple[int, int]
+) -> tuple[tuple[int, ...], ...] | None:
+    from PIL import Image
+
+    gray = image.convert("L")
+    left, right = box
+    crop = gray.crop((left, 0, right + 1, gray.height))
+    pixels = crop.load()
+    width, height = crop.size
+    dark_points = [(x, y) for y in range(height) for x in range(width) if pixels[x, y] <= 80]
+    if not dark_points:
+        return None
+
+    min_x = min(x for x, _ in dark_points)
+    max_x = max(x for x, _ in dark_points)
+    min_y = min(y for _, y in dark_points)
+    max_y = max(y for _, y in dark_points)
+    crop = crop.crop((min_x, min_y, max_x + 1, max_y + 1)).resize(
+        (_SPEEDUP_OCR_TEMPLATE_WIDTH, _SPEEDUP_OCR_TEMPLATE_HEIGHT),
+        resample=Image.Resampling.LANCZOS,
+    )
+    pixels = crop.load()
+    return tuple(
+        tuple(1 if pixels[x, y] <= 128 else 0 for x in range(_SPEEDUP_OCR_TEMPLATE_WIDTH))
+        for y in range(_SPEEDUP_OCR_TEMPLATE_HEIGHT)
+    )
+
+
+def _classify_speedup_ocr_character(character: tuple[tuple[int, ...], ...]) -> str | None:
+    templates = _decoded_speedup_ocr_templates()
+    best_character = None
+    best_distance: int | None = None
+    for template_character, template in templates.items():
+        distance = sum(
+            1
+            for y in range(_SPEEDUP_OCR_TEMPLATE_HEIGHT)
+            for x in range(_SPEEDUP_OCR_TEMPLATE_WIDTH)
+            if character[y][x] != template[y][x]
+        )
+        if best_distance is None or distance < best_distance:
+            best_character = template_character
+            best_distance = distance
+
+    if best_distance is None or best_distance > _SPEEDUP_OCR_MAX_DISTANCE:
+        return None
+    return best_character
+
+
+def _decoded_speedup_ocr_templates() -> dict[str, tuple[tuple[int, ...], ...]]:
+    global _DECODED_SPEEDUP_OCR_TEMPLATES
+    if _DECODED_SPEEDUP_OCR_TEMPLATES is None:
+        decoded = {}
+        for character, encoded in _SPEEDUP_OCR_TEMPLATES.items():
+            rows = []
+            for index in range(0, len(encoded), 2):
+                value = int(encoded[index : index + 2], 16)
+                rows.append(
+                    tuple(
+                        (value >> (_SPEEDUP_OCR_TEMPLATE_WIDTH - 1 - bit)) & 1
+                        for bit in range(_SPEEDUP_OCR_TEMPLATE_WIDTH)
+                    )
+                )
+            decoded[character] = tuple(rows)
+        _DECODED_SPEEDUP_OCR_TEMPLATES = decoded
+    return _DECODED_SPEEDUP_OCR_TEMPLATES
+
+
+def _apply_speedup_day_ocr_values(
+    result: InventoryVisionResult,
+    image_bytes: bytes,
+    import_type_hint: str | None,
+) -> InventoryVisionResult:
+    if not _is_speedup_hint(import_type_hint) or not result.ok:
+        return result
+
+    day_values = _speedup_day_values_from_image(image_bytes)
+    if not day_values:
+        return result
+
+    values = dict(result.values)
+    speedups = values.get("speedups")
+    if not isinstance(speedups, dict):
+        return result
+
+    merged_speedups = dict(speedups)
+    for speedup_type, days in day_values.items():
+        row = merged_speedups.get(speedup_type)
+        if not isinstance(row, dict):
+            row = {}
+        day_text = f"{days:,}"
+        merged_speedups[speedup_type] = {
+            **row,
+            "raw_duration_text": f"{day_text}d",
+            "day_digits_text": day_text,
+            "day_digits_verification_text": day_text,
+            "total_minutes": days * 1440,
+            "total_hours": days * 24,
+            "total_days_decimal": float(days),
+        }
+    values["speedups"] = merged_speedups
+
+    detected_image_type = (
+        "speedups" if len(day_values) == len(_SPEEDUP_DAY_KEYS) else result.detected_image_type
+    )
+
+    return InventoryVisionResult(
+        ok=result.ok,
+        detected_image_type=detected_image_type,
+        values=values,
+        confidence_score=result.confidence_score,
+        warnings=result.warnings,
+        prompt_version=result.prompt_version,
+        model=result.model,
+        fallback_used=result.fallback_used,
+        error=result.error,
+        raw_json=result.raw_json,
+    )
 
 
 def _build_image_content(
@@ -836,12 +1029,13 @@ class InventoryVisionClient:
                 fallback_used=fallback_used,
                 error="OpenAI vision response did not include output text.",
             )
-        return _parse_result_payload(
+        result = _parse_result_payload(
             text,
             model=model,
             prompt_version=self.config.prompt_version,
             fallback_used=fallback_used,
         )
+        return _apply_speedup_day_ocr_values(result, image_bytes, import_type_hint)
 
     def _create_client(self) -> Any:
         if self._client_factory is not None:

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -196,9 +196,10 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
-        "When a second image is provided, it is a labeled zoom sheet with one enlarged crop per "
-        "speedup row; use that zoom sheet as the primary source for speedup day digits, and use "
-        "the full screenshot only to confirm row order. "
+        "When a second image is provided, it is a labeled zoom sheet with one enlarged day-token "
+        "crop per speedup row; each crop intentionally shows only the day value ending in 'd' "
+        "and omits hours/minutes. Use that zoom sheet as the primary source for speedup day "
+        "digits, and use the full screenshot only to confirm row order. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -271,6 +272,7 @@ def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
                 )
                 crop = ImageEnhance.Contrast(crop).enhance(1.25)
                 crop = ImageEnhance.Sharpness(crop).enhance(1.6)
+                crop = _crop_first_bright_text_token(crop)
                 row_images.append((label, crop))
 
             row_height = max(crop.height for _, crop in row_images)
@@ -298,6 +300,39 @@ def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
         return None
 
     return _image_data_url(output.getvalue(), "image/png")
+
+
+def _crop_first_bright_text_token(image: Any) -> Any:
+    gray = image.convert("L")
+    width, height = gray.size
+    pixels = gray.load()
+    min_bright_pixels = max(2, int(height * 0.035))
+    bright_columns = []
+    for x in range(width):
+        count = 0
+        for y in range(height):
+            if pixels[x, y] >= 150:
+                count += 1
+        if count >= min_bright_pixels:
+            bright_columns.append(x)
+
+    if not bright_columns:
+        return image
+
+    max_character_gap = max(12, int(width * 0.018))
+    groups: list[list[int]] = [[bright_columns[0], bright_columns[0]]]
+    for x in bright_columns[1:]:
+        if x - groups[-1][1] <= max_character_gap:
+            groups[-1][1] = x
+        else:
+            groups.append([x, x])
+
+    min_token_width = max(30, int(width * 0.035))
+    token = next((group for group in groups if group[1] - group[0] >= min_token_width), groups[0])
+    padding = max(18, int(width * 0.012))
+    left = max(0, token[0] - padding)
+    right = min(width, token[1] + padding)
+    return image.crop((left, 0, right, height))
 
 
 def _build_image_content(

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -194,13 +194,12 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "schema. Use null for fields that do not apply to the detected image type or "
         "cannot be read. For resources, extract food, wood, stone, and gold from-items "
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
-        "For speedups, first transcribe the exact visible Total Duration text for "
-        "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
+        "For speedups, transcribe only the visible day token for Building, Research, "
+        "Training, Healing, and Universal rows into raw_duration_text. "
         "For speedups, the request may include five separate labeled high-contrast OCR strip "
-        "images instead of the full screenshot. Each labeled strip shows one speedup row's "
-        "black-on-white duration text. Use those labeled strip images as the source of truth, "
-        "and read only the first duration token ending in 'd'. "
-        "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
+        "images instead of the full screenshot. Each labeled strip shows only one speedup "
+        "row's black-on-white day token, such as '1,242d'. Use those labeled strip images "
+        "as the source of truth. Preserve thousands separators and every leading digit. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
         "After that, independently read only the same day digits again into "
@@ -321,6 +320,7 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
             crop = ImageEnhance.Contrast(crop).enhance(1.25)
             crop = ImageEnhance.Sharpness(crop).enhance(1.6)
             crop = _to_high_contrast_ocr_strip(crop)
+            crop = _crop_first_dark_text_token(crop)
             row_images.append((label, crop))
     return row_images
 
@@ -436,33 +436,32 @@ def _to_high_contrast_ocr_strip(image: Any) -> Any:
     return output
 
 
-def _crop_first_bright_text_token(image: Any) -> Any:
+def _crop_first_dark_text_token(image: Any) -> Any:
     gray = image.convert("L")
     width, height = gray.size
     pixels = gray.load()
-    min_bright_pixels = max(2, int(height * 0.035))
-    bright_columns = []
+    min_dark_pixels = max(2, int(height * 0.05))
+    dark_columns = []
     for x in range(width):
         count = 0
         for y in range(height):
-            if pixels[x, y] >= 150:
+            if pixels[x, y] <= 80:
                 count += 1
-        if count >= min_bright_pixels:
-            bright_columns.append(x)
+        if count >= min_dark_pixels:
+            dark_columns.append(x)
 
-    if not bright_columns:
+    if not dark_columns:
         return image
 
-    max_character_gap = max(12, int(width * 0.018))
-    groups: list[list[int]] = [[bright_columns[0], bright_columns[0]]]
-    for x in bright_columns[1:]:
+    max_character_gap = max(20, int(width * 0.02))
+    groups: list[list[int]] = [[dark_columns[0], dark_columns[0]]]
+    for x in dark_columns[1:]:
         if x - groups[-1][1] <= max_character_gap:
             groups[-1][1] = x
         else:
             groups.append([x, x])
 
-    min_token_width = max(30, int(width * 0.035))
-    token = next((group for group in groups if group[1] - group[0] >= min_token_width), groups[0])
+    token = groups[0]
     padding = max(18, int(width * 0.012))
     left = max(0, token[0] - padding)
     right = min(width, token[1] + padding)
@@ -486,7 +485,7 @@ def _build_image_content(
         crop_urls = _speedup_day_token_crop_data_urls(image_bytes)
         if crop_urls:
             for label, crop_url in crop_urls:
-                content.append({"type": "input_text", "text": f"{label} day-token crop:"})
+                content.append({"type": "input_text", "text": f"{label} days-only crop:"})
                 content.append({"type": "input_image", "image_url": crop_url})
             return content
 

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -196,10 +196,10 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
-        "When a second image is provided, it is a labeled zoom sheet with one enlarged day-token "
-        "crop per speedup row; each crop intentionally shows only the day value ending in 'd' "
-        "and omits hours/minutes. Use that zoom sheet as the primary source for speedup day "
-        "digits, and use the full screenshot only to confirm row order. "
+        "For speedups, the request may include five separate labeled day-token crop images "
+        "instead of the full screenshot. Each labeled crop intentionally shows only one day "
+        "value ending in 'd' and omits hours/minutes. Use those labeled crop images as the "
+        "source of truth for speedup day digits. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -231,75 +231,102 @@ def _is_speedup_hint(import_type_hint: str | None) -> bool:
 
 def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
     try:
-        from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+        from PIL import Image, ImageDraw, ImageFont
     except ImportError:
         return None
 
     try:
-        with Image.open(io.BytesIO(image_bytes)) as image:
-            image = image.convert("RGB")
-            width, height = image.size
-            if width < 200 or height < 200:
-                return None
+        row_images = _speedup_day_token_crop_images(image_bytes)
+        if not row_images:
+            return None
 
-            row_specs = (
-                ("Building", 0.355),
-                ("Research", 0.470),
-                ("Training", 0.585),
-                ("Healing", 0.700),
-                ("Universal", 0.815),
+        label_width = 260
+        row_gap = 18
+        row_height = max(crop.height for _, crop in row_images)
+        canvas_width = label_width + max(crop.width for _, crop in row_images) + 32
+        canvas_height = (row_height * len(row_images)) + (row_gap * (len(row_images) + 1))
+        canvas = Image.new("RGB", (canvas_width, canvas_height), (12, 18, 28))
+        draw = ImageDraw.Draw(canvas)
+        try:
+            font = ImageFont.truetype("arial.ttf", 38)
+        except OSError:
+            font = ImageFont.load_default()
+
+        y = row_gap
+        for label, crop in row_images:
+            draw.text(
+                (24, y + max(0, (row_height - 38) // 2)), label, fill=(255, 255, 255), font=font
             )
-            duration_x1 = int(width * 0.61)
-            duration_x2 = int(width * 0.95)
-            row_half_height = max(28, int(height * 0.038))
-            scale = 3
-            label_width = 260
-            row_gap = 18
-            row_images = []
-            for label, center_y_ratio in row_specs:
-                center_y = int(height * center_y_ratio)
-                crop = image.crop(
-                    (
-                        duration_x1,
-                        max(0, center_y - row_half_height),
-                        duration_x2,
-                        min(height, center_y + row_half_height),
-                    )
-                )
-                crop = crop.resize(
-                    (crop.width * scale, crop.height * scale),
-                    Image.Resampling.LANCZOS,
-                )
-                crop = ImageEnhance.Contrast(crop).enhance(1.25)
-                crop = ImageEnhance.Sharpness(crop).enhance(1.6)
-                crop = _crop_first_bright_text_token(crop)
-                row_images.append((label, crop))
+            canvas.paste(crop, (label_width, y + max(0, (row_height - crop.height) // 2)))
+            y += row_height + row_gap
 
-            row_height = max(crop.height for _, crop in row_images)
-            canvas_width = label_width + max(crop.width for _, crop in row_images) + 32
-            canvas_height = (row_height * len(row_images)) + (row_gap * (len(row_images) + 1))
-            canvas = Image.new("RGB", (canvas_width, canvas_height), (12, 18, 28))
-            draw = ImageDraw.Draw(canvas)
-            try:
-                font = ImageFont.truetype("arial.ttf", 38)
-            except OSError:
-                font = ImageFont.load_default()
-
-            y = row_gap
-            for label, crop in row_images:
-                draw.text(
-                    (24, y + max(0, (row_height - 38) // 2)), label, fill=(255, 255, 255), font=font
-                )
-                canvas.paste(crop, (label_width, y + max(0, (row_height - crop.height) // 2)))
-                y += row_height + row_gap
-
-            output = io.BytesIO()
-            canvas.save(output, format="PNG")
+        output = io.BytesIO()
+        canvas.save(output, format="PNG")
     except Exception:
         logger.debug("[inventory_vision] could not build speedup duration crop", exc_info=True)
         return None
 
     return _image_data_url(output.getvalue(), "image/png")
+
+
+def _speedup_day_token_crop_data_urls(image_bytes: bytes) -> list[tuple[str, str]]:
+    try:
+        row_images = _speedup_day_token_crop_images(image_bytes)
+    except Exception:
+        logger.debug("[inventory_vision] could not build speedup token crops", exc_info=True)
+        return []
+
+    data_urls: list[tuple[str, str]] = []
+    for label, crop in row_images:
+        output = io.BytesIO()
+        crop.save(output, format="PNG")
+        data_urls.append((label, _image_data_url(output.getvalue(), "image/png")))
+    return data_urls
+
+
+def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
+    try:
+        from PIL import Image, ImageEnhance
+    except ImportError:
+        return []
+
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        image = image.convert("RGB")
+        width, height = image.size
+        if width < 200 or height < 200:
+            return []
+
+        row_specs = (
+            ("Building", 0.355),
+            ("Research", 0.470),
+            ("Training", 0.585),
+            ("Healing", 0.700),
+            ("Universal", 0.815),
+        )
+        duration_x1 = int(width * 0.61)
+        duration_x2 = int(width * 0.95)
+        row_half_height = max(28, int(height * 0.038))
+        scale = 3
+        row_images = []
+        for label, center_y_ratio in row_specs:
+            center_y = int(height * center_y_ratio)
+            crop = image.crop(
+                (
+                    duration_x1,
+                    max(0, center_y - row_half_height),
+                    duration_x2,
+                    min(height, center_y + row_half_height),
+                )
+            )
+            crop = crop.resize(
+                (crop.width * scale, crop.height * scale),
+                Image.Resampling.LANCZOS,
+            )
+            crop = ImageEnhance.Contrast(crop).enhance(1.25)
+            crop = ImageEnhance.Sharpness(crop).enhance(1.6)
+            crop = _crop_first_bright_text_token(crop)
+            row_images.append((label, crop))
+    return row_images
 
 
 def _crop_first_bright_text_token(image: Any) -> Any:
@@ -346,16 +373,22 @@ def _build_image_content(
         {
             "type": "input_text",
             "text": _build_prompt(import_type_hint, prompt_version),
-        },
+        }
+    ]
+    if _is_speedup_hint(import_type_hint):
+        crop_urls = _speedup_day_token_crop_data_urls(image_bytes)
+        if crop_urls:
+            for label, crop_url in crop_urls:
+                content.append({"type": "input_text", "text": f"{label} day-token crop:"})
+                content.append({"type": "input_image", "image_url": crop_url})
+            return content
+
+    content.append(
         {
             "type": "input_image",
             "image_url": _image_data_url(image_bytes, content_type),
-        },
-    ]
-    if _is_speedup_hint(import_type_hint):
-        crop_url = _speedup_duration_crop_data_url(image_bytes)
-        if crop_url:
-            content.append({"type": "input_image", "image_url": crop_url})
+        }
+    )
     return content
 
 

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -75,6 +75,7 @@ def build_inventory_vision_schema() -> dict[str, Any]:
         "required": [
             "raw_duration_text",
             "day_digits_text",
+            "day_digits_verification_text",
             "total_minutes",
             "total_hours",
             "total_days_decimal",
@@ -82,6 +83,7 @@ def build_inventory_vision_schema() -> dict[str, Any]:
         "properties": {
             "raw_duration_text": {"type": ["string", "null"]},
             "day_digits_text": {"type": ["string", "null"]},
+            "day_digits_verification_text": {"type": ["string", "null"]},
             "total_minutes": nullable_integer,
             "total_hours": nullable_number,
             "total_days_decimal": nullable_number,
@@ -194,11 +196,16 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
-        "Read the day digits twice before returning them: 8 can look like 7, 5 can look like 3, "
-        "and 2 can look like 1 in this UI. For example, '1,242d 3h 35m' must have "
-        "day_digits_text set to '1,242' and must be stored as 1242 days, with total_minutes "
-        "set to 1788480, total_hours set to 29808, and total_days_decimal set to 1242. "
-        "Do not drop the leading thousands digit or round down by one or two days. "
+        "After that, independently read only the same day digits again into "
+        "day_digits_verification_text; do not copy the first answer. Compare "
+        "raw_duration_text, day_digits_text, and day_digits_verification_text before returning. "
+        "8 can look like 7, 5 can look like 3, and 2 can look like 1 in this UI, so zoom in "
+        "mentally on the final digit of each day value. If the day reads disagree, add a warning "
+        "for that row and set confidence_score below 0.90 so the fallback model can retry. "
+        "For example, '1,242d 3h 35m' must have day_digits_text and "
+        "day_digits_verification_text set to '1,242' and must be stored as 1242 days, with "
+        "total_minutes set to 1788480, total_hours set to 29808, and total_days_decimal set "
+        "to 1242. Do not drop the leading thousands digit or round down by one or two days. "
         "Use warnings for missing rows, unreadable values, low confidence, or mismatched "
         "image type. If the image is not readable, use detected_image_type unknown and "
         "a confidence_score below 0.70."

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -72,8 +72,14 @@ def build_inventory_vision_schema() -> dict[str, Any]:
     speedup_row = {
         "type": "object",
         "additionalProperties": False,
-        "required": ["total_minutes", "total_hours", "total_days_decimal"],
+        "required": [
+            "raw_duration_text",
+            "total_minutes",
+            "total_hours",
+            "total_days_decimal",
+        ],
         "properties": {
+            "raw_duration_text": {"type": ["string", "null"]},
             "total_minutes": nullable_integer,
             "total_hours": nullable_number,
             "total_days_decimal": nullable_number,
@@ -181,10 +187,13 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "schema. Use null for fields that do not apply to the detected image type or "
         "cannot be read. For resources, extract food, wood, stone, and gold from-items "
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
-        "For speedups, extract only the integer day count before the 'd' for Building, "
-        "Research, Training, Healing, and Universal rows. Ignore hours and minutes. "
-        "For example, '505d 3h 37m' must be stored as 505 days, with total_minutes "
-        "set to 727200, total_hours set to 12120, and total_days_decimal set to 505. "
+        "For speedups, first transcribe the exact visible Total Duration text for "
+        "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
+        "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
+        "Then extract only the integer day count before the 'd'. Ignore hours and minutes "
+        "for calculations. For example, '1,242d 3h 35m' must be stored as 1242 days, "
+        "with total_minutes set to 1788480, total_hours set to 29808, and "
+        "total_days_decimal set to 1242. Do not drop the leading thousands digit. "
         "Use warnings for missing rows, unreadable values, low confidence, or mismatched "
         "image type. If the image is not readable, use detected_image_type unknown and "
         "a confidence_score below 0.70."

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -74,12 +74,14 @@ def build_inventory_vision_schema() -> dict[str, Any]:
         "additionalProperties": False,
         "required": [
             "raw_duration_text",
+            "day_digits_text",
             "total_minutes",
             "total_hours",
             "total_days_decimal",
         ],
         "properties": {
             "raw_duration_text": {"type": ["string", "null"]},
+            "day_digits_text": {"type": ["string", "null"]},
             "total_minutes": nullable_integer,
             "total_hours": nullable_number,
             "total_days_decimal": nullable_number,
@@ -190,10 +192,13 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
-        "Then extract only the integer day count before the 'd'. Ignore hours and minutes "
-        "for calculations. For example, '1,242d 3h 35m' must be stored as 1242 days, "
-        "with total_minutes set to 1788480, total_hours set to 29808, and "
-        "total_days_decimal set to 1242. Do not drop the leading thousands digit. "
+        "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
+        "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
+        "Read the day digits twice before returning them: 8 can look like 7, 5 can look like 3, "
+        "and 2 can look like 1 in this UI. For example, '1,242d 3h 35m' must have "
+        "day_digits_text set to '1,242' and must be stored as 1242 days, with total_minutes "
+        "set to 1788480, total_hours set to 29808, and total_days_decimal set to 1242. "
+        "Do not drop the leading thousands digit or round down by one or two days. "
         "Use warnings for missing rows, unreadable values, low confidence, or mismatched "
         "image type. If the image is not readable, use detected_image_type unknown and "
         "a confidence_score below 0.70."

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -197,9 +197,9 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
         "For speedups, the request may include five separate labeled high-contrast OCR strip "
-        "images instead of the full screenshot. Each labeled strip intentionally shows only one "
-        "black-on-white day value ending in 'd' and omits hours/minutes. Use those labeled strip "
-        "images as the source of truth for speedup day digits. "
+        "images instead of the full screenshot. Each labeled strip shows one speedup row's "
+        "black-on-white duration text. Use those labeled strip images as the source of truth, "
+        "and read only the first duration token ending in 'd'. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -296,26 +296,22 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
         if width < 200 or height < 200:
             return []
 
-        row_specs = (
-            ("Building", 0.355),
-            ("Research", 0.470),
-            ("Training", 0.585),
-            ("Healing", 0.700),
-            ("Universal", 0.815),
-        )
-        duration_x1 = int(width * 0.61)
-        duration_x2 = int(width * 0.95)
-        row_half_height = max(28, int(height * 0.038))
+        labels = ("Building", "Research", "Training", "Healing", "Universal")
+        duration_x1 = int(width * 0.55)
+        duration_x2 = int(width * 0.98)
+        row_bounds = _detect_speedup_duration_row_bounds(image, duration_x1, duration_x2)
+        if len(row_bounds) < len(labels):
+            row_bounds = _fallback_speedup_duration_row_bounds(height)
         scale = 3
         row_images = []
-        for label, center_y_ratio in row_specs:
-            center_y = int(height * center_y_ratio)
+        for label, (row_top, row_bottom) in zip(labels, row_bounds, strict=False):
+            row_padding = max(24, int(height * 0.03))
             crop = image.crop(
                 (
                     duration_x1,
-                    max(0, center_y - row_half_height),
+                    max(0, row_top - row_padding),
                     duration_x2,
-                    min(height, center_y + row_half_height),
+                    min(height, row_bottom + row_padding),
                 )
             )
             crop = crop.resize(
@@ -324,10 +320,56 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
             )
             crop = ImageEnhance.Contrast(crop).enhance(1.25)
             crop = ImageEnhance.Sharpness(crop).enhance(1.6)
-            crop = _crop_first_bright_text_token(crop)
             crop = _to_high_contrast_ocr_strip(crop)
             row_images.append((label, crop))
     return row_images
+
+
+def _detect_speedup_duration_row_bounds(
+    image: Any, duration_x1: int, duration_x2: int
+) -> list[tuple[int, int]]:
+    gray = image.convert("L")
+    width, height = gray.size
+    pixels = gray.load()
+    min_row_pixels = max(3, int((duration_x2 - duration_x1) * 0.015))
+    bright_rows = []
+    for y in range(int(height * 0.10), int(height * 0.93)):
+        count = 0
+        for x in range(duration_x1, duration_x2):
+            if pixels[x, y] >= 150:
+                count += 1
+        if count >= min_row_pixels:
+            bright_rows.append(y)
+
+    if not bright_rows:
+        return []
+
+    row_groups: list[list[int]] = [[bright_rows[0], bright_rows[0]]]
+    max_row_gap = max(3, int(height * 0.01))
+    for y in bright_rows[1:]:
+        if y - row_groups[-1][1] <= max_row_gap:
+            row_groups[-1][1] = y
+        else:
+            row_groups.append([y, y])
+
+    min_group_height = max(10, int(height * 0.015))
+    candidates = [
+        (top, bottom)
+        for top, bottom in row_groups
+        if bottom - top >= min_group_height and ((top + bottom) / 2) >= height * 0.25
+    ]
+    return candidates[:5]
+
+
+def _fallback_speedup_duration_row_bounds(height: int) -> list[tuple[int, int]]:
+    row_half_height = max(28, int(height * 0.038))
+    return [
+        (
+            max(0, int(height * center_y_ratio) - row_half_height),
+            min(height, int(height * center_y_ratio) + row_half_height),
+        )
+        for center_y_ratio in (0.355, 0.470, 0.585, 0.700, 0.815)
+    ]
 
 
 def _to_high_contrast_ocr_strip(image: Any) -> Any:

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -4,13 +4,16 @@ import base64
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from inspect import isawaitable
+import io
 import json
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_FALLBACK_CONFIDENCE_THRESHOLD = 0.90
+_SPEEDUP_DAY_TEXT_RE = re.compile(r"^\s*(\d[\d,]*)(?:\s*d\b.*)?$", re.IGNORECASE)
 
 
 class VisionClientError(RuntimeError):
@@ -193,6 +196,9 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
+        "When a second image is provided, it is a zoomed crop of the Total Duration column; "
+        "use that crop as the primary source for speedup day digits, and use the full screenshot "
+        "only to confirm row order. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -216,6 +222,109 @@ def _image_data_url(image_bytes: bytes, content_type: str | None) -> str:
     mime = (content_type or "image/png").strip() or "image/png"
     encoded = base64.b64encode(image_bytes).decode("ascii")
     return f"data:{mime};base64,{encoded}"
+
+
+def _is_speedup_hint(import_type_hint: str | None) -> bool:
+    return (import_type_hint or "").strip().lower() == "speedups"
+
+
+def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
+    try:
+        from PIL import Image, ImageEnhance
+    except ImportError:
+        return None
+
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as image:
+            image = image.convert("RGB")
+            width, height = image.size
+            if width < 200 or height < 200:
+                return None
+
+            crop_box = (
+                int(width * 0.55),
+                int(height * 0.23),
+                int(width * 0.96),
+                int(height * 0.88),
+            )
+            crop = image.crop(crop_box)
+            scale = max(2, min(4, 1800 // max(1, crop.width)))
+            if scale > 1:
+                crop = crop.resize(
+                    (crop.width * scale, crop.height * scale),
+                    Image.Resampling.LANCZOS,
+                )
+            crop = ImageEnhance.Contrast(crop).enhance(1.2)
+            crop = ImageEnhance.Sharpness(crop).enhance(1.4)
+
+            output = io.BytesIO()
+            crop.save(output, format="PNG")
+    except Exception:
+        logger.debug("[inventory_vision] could not build speedup duration crop", exc_info=True)
+        return None
+
+    return _image_data_url(output.getvalue(), "image/png")
+
+
+def _build_image_content(
+    image_bytes: bytes,
+    *,
+    content_type: str | None,
+    import_type_hint: str | None,
+    prompt_version: str,
+) -> list[dict[str, str]]:
+    content = [
+        {
+            "type": "input_text",
+            "text": _build_prompt(import_type_hint, prompt_version),
+        },
+        {
+            "type": "input_image",
+            "image_url": _image_data_url(image_bytes, content_type),
+        },
+    ]
+    if _is_speedup_hint(import_type_hint):
+        crop_url = _speedup_duration_crop_data_url(image_bytes)
+        if crop_url:
+            content.append({"type": "input_image", "image_url": crop_url})
+    return content
+
+
+def _parse_speedup_day_text(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    match = _SPEEDUP_DAY_TEXT_RE.match(text)
+    if not match:
+        return None
+    return int(match.group(1).replace(",", ""))
+
+
+def _has_speedup_day_text_disagreement(result: InventoryVisionResult) -> bool:
+    if not result.ok or result.detected_image_type != "speedups":
+        return False
+
+    values = result.values.get("speedups") if isinstance(result.values, dict) else None
+    if not isinstance(values, dict):
+        return False
+
+    for row in values.values():
+        if not isinstance(row, dict):
+            continue
+        candidates = {
+            candidate
+            for candidate in (
+                _parse_speedup_day_text(row.get("raw_duration_text")),
+                _parse_speedup_day_text(row.get("day_digits_text")),
+                _parse_speedup_day_text(row.get("day_digits_verification_text")),
+            )
+            if candidate is not None
+        }
+        if len(candidates) > 1:
+            return True
+    return False
 
 
 def _extract_response_text(response: Any) -> str:
@@ -407,6 +516,7 @@ class InventoryVisionClient:
             import_type_hint=import_type_hint,
             fallback_used=False,
         )
+        primary_has_day_disagreement = _has_speedup_day_text_disagreement(primary)
         if not self._should_try_fallback(primary):
             return primary
 
@@ -430,6 +540,12 @@ class InventoryVisionClient:
             import_type_hint=import_type_hint,
             fallback_used=True,
         )
+        if (
+            primary_has_day_disagreement
+            and fallback.ok
+            and not _has_speedup_day_text_disagreement(fallback)
+        ):
+            return fallback
         if fallback.ok and fallback.confidence_score >= primary.confidence_score:
             return fallback
         return primary
@@ -438,6 +554,8 @@ class InventoryVisionClient:
         if result.fallback_used:
             return False
         if not result.ok:
+            return True
+        if _has_speedup_day_text_disagreement(result):
             return True
         return result.confidence_score < self.config.fallback_confidence_threshold
 
@@ -458,16 +576,12 @@ class InventoryVisionClient:
                 input=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "input_text",
-                                "text": _build_prompt(import_type_hint, self.config.prompt_version),
-                            },
-                            {
-                                "type": "input_image",
-                                "image_url": _image_data_url(image_bytes, content_type),
-                            },
-                        ],
+                        "content": _build_image_content(
+                            image_bytes,
+                            content_type=content_type,
+                            import_type_hint=import_type_hint,
+                            prompt_version=self.config.prompt_version,
+                        ),
                     }
                 ],
                 text={

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -196,9 +196,9 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
-        "When a second image is provided, it is a zoomed crop of the Total Duration column; "
-        "use that crop as the primary source for speedup day digits, and use the full screenshot "
-        "only to confirm row order. "
+        "When a second image is provided, it is a labeled zoom sheet with one enlarged crop per "
+        "speedup row; use that zoom sheet as the primary source for speedup day digits, and use "
+        "the full screenshot only to confirm row order. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -230,7 +230,7 @@ def _is_speedup_hint(import_type_hint: str | None) -> bool:
 
 def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
     try:
-        from PIL import Image, ImageEnhance
+        from PIL import Image, ImageDraw, ImageEnhance, ImageFont
     except ImportError:
         return None
 
@@ -241,24 +241,58 @@ def _speedup_duration_crop_data_url(image_bytes: bytes) -> str | None:
             if width < 200 or height < 200:
                 return None
 
-            crop_box = (
-                int(width * 0.55),
-                int(height * 0.23),
-                int(width * 0.96),
-                int(height * 0.88),
+            row_specs = (
+                ("Building", 0.355),
+                ("Research", 0.470),
+                ("Training", 0.585),
+                ("Healing", 0.700),
+                ("Universal", 0.815),
             )
-            crop = image.crop(crop_box)
-            scale = max(2, min(4, 1800 // max(1, crop.width)))
-            if scale > 1:
+            duration_x1 = int(width * 0.61)
+            duration_x2 = int(width * 0.95)
+            row_half_height = max(28, int(height * 0.038))
+            scale = 3
+            label_width = 260
+            row_gap = 18
+            row_images = []
+            for label, center_y_ratio in row_specs:
+                center_y = int(height * center_y_ratio)
+                crop = image.crop(
+                    (
+                        duration_x1,
+                        max(0, center_y - row_half_height),
+                        duration_x2,
+                        min(height, center_y + row_half_height),
+                    )
+                )
                 crop = crop.resize(
                     (crop.width * scale, crop.height * scale),
                     Image.Resampling.LANCZOS,
                 )
-            crop = ImageEnhance.Contrast(crop).enhance(1.2)
-            crop = ImageEnhance.Sharpness(crop).enhance(1.4)
+                crop = ImageEnhance.Contrast(crop).enhance(1.25)
+                crop = ImageEnhance.Sharpness(crop).enhance(1.6)
+                row_images.append((label, crop))
+
+            row_height = max(crop.height for _, crop in row_images)
+            canvas_width = label_width + max(crop.width for _, crop in row_images) + 32
+            canvas_height = (row_height * len(row_images)) + (row_gap * (len(row_images) + 1))
+            canvas = Image.new("RGB", (canvas_width, canvas_height), (12, 18, 28))
+            draw = ImageDraw.Draw(canvas)
+            try:
+                font = ImageFont.truetype("arial.ttf", 38)
+            except OSError:
+                font = ImageFont.load_default()
+
+            y = row_gap
+            for label, crop in row_images:
+                draw.text(
+                    (24, y + max(0, (row_height - 38) // 2)), label, fill=(255, 255, 255), font=font
+                )
+                canvas.paste(crop, (label_width, y + max(0, (row_height - crop.height) // 2)))
+                y += row_height + row_gap
 
             output = io.BytesIO()
-            crop.save(output, format="PNG")
+            canvas.save(output, format="PNG")
     except Exception:
         logger.debug("[inventory_vision] could not build speedup duration crop", exc_info=True)
         return None

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -353,11 +353,21 @@ def _detect_speedup_duration_row_bounds(
             row_groups.append([y, y])
 
     min_group_height = max(10, int(height * 0.015))
-    candidates = [
-        (top, bottom)
-        for top, bottom in row_groups
-        if bottom - top >= min_group_height and ((top + bottom) / 2) >= height * 0.25
-    ]
+    candidates = []
+    min_value_x = int(width * 0.60)
+    for top, bottom in row_groups:
+        if bottom - top < min_group_height or ((top + bottom) / 2) < height * 0.20:
+            continue
+
+        bright_x_values = [
+            x
+            for y in range(top, bottom + 1)
+            for x in range(duration_x1, duration_x2)
+            if pixels[x, y] >= 150
+        ]
+        if not bright_x_values or min(bright_x_values) < min_value_x:
+            continue
+        candidates.append((top, bottom))
     return candidates[:5]
 
 

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -196,10 +196,10 @@ def _build_prompt(import_type_hint: str | None, prompt_version: str) -> str:
         "and total-resources values as integer quantities after expanding K/M/B suffixes. "
         "For speedups, first transcribe the exact visible Total Duration text for "
         "Building, Research, Training, Healing, and Universal rows into raw_duration_text. "
-        "For speedups, the request may include five separate labeled day-token crop images "
-        "instead of the full screenshot. Each labeled crop intentionally shows only one day "
-        "value ending in 'd' and omits hours/minutes. Use those labeled crop images as the "
-        "source of truth for speedup day digits. "
+        "For speedups, the request may include five separate labeled high-contrast OCR strip "
+        "images instead of the full screenshot. Each labeled strip intentionally shows only one "
+        "black-on-white day value ending in 'd' and omits hours/minutes. Use those labeled strip "
+        "images as the source of truth for speedup day digits. "
         "Preserve thousands separators and every leading digit, for example '1,242d 3h 35m'. "
         "Then copy only the visible day digits immediately before the 'd' into day_digits_text, "
         "preserving commas if shown. Ignore hours and minutes for day_digits_text and calculations. "
@@ -325,8 +325,63 @@ def _speedup_day_token_crop_images(image_bytes: bytes) -> list[tuple[str, Any]]:
             crop = ImageEnhance.Contrast(crop).enhance(1.25)
             crop = ImageEnhance.Sharpness(crop).enhance(1.6)
             crop = _crop_first_bright_text_token(crop)
+            crop = _to_high_contrast_ocr_strip(crop)
             row_images.append((label, crop))
     return row_images
+
+
+def _to_high_contrast_ocr_strip(image: Any) -> Any:
+    from PIL import Image
+
+    gray = image.convert("L")
+    width, height = gray.size
+    pixels = gray.load()
+    threshold = 138
+    bright_points: list[tuple[int, int]] = []
+    for y in range(height):
+        for x in range(width):
+            if pixels[x, y] >= threshold:
+                bright_points.append((x, y))
+    if not bright_points:
+        return image.convert("RGB")
+
+    min_row_pixels = max(2, int(width * 0.01))
+    bright_rows = []
+    for y in range(height):
+        count = 0
+        for x in range(width):
+            if pixels[x, y] >= threshold:
+                count += 1
+        if count >= min_row_pixels:
+            bright_rows.append(y)
+
+    if bright_rows:
+        row_groups: list[list[int]] = [[bright_rows[0], bright_rows[0]]]
+        max_row_gap = max(3, int(height * 0.025))
+        for y in bright_rows[1:]:
+            if y - row_groups[-1][1] <= max_row_gap:
+                row_groups[-1][1] = y
+            else:
+                row_groups.append([y, y])
+        main_group = max(row_groups, key=lambda group: group[1] - group[0])
+        bright_points = [(x, y) for x, y in bright_points if main_group[0] <= y <= main_group[1]]
+
+    min_x = max(0, min(x for x, _ in bright_points) - 18)
+    max_x = min(width - 1, max(x for x, _ in bright_points) + 18)
+    min_y = max(0, min(y for _, y in bright_points) - 18)
+    max_y = min(height - 1, max(y for _, y in bright_points) + 18)
+    gray = gray.crop((min_x, min_y, max_x + 1, max_y + 1))
+    width, height = gray.size
+    pixels = gray.load()
+    margin_x = 36
+    margin_y = 22
+    output = Image.new("RGB", (width + (margin_x * 2), height + (margin_y * 2)), "white")
+    output_pixels = output.load()
+    for y in range(height):
+        for x in range(width):
+            if pixels[x, y] >= threshold:
+                output_pixels[x + margin_x, y + margin_y] = (0, 0, 0)
+    return output
 
 
 def _crop_first_bright_text_token(image: Any) -> Any:

--- a/services/vision_client.py
+++ b/services/vision_client.py
@@ -614,11 +614,15 @@ def _apply_speedup_day_ocr_values(
     image_bytes: bytes,
     import_type_hint: str | None,
 ) -> InventoryVisionResult:
-    if not _is_speedup_hint(import_type_hint) or not result.ok:
+    if not result.ok:
         return result
 
     day_values = _speedup_day_values_from_image(image_bytes)
     if not day_values:
+        return result
+
+    is_speedup = _is_speedup_hint(import_type_hint) or len(day_values) == len(_SPEEDUP_DAY_KEYS)
+    if not is_speedup:
         return result
 
     values = dict(result.values)

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -36,6 +36,7 @@ def test_parse_speedup_minutes_supports_day_hour_minute_tokens():
 
 def test_parse_speedup_days_uses_only_day_component():
     assert parse_speedup_days("505d 3h 37m") == 505
+    assert parse_speedup_days("1,242d 3h 35m") == 1242
     assert parse_speedup_days("505") == 505
     assert parse_speedup_days(505.0) == 505
 
@@ -74,6 +75,37 @@ def test_normalize_final_values_for_speedups_calculates_derived_fields():
 
     assert normalized["speedups"]["building"] == speedup_row_from_days(0)
     assert normalized["speedups"]["universal"]["total_days_decimal"] == 2.0
+
+
+def test_normalize_speedups_prefers_raw_duration_text_over_bad_numeric_fields():
+    normalized = normalize_final_values(
+        InventoryImportType.SPEEDUPS,
+        {
+            "speedups": {
+                "building": {
+                    "raw_duration_text": "1,068d 11h 36m",
+                    "total_minutes": 742 * 1440,
+                    "total_hours": 742 * 24,
+                    "total_days_decimal": 742,
+                },
+                "research": {
+                    "raw_duration_text": "1,242d 3h 35m",
+                    "total_minutes": 123 * 1440,
+                    "total_hours": 123 * 24,
+                    "total_days_decimal": 123,
+                },
+                "training": {"raw_duration_text": "935d 0h 7m"},
+                "healing": {"raw_duration_text": "503d 20h 7m"},
+                "universal": {"raw_duration_text": "2,422d 17h 58m"},
+            }
+        },
+    )
+
+    assert normalized["speedups"]["building"]["total_days_decimal"] == 1068.0
+    assert normalized["speedups"]["research"]["total_days_decimal"] == 1242.0
+    assert normalized["speedups"]["training"]["total_days_decimal"] == 935.0
+    assert normalized["speedups"]["healing"]["total_days_decimal"] == 503.0
+    assert normalized["speedups"]["universal"]["total_days_decimal"] == 2422.0
 
 
 def test_resource_total_corrections_only_change_total_resources():

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -132,6 +132,12 @@ def test_normalize_speedups_falls_back_when_raw_duration_text_is_unusable():
     assert normalized["speedups"]["training"]["total_days_decimal"] == 300.0
     assert normalized["speedups"]["healing"]["total_days_decimal"] == 400.0
     assert normalized["speedups"]["universal"]["total_days_decimal"] == 500.0
+    # raw_duration_text is always preserved even when it couldn't be parsed
+    assert normalized["speedups"]["building"]["raw_duration_text"] == ""
+    assert normalized["speedups"]["research"]["raw_duration_text"] == "garbled"
+    assert normalized["speedups"]["training"]["raw_duration_text"] is None
+    assert normalized["speedups"]["healing"]["raw_duration_text"] is None
+    assert normalized["speedups"]["universal"]["raw_duration_text"] is None
 
 
 def test_resource_total_corrections_only_change_total_resources():

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -155,6 +155,72 @@ def test_normalize_speedups_prefers_day_digits_text_over_bad_duration_text():
     assert normalized["speedups"]["universal"]["raw_duration_text"] == "2,421d 17h 58m"
 
 
+def test_normalize_speedups_uses_candidate_consensus_for_ocr_drift():
+    normalized = normalize_final_values(
+        InventoryImportType.SPEEDUPS,
+        {
+            "speedups": {
+                "building": {
+                    "day_digits_text": "1065",
+                    "day_digits_verification_text": "1068",
+                    "raw_duration_text": "1,068d 11h 36m",
+                    "total_days_decimal": 1065,
+                },
+                "research": {
+                    "day_digits_text": "1242",
+                    "day_digits_verification_text": "1242",
+                    "raw_duration_text": "1,242d 3h 35m",
+                },
+                "training": {
+                    "day_digits_text": "935",
+                    "day_digits_verification_text": "935",
+                    "raw_duration_text": "935d 0h 7m",
+                },
+                "healing": {
+                    "day_digits_text": "503",
+                    "day_digits_verification_text": "503",
+                    "raw_duration_text": "503d 20h 7m",
+                },
+                "universal": {
+                    "day_digits_text": "2418",
+                    "day_digits_verification_text": "2422",
+                    "raw_duration_text": "2,422d 17h 58m",
+                    "total_days_decimal": 2418,
+                },
+            }
+        },
+    )
+
+    assert normalized["speedups"]["building"]["total_days_decimal"] == 1068.0
+    assert normalized["speedups"]["research"]["total_days_decimal"] == 1242.0
+    assert normalized["speedups"]["training"]["total_days_decimal"] == 935.0
+    assert normalized["speedups"]["healing"]["total_days_decimal"] == 503.0
+    assert normalized["speedups"]["universal"]["total_days_decimal"] == 2422.0
+
+
+def test_normalize_speedups_preserves_verification_field():
+    normalized = normalize_final_values(
+        InventoryImportType.SPEEDUPS,
+        {
+            "speedups": {
+                "building": {"total_days_decimal": 1},
+                "research": {"total_days_decimal": 2},
+                "training": {"total_days_decimal": 3},
+                "healing": {"total_days_decimal": 4},
+                "universal": {
+                    "day_digits_text": "863",
+                    "day_digits_verification_text": "862",
+                    "raw_duration_text": "862d 17h 58m",
+                    "total_days_decimal": 863,
+                },
+            }
+        },
+    )
+
+    assert normalized["speedups"]["universal"]["total_days_decimal"] == 862.0
+    assert normalized["speedups"]["universal"]["day_digits_verification_text"] == "862"
+
+
 def test_normalize_speedups_falls_back_when_raw_duration_text_is_unusable():
     """Empty or malformed raw_duration_text must not suppress valid numeric fields."""
     normalized = normalize_final_values(

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -112,6 +112,49 @@ def test_normalize_speedups_prefers_raw_duration_text_over_bad_numeric_fields():
     assert normalized["speedups"]["universal"]["raw_duration_text"] == "2,422d 17h 58m"
 
 
+def test_normalize_speedups_prefers_day_digits_text_over_bad_duration_text():
+    normalized = normalize_final_values(
+        InventoryImportType.SPEEDUPS,
+        {
+            "speedups": {
+                "building": {
+                    "raw_duration_text": "1,067d 11h 36m",
+                    "day_digits_text": "1,068",
+                    "total_days_decimal": 1067,
+                },
+                "research": {
+                    "raw_duration_text": "1,242d 3h 35m",
+                    "day_digits_text": "1,242",
+                    "total_days_decimal": 1242,
+                },
+                "training": {
+                    "raw_duration_text": "933d 0h 7m",
+                    "day_digits_text": "935",
+                    "total_days_decimal": 933,
+                },
+                "healing": {
+                    "raw_duration_text": "503d 20h 7m",
+                    "day_digits_text": "503",
+                    "total_days_decimal": 503,
+                },
+                "universal": {
+                    "raw_duration_text": "2,421d 17h 58m",
+                    "day_digits_text": "2,422",
+                    "total_days_decimal": 2421,
+                },
+            }
+        },
+    )
+
+    assert normalized["speedups"]["building"]["total_days_decimal"] == 1068.0
+    assert normalized["speedups"]["research"]["total_days_decimal"] == 1242.0
+    assert normalized["speedups"]["training"]["total_days_decimal"] == 935.0
+    assert normalized["speedups"]["healing"]["total_days_decimal"] == 503.0
+    assert normalized["speedups"]["universal"]["total_days_decimal"] == 2422.0
+    assert normalized["speedups"]["building"]["day_digits_text"] == "1,068"
+    assert normalized["speedups"]["universal"]["raw_duration_text"] == "2,421d 17h 58m"
+
+
 def test_normalize_speedups_falls_back_when_raw_duration_text_is_unusable():
     """Empty or malformed raw_duration_text must not suppress valid numeric fields."""
     normalized = normalize_final_values(

--- a/tests/test_inventory_parsing.py
+++ b/tests/test_inventory_parsing.py
@@ -106,6 +106,32 @@ def test_normalize_speedups_prefers_raw_duration_text_over_bad_numeric_fields():
     assert normalized["speedups"]["training"]["total_days_decimal"] == 935.0
     assert normalized["speedups"]["healing"]["total_days_decimal"] == 503.0
     assert normalized["speedups"]["universal"]["total_days_decimal"] == 2422.0
+    # raw_duration_text must be preserved verbatim in the normalized payload
+    assert normalized["speedups"]["building"]["raw_duration_text"] == "1,068d 11h 36m"
+    assert normalized["speedups"]["research"]["raw_duration_text"] == "1,242d 3h 35m"
+    assert normalized["speedups"]["universal"]["raw_duration_text"] == "2,422d 17h 58m"
+
+
+def test_normalize_speedups_falls_back_when_raw_duration_text_is_unusable():
+    """Empty or malformed raw_duration_text must not suppress valid numeric fields."""
+    normalized = normalize_final_values(
+        InventoryImportType.SPEEDUPS,
+        {
+            "speedups": {
+                "building": {"raw_duration_text": "", "total_days_decimal": 100},
+                "research": {"raw_duration_text": "garbled", "total_days_decimal": 200},
+                "training": {"raw_duration_text": None, "total_days_decimal": 300},
+                "healing": {"total_days_decimal": 400},
+                "universal": {"total_minutes": 500 * 1440},
+            }
+        },
+    )
+
+    assert normalized["speedups"]["building"]["total_days_decimal"] == 100.0
+    assert normalized["speedups"]["research"]["total_days_decimal"] == 200.0
+    assert normalized["speedups"]["training"]["total_days_decimal"] == 300.0
+    assert normalized["speedups"]["healing"]["total_days_decimal"] == 400.0
+    assert normalized["speedups"]["universal"]["total_days_decimal"] == 500.0
 
 
 def test_resource_total_corrections_only_change_total_resources():

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -49,6 +49,7 @@ def _null_resource_row() -> dict:
 def _null_speedup_row() -> dict:
     return {
         "raw_duration_text": None,
+        "day_digits_text": None,
         "total_minutes": None,
         "total_hours": None,
         "total_days_decimal": None,
@@ -169,6 +170,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     speedups_primary = _null_values()
     speedups_primary["speedups"]["universal"] = {
         "raw_duration_text": "1d 0h 0m",
+        "day_digits_text": "1",
         "total_minutes": 1440,
         "total_hours": 24.0,
         "total_days_decimal": 1.0,
@@ -176,6 +178,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     speedups_fallback = _null_values()
     speedups_fallback["speedups"]["universal"] = {
         "raw_duration_text": "2d 0h 0m",
+        "day_digits_text": "2",
         "total_minutes": 2880,
         "total_hours": 48.0,
         "total_days_decimal": 2.0,
@@ -208,7 +211,31 @@ async def test_low_confidence_escalates_to_fallback_model():
     assert result.confidence_score == 0.94
     assert result.values["speedups"]["universal"]["total_minutes"] == 2880
     assert result.values["speedups"]["universal"]["raw_duration_text"] == "2d 0h 0m"
+    assert result.values["speedups"]["universal"]["day_digits_text"] == "2"
     assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
+
+
+@pytest.mark.asyncio
+async def test_speedup_prompt_requests_day_digits_text():
+    calls = []
+    payloads = [
+        {
+            "detected_image_type": "unknown",
+            "confidence_score": 0.95,
+            "warnings": [],
+            "values": _null_values(),
+        }
+    ]
+    client = InventoryVisionClient(
+        _config(fallback_model=None),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    await client.analyse_image(b"fake image", import_type_hint="speedups")
+
+    prompt = calls[0]["input"][0]["content"][0]["text"]
+    assert "day_digits_text" in prompt
+    assert "Read the day digits twice" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -168,17 +168,8 @@ async def test_primary_success_parses_structured_json_without_fallback():
 
 
 @pytest.mark.asyncio
-async def test_low_confidence_escalates_to_fallback_model():
+async def test_speedups_use_fallback_model_as_first_pass_when_configured():
     calls = []
-    speedups_primary = _null_values()
-    speedups_primary["speedups"]["universal"] = {
-        "raw_duration_text": "1d 0h 0m",
-        "day_digits_text": "1",
-        "day_digits_verification_text": "1",
-        "total_minutes": 1440,
-        "total_hours": 24.0,
-        "total_days_decimal": 1.0,
-    }
     speedups_fallback = _null_values()
     speedups_fallback["speedups"]["universal"] = {
         "raw_duration_text": "2d 0h 0m",
@@ -189,12 +180,6 @@ async def test_low_confidence_escalates_to_fallback_model():
         "total_days_decimal": 2.0,
     }
     payloads = [
-        {
-            "detected_image_type": "speedups",
-            "confidence_score": 0.72,
-            "warnings": ["Some values were hard to read."],
-            "values": speedups_primary,
-        },
         {
             "detected_image_type": "speedups",
             "confidence_score": 0.94,
@@ -218,7 +203,41 @@ async def test_low_confidence_escalates_to_fallback_model():
     assert result.values["speedups"]["universal"]["raw_duration_text"] == "2d 0h 0m"
     assert result.values["speedups"]["universal"]["day_digits_text"] == "2"
     assert result.values["speedups"]["universal"]["day_digits_verification_text"] == "2"
-    assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
+    assert [call["model"] for call in calls] == ["gpt-5.2"]
+
+
+@pytest.mark.asyncio
+async def test_speedups_use_primary_model_when_no_fallback_is_configured():
+    calls = []
+    speedups = _null_values()
+    speedups["speedups"]["universal"] = {
+        "raw_duration_text": "2d 0h 0m",
+        "day_digits_text": "2",
+        "day_digits_verification_text": "2",
+        "total_minutes": 2880,
+        "total_hours": 48.0,
+        "total_days_decimal": 2.0,
+    }
+    payloads = [
+        {
+            "detected_image_type": "speedups",
+            "confidence_score": 0.94,
+            "warnings": [],
+            "values": speedups,
+        },
+    ]
+
+    client = InventoryVisionClient(
+        _config(fallback_model=None),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    result = await client.analyse_image(b"fake image", import_type_hint="speedups")
+
+    assert result.ok
+    assert result.model == "gpt-4.1-mini"
+    assert not result.fallback_used
+    assert [call["model"] for call in calls] == ["gpt-4.1-mini"]
 
 
 @pytest.mark.asyncio
@@ -306,53 +325,6 @@ async def test_speedup_import_falls_back_to_original_image_when_crops_fail(monke
 
 def test_speedup_duration_crop_rejects_invalid_image():
     assert _speedup_duration_crop_data_url(b"not an image") is None
-
-
-@pytest.mark.asyncio
-async def test_speedup_day_disagreement_triggers_fallback_even_with_high_confidence():
-    calls = []
-    primary_values = _null_values()
-    primary_values["speedups"]["building"] = {
-        "raw_duration_text": "1,068d 11h 36m",
-        "day_digits_text": "1067",
-        "day_digits_verification_text": "1067",
-        "total_minutes": 1067 * 1440,
-        "total_hours": 1067 * 24,
-        "total_days_decimal": 1067,
-    }
-    fallback_values = _null_values()
-    fallback_values["speedups"]["building"] = {
-        "raw_duration_text": "1,068d 11h 36m",
-        "day_digits_text": "1068",
-        "day_digits_verification_text": "1068",
-        "total_minutes": 1068 * 1440,
-        "total_hours": 1068 * 24,
-        "total_days_decimal": 1068,
-    }
-    payloads = [
-        {
-            "detected_image_type": "speedups",
-            "confidence_score": 0.97,
-            "warnings": [],
-            "values": primary_values,
-        },
-        {
-            "detected_image_type": "speedups",
-            "confidence_score": 0.93,
-            "warnings": [],
-            "values": fallback_values,
-        },
-    ]
-    client = InventoryVisionClient(
-        _config(),
-        client_factory=lambda _api_key: FakeClient(payloads, calls),
-    )
-
-    result = await client.analyse_image(b"fake image", import_type_hint="speedups")
-
-    assert result.fallback_used
-    assert result.values["speedups"]["building"]["day_digits_text"] == "1068"
-    assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -50,6 +50,7 @@ def _null_speedup_row() -> dict:
     return {
         "raw_duration_text": None,
         "day_digits_text": None,
+        "day_digits_verification_text": None,
         "total_minutes": None,
         "total_hours": None,
         "total_days_decimal": None,
@@ -171,6 +172,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     speedups_primary["speedups"]["universal"] = {
         "raw_duration_text": "1d 0h 0m",
         "day_digits_text": "1",
+        "day_digits_verification_text": "1",
         "total_minutes": 1440,
         "total_hours": 24.0,
         "total_days_decimal": 1.0,
@@ -179,6 +181,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     speedups_fallback["speedups"]["universal"] = {
         "raw_duration_text": "2d 0h 0m",
         "day_digits_text": "2",
+        "day_digits_verification_text": "2",
         "total_minutes": 2880,
         "total_hours": 48.0,
         "total_days_decimal": 2.0,
@@ -212,6 +215,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     assert result.values["speedups"]["universal"]["total_minutes"] == 2880
     assert result.values["speedups"]["universal"]["raw_duration_text"] == "2d 0h 0m"
     assert result.values["speedups"]["universal"]["day_digits_text"] == "2"
+    assert result.values["speedups"]["universal"]["day_digits_verification_text"] == "2"
     assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
 
 
@@ -235,7 +239,8 @@ async def test_speedup_prompt_requests_day_digits_text():
 
     prompt = calls[0]["input"][0]["content"][0]["text"]
     assert "day_digits_text" in prompt
-    assert "Read the day digits twice" in prompt
+    assert "day_digits_verification_text" in prompt
+    assert "confidence_score below 0.90" in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -273,8 +273,35 @@ async def test_speedup_import_sends_labeled_zoom_sheet():
 
     content = calls[0]["input"][0]["content"]
     image_parts = [item for item in content if item["type"] == "input_image"]
-    assert len(image_parts) == 2
-    assert image_parts[1]["image_url"].startswith("data:image/png;base64,")
+    text_parts = [item["text"] for item in content if item["type"] == "input_text"]
+    assert len(image_parts) == 5
+    assert all(item["image_url"].startswith("data:image/png;base64,") for item in image_parts)
+    assert "Building day-token crop:" in text_parts
+    assert "Universal day-token crop:" in text_parts
+
+
+@pytest.mark.asyncio
+async def test_speedup_import_falls_back_to_original_image_when_crops_fail(monkeypatch):
+    calls = []
+    payloads = [
+        {
+            "detected_image_type": "unknown",
+            "confidence_score": 0.95,
+            "warnings": [],
+            "values": _null_values(),
+        }
+    ]
+    monkeypatch.setattr("services.vision_client._speedup_day_token_crop_data_urls", lambda _: [])
+    client = InventoryVisionClient(
+        _config(fallback_model=None),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    await client.analyse_image(b"fake image", content_type="image/png", import_type_hint="speedups")
+
+    content = calls[0]["input"][0]["content"]
+    image_parts = [item for item in content if item["type"] == "input_image"]
+    assert len(image_parts) == 1
 
 
 def test_speedup_duration_crop_rejects_invalid_image():

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -10,6 +10,7 @@ import pytest
 from services.vision_client import (
     InventoryVisionClient,
     InventoryVisionConfig,
+    _crop_first_dark_text_token,
     _detect_speedup_duration_row_bounds,
     _speedup_duration_crop_data_url,
     build_inventory_vision_schema,
@@ -296,8 +297,8 @@ async def test_speedup_import_sends_labeled_zoom_sheet():
     text_parts = [item["text"] for item in content if item["type"] == "input_text"]
     assert len(image_parts) == 5
     assert all(item["image_url"].startswith("data:image/png;base64,") for item in image_parts)
-    assert "Building day-token crop:" in text_parts
-    assert "Universal day-token crop:" in text_parts
+    assert "Building days-only crop:" in text_parts
+    assert "Universal days-only crop:" in text_parts
 
 
 @pytest.mark.asyncio
@@ -343,6 +344,19 @@ def test_speedup_duration_row_detection_ignores_header_text():
     rows = _detect_speedup_duration_row_bounds(image.convert("RGB"), 550, 980)
 
     assert rows == expected_rows
+
+
+def test_speedup_day_token_crop_keeps_only_first_duration_token():
+    pytest.importorskip("PIL")
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (760, 150), "white")
+    draw = ImageDraw.Draw(image)
+    draw.text((20, 40), "1,068d 11h 36m", fill="black")
+
+    token = _crop_first_dark_text_token(image)
+
+    assert token.width < image.width * 0.55
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import subprocess
 import sys
 
@@ -9,6 +10,7 @@ import pytest
 from services.vision_client import (
     InventoryVisionClient,
     InventoryVisionConfig,
+    _speedup_duration_crop_data_url,
     build_inventory_vision_schema,
 )
 
@@ -241,6 +243,88 @@ async def test_speedup_prompt_requests_day_digits_text():
     assert "day_digits_text" in prompt
     assert "day_digits_verification_text" in prompt
     assert "confidence_score below 0.90" in prompt
+
+
+@pytest.mark.asyncio
+async def test_speedup_import_sends_zoomed_duration_crop():
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    calls = []
+    image_path = Path("downloads") / "test_speedup_crop.png"
+    image_path.parent.mkdir(exist_ok=True)
+    image = Image.new("RGB", (1200, 800), "navy")
+    image.save(image_path)
+    image_bytes = image_path.read_bytes()
+    payloads = [
+        {
+            "detected_image_type": "unknown",
+            "confidence_score": 0.95,
+            "warnings": [],
+            "values": _null_values(),
+        }
+    ]
+    client = InventoryVisionClient(
+        _config(fallback_model=None),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    await client.analyse_image(image_bytes, content_type="image/png", import_type_hint="speedups")
+
+    content = calls[0]["input"][0]["content"]
+    image_parts = [item for item in content if item["type"] == "input_image"]
+    assert len(image_parts) == 2
+
+
+def test_speedup_duration_crop_rejects_invalid_image():
+    assert _speedup_duration_crop_data_url(b"not an image") is None
+
+
+@pytest.mark.asyncio
+async def test_speedup_day_disagreement_triggers_fallback_even_with_high_confidence():
+    calls = []
+    primary_values = _null_values()
+    primary_values["speedups"]["building"] = {
+        "raw_duration_text": "1,068d 11h 36m",
+        "day_digits_text": "1067",
+        "day_digits_verification_text": "1067",
+        "total_minutes": 1067 * 1440,
+        "total_hours": 1067 * 24,
+        "total_days_decimal": 1067,
+    }
+    fallback_values = _null_values()
+    fallback_values["speedups"]["building"] = {
+        "raw_duration_text": "1,068d 11h 36m",
+        "day_digits_text": "1068",
+        "day_digits_verification_text": "1068",
+        "total_minutes": 1068 * 1440,
+        "total_hours": 1068 * 24,
+        "total_days_decimal": 1068,
+    }
+    payloads = [
+        {
+            "detected_image_type": "speedups",
+            "confidence_score": 0.97,
+            "warnings": [],
+            "values": primary_values,
+        },
+        {
+            "detected_image_type": "speedups",
+            "confidence_score": 0.93,
+            "warnings": [],
+            "values": fallback_values,
+        },
+    ]
+    client = InventoryVisionClient(
+        _config(),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    result = await client.analyse_image(b"fake image", import_type_hint="speedups")
+
+    assert result.fallback_used
+    assert result.values["speedups"]["building"]["day_digits_text"] == "1068"
+    assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -47,7 +47,12 @@ def _null_resource_row() -> dict:
 
 
 def _null_speedup_row() -> dict:
-    return {"total_minutes": None, "total_hours": None, "total_days_decimal": None}
+    return {
+        "raw_duration_text": None,
+        "total_minutes": None,
+        "total_hours": None,
+        "total_days_decimal": None,
+    }
 
 
 def _null_material_row() -> dict:
@@ -163,12 +168,14 @@ async def test_low_confidence_escalates_to_fallback_model():
     calls = []
     speedups_primary = _null_values()
     speedups_primary["speedups"]["universal"] = {
+        "raw_duration_text": "1d 0h 0m",
         "total_minutes": 1440,
         "total_hours": 24.0,
         "total_days_decimal": 1.0,
     }
     speedups_fallback = _null_values()
     speedups_fallback["speedups"]["universal"] = {
+        "raw_duration_text": "2d 0h 0m",
         "total_minutes": 2880,
         "total_hours": 48.0,
         "total_days_decimal": 2.0,
@@ -200,6 +207,7 @@ async def test_low_confidence_escalates_to_fallback_model():
     assert result.fallback_used
     assert result.confidence_score == 0.94
     assert result.values["speedups"]["universal"]["total_minutes"] == 2880
+    assert result.values["speedups"]["universal"]["raw_duration_text"] == "2d 0h 0m"
     assert [call["model"] for call in calls] == ["gpt-4.1-mini", "gpt-5.2"]
 
 

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -183,7 +183,7 @@ async def test_speedups_use_fallback_model_as_first_pass_when_configured():
     }
     payloads = [
         {
-            "detected_image_type": "speedups",
+            "detected_image_type": "unknown",
             "confidence_score": 0.94,
             "warnings": [],
             "values": speedups_fallback,
@@ -206,6 +206,52 @@ async def test_speedups_use_fallback_model_as_first_pass_when_configured():
     assert result.values["speedups"]["universal"]["day_digits_text"] == "2"
     assert result.values["speedups"]["universal"]["day_digits_verification_text"] == "2"
     assert [call["model"] for call in calls] == ["gpt-5.2"]
+
+
+@pytest.mark.asyncio
+async def test_speedup_import_overrides_model_values_with_local_day_ocr(monkeypatch):
+    calls = []
+    speedups_fallback = _null_values()
+    speedups_fallback["speedups"]["training"] = {
+        "raw_duration_text": "938d",
+        "day_digits_text": "938",
+        "day_digits_verification_text": "938",
+        "total_minutes": 938 * 1440,
+        "total_hours": 938 * 24,
+        "total_days_decimal": 938.0,
+    }
+    payloads = [
+        {
+            "detected_image_type": "speedups",
+            "confidence_score": 0.94,
+            "warnings": [],
+            "values": speedups_fallback,
+        },
+    ]
+    monkeypatch.setattr(
+        "services.vision_client._speedup_day_values_from_image",
+        lambda _: {
+            "building": 1072,
+            "research": 1246,
+            "training": 940,
+            "healing": 505,
+            "universal": 2436,
+        },
+    )
+
+    client = InventoryVisionClient(
+        _config(),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    result = await client.analyse_image(b"fake image", import_type_hint="speedups")
+
+    assert result.ok
+    assert result.detected_image_type == "speedups"
+    assert result.values["speedups"]["training"]["raw_duration_text"] == "940d"
+    assert result.values["speedups"]["training"]["day_digits_text"] == "940"
+    assert result.values["speedups"]["training"]["total_minutes"] == 940 * 1440
+    assert result.values["speedups"]["training"]["total_days_decimal"] == 940.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -246,7 +246,7 @@ async def test_speedup_prompt_requests_day_digits_text():
 
 
 @pytest.mark.asyncio
-async def test_speedup_import_sends_zoomed_duration_crop():
+async def test_speedup_import_sends_labeled_zoom_sheet():
     pytest.importorskip("PIL")
     from PIL import Image
 
@@ -274,6 +274,7 @@ async def test_speedup_import_sends_zoomed_duration_crop():
     content = calls[0]["input"][0]["content"]
     image_parts = [item for item in content if item["type"] == "input_image"]
     assert len(image_parts) == 2
+    assert image_parts[1]["image_url"].startswith("data:image/png;base64,")
 
 
 def test_speedup_duration_crop_rejects_invalid_image():

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -10,6 +10,7 @@ import pytest
 from services.vision_client import (
     InventoryVisionClient,
     InventoryVisionConfig,
+    _detect_speedup_duration_row_bounds,
     _speedup_duration_crop_data_url,
     build_inventory_vision_schema,
 )
@@ -325,6 +326,23 @@ async def test_speedup_import_falls_back_to_original_image_when_crops_fail(monke
 
 def test_speedup_duration_crop_rejects_invalid_image():
     assert _speedup_duration_crop_data_url(b"not an image") is None
+
+
+def test_speedup_duration_row_detection_ignores_header_text():
+    pytest.importorskip("PIL")
+    from PIL import Image, ImageDraw
+
+    image = Image.new("L", (1000, 800), 0)
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((550, 150, 650, 170), fill=255)
+    expected_rows = []
+    for y in (260, 350, 440, 530, 620):
+        draw.rectangle((700, y, 880, y + 22), fill=255)
+        expected_rows.append((y, y + 22))
+
+    rows = _detect_speedup_duration_row_bounds(image.convert("RGB"), 550, 980)
+
+    assert rows == expected_rows
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_vision_client.py
+++ b/tests/test_inventory_vision_client.py
@@ -255,6 +255,50 @@ async def test_speedup_import_overrides_model_values_with_local_day_ocr(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_speedup_import_applies_local_day_ocr_without_hint(monkeypatch):
+    calls = []
+    speedups_fallback = _null_values()
+    speedups_fallback["speedups"]["universal"] = {
+        "raw_duration_text": "864d",
+        "day_digits_text": "864",
+        "day_digits_verification_text": "864",
+        "total_minutes": 864 * 1440,
+        "total_hours": 864 * 24,
+        "total_days_decimal": 864.0,
+    }
+    payloads = [
+        {
+            "detected_image_type": "speedups",
+            "confidence_score": 0.94,
+            "warnings": [],
+            "values": speedups_fallback,
+        },
+    ]
+    monkeypatch.setattr(
+        "services.vision_client._speedup_day_values_from_image",
+        lambda _: {
+            "building": 155,
+            "research": 319,
+            "training": 329,
+            "healing": 225,
+            "universal": 862,
+        },
+    )
+
+    client = InventoryVisionClient(
+        _config(),
+        client_factory=lambda _api_key: FakeClient(payloads, calls),
+    )
+
+    result = await client.analyse_image(b"fake image", import_type_hint=None)
+
+    assert result.ok
+    assert result.detected_image_type == "speedups"
+    assert result.values["speedups"]["universal"]["raw_duration_text"] == "862d"
+    assert result.values["speedups"]["universal"]["total_days_decimal"] == 862.0
+
+
+@pytest.mark.asyncio
 async def test_speedups_use_primary_model_when_no_fallback_is_configured():
     calls = []
     speedups = _null_values()


### PR DESCRIPTION
## Summary

Follow-up to the Phase 1D speedups polish after live smoke testing showed the day-only prompt still dropped leading/thousands digits in calculated speedup day values.

## Changes

- Adds `raw_duration_text` to the strict speedup vision schema.
- Updates the Speedups prompt to transcribe the exact visible Total Duration text first, preserving commas and leading digits.
- Makes Python prefer `raw_duration_text` when deriving whole-day speedup values, falling back to numeric fields only when raw text is unavailable.
- Keeps hours/minutes ignored for calculations while preserving the visible raw text for safer parsing/audit payloads.
- Adds regression coverage using the bad capture pattern: numeric fields like `742`, `123`, `93`, `50` are overridden by raw text such as `1,068d 11h 36m` and `1,242d 3h 35m`.

## Validation

- `python -m pytest -q tests/test_inventory_parsing.py tests/test_inventory_vision_client.py tests/test_inventory_views.py tests/test_inventory_service.py tests/test_inventory_upload_flow.py` -> `35 passed`
- `python -m py_compile inventory/parsing.py services/vision_client.py inventory/inventory_service.py ui/views/inventory_views.py`
- `python -m ruff check inventory/parsing.py services/vision_client.py tests/test_inventory_parsing.py tests/test_inventory_vision_client.py`
- `python -m black --check inventory/parsing.py services/vision_client.py tests/test_inventory_parsing.py tests/test_inventory_vision_client.py`
- `python scripts/validate_command_registration.py`
- `git diff --check`

## Notes

No SQL schema changes. Materials and `/my_stats` integration remain out of scope.