### PR TITLE
[codex] finish inventory phase 1e polish

### DIFF
--- a/commands/inventory_cmds.py
+++ b/commands/inventory_cmds.py
@@ -9,8 +9,11 @@ from bot_config import ADMIN_USER_ID, GUILD_ID, INVENTORY_UPLOAD_CHANNEL_ID
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import _is_admin, track_usage
 from inventory import audit_service, export_service, reporting_service
-from inventory.models import InventoryAuditRecord, InventoryReportVisibility
-from ui.views.inventory_report_views import start_myinventory_command
+from inventory.models import InventoryAuditRecord
+from ui.views.inventory_report_views import (
+    send_inventory_preference_prompt,
+    start_myinventory_command,
+)
 from ui.views.inventory_views import start_import_command
 from versioning import versioned
 
@@ -72,49 +75,11 @@ def register_inventory(bot: ext_commands.Bot) -> None:
     @versioned("v1.00")
     @safe_command
     @track_usage()
-    async def myinventory(
-        ctx: discord.ApplicationContext,
-        governor: int | None = discord.Option(
-            int,
-            "Governor ID to view (optional if you have one registered governor)",
-            required=False,
-            default=None,
-        ),
-        view: str = discord.Option(
-            str,
-            "Inventory view",
-            choices=["Resources", "Speedups", "All"],
-            required=False,
-            default="All",
-        ),
-        report_range: str = discord.Option(
-            str,
-            "Report range",
-            name="range",
-            choices=["1M", "3M", "6M", "12M"],
-            required=False,
-            default="1M",
-        ),
-        visibility: str | None = discord.Option(
-            str,
-            "Output visibility; saved as your default when changed",
-            choices=["Only Me", "Public Output Channel"],
-            required=False,
-            default=None,
-        ),
-    ) -> None:
+    async def myinventory(ctx: discord.ApplicationContext) -> None:
         try:
-            report_view = reporting_service.parse_report_view(view)
-            parsed_range = reporting_service.parse_report_range(report_range)
-            selected_visibility = reporting_service.parse_visibility(visibility)
-            final_visibility = await reporting_service.resolve_visibility(
-                discord_user_id=int(ctx.user.id),
-                selected_visibility=selected_visibility,
+            final_visibility = await reporting_service.get_visibility_preference_or_none(
+                int(ctx.user.id)
             )
-        except ValueError as exc:
-            await safe_defer(ctx, ephemeral=True)
-            await ctx.followup.send(str(exc), ephemeral=True)
-            return
         except Exception:
             logger.exception("myinventory_preference_resolution_failed actor=%s", ctx.user.id)
             await safe_defer(ctx, ephemeral=True)
@@ -124,13 +89,15 @@ def register_inventory(bot: ext_commands.Bot) -> None:
             )
             return
 
-        await safe_defer(ctx, ephemeral=final_visibility == InventoryReportVisibility.ONLY_ME)
+        if final_visibility is None:
+            await safe_defer(ctx, ephemeral=True)
+            await send_inventory_preference_prompt(ctx)
+            return
+
+        await safe_defer(ctx, ephemeral=True)
         try:
             await start_myinventory_command(
                 ctx=ctx,
-                governor_id=governor,
-                report_view=report_view,
-                range_key=parsed_range,
                 visibility=final_visibility,
             )
         except PermissionError as exc:
@@ -139,14 +106,25 @@ def register_inventory(bot: ext_commands.Bot) -> None:
             await ctx.followup.send(str(exc), ephemeral=True)
         except Exception:
             logger.exception(
-                "myinventory_command_failed actor=%s governor=%s",
+                "myinventory_command_failed actor=%s",
                 ctx.user.id,
-                governor,
             )
             await ctx.followup.send(
                 "Inventory report generation failed. Please try again or contact an admin.",
                 ephemeral=True,
             )
+
+    @bot.slash_command(
+        name="inventory_preferences",
+        description="Choose whether inventory reports are private or public",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def inventory_preferences(ctx: discord.ApplicationContext) -> None:
+        await safe_defer(ctx, ephemeral=True)
+        await send_inventory_preference_prompt(ctx)
 
     @bot.slash_command(
         name="export_inventory",

--- a/docs/Codex Task Pack — Inventory Image Import Module.md
+++ b/docs/Codex Task Pack — Inventory Image Import Module.md
@@ -8,6 +8,10 @@ Phase 1A is complete, tested, and deployed.
 
 Phase 1B is complete, tested, and deployed.
 
+Phase 1C is complete, tested, and deployed.
+
+Phase 1D is complete, tested, and deployed.
+
 Phase 0 delivered:
 
 - OpenAI Vision API setup documented in `docs/inventory_image_import_setup.md`.
@@ -91,6 +95,28 @@ Phase 1B validation:
 - Phase 1B has been tested and deployed.
 - Reporting service, image renderer, and report view test coverage added.
 
+Phase 1C delivered:
+
+- `/export_inventory` raw inventory exports.
+- `/inventory_import_audit` admin audit tooling.
+- Export and audit logic kept behind service/DAL boundaries.
+- Admin audit/debug reference access for import review.
+- Interaction boundary hardening follow-up.
+- Materials kept disabled until Phase 2.
+
+Phase 1D delivered:
+
+- Account picker wording and stale interaction cleanup.
+- User-safe typed correction modals for Resources and Speedups.
+- Inventory Import Review embed cleanup.
+- Corrected-review update clarity.
+- Reject/cancel simplification.
+- Terminal button state updates after approve, correct, reject, cancel, and timeout paths where covered.
+- `/myinventory` reporting preference runtime issue fixed.
+- Same-day duplicate import enforcement with admin override preserved.
+- Speedup import OCR accuracy hardened with deterministic days-only OCR from generated row crops.
+- Six saved speedup smoke-test images validated successfully after the deterministic OCR fix.
+
 Phase 0 sample validation:
 
 - `python scripts\test_inventory_vision.py C:\rok\rss_sample.png --type resources`
@@ -136,8 +162,9 @@ Development is split into:
 - Phase 0 - OpenAI Vision Integration Setup: complete and deployed.
 - Phase 1A - Foundation + Resources/Speedups Import: complete, tested, and deployed.
 - Phase 1B - Inventory reporting images and visibility preferences: complete, tested, and deployed.
-- Phase 1C - Inventory export, admin audit, and interaction boundary hardening: next phase.
-- Phase 1D - Final Resources/Speedups completion polish: planned follow-on.
+- Phase 1C - Inventory export, admin audit, and interaction boundary hardening: complete, tested, and deployed.
+- Phase 1D - Final Resources/Speedups completion polish: complete, tested, and deployed.
+- Phase 1E - Final Phase 1 smoke testing and report polish: next phase.
 - Phase 2 - Materials Import: later phase.
 
 Work must proceed phase by phase. The next phase should begin with review/scope only per repository rules.
@@ -275,8 +302,8 @@ Add:
 
 - `/import_inventory` - complete in Phase 1A.
 - `/myinventory` - complete in Phase 1B.
-- `/export_inventory` - Phase 1C.
-- `/inventory_import_audit` - Phase 1C.
+- `/export_inventory` - complete in Phase 1C.
+- `/inventory_import_audit` - complete in Phase 1C.
 
 Commands must live in the target architecture, likely `commands/inventory_cmds.py`, with business logic in service modules and data access in DAL/repository modules.
 
@@ -354,7 +381,7 @@ Discord cannot convert a public user message into an ephemeral/private message a
 
 Status: partially complete in Phase 1A.
 
-Phase 1A supports rejecting imports and admin debug retention. Phase 1C should review whether a richer same-session retry UX is still needed now that upload-first and command-led uploads share the inventory channel.
+Phase 1A supports rejecting imports and admin debug retention. Phase 1C reviewed the export/audit boundaries. Phase 1E should smoke test reject, cancel, timeout, and repeat-upload behaviour end to end.
 
 If user selects Reject Import:
 
@@ -599,7 +626,7 @@ Output behaviour:
 
 ### `/export_inventory`
 
-Status: Phase 1C.
+Status: complete in Phase 1C.
 
 Purpose:
 
@@ -743,9 +770,9 @@ Speedups output should show:
 
 ## Phase 1C - Export, Audit, and Boundary Hardening
 
-Phase 1C should be a linked follow-on PR after Phase 1B, not an untracked deferred optimisation.
+Phase 1C is complete, tested, and deployed.
 
-Recommended scope:
+Delivered scope:
 
 - `/export_inventory`
 - `/inventory_import_audit`
@@ -763,61 +790,103 @@ Boundary hardening goals:
 - Preserve Phase 1A behaviour while tightening layer ownership.
 - Reassess whether same-session retry after reject needs richer UX or whether upload-first replacement is sufficient.
 
-Phase 1C should remain Materials-free. Materials belong to Phase 2.
+Phase 1C remained Materials-free. Materials belong to Phase 2.
 
 ## Phase 1D - Final Resources/Speedups Completion Polish
 
-Phase 1D should be a small follow-on phase after Phase 1C to finish the remaining
-Resources and Speedups user-experience surface before declaring Phase 1 complete.
+Phase 1D is complete, tested, and deployed.
 
-Recommended scope:
+Delivered scope:
 
-- Add export buttons under `/myinventory` report output where appropriate.
-- Reuse the `/export_inventory` service/DAL path rather than adding export SQL or file generation to views.
-- Perform targeted OCR/prompt tuning for Resources and Speedups only, based on production smoke-test failures or recurring admin-audit findings.
-- Review the Phase 1A/1B/1C scenario matrix end to end for Resources and Speedups:
-  - no registered governors
-  - governor selector timeout/no approval
-  - reject then repeat import
-  - same-day duplicate approved import
-  - random/unknown image
-  - Materials-disabled image
-  - export/audit access and empty-data handling
-- Fix production smoke-test UX issues from Phase 1C deployment:
-  - shared account picker dropdown placeholder says `Choose an account to view...`; change to a generic `Select Governor` so it fits inventory, stats, and targets flows.
-  - after a governor is selected, the old picker remains active and stale select/lookup/refresh interactions can fail; disable or update the picker after successful selection.
-  - user-facing Inventory Import Review embeds show model/fallback details that should remain admin-only.
-  - detected Resources/Speedups values need user-friendly formatting; speedups should show days/hours/minutes or rounded days only, not raw minute totals.
-  - raw JSON correction is too error-prone for normal users; replace it with typed correction fields for the detected import type.
-  - corrected data is currently shown in a separate message, making it unclear that the original import must still be approved; update the original review message and make the approval state explicit.
-  - Reject Import and Cancel Import are unclear as separate user actions; simplify or clearly distinguish them based on audit/debug retention needs.
-  - buttons can remain clickable after terminal actions and produce failed interactions; ensure controls are disabled/updated after approve, correct, reject, cancel, and timeout.
-- Fix OCR/prompt accuracy issues observed in Phase 1C smoke testing:
-  - speedup screenshots can return high confidence (`0.95`-`0.98`) while one or more rows are materially wrong.
-  - observed example: Healing Speedup should be read as `505d 3h 37m`, but was detected as about `50.52` days / `72,757` minutes.
-  - the same screenshot may fail or produce different results across attempts/model versions, so confidence alone is not sufficient as a correctness signal.
-  - add deterministic post-OCR validation and anomaly checks for speedup rows, especially missing hundreds/thousands digits and mismatches between days/hours/minutes and total minutes.
-- Fix same-day duplicate import enforcement:
-  - Phase 1 smoke testing allowed multiple approved imports for the same governor/import type/day.
-  - preserve an admin override for repeated same-day imports because it is useful for testing and correction workflows.
-  - normal users should be blocked from approving a second import of the same type for the same governor on the same UTC day.
-- Investigate `/myinventory` runtime failure:
-  - `/myinventory` should work after Phase 1B for Resources and Speedups reports.
-  - observed response: `Inventory reporting preferences are not available yet. Please contact an admin.`
-  - likely area to check first: `dbo.InventoryReportPreference` deployment/permissions and `inventory_reporting_dal.fetch_visibility_preference`.
-  - preserve the persistent visibility preference behaviour; if the preference table is unavailable, return a clearer admin-facing diagnostic in logs and a useful user-facing fallback where safe.
-- Confirm documentation and user-facing guidance are aligned with final Phase 1 behaviour.
+- Account picker placeholder wording changed to fit inventory, stats, and target flows.
+- Account picker stale interactions cleaned up after governor selection.
+- Inventory Import Review embed simplified for user-facing review.
+- Resource correction moved from raw JSON to typed total-resource correction fields.
+- Speedup correction moved from raw JSON to typed days-only correction fields.
+- Corrected review updates now edit the original review and keep approval state clear.
+- Reject/cancel interaction was simplified for normal users.
+- Terminal import button states were updated for approve/correct/reject/cancel paths where covered.
+- Same-day duplicate import enforcement was fixed for normal users, with admin override preserved.
+- `/myinventory` reporting preference runtime failure was fixed.
+- Speedup OCR was made deterministic for the Phase 1 speedup screen:
+  - row crops are generated from the value column
+  - only the day token is sent for model review
+  - a local deterministic OCR pass reads the generated day-token crops
+  - the local OCR pass is applied even when upload-first detection did not pass a speedup type hint
+- Six saved speedup smoke-test images passed final validation:
+  - test image 1: `1068 / 1242 / 935 / 503 / 2422`
+  - test image 2: `1072 / 1246 / 940 / 505 / 2436`
+  - test image 3: `155 / 319 / 329 / 225 / 862`
+  - test image 4: `1072 / 1246 / 940 / 505 / 2436`
+  - test image 5: `1075 / 1249 / 946 / 507 / 2448`
+  - test image 6: `122 / 193 / 324 / 87 / 370`
 
-Out of scope for Phase 1D:
+Phase 1D deferred/carry-forward items:
+
+- Final end-to-end smoke testing across Resources and Speedups should move to Phase 1E.
+- A timeout bug remains where the Inventory Import Review buttons can stay active after expiry and lead to `Interaction failed`; the active upload session can then strand the user with no approve/correct/reject/cancel path.
+- The "significantly different from previous import" double-check does not appear to trigger for Speedups and needs review.
+- `/myinventory` report image polish remains:
+  - add x/y axis scales to Resources and Speedups graphs
+  - ensure Resources graph uses distinct colours for Food, Wood, Stone, and Gold
+  - fix text fitting in RSS Troop Training Capacity and RSS Troop Healing Capacity boxes
+  - align separator lines so they do not cut through value/delta text
+
+Out of scope for Phase 1D and Phase 1E:
 
 - Materials processing or reporting.
 - `/my_stats` integration.
 - The stats export SQL refactor tracked by GitHub issue #46.
-- Broad OCR redesign beyond targeted Resources/Speedups tuning.
+- Broad OCR redesign beyond targeted Resources/Speedups tuning unless Phase 1E smoke tests reveal a concrete regression.
 
-Phase 1 for Resources and Speedups should be considered complete only after Phase 1D
-validates import, report, export, audit, retry/repeat, and targeted OCR/prompt behaviour
-against the documented scenario matrix.
+## Phase 1E - Final Phase 1 Smoke Testing and Report Polish
+
+Phase 1E should be a small final follow-on phase before declaring Phase 1 fully complete.
+
+Primary goal:
+
+- Smoke test the complete Resources and Speedups import/report/export/audit flow after Phase 1D.
+- Re-test Resources import because it has not been exercised recently.
+- Fix the remaining small bugs and report-image presentation issues found during final smoke testing.
+
+Recommended scope:
+
+- Begin with audit/scope only per repository rules.
+- Re-run the final Resources and Speedups scenario matrix:
+  - upload-first single-governor flow
+  - upload-first multi-governor account picker
+  - `/import_inventory` command-led flow
+  - correction modal flow
+  - approve flow
+  - reject/cancel flow
+  - timeout/no-response flow
+  - same-day duplicate approved import
+  - admin duplicate override
+  - random/unknown image
+  - Materials-disabled image
+  - `/myinventory` Resources output
+  - `/myinventory` Speedups output
+  - `/export_inventory`
+  - `/inventory_import_audit`
+- Fix Inventory Import Review timeout handling:
+  - disable or expire review buttons when the interaction times out
+  - ensure stale button clicks return a clear message instead of `Interaction failed`
+  - ensure expired active upload sessions are cleaned up so users can retry without admin intervention
+- Recheck the significant-change double-confirmation logic:
+  - verify Resources and Speedups compare against the latest approved values
+  - ensure materially different Speedup values trigger the intended warning/confirmation
+  - keep normal small deltas frictionless
+- Improve `/myinventory` report readability:
+  - add x-axis and y-axis scale labels/ticks to Resources and Speedups graphs
+  - use clearly distinct Resources graph colours for Food, Wood, Stone, and Gold
+  - fix RSS Troop Training Capacity text wrapping/fitting
+  - fix RSS Troop Healing Capacity text wrapping/fitting
+  - align value/delta separator lines so they do not cut through text
+- Confirm final documentation and user-facing guidance are aligned with Phase 1 behaviour.
+
+Phase 1 should be considered fully complete only after Phase 1E validates import,
+report, export, audit, retry/repeat, timeout, duplicate, and targeted OCR behaviour
+against the documented Resources/Speedups scenario matrix.
 
 ## Phase 2 - Materials
 
@@ -932,7 +1001,7 @@ Add:
 
 Admin only.
 
-Status: Phase 1C.
+Status: complete in Phase 1C.
 
 Purpose:
 
@@ -1008,9 +1077,9 @@ Completed Phase 1B audit points:
 
 ### Phase 1C
 
-Next phase.
+Complete, tested, and deployed.
 
-Recommended scope:
+Delivered scope:
 
 - `/export_inventory`
 - `/inventory_import_audit`
@@ -1028,13 +1097,39 @@ Recommended Phase 1C audit points:
 
 ### Phase 1D
 
-Planned follow-on phase.
+Complete, tested, and deployed.
+
+Delivered scope:
+
+- Account picker wording/stale interaction cleanup.
+- Typed correction modals for Resources and Speedups.
+- Inventory Import Review embed cleanup and corrected-review clarity.
+- Reject/cancel simplification.
+- Same-day duplicate import enforcement fix with admin override preserved.
+- `/myinventory` reporting preference runtime fix.
+- Deterministic Speedup day OCR based on generated days-only crops.
+
+Do not include:
+
+- Materials processing.
+- `/my_stats` integration.
+- Stats export SQL refactor work tracked by GitHub issue #46.
+
+### Phase 1E
+
+Next phase.
 
 Recommended scope:
 
-- `/myinventory` export buttons wired to the Phase 1C export service/DAL path.
-- Targeted Resources/Speedups OCR and prompt tuning based on smoke-test/audit evidence.
-- Final Phase 1 Resources/Speedups scenario validation and documentation alignment.
+- Final Resources and Speedups smoke testing.
+- Re-test Resources import accuracy and correction flow.
+- Fix Inventory Import Review timeout/stale button handling.
+- Recheck significant-change double-confirmation behaviour.
+- Polish `/myinventory` Resources and Speedups report image readability:
+  - graph x/y axis scales
+  - distinct Resources colours
+  - capacity-box text fitting
+  - separator-line alignment
 
 Do not include:
 
@@ -1080,6 +1175,13 @@ Do not include in Phase 1C:
 - Export button under image
 - Further OCR/prompt tuning unless a Phase 1A production issue specifically requires it
 
+Do not include in Phase 1E:
+
+- Materials processing
+- `/my_stats` integration
+- Stats export SQL refactor work tracked by GitHub issue #46
+- Broad OCR redesign unless final smoke testing finds a concrete Resources/Speedups regression
+
 Downstream task:
 
 - Integrate inventory summaries into existing `/my_stats` or future refactored `/my_stats` experience.
@@ -1105,5 +1207,5 @@ Do not create a duplicate issue for this item. Reference issue #46 whenever Phas
 ## Suggested Next Chat Opening Prompt
 
 ```text
-Start Phase 1C review/scope for the Inventory Image Import Module. Phase 0, Phase 1A, and Phase 1B are complete, tested, and deployed. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 1A delivered /import_inventory, upload-first import in INVENTORY_UPLOAD_CHANNEL_ID, Vision-derived image type, Resources/Speedups SQL-backed imports, correction/reject/cancel flow, and admin debug channel retention. Phase 1B delivered /myinventory, generated Resources/Speedups report images, 1M/3M/6M/12M range controls, summary-only output for one approved record, trend graphs for two or more approved records, and persistent visibility preference. For Phase 1C, assess and scope /export_inventory, /inventory_import_audit, raw inventory export files, admin audit filtering/debug-message reference access, and targeted cleanup of Phase 1A inventory view/service boundaries. Keep commands thin, use service/DAL boundaries, do not copy the direct SQL pattern from /my_stats_export, reference GitHub issue #46 for the existing stats export SQL refactor, keep Materials out of scope until Phase 2, and begin with audit/scope only per repo rules.
+Start Phase 1E review/scope for the Inventory Image Import Module. Phase 0, Phase 1A, Phase 1B, Phase 1C, and Phase 1D are complete, tested, and deployed. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 1D completed final Resources/Speedups import polish, including account picker wording/stale interaction cleanup, typed correction modals, Inventory Import Review embed cleanup, corrected-review clarity, reject/cancel simplification, same-day duplicate import enforcement with admin override preserved, /myinventory reporting preference repair, and deterministic days-only Speedup OCR validated against six saved smoke-test images. Phase 1E should focus on final Resources/Speedups smoke testing and report polish before declaring Phase 1 complete. Re-test Resources import because it has not been exercised recently. Carry forward these known issues: Inventory Import Review timeout leaves active buttons and can strand an active upload session; significant-change double-confirmation for Speedups does not appear to trigger; /myinventory graphs need x/y axis scales; Resources graph colours need clearer Food/Wood/Stone/Gold separation; RSS Troop Training Capacity and RSS Troop Healing Capacity text needs to fit cleanly; value/delta separator lines need alignment so they do not cut through text. Keep Materials out of scope until Phase 2. Keep /my_stats integration out of scope. Keep the stats export SQL refactor out of scope and continue referencing GitHub issue #46 for that existing debt. Begin with audit/scope only per repo rules, then stop for architecture validation before coding.
 ```

--- a/docs/Codex Task Pack — Inventory Image Import Module.md
+++ b/docs/Codex Task Pack — Inventory Image Import Module.md
@@ -12,6 +12,15 @@ Phase 1C is complete, tested, and deployed.
 
 Phase 1D is complete, tested, and deployed.
 
+Phase 1E is complete and ready for full user launch.
+
+Plan after Phase 1:
+
+- Launch Phase 1 fully to users before starting Phase 2.
+- Use the live launch/soak period to capture any Resources or Speedups import/report/audit issues.
+- Start Phase 2 after the launch soak with Materials as a separately scoped phase.
+- Add Phase 3 for Action Points (AP) as a separately scoped phase after Materials planning is clear.
+
 Phase 0 delivered:
 
 - OpenAI Vision API setup documented in `docs/inventory_image_import_setup.md`.
@@ -117,6 +126,24 @@ Phase 1D delivered:
 - Speedup import OCR accuracy hardened with deterministic days-only OCR from generated row crops.
 - Six saved speedup smoke-test images validated successfully after the deterministic OCR fix.
 
+Phase 1E delivered:
+
+- Final Resources and Speedups smoke testing and report polish.
+- Resources import re-tested after a gap in recent smoke coverage.
+- Inventory Import Review timeout/deletion repaired so users can retry after expiry.
+- Expired/stale review interaction failures cleaned up.
+- Significant-change double-confirmation smoke tested for Speedups and passed.
+- `/myinventory` Resources and Speedups y-axis scaling fixed to start from zero and scale to visible values.
+- `/myinventory` graph rendering changed from confusing stacked areas to transparent overlays with visible series lines.
+- Resources graph colours separated more clearly for Food, Wood, Stone, and Gold.
+- RSS Troop Training Capacity and RSS Troop Healing Capacity text fitting improved.
+- KPI value/delta separator lines aligned so they do not cut through text.
+- Inventory review reduced to a single `Cancel Import` path alongside `Approve Import` and `Correct Data`.
+- Upload-first original image retention changed so users can compare detected values before approving/cancelling.
+- `/myinventory` command simplified into guided governor/output selectors, with report range handled by buttons.
+- `/inventory_preferences` added and first-run report visibility preference flow enforced.
+- `/myinventory` selector now disables after `Show Report` to prevent second-use interaction failures.
+
 Phase 0 sample validation:
 
 - `python scripts\test_inventory_vision.py C:\rok\rss_sample.png --type resources`
@@ -164,10 +191,11 @@ Development is split into:
 - Phase 1B - Inventory reporting images and visibility preferences: complete, tested, and deployed.
 - Phase 1C - Inventory export, admin audit, and interaction boundary hardening: complete, tested, and deployed.
 - Phase 1D - Final Resources/Speedups completion polish: complete, tested, and deployed.
-- Phase 1E - Final Phase 1 smoke testing and report polish: next phase.
-- Phase 2 - Materials Import: later phase.
+- Phase 1E - Final Phase 1 smoke testing and report polish: complete and ready for full user launch.
+- Phase 2 - Materials Import: next build phase after Phase 1 launch/soak.
+- Phase 3 - Action Points (AP) Import: later phase after Materials scope is validated.
 
-Work must proceed phase by phase. The next phase should begin with review/scope only per repository rules.
+Work must proceed phase by phase. Phase 1 should launch fully to users before Phase 2 begins. The next build phase should begin with review/scope only per repository rules.
 
 ## Phase 0 - OpenAI Vision Integration Setup
 
@@ -347,12 +375,11 @@ Status: complete in Phase 1A.
 9. User chooses:
    - Approve Import
    - Correct Data
-   - Reject Import
    - Cancel Import
 10. On approval, bot writes values to SQL with timestamp/history.
 11. Bot generates output image if at least two approved records exist.
 
-The normal flow must not ask the user to choose Resources vs Speedups before analysis. The user can correct or reject the detected result, and every avoidable click should be removed from the import path.
+The normal flow must not ask the user to choose Resources vs Speedups before analysis. The user can correct detected values or cancel the import if the image/result is wrong, and every avoidable click should be removed from the import path.
 
 If the detected type is Materials during Phase 1, the bot must explain that Materials import is not available yet and no inventory values are written.
 
@@ -371,25 +398,25 @@ Users may start an import by uploading an image directly in the configured inven
 7. If multiple registered governors exist, bot asks which governor the image is for using the standard account selector.
 8. Once the governor is confirmed, bot deletes the original public upload message when it has permission to reduce the public visibility window.
 9. If the user does not respond to the governor-selection follow-up before timeout, bot deletes the original public upload message when it has permission and exits cleanly.
-10. After governor confirmation, the same vision analysis, confirmation, correction, reject, approval, daily limit, and debug retention rules as `/import_inventory` apply.
+10. After governor confirmation, the same vision analysis, confirmation, correction, cancellation, approval, daily limit, and debug retention rules as `/import_inventory` apply.
 
 Upload-first detection must never run outside `INVENTORY_UPLOAD_CHANNEL_ID`.
 
-Discord cannot convert a public user message into an ephemeral/private message after it has been posted. The intended privacy mitigation is to read the image, capture the needed bytes/source metadata, then delete the original upload message after governor confirmation or after timeout where permissions allow.
+Discord cannot convert a public user message into an ephemeral/private message after it has been posted. The intended privacy/usability balance is to read the image, capture the needed bytes/source metadata, keep the original upload visible during review for comparison, then delete it after approval, cancellation, or selector timeout where permissions allow.
 
-### Reject / Retry Flow
+### Cancel / Retry Flow
 
-Status: partially complete in Phase 1A.
+Status: complete in Phase 1E for Phase 1 Resources/Speedups behaviour.
 
-Phase 1A supports rejecting imports and admin debug retention. Phase 1C reviewed the export/audit boundaries. Phase 1E should smoke test reject, cancel, timeout, and repeat-upload behaviour end to end.
+Phase 1E consolidated normal-user rejection/cancellation into a single `Cancel Import` action to reduce confusion.
 
-If user selects Reject Import:
+If user selects Cancel Import:
 
-1. Mark batch as rejected.
-2. Post retained debug image and metadata to the admin debug channel.
+1. Mark batch as cancelled.
+2. Post retained debug image and metadata to the admin debug channel where useful for import issue review.
 3. Show screenshot guidelines and example image guidance for the selected import type.
-4. Allow one retry in the same session.
-5. If retry is rejected or fails, exit cleanly.
+4. Delete the original upload message where permissions allow.
+5. Let the user upload a replacement screenshot as a fresh import.
 6. No SQL inventory values are written unless approved.
 
 ### Locking
@@ -425,11 +452,12 @@ Command-led uploads should only ever be visible to:
 - the uploading user
 - admins
 
-Upload-first images are initially visible in the configured inventory channel because they are user-posted public messages. The bot should minimise the visibility window:
+Upload-first images are initially visible in the configured inventory channel because they are user-posted public messages. The bot should balance privacy with review usability:
 
-- Delete the original public upload message after governor confirmation and byte capture where permissions allow.
+- Keep the original public upload message visible during the import review so the user can compare the detected values to the uploaded image.
+- Delete the original public upload message after approval or cancellation where permissions allow.
 - Delete the original public upload message after selection timeout where permissions allow.
-- Continue the remaining workflow through ephemeral/private interaction responses where possible.
+- Continue the remaining workflow through owner-guarded interactions and private responses where possible.
 - Do not retain the original image after successful approved import unless debug/audit retention is required.
 
 ### Image Retention Decision
@@ -441,7 +469,7 @@ Default:
 Retain/log for admin debug if:
 
 - image analysis failed
-- image was rejected
+- image was cancelled after review
 - values were corrected
 - very large correction warning was triggered
 
@@ -590,29 +618,36 @@ SQL schema changes belong in the SQL Server repository, not only in Python.
 
 ### `/myinventory`
 
-Status: complete in Phase 1B.
+Status: complete in Phase 1B and simplified/polished in Phase 1E.
 
 Purpose:
 
 View latest generated inventory summary image.
 
-Options:
+Current user flow:
 
-- governor: optional
-- view: Resources / Speedups / Materials / All
-- range: 1M / 3M / 6M / 12M
-- visibility: Only Me / Public Output Channel
+- `/myinventory` has no manual slash-command options.
+- On first use, users must set report visibility preference:
+  - Only Me
+  - Public
+- Users can change report visibility later with `/inventory_preferences`.
+- If the user has more than one registered governor, show a governor dropdown selector.
+- Always show an output dropdown selector:
+  - All
+  - RSS
+  - Speedups
+- Materials and AP can be added to the output selector in later phases.
+- Report range is controlled by the report buttons:
+  - 1M
+  - 3M
+  - 6M
+  - 12M
 
 Visibility preference must be persistent.
 
 Once selected, it becomes the default until changed. Do not ask every time.
 
-Output image buttons:
-
-- 1M
-- 3M
-- 6M
-- 12M
+The `/myinventory` selector must disable itself after `Show Report` so users cannot accidentally run a second selection from the same selector and trigger a stale interaction failure.
 
 Do not add:
 
@@ -823,14 +858,8 @@ Delivered scope:
 
 Phase 1D deferred/carry-forward items:
 
-- Final end-to-end smoke testing across Resources and Speedups should move to Phase 1E.
-- A timeout bug remains where the Inventory Import Review buttons can stay active after expiry and lead to `Interaction failed`; the active upload session can then strand the user with no approve/correct/reject/cancel path.
-- The "significantly different from previous import" double-check does not appear to trigger for Speedups and needs review.
-- `/myinventory` report image polish remains:
-  - add x/y axis scales to Resources and Speedups graphs
-  - ensure Resources graph uses distinct colours for Food, Wood, Stone, and Gold
-  - fix text fitting in RSS Troop Training Capacity and RSS Troop Healing Capacity boxes
-  - align separator lines so they do not cut through value/delta text
+- All Phase 1D carry-forward items were completed in Phase 1E.
+- No open Phase 1 Resources/Speedups launch blockers remain in this task pack.
 
 Out of scope for Phase 1D and Phase 1E:
 
@@ -841,56 +870,56 @@ Out of scope for Phase 1D and Phase 1E:
 
 ## Phase 1E - Final Phase 1 Smoke Testing and Report Polish
 
-Phase 1E should be a small final follow-on phase before declaring Phase 1 fully complete.
+Phase 1E is complete and ready for full user launch.
 
-Primary goal:
+Delivered scope:
 
-- Smoke test the complete Resources and Speedups import/report/export/audit flow after Phase 1D.
-- Re-test Resources import because it has not been exercised recently.
-- Fix the remaining small bugs and report-image presentation issues found during final smoke testing.
+- Final end-to-end Resources and Speedups smoke testing.
+- Resources import re-tested and confirmed after not being exercised recently.
+- Inventory Import Review timeout repaired:
+  - review buttons expire/delete cleanly
+  - users can retry after expiry
+  - stale interactions no longer strand an active upload session
+- Significant-change double-confirmation smoke tested for Speedups and passed.
+- `/myinventory` report readability improved:
+  - y-axis scale starts at zero and is based on visible values
+  - x/y axis labels added for Resources and Speedups graphs
+  - Resources colours made more distinct for Food, Wood, Stone, and Gold
+  - graph rendering uses transparent overlays with visible series lines rather than stacked totals
+  - RSS Troop Training Capacity and RSS Troop Healing Capacity text fitting improved
+  - value/delta separator lines aligned
+- Import review simplified:
+  - removed separate `Reject Import` button
+  - retained `Approve Import`, `Correct Data`, and `Cancel Import`
+  - cancellation preserves admin debug context and allows replacement uploads
+- Upload-first review improved:
+  - original uploaded image remains visible during review for comparison
+  - original upload is deleted after approval or cancellation where permissions allow
+  - account-picker/long-analysis webhook expiry handled without significant failure
+- `/myinventory` flow simplified:
+  - no manual slash options
+  - first-run report visibility preference required before report posting
+  - `/inventory_preferences` added for later preference changes
+  - guided governor selector used when more than one governor is registered
+  - output selector supports `All`, `RSS`, and `Speedups`
+  - selector disables after `Show Report` to prevent second-use interaction failures
 
-Recommended scope:
+Phase 1 launch decision:
 
-- Begin with audit/scope only per repository rules.
-- Re-run the final Resources and Speedups scenario matrix:
-  - upload-first single-governor flow
-  - upload-first multi-governor account picker
-  - `/import_inventory` command-led flow
-  - correction modal flow
-  - approve flow
-  - reject/cancel flow
-  - timeout/no-response flow
-  - same-day duplicate approved import
-  - admin duplicate override
-  - random/unknown image
-  - Materials-disabled image
-  - `/myinventory` Resources output
-  - `/myinventory` Speedups output
-  - `/export_inventory`
-  - `/inventory_import_audit`
-- Fix Inventory Import Review timeout handling:
-  - disable or expire review buttons when the interaction times out
-  - ensure stale button clicks return a clear message instead of `Interaction failed`
-  - ensure expired active upload sessions are cleaned up so users can retry without admin intervention
-- Recheck the significant-change double-confirmation logic:
-  - verify Resources and Speedups compare against the latest approved values
-  - ensure materially different Speedup values trigger the intended warning/confirmation
-  - keep normal small deltas frictionless
-- Improve `/myinventory` report readability:
-  - add x-axis and y-axis scale labels/ticks to Resources and Speedups graphs
-  - use clearly distinct Resources graph colours for Food, Wood, Stone, and Gold
-  - fix RSS Troop Training Capacity text wrapping/fitting
-  - fix RSS Troop Healing Capacity text wrapping/fitting
-  - align value/delta separator lines so they do not cut through text
-- Confirm final documentation and user-facing guidance are aligned with Phase 1 behaviour.
-
-Phase 1 should be considered fully complete only after Phase 1E validates import,
-report, export, audit, retry/repeat, timeout, duplicate, and targeted OCR behaviour
-against the documented Resources/Speedups scenario matrix.
+- Phase 1 is complete.
+- Fully launch Phase 1 to users before starting Materials.
+- Use the post-launch soak period to capture any real-world Resources/Speedups issues.
+- Keep Materials out of launch fixes unless a production issue requires defensive handling.
 
 ## Phase 2 - Materials
 
 Materials remain disabled in Phase 1.
+
+Phase 2 should begin only after Phase 1 is fully launched to users and has had a short production soak period.
+
+Phase 2 should begin with review/scope only per repository rules, then stop for architecture validation before coding.
+
+Do not include Action Points (AP) in Phase 2 unless explicitly re-scoped. AP is planned as Phase 3.
 
 ### Materials Image Inputs
 
@@ -941,6 +970,22 @@ Show:
 - Total legendary equivalent
 - Net change over last 30 days
 - Line graph by material type
+
+## Phase 3 - Action Points (AP)
+
+Action Points are planned as a later phase after Materials.
+
+Phase 3 should begin with review/scope only per repository rules, then stop for architecture validation before coding.
+
+Initial expected scope:
+
+- AP image import/detection.
+- AP correction workflow.
+- AP approved history storage.
+- AP report image/output selector support.
+- AP export/audit support if needed for parity with Resources, Speedups, and Materials.
+
+Phase 3 should not be mixed into Phase 2 Materials unless explicitly approved during architecture validation.
 
 ## Validation and Warning Rules
 
@@ -1042,7 +1087,7 @@ Test:
 - unsupported Materials detection in Phase 1 - Phase 1A complete
 - one active session per governor - Phase 1A complete
 - one approved import per governor/type/day - Phase 1A complete
-- reject + one retry - reject complete in Phase 1A; retry UX should be reassessed in Phase 1C
+- cancel + replacement upload - complete in Phase 1E
 - correction workflow - Phase 1A complete
 - large correction warning - review/extend in Phase 1C if additional comparison/audit UX is needed
 - admin debug channel logging - Phase 1A complete
@@ -1117,19 +1162,23 @@ Do not include:
 
 ### Phase 1E
 
-Next phase.
+Complete and ready for full user launch.
 
-Recommended scope:
+Delivered scope:
 
 - Final Resources and Speedups smoke testing.
-- Re-test Resources import accuracy and correction flow.
-- Fix Inventory Import Review timeout/stale button handling.
-- Recheck significant-change double-confirmation behaviour.
-- Polish `/myinventory` Resources and Speedups report image readability:
+- Re-tested Resources import accuracy and correction flow.
+- Fixed Inventory Import Review timeout/stale button handling.
+- Rechecked significant-change double-confirmation behaviour.
+- Polished `/myinventory` Resources and Speedups report image readability:
   - graph x/y axis scales
   - distinct Resources colours
   - capacity-box text fitting
   - separator-line alignment
+- Simplified import review actions to Approve, Correct, and Cancel.
+- Added guided `/myinventory` selectors and `/inventory_preferences`.
+- Kept upload-first original image visible until approve/cancel for user comparison.
+- Prevented `/myinventory` selector reuse after `Show Report`.
 
 Do not include:
 
@@ -1139,6 +1188,8 @@ Do not include:
 
 ### Phase 2
 
+Next build phase after Phase 1 launch/soak.
+
 Test:
 
 - 1-image material chest upload
@@ -1146,6 +1197,18 @@ Test:
 - legendary equivalent calculations
 - material correction workflow
 - material output image
+
+### Phase 3
+
+Later phase for Action Points (AP).
+
+Test:
+
+- AP screenshot import/detection
+- AP correction workflow
+- AP approved history storage
+- AP output image/report selector support
+- AP export/audit support if included in scope
 
 ## Deferred / Downstream Work
 
@@ -1182,6 +1245,18 @@ Do not include in Phase 1E:
 - Stats export SQL refactor work tracked by GitHub issue #46
 - Broad OCR redesign unless final smoke testing finds a concrete Resources/Speedups regression
 
+Do not include in Phase 2:
+
+- Action Points (AP), unless explicitly re-scoped during architecture validation
+- `/my_stats` integration
+- Stats export SQL refactor work tracked by GitHub issue #46
+
+Do not include in Phase 3:
+
+- Broad inventory redesign unless a Phase 3 architecture review explicitly requires it
+- `/my_stats` integration
+- Stats export SQL refactor work tracked by GitHub issue #46
+
 Downstream task:
 
 - Integrate inventory summaries into existing `/my_stats` or future refactored `/my_stats` experience.
@@ -1207,5 +1282,5 @@ Do not create a duplicate issue for this item. Reference issue #46 whenever Phas
 ## Suggested Next Chat Opening Prompt
 
 ```text
-Start Phase 1E review/scope for the Inventory Image Import Module. Phase 0, Phase 1A, Phase 1B, Phase 1C, and Phase 1D are complete, tested, and deployed. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 1D completed final Resources/Speedups import polish, including account picker wording/stale interaction cleanup, typed correction modals, Inventory Import Review embed cleanup, corrected-review clarity, reject/cancel simplification, same-day duplicate import enforcement with admin override preserved, /myinventory reporting preference repair, and deterministic days-only Speedup OCR validated against six saved smoke-test images. Phase 1E should focus on final Resources/Speedups smoke testing and report polish before declaring Phase 1 complete. Re-test Resources import because it has not been exercised recently. Carry forward these known issues: Inventory Import Review timeout leaves active buttons and can strand an active upload session; significant-change double-confirmation for Speedups does not appear to trigger; /myinventory graphs need x/y axis scales; Resources graph colours need clearer Food/Wood/Stone/Gold separation; RSS Troop Training Capacity and RSS Troop Healing Capacity text needs to fit cleanly; value/delta separator lines need alignment so they do not cut through text. Keep Materials out of scope until Phase 2. Keep /my_stats integration out of scope. Keep the stats export SQL refactor out of scope and continue referencing GitHub issue #46 for that existing debt. Begin with audit/scope only per repo rules, then stop for architecture validation before coding.
+Start Phase 2 review/scope for the Inventory Image Import Module. Phase 0, Phase 1A, Phase 1B, Phase 1C, Phase 1D, and Phase 1E are complete. Phase 1 is ready for full user launch before Phase 2 coding begins. Use the updated in-repo task pack at C:\discord_file_downloader\docs\Codex Task Pack — Inventory Image Import Module.md. Phase 2 should focus on Materials import/reporting after a Phase 1 launch/soak period. Keep Action Points (AP) out of Phase 2 unless explicitly re-scoped; AP is planned as Phase 3. Keep /my_stats integration out of scope. Keep the stats export SQL refactor out of scope and continue referencing GitHub issue #46 for that existing debt. Begin with audit/scope only per repo rules, then stop for architecture validation before coding.
 ```

--- a/inventory/dal/inventory_dal.py
+++ b/inventory/dal/inventory_dal.py
@@ -146,6 +146,34 @@ def fetch_active_batch_for_governor(governor_id: int) -> dict[str, Any] | None:
         conn.close()
 
 
+def fetch_import_batch(import_batch_id: int) -> dict[str, Any] | None:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT TOP 1
+                   ImportBatchID,
+                   GovernorID,
+                   DiscordUserID,
+                   ImportType,
+                   FlowType,
+                   Status,
+                   CreatedAtUtc,
+                   ApprovedAtUtc,
+                   RejectedAtUtc,
+                   ExpiresAtUtc
+            FROM dbo.InventoryImportBatch
+            WHERE ImportBatchID = ?
+            """,
+            (int(import_batch_id),),
+        )
+        rows = _rows_to_dicts(cur)
+        return rows[0] if rows else None
+    finally:
+        conn.close()
+
+
 def fetch_pending_upload_for_user(discord_user_id: int) -> dict[str, Any] | None:
     conn = _get_conn()
     try:
@@ -164,6 +192,82 @@ def fetch_pending_upload_for_user(discord_user_id: int) -> dict[str, Any] | None
         )
         rows = _rows_to_dicts(cur)
         return rows[0] if rows else None
+    finally:
+        conn.close()
+
+
+def fetch_latest_approved_resource_values(governor_id: int) -> dict[str, dict[str, int]]:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            WITH LatestBatch AS (
+                SELECT TOP 1 ImportBatchID
+                FROM dbo.InventoryImportBatch
+                WHERE GovernorID = ?
+                  AND ImportType = N'resources'
+                  AND Status = N'approved'
+                ORDER BY ApprovedAtUtc DESC, ImportBatchID DESC
+            )
+            SELECT r.ResourceType,
+                   r.FromItemsValue,
+                   r.TotalResourcesValue
+            FROM dbo.GovernorResourceInventory AS r
+            INNER JOIN LatestBatch AS b
+                ON b.ImportBatchID = r.ImportBatchID
+            ORDER BY r.ResourceType ASC
+            """,
+            (int(governor_id),),
+        )
+        rows = _rows_to_dicts(cur)
+        return {
+            str(row["ResourceType"]).lower(): {
+                "from_items_value": int(row.get("FromItemsValue") or 0),
+                "total_resources_value": int(row.get("TotalResourcesValue") or 0),
+            }
+            for row in rows
+        }
+    finally:
+        conn.close()
+
+
+def fetch_latest_approved_speedup_values(
+    governor_id: int,
+) -> dict[str, dict[str, int | float]]:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            WITH LatestBatch AS (
+                SELECT TOP 1 ImportBatchID
+                FROM dbo.InventoryImportBatch
+                WHERE GovernorID = ?
+                  AND ImportType = N'speedups'
+                  AND Status = N'approved'
+                ORDER BY ApprovedAtUtc DESC, ImportBatchID DESC
+            )
+            SELECT s.SpeedupType,
+                   s.TotalMinutes,
+                   s.TotalHours,
+                   s.TotalDaysDecimal
+            FROM dbo.GovernorSpeedupInventory AS s
+            INNER JOIN LatestBatch AS b
+                ON b.ImportBatchID = s.ImportBatchID
+            ORDER BY s.SpeedupType ASC
+            """,
+            (int(governor_id),),
+        )
+        rows = _rows_to_dicts(cur)
+        return {
+            str(row["SpeedupType"]).lower(): {
+                "total_minutes": int(row.get("TotalMinutes") or 0),
+                "total_hours": float(row.get("TotalHours") or 0.0),
+                "total_days_decimal": float(row.get("TotalDaysDecimal") or 0.0),
+            }
+            for row in rows
+        }
     finally:
         conn.close()
 

--- a/inventory/inventory_service.py
+++ b/inventory/inventory_service.py
@@ -446,8 +446,10 @@ def _significant_change_warning(
     ratio = _change_ratio(previous, current)
     if ratio <= SIGNIFICANT_CHANGE_RATIO:
         return None
+    pct = int(SIGNIFICANT_CHANGE_RATIO * 100)
     return (
-        f"{label} changed by more than 50% " f"({previous:,.0f}{suffix} -> {current:,.0f}{suffix})."
+        f"{label} changed by more than {pct}% "
+        f"({previous:,.0f}{suffix} -> {current:,.0f}{suffix})."
     )
 
 

--- a/inventory/inventory_service.py
+++ b/inventory/inventory_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 import logging
 from typing import Any
@@ -26,6 +27,28 @@ SUPPORTED_IMAGE_CONTENT_TYPES = {"image/png", "image/jpeg", "image/webp"}
 LOW_CONFIDENCE_REJECT_THRESHOLD = 0.70
 SPEEDUP_DIGIT_LOSS_DAY_THRESHOLD = 45.0
 SPEEDUP_DIGIT_LOSS_RATIO = 0.20
+SIGNIFICANT_CHANGE_RATIO = 0.50
+
+
+@dataclass(frozen=True)
+class InventoryReviewActionState:
+    active: bool
+    status: InventoryImportStatus | None = None
+    expired: bool = False
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class InventorySignificantChangeAssessment:
+    requires_confirmation: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class InventoryAnalysisDecision:
+    action: str
+    debug_status: str | None = None
+    error: str | None = None
 
 
 def is_supported_image_attachment(filename: str | None, content_type: str | None) -> bool:
@@ -141,6 +164,50 @@ async def create_upload_first_batch(
         image_attachment_url=payload.image_attachment_url,
         is_admin_import=admin,
     )
+
+
+def _coerce_utc(value: Any) -> datetime | None:
+    if value is None or not hasattr(value, "replace"):
+        return None
+    if getattr(value, "tzinfo", None) is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _parse_status(value: Any) -> InventoryImportStatus | None:
+    try:
+        return InventoryImportStatus(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+async def get_review_action_state(import_batch_id: int) -> InventoryReviewActionState:
+    row = await asyncio.to_thread(inventory_dal.fetch_import_batch, int(import_batch_id))
+    if not row:
+        return InventoryReviewActionState(
+            active=False,
+            message="This import review is no longer available. Please upload the screenshot again.",
+        )
+
+    status = _parse_status(row.get("Status"))
+    if status not in {InventoryImportStatus.AWAITING_UPLOAD, InventoryImportStatus.ANALYSED}:
+        return InventoryReviewActionState(
+            active=False,
+            status=status,
+            message="This import has already been completed.",
+        )
+
+    expires_at = _coerce_utc(row.get("ExpiresAtUtc"))
+    if expires_at is not None and expires_at <= datetime.now(UTC):
+        await cancel_import(int(import_batch_id))
+        return InventoryReviewActionState(
+            active=False,
+            status=InventoryImportStatus.CANCELLED,
+            expired=True,
+            message="This import review expired. Please upload the screenshot again.",
+        )
+
+    return InventoryReviewActionState(active=True, status=status)
 
 
 def _map_detected_type(raw: str | None) -> InventoryImportType:
@@ -300,6 +367,28 @@ async def analyse_inventory_image(
     return summary
 
 
+def decide_analysis_outcome(summary: InventoryAnalysisSummary) -> InventoryAnalysisDecision:
+    if (
+        not summary.ok
+        or summary.confidence_score < LOW_CONFIDENCE_REJECT_THRESHOLD
+        or summary.import_type == InventoryImportType.UNKNOWN
+    ):
+        return InventoryAnalysisDecision(
+            action="fail",
+            debug_status="failed",
+            error=summary.error or "Analysis failed.",
+        )
+
+    if summary.import_type == InventoryImportType.MATERIALS:
+        return InventoryAnalysisDecision(
+            action="reject",
+            debug_status="materials_disabled",
+            error="Materials disabled in Phase 1.",
+        )
+
+    return InventoryAnalysisDecision(action="review")
+
+
 async def approve_import(
     *,
     import_batch_id: int,
@@ -343,6 +432,81 @@ async def approve_import(
         summary.import_type.value,
     )
     return normalized
+
+
+def _change_ratio(previous: float, current: float) -> float:
+    if previous == 0:
+        return 1.0 if current != 0 else 0.0
+    return abs(current - previous) / abs(previous)
+
+
+def _significant_change_warning(
+    *, label: str, previous: float, current: float, suffix: str = ""
+) -> str | None:
+    ratio = _change_ratio(previous, current)
+    if ratio <= SIGNIFICANT_CHANGE_RATIO:
+        return None
+    return (
+        f"{label} changed by more than 50% " f"({previous:,.0f}{suffix} -> {current:,.0f}{suffix})."
+    )
+
+
+async def assess_significant_change(
+    *,
+    governor_id: int,
+    import_type: InventoryImportType,
+    values: dict[str, Any],
+) -> InventorySignificantChangeAssessment:
+    if import_type == InventoryImportType.RESOURCES:
+        normalized = normalize_final_values(import_type, values)
+        previous = await asyncio.to_thread(
+            inventory_dal.fetch_latest_approved_resource_values,
+            int(governor_id),
+        )
+        if not previous:
+            return InventorySignificantChangeAssessment()
+        warnings: list[str] = []
+        for resource_type, row in normalized["resources"].items():
+            prior = previous.get(resource_type)
+            if not prior:
+                continue
+            current_value = float(row["total_resources_value"])
+            previous_value = float(prior["total_resources_value"])
+            warning = _significant_change_warning(
+                label=resource_type.title(),
+                previous=previous_value,
+                current=current_value,
+            )
+            if warning:
+                warnings.append(warning)
+        return InventorySignificantChangeAssessment(bool(warnings), warnings)
+
+    if import_type == InventoryImportType.SPEEDUPS:
+        normalized = normalize_final_values(import_type, values)
+        previous = await asyncio.to_thread(
+            inventory_dal.fetch_latest_approved_speedup_values,
+            int(governor_id),
+        )
+        if not previous:
+            return InventorySignificantChangeAssessment()
+        warnings = []
+        for speedup_type, row in normalized["speedups"].items():
+            prior = previous.get(speedup_type)
+            if not prior:
+                continue
+            current_days = float(row["total_days_decimal"])
+            previous_days = float(prior["total_days_decimal"])
+            warning = _significant_change_warning(
+                label=f"{speedup_type.title()} speedups",
+                previous=previous_days,
+                current=current_days,
+                suffix="d",
+            )
+            if warning:
+                warnings.append(warning)
+        return InventorySignificantChangeAssessment(bool(warnings), warnings)
+
+    return InventorySignificantChangeAssessment()
 
 
 async def reject_import(import_batch_id: int, *, error: str | None = None) -> None:

--- a/inventory/report_image_renderer.py
+++ b/inventory/report_image_renderer.py
@@ -196,13 +196,16 @@ def _draw_kpi(
         title_w = content_w
     title_font = _fit_font(draw, title, max_width=title_w, size=18, min_size=13, bold=True)
     value_font = _fit_font(draw, value, max_width=content_w, size=34, min_size=24, bold=True)
-    delta_font = _fit_font(draw, delta, max_width=content_w, size=20, min_size=14, bold=True)
+    delta_font = _fit_font(draw, delta, max_width=content_w, size=20, min_size=11, bold=True)
     draw.text((title_x, y1 + 20), title, fill=MUTED, font=title_font)
-    draw.text((x1 + 20, y1 + 68), value, fill=TEXT, font=value_font)
-    separator_y = min(y1 + 112, y2 - 48)
+    value_xy = (x1 + 20, y1 + 68)
+    draw.text(value_xy, value, fill=TEXT, font=value_font)
+    value_box = draw.textbbox(value_xy, value, font=value_font)
+    separator_y = min(max(value_box[3] + 14, y1 + 108), y2 - 36)
     draw.line((x1 + 18, separator_y, x2 - 18, separator_y), fill=(65, 127, 187), width=1)
+    max_delta_lines = 1 if _text_width(draw, delta, delta_font) <= content_w else 2
     for idx, line in enumerate(
-        _wrap_text(draw, delta, font=delta_font, max_width=content_w, max_lines=2)
+        _wrap_text(draw, delta, font=delta_font, max_width=content_w, max_lines=max_delta_lines)
     ):
         draw.text((x1 + 20, separator_y + 10 + (idx * 22)), line, fill=delta_color, font=delta_font)
 
@@ -229,6 +232,17 @@ def _date_axis_label(label: str) -> str:
     return text[:10]
 
 
+def _stacked_totals(series: dict[str, list[float]]) -> list[float]:
+    if not series:
+        return []
+    length = max(len(values) for values in series.values())
+    totals = [0.0] * length
+    for values in series.values():
+        for idx, value in enumerate(values):
+            totals[idx] += max(float(value), 0.0)
+    return totals
+
+
 def _line_chart(
     draw: ImageDraw.ImageDraw,
     xy: tuple[int, int, int, int],
@@ -240,18 +254,16 @@ def _line_chart(
 ) -> None:
     _panel(draw, xy, fill=(9, 36, 78))
     x1, y1, x2, y2 = xy
-    all_values = [v for values in series.values() for v in values]
-    if len(labels) < 2 or not all_values:
+    stacked_totals = _stacked_totals(series)
+    if len(labels) < 2 or not stacked_totals:
         draw.text((x1 + 24, y1 + 26), "Trend graph unavailable", fill=MUTED, font=_font(22))
         return
 
-    min_v = min(all_values)
-    max_v = max(all_values)
-    if min_v == max_v:
-        pad = max(abs(max_v) * 0.25, 1.0)
-        min_v -= pad
-        max_v += pad
-    span = max(max_v - min_v, 1)
+    min_v = 0.0
+    max_v = max(stacked_totals)
+    if max_v <= 0:
+        max_v = 1.0
+    span = max_v
     plot = (x1 + 96, y1 + 42, x2 - 42, y2 - 78)
     ticks = _chart_ticks(min_v, max_v)
     for tick in ticks:
@@ -268,16 +280,23 @@ def _line_chart(
         draw.line((x, plot[3], x, plot[3] + 6), fill=AXIS, width=1)
         draw.text((x - 24, plot[3] + 12), _date_axis_label(labels[idx]), fill=AXIS, font=_font(15))
 
-    for (name, values), color in zip(series.items(), colors, strict=False):
-        pts = []
+    cumulative = [0.0] * len(labels)
+    for (_name, values), color in zip(series.items(), colors, strict=False):
+        upper_pts = []
+        lower_pts = []
         for idx, val in enumerate(values):
             x = plot[0] + (plot[2] - plot[0]) * idx / max(len(values) - 1, 1)
-            y = plot[3] - ((val - min_v) / span) * (plot[3] - plot[1])
-            pts.append((x, y))
-        if len(pts) >= 2:
-            area = [(pts[0][0], plot[3]), *pts, (pts[-1][0], plot[3])]
-            draw.polygon(area, fill=(*color[:3], 58))
-            draw.line(pts, fill=color, width=4)
+            lower_value = cumulative[idx]
+            upper_value = lower_value + max(float(val), 0.0)
+            cumulative[idx] = upper_value
+            lower_y = plot[3] - (lower_value / span) * (plot[3] - plot[1])
+            upper_y = plot[3] - (upper_value / span) * (plot[3] - plot[1])
+            lower_pts.append((x, lower_y))
+            upper_pts.append((x, upper_y))
+        if len(upper_pts) >= 2:
+            area = [*upper_pts, *reversed(lower_pts)]
+            draw.polygon(area, fill=(*color[:3], 190))
+            draw.line(upper_pts, fill=color, width=3)
     legend_x = plot[0]
     for name, color in zip(series.keys(), colors, strict=False):
         draw.rounded_rectangle((legend_x, y2 - 42, legend_x + 22, y2 - 22), radius=4, fill=color)

--- a/inventory/report_image_renderer.py
+++ b/inventory/report_image_renderer.py
@@ -29,6 +29,7 @@ RED = (248, 113, 113)
 GOLD = (250, 204, 21)
 GRID = (31, 83, 139)
 AXIS = (122, 168, 210)
+CHART_FILL_ALPHA = 14
 RESOURCE_CHART_COLORS = {
     "Food": (82, 196, 113),
     "Wood": (181, 116, 62),
@@ -232,18 +233,14 @@ def _date_axis_label(label: str) -> str:
     return text[:10]
 
 
-def _stacked_totals(series: dict[str, list[float]]) -> list[float]:
+def _series_values(series: dict[str, list[float]]) -> list[float]:
     if not series:
         return []
-    length = max(len(values) for values in series.values())
-    totals = [0.0] * length
-    for values in series.values():
-        for idx, value in enumerate(values):
-            totals[idx] += max(float(value), 0.0)
-    return totals
+    return [max(float(value), 0.0) for values in series.values() for value in values]
 
 
 def _line_chart(
+    canvas: Image.Image,
     draw: ImageDraw.ImageDraw,
     xy: tuple[int, int, int, int],
     series: dict[str, list[float]],
@@ -254,13 +251,13 @@ def _line_chart(
 ) -> None:
     _panel(draw, xy, fill=(9, 36, 78))
     x1, y1, x2, y2 = xy
-    stacked_totals = _stacked_totals(series)
-    if len(labels) < 2 or not stacked_totals:
+    visible_values = _series_values(series)
+    if len(labels) < 2 or not visible_values:
         draw.text((x1 + 24, y1 + 26), "Trend graph unavailable", fill=MUTED, font=_font(22))
         return
 
     min_v = 0.0
-    max_v = max(stacked_totals)
+    max_v = max(visible_values)
     if max_v <= 0:
         max_v = 1.0
     span = max_v
@@ -280,23 +277,31 @@ def _line_chart(
         draw.line((x, plot[3], x, plot[3] + 6), fill=AXIS, width=1)
         draw.text((x - 24, plot[3] + 12), _date_axis_label(labels[idx]), fill=AXIS, font=_font(15))
 
-    cumulative = [0.0] * len(labels)
-    for (_name, values), color in zip(series.items(), colors, strict=False):
-        upper_pts = []
-        lower_pts = []
+    series_with_colors = list(zip(series.items(), colors, strict=False))
+    fill_layer = Image.new("RGBA", canvas.size, (0, 0, 0, 0))
+    fill_draw = ImageDraw.Draw(fill_layer, "RGBA")
+    for (_name, values), color in sorted(
+        series_with_colors,
+        key=lambda item: max(item[0][1]) if item[0][1] else 0,
+        reverse=True,
+    ):
+        pts = []
         for idx, val in enumerate(values):
             x = plot[0] + (plot[2] - plot[0]) * idx / max(len(values) - 1, 1)
-            lower_value = cumulative[idx]
-            upper_value = lower_value + max(float(val), 0.0)
-            cumulative[idx] = upper_value
-            lower_y = plot[3] - (lower_value / span) * (plot[3] - plot[1])
-            upper_y = plot[3] - (upper_value / span) * (plot[3] - plot[1])
-            lower_pts.append((x, lower_y))
-            upper_pts.append((x, upper_y))
-        if len(upper_pts) >= 2:
-            area = [*upper_pts, *reversed(lower_pts)]
-            draw.polygon(area, fill=(*color[:3], 190))
-            draw.line(upper_pts, fill=color, width=3)
+            y = plot[3] - (max(float(val), 0.0) / span) * (plot[3] - plot[1])
+            pts.append((x, y))
+        if len(pts) >= 2:
+            area = [(pts[0][0], plot[3]), *pts, (pts[-1][0], plot[3])]
+            fill_draw.polygon(area, fill=(*color[:3], CHART_FILL_ALPHA))
+    canvas.alpha_composite(fill_layer)
+    for (_name, values), color in series_with_colors:
+        pts = []
+        for idx, val in enumerate(values):
+            x = plot[0] + (plot[2] - plot[0]) * idx / max(len(values) - 1, 1)
+            y = plot[3] - (max(float(val), 0.0) / span) * (plot[3] - plot[1])
+            pts.append((x, y))
+        if len(pts) >= 2:
+            draw.line(pts, fill=color, width=4)
     legend_x = plot[0]
     for name, color in zip(series.keys(), colors, strict=False):
         draw.rounded_rectangle((legend_x, y2 - 42, legend_x + 22, y2 - 22), radius=4, fill=color)
@@ -429,6 +434,7 @@ def render_resources_report(
             "Gold": [float(p.gold) for p in payload.resources],
         }
         _line_chart(
+            canvas,
             draw,
             (44, 510, 1356, 924),
             resource_series,
@@ -517,6 +523,7 @@ def render_speedups_report(
 
     if len(payload.speedups) >= 2:
         _line_chart(
+            canvas,
             draw,
             (44, 540, 1356, 924),
             {

--- a/inventory/report_image_renderer.py
+++ b/inventory/report_image_renderer.py
@@ -27,6 +27,14 @@ MUTED = (174, 205, 232)
 GREEN = (73, 222, 128)
 RED = (248, 113, 113)
 GOLD = (250, 204, 21)
+GRID = (31, 83, 139)
+AXIS = (122, 168, 210)
+RESOURCE_CHART_COLORS = {
+    "Food": (82, 196, 113),
+    "Wood": (181, 116, 62),
+    "Stone": (156, 163, 175),
+    "Gold": (245, 180, 52),
+}
 
 
 @dataclass(frozen=True)
@@ -116,6 +124,55 @@ def _panel(draw: ImageDraw.ImageDraw, xy: tuple[int, int, int, int], fill=PANEL)
     draw.rounded_rectangle(xy, radius=14, fill=fill, outline=(71, 139, 202), width=2)
 
 
+def _text_width(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> int:
+    box = draw.textbbox((0, 0), text, font=font)
+    return int(box[2] - box[0])
+
+
+def _fit_font(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    *,
+    max_width: int,
+    size: int,
+    min_size: int,
+    bold: bool = False,
+) -> ImageFont.ImageFont:
+    font = _font(size, bold=bold)
+    while size > min_size and _text_width(draw, text, font) > max_width:
+        size -= 1
+        font = _font(size, bold=bold)
+    return font
+
+
+def _wrap_text(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    *,
+    font: ImageFont.ImageFont,
+    max_width: int,
+    max_lines: int = 2,
+) -> list[str]:
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if not current or _text_width(draw, candidate, font) <= max_width:
+            current = candidate
+            continue
+        lines.append(current)
+        current = word
+        if len(lines) >= max_lines:
+            break
+    if current and len(lines) < max_lines:
+        lines.append(current)
+    if len(lines) == max_lines and words:
+        while _text_width(draw, lines[-1], font) > max_width and len(lines[-1]) > 1:
+            lines[-1] = lines[-1][:-2].rstrip() + "."
+    return lines or [text]
+
+
 def _draw_kpi(
     canvas: Image.Image,
     draw: ImageDraw.ImageDraw,
@@ -128,16 +185,48 @@ def _draw_kpi(
     icon: Path | None = None,
 ) -> None:
     _panel(draw, xy)
-    x1, y1, x2, _ = xy
+    x1, y1, x2, y2 = xy
+    content_w = x2 - x1 - 40
     if icon:
         _paste_icon(canvas, icon, (x1 + 16, y1 + 18, x1 + 62, y1 + 64))
         title_x = x1 + 72
+        title_w = x2 - title_x - 18
     else:
         title_x = x1 + 20
-    draw.text((title_x, y1 + 20), title, fill=MUTED, font=_font(18, bold=True))
-    draw.text((x1 + 20, y1 + 68), value, fill=TEXT, font=_font(34, bold=True))
-    draw.text((x1 + 20, y1 + 112), delta, fill=delta_color, font=_font(20, bold=True))
-    draw.line((x1 + 18, y1 + 104, x2 - 18, y1 + 104), fill=(65, 127, 187), width=1)
+        title_w = content_w
+    title_font = _fit_font(draw, title, max_width=title_w, size=18, min_size=13, bold=True)
+    value_font = _fit_font(draw, value, max_width=content_w, size=34, min_size=24, bold=True)
+    delta_font = _fit_font(draw, delta, max_width=content_w, size=20, min_size=14, bold=True)
+    draw.text((title_x, y1 + 20), title, fill=MUTED, font=title_font)
+    draw.text((x1 + 20, y1 + 68), value, fill=TEXT, font=value_font)
+    separator_y = min(y1 + 112, y2 - 48)
+    draw.line((x1 + 18, separator_y, x2 - 18, separator_y), fill=(65, 127, 187), width=1)
+    for idx, line in enumerate(
+        _wrap_text(draw, delta, font=delta_font, max_width=content_w, max_lines=2)
+    ):
+        draw.text((x1 + 20, separator_y + 10 + (idx * 22)), line, fill=delta_color, font=delta_font)
+
+
+def _chart_ticks(min_v: float, max_v: float, *, count: int = 5) -> list[float]:
+    if count <= 1:
+        return [max_v]
+    if max_v == min_v:
+        step = max(abs(max_v) * 0.25, 1.0)
+        min_v -= step * 2
+        max_v += step * 2
+    span = max_v - min_v
+    return [min_v + (span * idx / (count - 1)) for idx in range(count)]
+
+
+def _axis_label(value: float, *, suffix: str = "") -> str:
+    return _compact(value, suffix=suffix)
+
+
+def _date_axis_label(label: str) -> str:
+    text = str(label)
+    if len(text) >= 10 and text[4:5] == "-" and text[7:8] == "-":
+        return text[5:10]
+    return text[:10]
 
 
 def _line_chart(
@@ -146,6 +235,8 @@ def _line_chart(
     series: dict[str, list[float]],
     labels: list[str],
     colors: list[tuple[int, int, int]],
+    *,
+    y_suffix: str = "",
 ) -> None:
     _panel(draw, xy, fill=(9, 36, 78))
     x1, y1, x2, y2 = xy
@@ -156,11 +247,26 @@ def _line_chart(
 
     min_v = min(all_values)
     max_v = max(all_values)
+    if min_v == max_v:
+        pad = max(abs(max_v) * 0.25, 1.0)
+        min_v -= pad
+        max_v += pad
     span = max(max_v - min_v, 1)
-    plot = (x1 + 70, y1 + 42, x2 - 42, y2 - 62)
-    for i in range(5):
-        y = plot[3] - (plot[3] - plot[1]) * i / 4
-        draw.line((plot[0], y, plot[2], y), fill=(31, 83, 139), width=1)
+    plot = (x1 + 96, y1 + 42, x2 - 42, y2 - 78)
+    ticks = _chart_ticks(min_v, max_v)
+    for tick in ticks:
+        y = plot[3] - ((tick - min_v) / span) * (plot[3] - plot[1])
+        draw.line((plot[0], y, plot[2], y), fill=GRID, width=1)
+        label = _axis_label(tick, suffix=y_suffix)
+        draw.text((x1 + 20, y - 9), label, fill=AXIS, font=_font(15))
+    draw.line((plot[0], plot[1], plot[0], plot[3]), fill=AXIS, width=2)
+    draw.line((plot[0], plot[3], plot[2], plot[3]), fill=AXIS, width=2)
+
+    axis_indices = sorted({0, len(labels) // 2, len(labels) - 1})
+    for idx in axis_indices:
+        x = plot[0] + (plot[2] - plot[0]) * idx / max(len(labels) - 1, 1)
+        draw.line((x, plot[3], x, plot[3] + 6), fill=AXIS, width=1)
+        draw.text((x - 24, plot[3] + 12), _date_axis_label(labels[idx]), fill=AXIS, font=_font(15))
 
     for (name, values), color in zip(series.items(), colors, strict=False):
         pts = []
@@ -297,17 +403,18 @@ def render_resources_report(
         )
 
     if len(payload.resources) >= 2:
+        resource_series = {
+            "Food": [float(p.food) for p in payload.resources],
+            "Wood": [float(p.wood) for p in payload.resources],
+            "Stone": [float(p.stone) for p in payload.resources],
+            "Gold": [float(p.gold) for p in payload.resources],
+        }
         _line_chart(
             draw,
             (44, 510, 1356, 924),
-            {
-                "Food": [float(p.food) for p in payload.resources],
-                "Wood": [float(p.wood) for p in payload.resources],
-                "Stone": [float(p.stone) for p in payload.resources],
-                "Gold": [float(p.gold) for p in payload.resources],
-            },
+            resource_series,
             [str(p.scan_utc) for p in payload.resources],
-            [(74, 222, 128), (250, 204, 21), (148, 163, 184), (251, 191, 36)],
+            [RESOURCE_CHART_COLORS[name] for name in resource_series],
         )
     else:
         draw.text(
@@ -400,6 +507,7 @@ def render_speedups_report(
             },
             [str(p.scan_utc) for p in payload.speedups],
             [(250, 204, 21), (96, 165, 250), (248, 113, 113)],
+            y_suffix="d",
         )
     else:
         draw.text(

--- a/inventory/reporting_service.py
+++ b/inventory/reporting_service.py
@@ -63,7 +63,9 @@ def parse_visibility(value: str | None) -> InventoryReportVisibility | None:
     return aliases[normalized]
 
 
-async def get_visibility_preference(discord_user_id: int) -> InventoryReportVisibility:
+async def get_visibility_preference_or_none(
+    discord_user_id: int,
+) -> InventoryReportVisibility | None:
     try:
         pref = await asyncio.to_thread(
             inventory_reporting_dal.fetch_visibility_preference,
@@ -77,6 +79,13 @@ async def get_visibility_preference(discord_user_id: int) -> InventoryReportVisi
             discord_user_id,
             InventoryReportVisibility.ONLY_ME.value,
         )
+        return None
+    return pref
+
+
+async def get_visibility_preference(discord_user_id: int) -> InventoryReportVisibility:
+    pref = await get_visibility_preference_or_none(discord_user_id)
+    if pref is None:
         return InventoryReportVisibility.ONLY_ME
     return pref or InventoryReportVisibility.ONLY_ME
 

--- a/tests/test_inventory_command_registration.py
+++ b/tests/test_inventory_command_registration.py
@@ -19,5 +19,6 @@ def test_register_inventory_command_registers_import_inventory():
 
     assert "import_inventory" in fake_bot.registered
     assert "myinventory" in fake_bot.registered
+    assert "inventory_preferences" in fake_bot.registered
     assert "export_inventory" in fake_bot.registered
     assert "inventory_import_audit" in fake_bot.registered

--- a/tests/test_inventory_report_image_renderer.py
+++ b/tests/test_inventory_report_image_renderer.py
@@ -54,8 +54,8 @@ def test_chart_ticks_start_at_zero_for_report_domain():
     assert ticks[-1] == 100
 
 
-def test_stacked_totals_sum_visible_series():
-    totals = report_image_renderer._stacked_totals(
+def test_series_values_flattens_visible_series_for_y_scale():
+    values = report_image_renderer._series_values(
         {
             "Food": [10, 20],
             "Wood": [5, 7],
@@ -63,7 +63,7 @@ def test_stacked_totals_sum_visible_series():
         }
     )
 
-    assert totals == [16, 29]
+    assert values == [10, 20, 5, 7, 1, 2]
 
 
 def test_resource_chart_colours_are_distinct():

--- a/tests/test_inventory_report_image_renderer.py
+++ b/tests/test_inventory_report_image_renderer.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
+from inventory import report_image_renderer
 from inventory.models import (
     InventoryReportPayload,
     InventoryReportRange,
@@ -36,3 +37,22 @@ def test_render_inventory_reports_returns_png_files_for_resources_and_speedups()
     ]
     for item in rendered:
         assert item.image_bytes.getvalue().startswith(b"\x89PNG")
+
+
+def test_chart_ticks_expand_flat_values():
+    ticks = report_image_renderer._chart_ticks(100, 100)
+
+    assert len(ticks) == 5
+    assert ticks[0] < 100
+    assert ticks[-1] > 100
+
+
+def test_resource_chart_colours_are_distinct():
+    colours = list(report_image_renderer.RESOURCE_CHART_COLORS.values())
+
+    assert len(colours) == 4
+    assert len(set(colours)) == 4
+    assert (
+        report_image_renderer.RESOURCE_CHART_COLORS["Wood"]
+        != report_image_renderer.RESOURCE_CHART_COLORS["Gold"]
+    )

--- a/tests/test_inventory_report_image_renderer.py
+++ b/tests/test_inventory_report_image_renderer.py
@@ -47,6 +47,25 @@ def test_chart_ticks_expand_flat_values():
     assert ticks[-1] > 100
 
 
+def test_chart_ticks_start_at_zero_for_report_domain():
+    ticks = report_image_renderer._chart_ticks(0, 100)
+
+    assert ticks[0] == 0
+    assert ticks[-1] == 100
+
+
+def test_stacked_totals_sum_visible_series():
+    totals = report_image_renderer._stacked_totals(
+        {
+            "Food": [10, 20],
+            "Wood": [5, 7],
+            "Stone": [1, 2],
+        }
+    )
+
+    assert totals == [16, 29]
+
+
 def test_resource_chart_colours_are_distinct():
     colours = list(report_image_renderer.RESOURCE_CHART_COLORS.values())
 

--- a/tests/test_inventory_report_views.py
+++ b/tests/test_inventory_report_views.py
@@ -187,11 +187,45 @@ async def test_show_report_sends_report_for_selected_governor_and_output(monkeyp
         },
     )()
 
+    async def _edit_original_response(**kwargs):
+        captured["selector_edit"] = kwargs
+
+    valid_interaction.edit_original_response = _edit_original_response
+
     await picker_view.send_report(valid_interaction)
 
     assert captured["governor"].governor_id == 222
     assert captured["requester_id"] == 42
     assert captured["report_view"] == InventoryReportView.SPEEDUPS
+    assert picker_view._completed is True
+    assert all(getattr(item, "disabled", False) for item in picker_view.children)
+    assert captured["selector_edit"]["content"] == "Inventory report selected."
+
+
+@pytest.mark.asyncio
+async def test_show_report_rejects_reused_selector(monkeypatch):
+    _ctx, _followup, picker_view = await _start_and_get_picker(monkeypatch, user_id=42)
+    picker_view._completed = True
+    response = {}
+
+    class _Response:
+        async def send_message(self, content=None, **kwargs):
+            response["content"] = content
+            response.update(kwargs)
+
+    interaction = type(
+        "_Interaction",
+        (),
+        {
+            "user": type("_User", (), {"id": 42, "display_name": "Tester"})(),
+            "response": _Response(),
+        },
+    )()
+
+    await picker_view.send_report(interaction)
+
+    assert "already been used" in response["content"]
+    assert response["ephemeral"] is True
 
 
 @pytest.mark.asyncio
@@ -232,6 +266,7 @@ async def test_preference_view_saves_visibility(monkeypatch):
 
     assert saved["discord_user_id"] == 42
     assert saved["selected_visibility"] == InventoryReportVisibility.PUBLIC
+    assert "/inventory_preferences" in saved["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inventory_report_views.py
+++ b/tests/test_inventory_report_views.py
@@ -1,8 +1,17 @@
 import pytest
 
-from inventory.models import InventoryReportRange, InventoryReportView, RegisteredGovernor
+from inventory.models import (
+    InventoryReportRange,
+    InventoryReportView,
+    InventoryReportVisibility,
+    RegisteredGovernor,
+)
 from ui.views import inventory_report_views
-from ui.views.inventory_report_views import InventoryRangeView
+from ui.views.inventory_report_views import (
+    InventoryPreferenceView,
+    InventoryRangeView,
+    InventoryReportSelectionView,
+)
 
 
 @pytest.mark.asyncio
@@ -61,17 +70,9 @@ def _two_governors():
 async def _start_and_get_picker(monkeypatch, user_id=42):
     ctx, followup = _make_ctx(user_id=user_id)
 
-    async def _resolve(**_kwargs):
-        return None
-
     async def _get_governors(_user_id):
         return _two_governors()
 
-    monkeypatch.setattr(
-        inventory_report_views.reporting_service,
-        "resolve_governor_for_report",
-        _resolve,
-    )
     monkeypatch.setattr(
         inventory_report_views.reporting_service,
         "get_registered_governors_for_user",
@@ -80,10 +81,7 @@ async def _start_and_get_picker(monkeypatch, user_id=42):
 
     await inventory_report_views.start_myinventory_command(
         ctx=ctx,
-        governor_id=None,
-        report_view=InventoryReportView.ALL,
-        range_key=InventoryReportRange.ONE_MONTH,
-        visibility=inventory_report_views.InventoryReportVisibility.ONLY_ME,
+        visibility=InventoryReportVisibility.ONLY_ME,
     )
 
     return ctx, followup, followup.sent["view"]
@@ -93,21 +91,21 @@ async def _start_and_get_picker(monkeypatch, user_id=42):
 async def test_myinventory_uses_picker_for_multiple_governors(monkeypatch):
     _ctx, followup, view = await _start_and_get_picker(monkeypatch)
 
-    assert followup.sent["content"] == "Select which governor inventory report to view:"
+    assert followup.sent["content"] == "Choose the inventory report to view:"
     assert followup.sent["ephemeral"] is True
-    assert view.children[0].placeholder == "Select Governor"
+    placeholders = [getattr(item, "placeholder", None) for item in view.children]
+    assert "Select Governor" in placeholders
+    assert "Select Output" in placeholders
 
 
 @pytest.mark.asyncio
 async def test_on_select_rejects_wrong_user(monkeypatch):
     """_on_select must refuse interactions from users other than the command invoker."""
     _ctx, _followup, picker_view = await _start_and_get_picker(monkeypatch, user_id=42)
-    on_select = picker_view._on_select_governor
-
     rejected = {}
 
-    class _Followup2:
-        async def send(self, content=None, **kwargs):
+    class _Response:
+        async def send_message(self, content=None, **kwargs):
             rejected["content"] = content
             rejected.update(kwargs)
 
@@ -116,55 +114,54 @@ async def test_on_select_rejects_wrong_user(monkeypatch):
         (),
         {
             "user": type("_User", (), {"id": 999})(),
-            "followup": _Followup2(),
+            "response": _Response(),
         },
     )()
 
-    await on_select(intruder_interaction, "111", True)  # ephemeral=True (picker is ephemeral)
+    await picker_view.send_report(intruder_interaction)
 
     assert "not for you" in rejected.get("content", "")
     assert rejected.get("ephemeral") is True
 
 
 @pytest.mark.asyncio
-async def test_on_select_rejects_stale_governor(monkeypatch):
-    """_on_select must handle a governor_id that was removed after the picker was shown."""
+async def test_show_report_requires_governor_selection(monkeypatch):
     _ctx, _followup, picker_view = await _start_and_get_picker(monkeypatch, user_id=42)
-    on_select = picker_view._on_select_governor
+    picker_view.selected_governor_id = None
 
-    stale_response = {}
+    response = {}
 
-    class _Followup3:
-        async def send(self, content=None, **kwargs):
-            stale_response["content"] = content
-            stale_response.update(kwargs)
+    class _Response:
+        async def send_message(self, content=None, **kwargs):
+            response["content"] = content
+            response.update(kwargs)
 
     valid_interaction = type(
         "_Interaction",
         (),
         {
             "user": type("_User", (), {"id": 42})(),
-            "followup": _Followup3(),
+            "response": _Response(),
         },
     )()
 
-    await on_select(valid_interaction, "9999", True)  # ephemeral=True (picker is ephemeral)
+    await picker_view.send_report(valid_interaction)
 
-    assert "no longer available" in stale_response.get("content", "")
-    assert stale_response.get("ephemeral") is True
+    assert "Choose a governor" in response.get("content", "")
+    assert response.get("ephemeral") is True
 
 
 @pytest.mark.asyncio
-async def test_on_select_sends_report_for_valid_governor(monkeypatch):
-    """_on_select must hand off to _send_inventory_report_message with the selected governor."""
+async def test_show_report_sends_report_for_selected_governor_and_output(monkeypatch):
     _ctx, _followup, picker_view = await _start_and_get_picker(monkeypatch, user_id=42)
-    on_select = picker_view._on_select_governor
-
+    picker_view.selected_governor_id = 222
+    picker_view.selected_view = InventoryReportView.SPEEDUPS
     captured = {}
 
     async def _mock_send_report(*, send, user, requester_id, governor, **kwargs):
         captured["governor"] = governor
         captured["requester_id"] = requester_id
+        captured.update(kwargs)
 
     monkeypatch.setattr(
         inventory_report_views,
@@ -172,7 +169,11 @@ async def test_on_select_sends_report_for_valid_governor(monkeypatch):
         _mock_send_report,
     )
 
-    class _Followup4:
+    class _Response:
+        async def defer(self, **kwargs):
+            captured["defer"] = kwargs
+
+    class _Followup:
         async def send(self, content=None, **kwargs):
             pass
 
@@ -181,11 +182,68 @@ async def test_on_select_sends_report_for_valid_governor(monkeypatch):
         (),
         {
             "user": type("_User", (), {"id": 42, "display_name": "Tester"})(),
-            "followup": _Followup4(),
+            "response": _Response(),
+            "followup": _Followup(),
         },
     )()
 
-    await on_select(valid_interaction, "222", True)  # ephemeral=True (picker is ephemeral)
+    await picker_view.send_report(valid_interaction)
 
     assert captured["governor"].governor_id == 222
     assert captured["requester_id"] == 42
+    assert captured["report_view"] == InventoryReportView.SPEEDUPS
+
+
+@pytest.mark.asyncio
+async def test_preference_view_saves_visibility(monkeypatch):
+    saved = {}
+
+    async def _resolve_visibility(**kwargs):
+        saved.update(kwargs)
+
+    monkeypatch.setattr(
+        inventory_report_views.reporting_service,
+        "resolve_visibility",
+        _resolve_visibility,
+    )
+    view = InventoryPreferenceView(requester_id=42)
+
+    class _Response:
+        async def defer(self, **_kwargs):
+            return None
+
+    class _Followup:
+        async def send(self, content=None, **kwargs):
+            saved["content"] = content
+            saved.update(kwargs)
+
+    interaction = type(
+        "_Interaction",
+        (),
+        {
+            "user": type("_User", (), {"id": 42})(),
+            "response": _Response(),
+            "followup": _Followup(),
+            "edit_original_response": lambda self, **_kwargs: None,
+        },
+    )()
+
+    await view._save(interaction, InventoryReportVisibility.PUBLIC)
+
+    assert saved["discord_user_id"] == 42
+    assert saved["selected_visibility"] == InventoryReportVisibility.PUBLIC
+
+
+@pytest.mark.asyncio
+async def test_report_selection_view_single_governor_only_shows_output_select():
+    ctx, _followup = _make_ctx()
+    view = InventoryReportSelectionView(
+        ctx=ctx,
+        governors=[RegisteredGovernor(111, "MainGov", "Main")],
+        visibility=InventoryReportVisibility.ONLY_ME,
+    )
+
+    placeholders = [getattr(item, "placeholder", None) for item in view.children]
+
+    assert "Select Governor" not in placeholders
+    assert "Select Output" in placeholders

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -128,6 +128,20 @@ async def test_analyse_inventory_image_marks_random_image_failed(monkeypatch):
     assert captured["status"] == InventoryImportStatus.FAILED
 
 
+async def test_decide_analysis_outcome_keeps_materials_disabled_in_service():
+    result = _VisionResult()
+    result.detected_image_type = "materials"
+    result.values = {"materials": {}}
+
+    decision = inventory_service.decide_analysis_outcome(
+        inventory_service._summary_from_vision_result(result)
+    )
+
+    assert decision.action == "reject"
+    assert decision.debug_status == "materials_disabled"
+    assert decision.error == "Materials disabled in Phase 1."
+
+
 async def test_approve_import_blocks_duplicate_same_day_for_non_admin(monkeypatch):
     monkeypatch.setattr(
         inventory_service.inventory_dal,
@@ -200,3 +214,140 @@ async def test_speedup_digit_loss_anomaly_adds_warning():
     summary = inventory_service._summary_from_vision_result(result)
 
     assert any("Healing" in warning and "missing digit" in warning for warning in summary.warnings)
+
+
+async def test_resource_significant_change_requires_confirmation(monkeypatch):
+    monkeypatch.setattr(
+        inventory_service.inventory_dal,
+        "fetch_latest_approved_resource_values",
+        lambda governor_id: {
+            "food": {"from_items_value": 0, "total_resources_value": 100},
+            "wood": {"from_items_value": 0, "total_resources_value": 100},
+            "stone": {"from_items_value": 0, "total_resources_value": 100},
+            "gold": {"from_items_value": 0, "total_resources_value": 100},
+        },
+    )
+    values = {
+        "resources": {
+            "food": {"from_items_value": 0, "total_resources_value": 175},
+            "wood": {"from_items_value": 0, "total_resources_value": 101},
+            "stone": {"from_items_value": 0, "total_resources_value": 99},
+            "gold": {"from_items_value": 0, "total_resources_value": 100},
+        }
+    }
+
+    assessment = await inventory_service.assess_significant_change(
+        governor_id=111,
+        import_type=InventoryImportType.RESOURCES,
+        values=values,
+    )
+
+    assert assessment.requires_confirmation is True
+    assert any("Food" in warning for warning in assessment.warnings)
+
+
+async def test_speedup_significant_change_requires_confirmation(monkeypatch):
+    monkeypatch.setattr(
+        inventory_service.inventory_dal,
+        "fetch_latest_approved_speedup_values",
+        lambda governor_id: {
+            "building": {
+                "total_minutes": 100 * 1440,
+                "total_hours": 2400,
+                "total_days_decimal": 100,
+            },
+            "research": {
+                "total_minutes": 100 * 1440,
+                "total_hours": 2400,
+                "total_days_decimal": 100,
+            },
+            "training": {
+                "total_minutes": 100 * 1440,
+                "total_hours": 2400,
+                "total_days_decimal": 100,
+            },
+            "healing": {
+                "total_minutes": 100 * 1440,
+                "total_hours": 2400,
+                "total_days_decimal": 100,
+            },
+            "universal": {
+                "total_minutes": 100 * 1440,
+                "total_hours": 2400,
+                "total_days_decimal": 100,
+            },
+        },
+    )
+    values = {
+        "speedups": {
+            "building": {"total_minutes": 100 * 1440},
+            "research": {"total_minutes": 100 * 1440},
+            "training": {"total_minutes": 151 * 1440},
+            "healing": {"total_minutes": 100 * 1440},
+            "universal": {"total_minutes": 100 * 1440},
+        }
+    }
+
+    assessment = await inventory_service.assess_significant_change(
+        governor_id=111,
+        import_type=InventoryImportType.SPEEDUPS,
+        values=values,
+    )
+
+    assert assessment.requires_confirmation is True
+    assert any("Training" in warning for warning in assessment.warnings)
+
+
+async def test_significant_change_allows_small_delta(monkeypatch):
+    monkeypatch.setattr(
+        inventory_service.inventory_dal,
+        "fetch_latest_approved_resource_values",
+        lambda governor_id: {
+            "food": {"from_items_value": 0, "total_resources_value": 100},
+            "wood": {"from_items_value": 0, "total_resources_value": 100},
+            "stone": {"from_items_value": 0, "total_resources_value": 100},
+            "gold": {"from_items_value": 0, "total_resources_value": 100},
+        },
+    )
+    values = {
+        "resources": {
+            "food": {"from_items_value": 0, "total_resources_value": 125},
+            "wood": {"from_items_value": 0, "total_resources_value": 100},
+            "stone": {"from_items_value": 0, "total_resources_value": 100},
+            "gold": {"from_items_value": 0, "total_resources_value": 100},
+        }
+    }
+
+    assessment = await inventory_service.assess_significant_change(
+        governor_id=111,
+        import_type=InventoryImportType.RESOURCES,
+        values=values,
+    )
+
+    assert assessment.requires_confirmation is False
+    assert assessment.warnings == []
+
+
+async def test_significant_change_skips_when_no_previous_import(monkeypatch):
+    monkeypatch.setattr(
+        inventory_service.inventory_dal,
+        "fetch_latest_approved_speedup_values",
+        lambda governor_id: {},
+    )
+    values = {
+        "speedups": {
+            "building": {"total_minutes": 100 * 1440},
+            "research": {"total_minutes": 100 * 1440},
+            "training": {"total_minutes": 100 * 1440},
+            "healing": {"total_minutes": 100 * 1440},
+            "universal": {"total_minutes": 100 * 1440},
+        }
+    }
+
+    assessment = await inventory_service.assess_significant_change(
+        governor_id=111,
+        import_type=InventoryImportType.SPEEDUPS,
+        values=values,
+    )
+
+    assert assessment.requires_confirmation is False

--- a/tests/test_inventory_upload_flow.py
+++ b/tests/test_inventory_upload_flow.py
@@ -188,3 +188,71 @@ async def test_confirmation_view_timeout_watch_disables_message(monkeypatch):
     assert view._expired is True
     assert message.edits
     assert all(getattr(item, "disabled", False) for item in view.children)
+
+
+async def test_interaction_review_followup_gets_ephemeral_delete_after(monkeypatch):
+    message = _Message()
+    sent = {}
+
+    class _Response:
+        def __init__(self):
+            self.done = False
+
+        def is_done(self):
+            return self.done
+
+        async def defer(self, **_kwargs):
+            self.done = True
+
+    class _Followup:
+        async def send(self, **kwargs):
+            sent.update(kwargs)
+            return types.SimpleNamespace(edit=lambda **_k: None)
+
+    interaction = types.SimpleNamespace(
+        user=types.SimpleNamespace(id=42),
+        response=_Response(),
+        followup=_Followup(),
+    )
+    summary = InventoryAnalysisSummary(
+        ok=True,
+        import_type=InventoryImportType.SPEEDUPS,
+        values={"speedups": {}},
+        confidence_score=0.95,
+    )
+
+    async def _create_upload_first_batch(**_kwargs):
+        return 99
+
+    async def _analyse_inventory_image(**_kwargs):
+        return summary
+
+    monkeypatch.setattr(
+        inventory_views.inventory_service,
+        "create_upload_first_batch",
+        _create_upload_first_batch,
+    )
+    monkeypatch.setattr(
+        inventory_views.inventory_service,
+        "analyse_inventory_image",
+        _analyse_inventory_image,
+    )
+    monkeypatch.setattr(
+        inventory_views.InventoryConfirmationView,
+        "start_timeout_watch",
+        lambda self: None,
+    )
+
+    await inventory_views._process_payload_for_governor(
+        bot=object(),
+        interaction=interaction,
+        governor_id=111,
+        actor_discord_id=42,
+        payload=InventoryImagePayload(image_bytes=b"img", filename="inventory.png"),
+        original_message=message,
+        batch_id=None,
+        flow_from_pending_command=False,
+    )
+
+    assert sent["ephemeral"] is True
+    assert sent["delete_after"] == inventory_views.INVENTORY_REVIEW_UI_TIMEOUT_SECONDS

--- a/tests/test_inventory_upload_flow.py
+++ b/tests/test_inventory_upload_flow.py
@@ -115,3 +115,39 @@ async def test_confirmation_view_timeout_cancels_active_batch(monkeypatch):
     await view.on_timeout()
 
     assert cancelled == [99]
+    assert view._expired is True
+    assert all(getattr(item, "disabled", False) for item in view.children)
+
+
+async def test_confirmation_view_timeout_edits_message(monkeypatch):
+    async def _cancel(_batch_id):
+        return None
+
+    class _ReviewMessage:
+        def __init__(self):
+            self.edits = []
+
+        async def edit(self, **kwargs):
+            self.edits.append(kwargs)
+
+    monkeypatch.setattr(inventory_views.inventory_service, "cancel_import", _cancel)
+    view = inventory_views.InventoryConfirmationView(
+        bot=object(),
+        actor_discord_id=42,
+        governor_id=111,
+        batch_id=99,
+        payload=InventoryImagePayload(image_bytes=b"img", filename="inventory.png"),
+        summary=InventoryAnalysisSummary(
+            ok=True,
+            import_type=InventoryImportType.RESOURCES,
+            values={"resources": {}},
+            confidence_score=0.95,
+        ),
+    )
+    message = _ReviewMessage()
+    view.message = message
+
+    await view.on_timeout()
+
+    assert message.edits
+    assert "expired" in message.edits[0]["content"]

--- a/tests/test_inventory_upload_flow.py
+++ b/tests/test_inventory_upload_flow.py
@@ -1,3 +1,4 @@
+import asyncio
 import types
 
 import pytest
@@ -151,3 +152,39 @@ async def test_confirmation_view_timeout_edits_message(monkeypatch):
 
     assert message.edits
     assert "expired" in message.edits[0]["content"]
+
+
+async def test_confirmation_view_timeout_watch_disables_message(monkeypatch):
+    async def _cancel(_batch_id):
+        return None
+
+    class _ReviewMessage:
+        def __init__(self):
+            self.edits = []
+
+        async def edit(self, **kwargs):
+            self.edits.append(kwargs)
+
+    monkeypatch.setattr(inventory_views.inventory_service, "cancel_import", _cancel)
+    view = inventory_views.InventoryConfirmationView(
+        bot=object(),
+        actor_discord_id=42,
+        governor_id=111,
+        batch_id=99,
+        payload=InventoryImagePayload(image_bytes=b"img", filename="inventory.png"),
+        summary=InventoryAnalysisSummary(
+            ok=True,
+            import_type=InventoryImportType.SPEEDUPS,
+            values={"speedups": {}},
+            confidence_score=0.95,
+        ),
+    )
+    message = _ReviewMessage()
+    view.message = message
+
+    view.start_timeout_watch(timeout_seconds=0.01)
+    await asyncio.sleep(0.03)
+
+    assert view._expired is True
+    assert message.edits
+    assert all(getattr(item, "disabled", False) for item in view.children)

--- a/tests/test_inventory_upload_flow.py
+++ b/tests/test_inventory_upload_flow.py
@@ -190,9 +190,8 @@ async def test_confirmation_view_timeout_watch_disables_message(monkeypatch):
     assert all(getattr(item, "disabled", False) for item in view.children)
 
 
-async def test_interaction_review_followup_gets_ephemeral_delete_after(monkeypatch):
+async def test_interaction_review_prefers_channel_message_when_upload_message_exists(monkeypatch):
     message = _Message()
-    sent = {}
 
     class _Response:
         def __init__(self):
@@ -204,15 +203,10 @@ async def test_interaction_review_followup_gets_ephemeral_delete_after(monkeypat
         async def defer(self, **_kwargs):
             self.done = True
 
-    class _Followup:
-        async def send(self, **kwargs):
-            sent.update(kwargs)
-            return types.SimpleNamespace(edit=lambda **_k: None)
-
     interaction = types.SimpleNamespace(
         user=types.SimpleNamespace(id=42),
         response=_Response(),
-        followup=_Followup(),
+        followup=types.SimpleNamespace(send=None),
     )
     summary = InventoryAnalysisSummary(
         ok=True,
@@ -254,5 +248,63 @@ async def test_interaction_review_followup_gets_ephemeral_delete_after(monkeypat
         flow_from_pending_command=False,
     )
 
-    assert sent["ephemeral"] is True
-    assert sent["delete_after"] == inventory_views.INVENTORY_REVIEW_UI_TIMEOUT_SECONDS
+    assert message.deleted is False
+    assert message.channel.sent
+    assert message.channel.sent[-1][1]["view"] is not None
+    assert (
+        message.channel.sent[-1][1]["delete_after"]
+        == inventory_views.INVENTORY_REVIEW_TIMEOUT_SECONDS
+    )
+
+
+async def test_approve_deletes_original_upload_after_success(monkeypatch):
+    async def _state(_batch_id):
+        return inventory_views.inventory_service.InventoryReviewActionState(active=True)
+
+    async def _assessment(**_kwargs):
+        return inventory_views.inventory_service.InventorySignificantChangeAssessment()
+
+    async def _approve(**_kwargs):
+        return {"resources": {}}
+
+    monkeypatch.setattr(inventory_views.inventory_service, "get_review_action_state", _state)
+    monkeypatch.setattr(inventory_views.inventory_service, "assess_significant_change", _assessment)
+    monkeypatch.setattr(inventory_views.inventory_service, "approve_import", _approve)
+    monkeypatch.setattr(
+        inventory_views.inventory_service, "mark_original_upload_deleted", lambda _id: None
+    )
+
+    original = _Message()
+    view = inventory_views.InventoryConfirmationView(
+        bot=object(),
+        actor_discord_id=42,
+        governor_id=111,
+        batch_id=99,
+        payload=InventoryImagePayload(image_bytes=b"img", filename="inventory.png"),
+        summary=InventoryAnalysisSummary(
+            ok=True,
+            import_type=InventoryImportType.RESOURCES,
+            values={"resources": {}},
+            confidence_score=0.95,
+        ),
+        original_message=original,
+    )
+
+    class _Response:
+        async def defer(self, **_kwargs):
+            return None
+
+    class _Followup:
+        async def send(self, *_args, **_kwargs):
+            return None
+
+    interaction = types.SimpleNamespace(
+        user=types.SimpleNamespace(id=42),
+        response=_Response(),
+        followup=_Followup(),
+        message=None,
+    )
+
+    await view.approve.callback(interaction)
+
+    assert original.deleted is True

--- a/tests/test_inventory_views.py
+++ b/tests/test_inventory_views.py
@@ -157,15 +157,23 @@ async def test_speedup_correction_modal_prompts_friendly_durations():
 
 
 @pytest.mark.asyncio
-async def test_speedup_correction_updates_original_review_message():
+async def test_speedup_correction_updates_original_review_message(monkeypatch):
     parent = _view(InventoryImportType.SPEEDUPS)
     edited = {}
+
+    async def _state(_batch_id):
+        return inventory_service.InventoryReviewActionState(active=True)
+
+    monkeypatch.setattr(inventory_views.inventory_service, "get_review_action_state", _state)
 
     class _Message:
         async def edit(self, **kwargs):
             edited.update(kwargs)
 
     class _Response:
+        def is_done(self):
+            return False
+
         async def send_message(self, *args, **kwargs):
             edited["response"] = (args, kwargs)
 

--- a/tests/test_inventory_views.py
+++ b/tests/test_inventory_views.py
@@ -99,6 +99,15 @@ def test_inventory_review_embed_hides_model_and_fallback_details():
 
 
 @pytest.mark.asyncio
+async def test_inventory_review_uses_single_cancel_button():
+    view = _view(InventoryImportType.SPEEDUPS)
+    custom_ids = [item.custom_id for item in view.children]
+
+    assert "inventory_import_cancel" in custom_ids
+    assert "inventory_import_reject" not in custom_ids
+
+
+@pytest.mark.asyncio
 async def test_resource_correction_modal_only_prompts_total_resources():
     modal = ResourceCorrectionModal(_view(InventoryImportType.RESOURCES))
 

--- a/tests/test_inventory_views.py
+++ b/tests/test_inventory_views.py
@@ -248,6 +248,22 @@ async def test_stale_click_after_timeout_returns_expired_message(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_review_buttons_reject_non_initiating_user(monkeypatch):
+    parent = _view(InventoryImportType.RESOURCES)
+    interaction = _Interaction(user_id=999)
+
+    async def _state(_batch_id):
+        raise AssertionError("actor check should run before state lookup")
+
+    monkeypatch.setattr(inventory_views.inventory_service, "get_review_action_state", _state)
+
+    denied = await parent._deny_if_not_actor(interaction)
+
+    assert denied is True
+    assert "Only the user who started this import" in interaction.response.messages[0][0]
+
+
+@pytest.mark.asyncio
 async def test_correction_modal_rejects_expired_parent():
     parent = _view(InventoryImportType.SPEEDUPS)
     parent._expired = True

--- a/tests/test_inventory_views.py
+++ b/tests/test_inventory_views.py
@@ -1,6 +1,8 @@
 import pytest
 
+from inventory import inventory_service
 from inventory.models import InventoryAnalysisSummary, InventoryImportType
+from ui.views import inventory_views
 from ui.views.inventory_views import (
     InventoryConfirmationView,
     ResourceCorrectionModal,
@@ -44,6 +46,46 @@ def _view(import_type):
         payload=object(),
         summary=_summary(import_type),
     )
+
+
+class _DoneResponse:
+    def __init__(self):
+        self.messages = []
+        self.deferred = False
+
+    def is_done(self):
+        return self.deferred
+
+    async def defer(self, **_kwargs):
+        self.deferred = True
+
+    async def send_message(self, content=None, **kwargs):
+        self.messages.append((content, kwargs))
+        self.deferred = True
+
+
+class _Followup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append((content, kwargs))
+
+
+class _Message:
+    def __init__(self):
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+class _Interaction:
+    def __init__(self, user_id=42):
+        self.user = type("_User", (), {"id": user_id})()
+        self.response = _DoneResponse()
+        self.followup = _Followup()
+        self.message = _Message()
 
 
 def test_inventory_review_embed_hides_model_and_fallback_details():
@@ -149,3 +191,62 @@ async def test_speedup_correction_updates_original_review_message():
         field for field in edited["embed"].fields if field.name == "Corrected Values"
     )
     assert "Healing: `505d`" in corrected_field.value
+
+
+@pytest.mark.asyncio
+async def test_approve_requires_second_click_for_significant_change(monkeypatch):
+    parent = _view(InventoryImportType.RESOURCES)
+    interaction = _Interaction()
+
+    async def _state(_batch_id):
+        return inventory_service.InventoryReviewActionState(active=True)
+
+    async def _assessment(**_kwargs):
+        return inventory_service.InventorySignificantChangeAssessment(
+            requires_confirmation=True,
+            warnings=["Food changed by more than 50% (100 -> 200)."],
+        )
+
+    async def _approve(**_kwargs):
+        raise AssertionError("approval should wait for the second confirmation")
+
+    monkeypatch.setattr(inventory_views.inventory_service, "get_review_action_state", _state)
+    monkeypatch.setattr(inventory_views.inventory_service, "assess_significant_change", _assessment)
+    monkeypatch.setattr(inventory_views.inventory_service, "approve_import", _approve)
+
+    await parent.approve.callback(interaction)
+
+    assert parent._significant_change_confirmed is True
+    assert "significantly different" in interaction.followup.sent[0][0]
+    assert interaction.message.edits
+
+
+@pytest.mark.asyncio
+async def test_stale_click_after_timeout_returns_expired_message(monkeypatch):
+    parent = _view(InventoryImportType.RESOURCES)
+    parent._expired = True
+    parent._terminal = True
+    interaction = _Interaction()
+
+    async def _state(_batch_id):
+        raise AssertionError("local expired state should short-circuit")
+
+    monkeypatch.setattr(inventory_views.inventory_service, "get_review_action_state", _state)
+
+    denied = await parent._deny_if_not_actor(interaction)
+
+    assert denied is True
+    assert "expired" in interaction.response.messages[0][0]
+
+
+@pytest.mark.asyncio
+async def test_correction_modal_rejects_expired_parent():
+    parent = _view(InventoryImportType.SPEEDUPS)
+    parent._expired = True
+    parent._terminal = True
+    modal = SpeedupCorrectionModal(parent)
+    interaction = _Interaction()
+
+    await modal.callback(interaction)
+
+    assert "expired" in interaction.response.messages[0][0]

--- a/ui/views/inventory_report_views.py
+++ b/ui/views/inventory_report_views.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import discord
 
-from account_picker import AccountPickerView, build_unique_gov_options
 from inventory import export_service, reporting_service
 from inventory.models import (
     InventoryExportFormat,
@@ -16,9 +15,14 @@ from inventory.models import (
     RegisteredGovernor,
 )
 from inventory.report_image_renderer import render_inventory_reports
-from ui.views.inventory_views import governors_to_accounts
 
 logger = logging.getLogger(__name__)
+
+REPORT_VIEW_OPTIONS = {
+    "All": InventoryReportView.ALL,
+    "RSS": InventoryReportView.RESOURCES,
+    "Speedups": InventoryReportView.SPEEDUPS,
+}
 
 
 async def _avatar_bytes(user: Any) -> bytes | None:
@@ -274,69 +278,190 @@ async def send_inventory_report(
     )
 
 
-async def start_myinventory_command(
-    *,
-    ctx: discord.ApplicationContext,
-    governor_id: int | None,
-    report_view: InventoryReportView,
-    range_key: InventoryReportRange,
-    visibility: InventoryReportVisibility,
-) -> None:
-    governor = await reporting_service.resolve_governor_for_report(
-        discord_user_id=int(ctx.user.id),
-        governor_id=governor_id,
-        discord_user=ctx.user,
+class InventoryPreferenceView(discord.ui.View):
+    def __init__(self, *, requester_id: int) -> None:
+        super().__init__(timeout=300)
+        self.requester_id = int(requester_id)
+
+    async def _save(
+        self, interaction: discord.Interaction, visibility: InventoryReportVisibility
+    ) -> None:
+        if int(interaction.user.id) != self.requester_id:
+            await interaction.response.send_message(
+                "This preference prompt is not for you.", ephemeral=True
+            )
+            return
+        await interaction.response.defer(ephemeral=True)
+        await reporting_service.resolve_visibility(
+            discord_user_id=self.requester_id,
+            selected_visibility=visibility,
+        )
+        for item in self.children:
+            item.disabled = True
+        self.stop()
+        await interaction.followup.send(
+            "Inventory report preference saved. Run `/myinventory` again to view your report.",
+            ephemeral=True,
+        )
+        try:
+            await interaction.edit_original_response(view=self)
+        except Exception:
+            logger.debug("inventory_preference_prompt_update_failed", exc_info=True)
+
+    @discord.ui.button(
+        label="Only Me",
+        style=discord.ButtonStyle.primary,
+        custom_id="inventory_pref_only_me",
     )
-    if governor is None:
-        governors = await reporting_service.get_registered_governors_for_user(int(ctx.user.id))
-        if not governors:
-            await ctx.followup.send(
-                "I do not see any governors registered to you. Use `/register_governor` first.",
+    async def only_me(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+        await self._save(interaction, InventoryReportVisibility.ONLY_ME)
+
+    @discord.ui.button(
+        label="Public",
+        style=discord.ButtonStyle.secondary,
+        custom_id="inventory_pref_public",
+    )
+    async def public(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+        await self._save(interaction, InventoryReportVisibility.PUBLIC)
+
+
+async def send_inventory_preference_prompt(ctx: discord.ApplicationContext) -> None:
+    await ctx.followup.send(
+        "Choose how `/myinventory` should post your reports.",
+        view=InventoryPreferenceView(requester_id=int(ctx.user.id)),
+        ephemeral=True,
+    )
+
+
+class InventoryReportSelectionView(discord.ui.View):
+    def __init__(
+        self,
+        *,
+        ctx: discord.ApplicationContext,
+        governors: list[RegisteredGovernor],
+        visibility: InventoryReportVisibility,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.ctx = ctx
+        self.requester_id = int(ctx.user.id)
+        self.governors_by_id = {item.governor_id: item for item in governors}
+        self.selected_governor_id = governors[0].governor_id if len(governors) == 1 else None
+        self.selected_view = InventoryReportView.ALL
+        self.visibility = visibility
+        if len(governors) > 1:
+            self.add_item(InventoryGovernorSelect(governors))
+        self.add_item(InventoryOutputSelect())
+
+    async def send_report(self, interaction: discord.Interaction) -> None:
+        if int(interaction.user.id) != self.requester_id:
+            await interaction.response.send_message(
+                "This inventory selector is not for you. Run `/myinventory` to get your own.",
                 ephemeral=True,
             )
             return
-
-        options = build_unique_gov_options(governors_to_accounts(governors))
-        governors_by_id = {item.governor_id: item for item in governors}
-
-        async def _on_select(
-            interaction: discord.Interaction, selected_governor_id: str, ephemeral: bool
-        ) -> None:
-            if int(interaction.user.id) != int(ctx.user.id):
-                await interaction.followup.send("This selector is not for you.", ephemeral=True)
-                return
-            selected = governors_by_id.get(int(selected_governor_id))
-            if selected is None:
-                await interaction.followup.send(
-                    "Selected governor is no longer available. Run `/myinventory` again.",
-                    ephemeral=True,
-                )
-                return
-            await _send_inventory_report_message(
-                send=interaction.followup.send,
-                user=interaction.user,
-                requester_id=int(ctx.user.id),
-                governor=selected,
-                report_view=report_view,
-                range_key=range_key,
-                visibility=visibility,
+        if self.selected_governor_id is None:
+            await interaction.response.send_message("Choose a governor first.", ephemeral=True)
+            return
+        governor = self.governors_by_id.get(int(self.selected_governor_id))
+        if governor is None:
+            await interaction.response.send_message(
+                "Selected governor is no longer available. Run `/myinventory` again.",
+                ephemeral=True,
             )
+            return
+        await interaction.response.defer(
+            ephemeral=self.visibility == InventoryReportVisibility.ONLY_ME
+        )
+        await _send_inventory_report_message(
+            send=interaction.followup.send,
+            user=interaction.user,
+            requester_id=self.requester_id,
+            governor=governor,
+            report_view=self.selected_view,
+            range_key=InventoryReportRange.ONE_MONTH,
+            visibility=self.visibility,
+        )
 
-        view = AccountPickerView(
-            ctx=ctx,
+    @discord.ui.button(
+        label="Show Report",
+        style=discord.ButtonStyle.primary,
+        custom_id="inventory_report_show",
+        row=2,
+    )
+    async def show_report(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ) -> None:
+        await self.send_report(interaction)
+
+
+class InventoryGovernorSelect(discord.ui.Select):
+    def __init__(self, governors: list[RegisteredGovernor]) -> None:
+        options = [
+            discord.SelectOption(
+                label=item.governor_name[:100],
+                value=str(item.governor_id),
+                description=item.account_type[:100],
+            )
+            for item in governors
+        ]
+        super().__init__(
+            placeholder="Select Governor",
+            min_values=1,
+            max_values=1,
             options=options,
-            on_select_governor=_on_select,
-            heading="Select which governor inventory report to view:",
-            show_register_btn=False,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, InventoryReportSelectionView):
+            return
+        if int(interaction.user.id) != view.requester_id:
+            await interaction.response.send_message("This selector is not for you.", ephemeral=True)
+            return
+        view.selected_governor_id = int(self.values[0])
+        await interaction.response.defer(ephemeral=True)
+
+
+class InventoryOutputSelect(discord.ui.Select):
+    def __init__(self) -> None:
+        options = [
+            discord.SelectOption(label=label, value=view.value)
+            for label, view in REPORT_VIEW_OPTIONS.items()
+        ]
+        super().__init__(
+            placeholder="Select Output",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, InventoryReportSelectionView):
+            return
+        if int(interaction.user.id) != view.requester_id:
+            await interaction.response.send_message("This selector is not for you.", ephemeral=True)
+            return
+        view.selected_view = InventoryReportView(self.values[0])
+        await interaction.response.defer(ephemeral=True)
+
+
+async def start_myinventory_command(
+    *,
+    ctx: discord.ApplicationContext,
+    visibility: InventoryReportVisibility,
+) -> None:
+    governors = await reporting_service.get_registered_governors_for_user(int(ctx.user.id))
+    if not governors:
+        await ctx.followup.send(
+            "I do not see any governors registered to you. Use `/register_governor` first.",
             ephemeral=True,
         )
-        await ctx.followup.send(view.heading, view=view, ephemeral=True)
         return
-
-    await send_inventory_report(
-        ctx=ctx,
-        governor=governor,
-        report_view=report_view,
-        range_key=range_key,
-        visibility=visibility,
+    await ctx.followup.send(
+        "Choose the inventory report to view:",
+        view=InventoryReportSelectionView(ctx=ctx, governors=governors, visibility=visibility),
+        ephemeral=True,
     )

--- a/ui/views/inventory_report_views.py
+++ b/ui/views/inventory_report_views.py
@@ -300,7 +300,8 @@ class InventoryPreferenceView(discord.ui.View):
             item.disabled = True
         self.stop()
         await interaction.followup.send(
-            "Inventory report preference saved. Run `/myinventory` again to view your report.",
+            "Inventory report preference saved. Run `/myinventory` again to view your report. "
+            "You can change this later with `/inventory_preferences`.",
             ephemeral=True,
         )
         try:
@@ -327,7 +328,8 @@ class InventoryPreferenceView(discord.ui.View):
 
 async def send_inventory_preference_prompt(ctx: discord.ApplicationContext) -> None:
     await ctx.followup.send(
-        "Choose how `/myinventory` should post your reports.",
+        "Choose how `/myinventory` should post your reports. "
+        "You can change this later with `/inventory_preferences`.",
         view=InventoryPreferenceView(requester_id=int(ctx.user.id)),
         ephemeral=True,
     )
@@ -348,6 +350,7 @@ class InventoryReportSelectionView(discord.ui.View):
         self.selected_governor_id = governors[0].governor_id if len(governors) == 1 else None
         self.selected_view = InventoryReportView.ALL
         self.visibility = visibility
+        self._completed = False
         if len(governors) > 1:
             self.add_item(InventoryGovernorSelect(governors))
         self.add_item(InventoryOutputSelect())
@@ -356,6 +359,12 @@ class InventoryReportSelectionView(discord.ui.View):
         if int(interaction.user.id) != self.requester_id:
             await interaction.response.send_message(
                 "This inventory selector is not for you. Run `/myinventory` to get your own.",
+                ephemeral=True,
+            )
+            return
+        if self._completed:
+            await interaction.response.send_message(
+                "This inventory selector has already been used. Run `/myinventory` again to choose another report.",
                 ephemeral=True,
             )
             return
@@ -372,6 +381,17 @@ class InventoryReportSelectionView(discord.ui.View):
         await interaction.response.defer(
             ephemeral=self.visibility == InventoryReportVisibility.ONLY_ME
         )
+        self._completed = True
+        for item in self.children:
+            item.disabled = True
+        self.stop()
+        try:
+            await interaction.edit_original_response(
+                content="Inventory report selected.",
+                view=self,
+            )
+        except Exception:
+            logger.debug("inventory_report_selector_complete_update_failed", exc_info=True)
         await _send_inventory_report_message(
             send=interaction.followup.send,
             user=interaction.user,
@@ -416,6 +436,11 @@ class InventoryGovernorSelect(discord.ui.Select):
         view = self.view
         if not isinstance(view, InventoryReportSelectionView):
             return
+        if getattr(view, "_completed", False):
+            await interaction.response.send_message(
+                "This inventory selector has already been used.", ephemeral=True
+            )
+            return
         if int(interaction.user.id) != view.requester_id:
             await interaction.response.send_message("This selector is not for you.", ephemeral=True)
             return
@@ -440,6 +465,11 @@ class InventoryOutputSelect(discord.ui.Select):
     async def callback(self, interaction: discord.Interaction) -> None:
         view = self.view
         if not isinstance(view, InventoryReportSelectionView):
+            return
+        if getattr(view, "_completed", False):
+            await interaction.response.send_message(
+                "This inventory selector has already been used.", ephemeral=True
+            )
             return
         if int(interaction.user.id) != view.requester_id:
             await interaction.response.send_message("This selector is not for you.", ephemeral=True)

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -35,6 +35,7 @@ SCREENSHOT_GUIDELINES = (
     "Do not upload edited or compressed screenshots."
 )
 INVENTORY_REVIEW_TIMEOUT_SECONDS = 900
+INVENTORY_REVIEW_UI_TIMEOUT_SECONDS = 870
 
 
 def governors_to_accounts(governors: list[RegisteredGovernor]) -> dict[str, dict[str, Any]]:
@@ -185,7 +186,7 @@ class InventoryConfirmationView(discord.ui.View):
         payload: InventoryImagePayload,
         summary: InventoryAnalysisSummary,
     ) -> None:
-        super().__init__(timeout=INVENTORY_REVIEW_TIMEOUT_SECONDS)
+        super().__init__(timeout=INVENTORY_REVIEW_UI_TIMEOUT_SECONDS)
         self.bot = bot
         self.actor_discord_id = int(actor_discord_id)
         self.governor_id = int(governor_id)
@@ -208,7 +209,7 @@ class InventoryConfirmationView(discord.ui.View):
     def start_timeout_watch(self, *, timeout_seconds: float | None = None) -> None:
         if self._timeout_task is not None and not self._timeout_task.done():
             return
-        delay = float(timeout_seconds or INVENTORY_REVIEW_TIMEOUT_SECONDS)
+        delay = float(timeout_seconds or INVENTORY_REVIEW_UI_TIMEOUT_SECONDS)
         self._timeout_task = asyncio.create_task(self._timeout_watch(delay))
 
     async def _timeout_watch(self, delay: float) -> None:
@@ -811,6 +812,7 @@ async def _process_payload_for_governor(
                 embed=embed,
                 view=view,
                 ephemeral=True,
+                delete_after=INVENTORY_REVIEW_UI_TIMEOUT_SECONDS,
             )
             view.message = sent
             view.start_timeout_watch()
@@ -819,6 +821,7 @@ async def _process_payload_for_governor(
                 f"<@{actor_discord_id}> {content}",
                 embed=embed,
                 view=view,
+                delete_after=INVENTORY_REVIEW_TIMEOUT_SECONDS,
             )
             view.message = sent
             view.start_timeout_watch()

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
@@ -33,6 +34,7 @@ SCREENSHOT_GUIDELINES = (
     "Use English game language if possible.\n"
     "Do not upload edited or compressed screenshots."
 )
+INVENTORY_REVIEW_TIMEOUT_SECONDS = 900
 
 
 def governors_to_accounts(governors: list[RegisteredGovernor]) -> dict[str, dict[str, Any]]:
@@ -183,7 +185,7 @@ class InventoryConfirmationView(discord.ui.View):
         payload: InventoryImagePayload,
         summary: InventoryAnalysisSummary,
     ) -> None:
-        super().__init__(timeout=900)
+        super().__init__(timeout=INVENTORY_REVIEW_TIMEOUT_SECONDS)
         self.bot = bot
         self.actor_discord_id = int(actor_discord_id)
         self.governor_id = int(governor_id)
@@ -196,11 +198,32 @@ class InventoryConfirmationView(discord.ui.View):
         self._significant_change_confirmed = False
         self._significant_change_warnings: list[str] = []
         self.message: discord.Message | None = None
+        self._timeout_task: asyncio.Task[None] | None = None
 
         if summary.import_type in {InventoryImportType.MATERIALS, InventoryImportType.UNKNOWN}:
             for child in self.children:
                 if getattr(child, "custom_id", "") == "inventory_import_approve":
                     child.disabled = True
+
+    def start_timeout_watch(self, *, timeout_seconds: float | None = None) -> None:
+        if self._timeout_task is not None and not self._timeout_task.done():
+            return
+        delay = float(timeout_seconds or INVENTORY_REVIEW_TIMEOUT_SECONDS)
+        self._timeout_task = asyncio.create_task(self._timeout_watch(delay))
+
+    async def _timeout_watch(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            if not self._terminal:
+                await self.on_timeout()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug(
+                "inventory_review_timeout_watch_failed batch_id=%s",
+                self.batch_id,
+                exc_info=True,
+            )
 
     async def _mark_unusable(
         self, interaction: discord.Interaction | None, *, expired: bool, content: str
@@ -209,6 +232,13 @@ class InventoryConfirmationView(discord.ui.View):
         self._expired = expired
         self.disable_all_items()
         self.stop()
+        current_task = asyncio.current_task()
+        if (
+            self._timeout_task is not None
+            and self._timeout_task is not current_task
+            and not self._timeout_task.done()
+        ):
+            self._timeout_task.cancel()
         message = getattr(interaction, "message", None) if interaction is not None else None
         message = message or self.message
         if message is None:
@@ -783,14 +813,15 @@ async def _process_payload_for_governor(
                 ephemeral=True,
             )
             view.message = sent
+            view.start_timeout_watch()
         elif original_message is not None:
             sent = await original_message.channel.send(
                 f"<@{actor_discord_id}> {content}",
                 embed=embed,
                 view=view,
-                delete_after=900,
             )
             view.message = sent
+            view.start_timeout_watch()
     except Exception:
         logger.exception("inventory_process_payload_failed governor_id=%s", governor_id)
         if interaction is not None:

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -256,9 +256,26 @@ class InventoryConfirmationView(discord.ui.View):
         return True
 
     async def _deny_if_modal_unusable(self, interaction: discord.Interaction) -> bool:
-        if not self._is_locally_unusable():
+        if self._is_locally_unusable():
+            await _send_private(interaction, self._terminal_message())
+            return True
+        try:
+            state = await inventory_service.get_review_action_state(self.batch_id)
+        except Exception:
+            logger.exception("inventory_review_state_check_failed batch_id=%s", self.batch_id)
+            await _send_private(
+                interaction,
+                f"Could not verify this import state. Please try again or contact an admin with batch ID {self.batch_id}.",
+            )
+            return True
+        if state.active:
             return False
-        await _send_private(interaction, self._terminal_message())
+        await self._mark_unusable(
+            interaction,
+            expired=state.expired,
+            content=state.message or self._terminal_message(),
+        )
+        await _send_private(interaction, state.message or self._terminal_message())
         return True
 
     async def _requires_second_approve(self, interaction: discord.Interaction) -> bool:
@@ -273,7 +290,12 @@ class InventoryConfirmationView(discord.ui.View):
             )
         except Exception:
             logger.exception("inventory_significant_change_check_failed batch_id=%s", self.batch_id)
-            return False
+            await _send_private(
+                interaction,
+                f"Could not assess whether this import is significantly different from the latest approved import. "
+                f"Please try again or contact an admin with batch ID {self.batch_id}.",
+            )
+            return True
         if not assessment.requires_confirmation:
             return False
         self._significant_change_confirmed = True

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -94,7 +94,8 @@ def _analysis_embed(
 
 
 async def _send_private(interaction: discord.Interaction, content: str, **kwargs: Any) -> None:
-    if interaction.response.is_done():
+    response_done = getattr(interaction.response, "is_done", None)
+    if callable(response_done) and response_done():
         await interaction.followup.send(content, ephemeral=True, **kwargs)
     else:
         await interaction.response.send_message(content, ephemeral=True, **kwargs)

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -191,6 +191,9 @@ class InventoryConfirmationView(discord.ui.View):
         self.summary = summary
         self.corrected_values: dict[str, Any] | None = None
         self._terminal = False
+        self._expired = False
+        self._significant_change_confirmed = False
+        self._significant_change_warnings: list[str] = []
         self.message: discord.Message | None = None
 
         if summary.import_type in {InventoryImportType.MATERIALS, InventoryImportType.UNKNOWN}:
@@ -198,14 +201,94 @@ class InventoryConfirmationView(discord.ui.View):
                 if getattr(child, "custom_id", "") == "inventory_import_approve":
                     child.disabled = True
 
+    async def _mark_unusable(
+        self, interaction: discord.Interaction | None, *, expired: bool, content: str
+    ) -> None:
+        self._terminal = True
+        self._expired = expired
+        self.disable_all_items()
+        self.stop()
+        message = getattr(interaction, "message", None) if interaction is not None else None
+        message = message or self.message
+        if message is None:
+            return
+        self.message = message
+        try:
+            await message.edit(content=content, view=self)
+        except Exception:
+            logger.debug("inventory_review_unusable_message_edit_failed", exc_info=True)
+
+    def _terminal_message(self) -> str:
+        if self._expired:
+            return "This import review expired. Please upload the screenshot again."
+        return "This import has already been completed."
+
+    def _is_locally_unusable(self) -> bool:
+        return self._terminal or self._expired
+
     async def _deny_if_not_actor(self, interaction: discord.Interaction) -> bool:
-        if self._terminal:
-            await _send_private(interaction, "This import has already been completed.")
+        actor = getattr(interaction, "user", None)
+        if actor is not None and int(actor.id) != self.actor_discord_id:
+            await _send_private(
+                interaction, "Only the user who started this import can use these buttons."
+            )
             return True
-        if int(interaction.user.id) == self.actor_discord_id:
+        if self._is_locally_unusable():
+            await _send_private(interaction, self._terminal_message())
+            return True
+        try:
+            state = await inventory_service.get_review_action_state(self.batch_id)
+        except Exception:
+            logger.exception("inventory_review_state_check_failed batch_id=%s", self.batch_id)
+            await _send_private(
+                interaction,
+                f"Could not verify this import state. Please try again or contact an admin with batch ID {self.batch_id}.",
+            )
+            return True
+        if state.active:
             return False
+        await self._mark_unusable(
+            interaction,
+            expired=state.expired,
+            content=state.message or self._terminal_message(),
+        )
+        await _send_private(interaction, state.message or self._terminal_message())
+        return True
+
+    async def _deny_if_modal_unusable(self, interaction: discord.Interaction) -> bool:
+        if not self._is_locally_unusable():
+            return False
+        await _send_private(interaction, self._terminal_message())
+        return True
+
+    async def _requires_second_approve(self, interaction: discord.Interaction) -> bool:
+        if self._significant_change_confirmed:
+            return False
+        final_values = self.corrected_values or self.summary.values
+        try:
+            assessment = await inventory_service.assess_significant_change(
+                governor_id=self.governor_id,
+                import_type=self.summary.import_type,
+                values=final_values,
+            )
+        except Exception:
+            logger.exception("inventory_significant_change_check_failed batch_id=%s", self.batch_id)
+            return False
+        if not assessment.requires_confirmation:
+            return False
+        self._significant_change_confirmed = True
+        self._significant_change_warnings = assessment.warnings
+        warning_text = "\n".join(f"- {item}" for item in assessment.warnings[:5])
         await _send_private(
-            interaction, "Only the user who started this import can use these buttons."
+            interaction,
+            (
+                "This import is significantly different from the latest approved import for this governor.\n"
+                f"{warning_text}\n\nPress Approve Import again to confirm these values."
+            ),
+        )
+        await self._update_review_message(
+            interaction,
+            content="Significant change detected. Press Approve Import again to confirm.",
         )
         return True
 
@@ -246,6 +329,15 @@ class InventoryConfirmationView(discord.ui.View):
                     value="Corrections are saved for this pending import. Press Approve Import to save them.",
                     inline=False,
                 )
+        if self._significant_change_warnings and not self._terminal:
+            embed.add_field(
+                name="Significant Change Check",
+                value=(
+                    "\n".join(self._significant_change_warnings[:5])
+                    + "\nPress Approve Import again to confirm."
+                )[:1024],
+                inline=False,
+            )
         try:
             await message.edit(
                 content=content or "Review the detected inventory values before approving.",
@@ -274,6 +366,8 @@ class InventoryConfirmationView(discord.ui.View):
         await interaction.response.defer(ephemeral=True)
         try:
             final_values = self.corrected_values or self.summary.values
+            if await self._requires_second_approve(interaction):
+                return
             normalized = await inventory_service.approve_import(
                 import_batch_id=self.batch_id,
                 governor_id=self.governor_id,
@@ -410,13 +504,11 @@ class InventoryConfirmationView(discord.ui.View):
                     self.batch_id,
                     exc_info=True,
                 )
-        self.disable_all_items()
-        message = getattr(self, "message", None)
-        if message is not None:
-            try:
-                await message.edit(view=self)
-            except Exception:
-                logger.debug("inventory_timeout_message_edit_failed", exc_info=True)
+        await self._mark_unusable(
+            None,
+            expired=True,
+            content="Inventory import review expired. Please upload the screenshot again.",
+        )
 
 
 class ResourceCorrectionModal(discord.ui.Modal):
@@ -437,6 +529,8 @@ class ResourceCorrectionModal(discord.ui.Modal):
             self.add_item(field)
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        if await self.parent_view._deny_if_modal_unusable(interaction):
+            return
         corrections = {key: str(field.value or "") for key, field in self.inputs.items()}
         try:
             corrected = apply_resource_total_corrections(
@@ -450,6 +544,8 @@ class ResourceCorrectionModal(discord.ui.Modal):
             )
             return
         self.parent_view.corrected_values = corrected
+        self.parent_view._significant_change_confirmed = False
+        self.parent_view._significant_change_warnings = []
         await interaction.response.send_message(
             "Correction saved. Press Approve Import on the updated review to save it.",
             ephemeral=True,
@@ -475,6 +571,8 @@ class SpeedupCorrectionModal(discord.ui.Modal):
             self.add_item(field)
 
     async def callback(self, interaction: discord.Interaction) -> None:
+        if await self.parent_view._deny_if_modal_unusable(interaction):
+            return
         corrections = {key: str(field.value or "") for key, field in self.inputs.items()}
         try:
             corrected = apply_speedup_duration_corrections(
@@ -488,6 +586,8 @@ class SpeedupCorrectionModal(discord.ui.Modal):
             )
             return
         self.parent_view.corrected_values = corrected
+        self.parent_view._significant_change_confirmed = False
+        self.parent_view._significant_change_warnings = []
         await interaction.response.send_message(
             "Correction saved. Press Approve Import on the updated review to save it.",
             ephemeral=True,
@@ -592,21 +692,18 @@ async def _process_payload_for_governor(
             import_batch_id=batch_id,
             payload=payload,
         )
-        if (
-            not summary.ok
-            or summary.confidence_score < 0.70
-            or summary.import_type == InventoryImportType.UNKNOWN
-        ):
-            await inventory_service.fail_import(batch_id, error=summary.error or "Analysis failed.")
+        decision = inventory_service.decide_analysis_outcome(summary)
+        if decision.action == "fail":
+            await inventory_service.fail_import(batch_id, error=decision.error)
             await _post_admin_debug(
                 bot=bot,
                 batch_id=batch_id,
                 governor_id=governor_id,
                 discord_user_id=actor_discord_id,
-                status="failed",
+                status=decision.debug_status or "failed",
                 payload=payload,
                 summary=summary,
-                error_json={"error": summary.error or "Analysis failed."},
+                error_json={"error": decision.error},
             )
             message = (
                 "I could not read this inventory screenshot clearly enough. No values were saved.\n\n"
@@ -621,17 +718,17 @@ async def _process_payload_for_governor(
             return
 
         embed = _analysis_embed(governor_id=governor_id, summary=summary)
-        if summary.import_type == InventoryImportType.MATERIALS:
-            await inventory_service.reject_import(batch_id, error="Materials disabled in Phase 1.")
+        if decision.action == "reject":
+            await inventory_service.reject_import(batch_id, error=decision.error)
             await _post_admin_debug(
                 bot=bot,
                 batch_id=batch_id,
                 governor_id=governor_id,
                 discord_user_id=actor_discord_id,
-                status="materials_disabled",
+                status=decision.debug_status or "rejected",
                 payload=payload,
                 summary=summary,
-                error_json={"error": "Materials disabled in Phase 1."},
+                error_json={"error": decision.error},
             )
             content = "Materials import is not available yet. No values were saved."
             if interaction is not None:

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -111,6 +111,50 @@ async def _send_followup_capture_message(interaction: discord.Interaction, **kwa
         return await interaction.followup.send(**kwargs)
 
 
+async def _safe_followup_send(interaction: discord.Interaction, **kwargs: Any) -> Any:
+    try:
+        return await interaction.followup.send(**kwargs)
+    except discord.NotFound:
+        logger.debug("inventory_followup_webhook_expired", exc_info=True)
+        return None
+
+
+async def _send_review_message(
+    *,
+    interaction: discord.Interaction | None,
+    original_message: discord.Message | None,
+    actor_discord_id: int,
+    content: str,
+    embed: discord.Embed,
+    view: discord.ui.View,
+) -> discord.Message | None:
+    if original_message is not None:
+        return await original_message.channel.send(
+            f"<@{actor_discord_id}> {content}",
+            embed=embed,
+            view=view,
+            delete_after=INVENTORY_REVIEW_TIMEOUT_SECONDS,
+        )
+    if interaction is None:
+        return None
+    try:
+        return await _send_followup_capture_message(
+            interaction,
+            content=content,
+            embed=embed,
+            view=view,
+            ephemeral=True,
+            delete_after=INVENTORY_REVIEW_UI_TIMEOUT_SECONDS,
+        )
+    except discord.NotFound:
+        logger.warning(
+            "inventory_review_followup_expired actor=%s",
+            actor_discord_id,
+            exc_info=True,
+        )
+        return None
+
+
 async def _post_admin_debug(
     *,
     bot: Any,
@@ -185,6 +229,7 @@ class InventoryConfirmationView(discord.ui.View):
         batch_id: int,
         payload: InventoryImagePayload,
         summary: InventoryAnalysisSummary,
+        original_message: discord.Message | None = None,
     ) -> None:
         super().__init__(timeout=INVENTORY_REVIEW_UI_TIMEOUT_SECONDS)
         self.bot = bot
@@ -193,6 +238,7 @@ class InventoryConfirmationView(discord.ui.View):
         self.batch_id = int(batch_id)
         self.payload = payload
         self.summary = summary
+        self.original_message = original_message
         self.corrected_values: dict[str, Any] | None = None
         self._terminal = False
         self._expired = False
@@ -459,6 +505,10 @@ class InventoryConfirmationView(discord.ui.View):
                 )
             except Exception:
                 logger.exception("inventory_approve_debug_post_failed batch_id=%s", self.batch_id)
+        await _delete_original_upload(
+            original_message=self.original_message,
+            batch_id=self.batch_id,
+        )
         await interaction.followup.send("Inventory import approved.", ephemeral=True)
         await self._update_review_message(interaction, content="Inventory import approved.")
 
@@ -483,48 +533,6 @@ class InventoryConfirmationView(discord.ui.View):
         )
 
     @discord.ui.button(
-        label="Reject Import",
-        style=discord.ButtonStyle.danger,
-        custom_id="inventory_import_reject",
-    )
-    async def reject(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
-        if await self._deny_if_not_actor(interaction):
-            return
-        self.message = getattr(interaction, "message", None)
-        await interaction.response.defer(ephemeral=True)
-        try:
-            await inventory_service.reject_import(self.batch_id, error="Rejected by user.")
-        except Exception:
-            logger.exception("inventory_import_reject_failed batch_id=%s", self.batch_id)
-            await interaction.followup.send(
-                f"Rejection failed due to an internal error. Please try again or contact an admin with batch ID {self.batch_id}.",
-                ephemeral=True,
-            )
-            return
-        self._terminal = True
-        self.disable_all_items()
-        self.stop()
-        try:
-            await _post_admin_debug(
-                bot=self.bot,
-                batch_id=self.batch_id,
-                governor_id=self.governor_id,
-                discord_user_id=self.actor_discord_id,
-                status="rejected",
-                payload=self.payload,
-                summary=self.summary,
-                error_json={"error": "Rejected by user."},
-            )
-        except Exception:
-            logger.exception("inventory_reject_debug_post_failed batch_id=%s", self.batch_id)
-        await interaction.followup.send(
-            "Import rejected. You can upload one replacement screenshot if needed.\n\n"
-            + SCREENSHOT_GUIDELINES,
-            ephemeral=True,
-        )
-        await self._update_review_message(interaction, content="Inventory import rejected.")
-
-    @discord.ui.button(
         label="Cancel Import",
         style=discord.ButtonStyle.secondary,
         custom_id="inventory_import_cancel",
@@ -546,7 +554,28 @@ class InventoryConfirmationView(discord.ui.View):
         self._terminal = True
         self.disable_all_items()
         self.stop()
-        await interaction.followup.send("Import cancelled.", ephemeral=True)
+        await _delete_original_upload(
+            original_message=self.original_message,
+            batch_id=self.batch_id,
+        )
+        try:
+            await _post_admin_debug(
+                bot=self.bot,
+                batch_id=self.batch_id,
+                governor_id=self.governor_id,
+                discord_user_id=self.actor_discord_id,
+                status="cancelled",
+                payload=self.payload,
+                summary=self.summary,
+                error_json={"error": "Cancelled by user."},
+            )
+        except Exception:
+            logger.exception("inventory_cancel_debug_post_failed batch_id=%s", self.batch_id)
+        await interaction.followup.send(
+            "Import cancelled. You can upload a replacement screenshot if needed.\n\n"
+            + SCREENSHOT_GUIDELINES,
+            ephemeral=True,
+        )
         await self._update_review_message(interaction, content="Inventory import cancelled.")
 
     async def on_timeout(self) -> None:
@@ -742,7 +771,6 @@ async def _process_payload_for_governor(
                 payload=payload,
                 is_admin=_is_admin(getattr(interaction, "user", None)) if interaction else False,
             )
-        await _delete_original_upload(original_message=original_message, batch_id=batch_id)
         summary = await inventory_service.analyse_inventory_image(
             import_batch_id=batch_id,
             payload=payload,
@@ -765,7 +793,11 @@ async def _process_payload_for_governor(
                 + SCREENSHOT_GUIDELINES
             )
             if interaction is not None:
-                await interaction.followup.send(message, ephemeral=True)
+                sent = await _safe_followup_send(interaction, content=message, ephemeral=True)
+                if sent is None and original_message is not None:
+                    await original_message.channel.send(
+                        f"<@{actor_discord_id}> {message}", delete_after=120
+                    )
             elif original_message is not None:
                 await original_message.channel.send(
                     f"<@{actor_discord_id}> {message}", delete_after=120
@@ -787,7 +819,16 @@ async def _process_payload_for_governor(
             )
             content = "Materials import is not available yet. No values were saved."
             if interaction is not None:
-                await interaction.followup.send(content, embed=embed, ephemeral=True)
+                sent = await _safe_followup_send(
+                    interaction,
+                    content=content,
+                    embed=embed,
+                    ephemeral=True,
+                )
+                if sent is None and original_message is not None:
+                    await original_message.channel.send(
+                        f"<@{actor_discord_id}> {content}", embed=embed, delete_after=120
+                    )
             elif original_message is not None:
                 await original_message.channel.send(
                     f"<@{actor_discord_id}> {content}", embed=embed, delete_after=120
@@ -805,33 +846,33 @@ async def _process_payload_for_governor(
         content = "Review the detected inventory values before approving."
         if flow_from_pending_command:
             content = "Screenshot received. Review the detected inventory values before approving."
-        if interaction is not None:
-            sent = await _send_followup_capture_message(
-                interaction,
-                content=content,
-                embed=embed,
-                view=view,
-                ephemeral=True,
-                delete_after=INVENTORY_REVIEW_UI_TIMEOUT_SECONDS,
-            )
-            view.message = sent
-            view.start_timeout_watch()
-        elif original_message is not None:
-            sent = await original_message.channel.send(
-                f"<@{actor_discord_id}> {content}",
-                embed=embed,
-                view=view,
-                delete_after=INVENTORY_REVIEW_TIMEOUT_SECONDS,
-            )
-            view.message = sent
-            view.start_timeout_watch()
+        view.original_message = original_message
+        sent = await _send_review_message(
+            interaction=interaction,
+            original_message=original_message,
+            actor_discord_id=actor_discord_id,
+            content=content,
+            embed=embed,
+            view=view,
+        )
+        view.message = sent
+        view.start_timeout_watch()
     except Exception:
         logger.exception("inventory_process_payload_failed governor_id=%s", governor_id)
         if interaction is not None:
-            await interaction.followup.send(
-                "Inventory import failed due to an internal error. Please try again or contact an admin.",
+            sent = await _safe_followup_send(
+                interaction,
+                content=(
+                    "Inventory import failed due to an internal error. "
+                    "Please try again or contact an admin."
+                ),
                 ephemeral=True,
             )
+            if sent is None and original_message is not None:
+                await original_message.channel.send(
+                    f"<@{actor_discord_id}> Inventory import failed. Please try again or contact an admin.",
+                    delete_after=120,
+                )
         elif original_message is not None:
             await original_message.channel.send(
                 f"<@{actor_discord_id}> Inventory import failed. Please try again or contact an admin.",

--- a/ui/views/inventory_views.py
+++ b/ui/views/inventory_views.py
@@ -270,12 +270,13 @@ class InventoryConfirmationView(discord.ui.View):
             return True
         if state.active:
             return False
+        terminal_msg = state.message or self._terminal_message()
         await self._mark_unusable(
             interaction,
             expired=state.expired,
-            content=state.message or self._terminal_message(),
+            content=terminal_msg,
         )
-        await _send_private(interaction, state.message or self._terminal_message())
+        await _send_private(interaction, terminal_msg)
         return True
 
     async def _requires_second_approve(self, interaction: discord.Interaction) -> bool:


### PR DESCRIPTION
## Summary

Finishes Phase 1E review/import/report polish for the Inventory Image Import Module before declaring Phase 1 complete.

## Changes

- Adds service/DAL-backed Inventory Import Review state checks so expired or completed reviews return clear messages and disable stale controls.
- Adds significant-change assessment for Resources and Speedups against the latest approved import, requiring a second approval only for material >50% changes.
- Moves analysis outcome decisions out of the Discord view layer and into `inventory_service`.
- Polishes `/myinventory` report images with graph axis ticks, clearer Resources graph colours, fitted/wrapped capacity text, and safer separator placement.
- Includes the updated in-repo task pack in the branch.

## Out of Scope

- Materials import/reporting remains Phase 2.
- `/my_stats` integration remains out of scope.
- Stats export SQL refactor remains tracked by GitHub issue #46.

## Validation

- `python -m pytest -q tests -k inventory` -> `84 passed, 1044 deselected`
- Focused inventory slice -> `81 passed`
- Command/import smoke tests -> `3 passed`
- `python -m black --check ...` on touched Python files -> passed
- `python -m ruff check ...` on touched Python files -> passed
- `python -m py_compile ...` on touched inventory modules -> passed
- `git diff --check` -> passed
- `python scripts/test_inventory_vision.py C:\rok\rss_sample.png --type resources` -> ok, resources, confidence 0.99, `gpt-4.1-mini`, no fallback, no warnings
- `python scripts/test_inventory_vision.py C:\rok\speedup_sample.png --type speedups` -> ok, speedups, confidence 0.96, fallback `gpt-5.2`, no warnings; days `1068 / 1242 / 935 / 503 / 2422`

## Risk / Rollback

Risk is limited to inventory import review interactions, significant-change confirmation, DAL reads for latest approved records, and report image rendering. Rollback is reverting this branch; no SQL schema migration is included.