### PR TITLE
[codex] standardise PreKvK schema import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,33 @@ Before beginning repo work, read the current versions of:
 - Production promotion happens only after local validation.
 - Production changes are promoted by pushing the same branch to the `production` remote and opening a PR into `K98-bot/main`.
 - The bot machine must deploy only from `K98-bot/main`, never from `K98-bot-mirror`.
+
+
+## SQL Validation Source
+
+The authoritative SQL schema and stored procedures are stored in:
+
+C:\K98-bot-SQL-Server
+
+Codex must validate all:
+- table names
+- column names
+- stored procedures
+- indexes
+- views
+- ProcConfig usage
+- staging/output table structure
+
+against the SQL repo before implementation.
+
+Do not infer schema purely from Python usage if SQL definitions exist in the SQL repo.
+
+If schema ambiguity exists:
+1. Search the SQL repo first
+2. Report missing objects explicitly
+3. Do not guess column names
+
+rg "CREATE TABLE.*STAGING_STATS" C:\K98-bot-SQL-Server
+rg "ProcConfig" C:\K98-bot-SQL-Server
+rg "EXCEL_FOR_KVK" C:\K98-bot-SQL-Server
+rg "GovernorID" C:\K98-bot-SQL-Server

--- a/DL_bot.py
+++ b/DL_bot.py
@@ -762,9 +762,12 @@ async def on_message(message: discord.Message):
     if message.channel.id == PREKVK_CHANNEL_ID and message.attachments:
         notify_ch = await _get_notify_channel() or message.channel
 
-        # Only accept the canonical filename
+        prekvk_name_rx = re.compile(
+            r"^(?:1198_prekvk|PreKvK_Rankings_[^\\/:*?\"<>|]+)\.xlsx$",
+            re.IGNORECASE,
+        )
         target = next(
-            (a for a in message.attachments if a.filename.lower().strip() == "1198_prekvk.xlsx"),
+            (a for a in message.attachments if prekvk_name_rx.match(a.filename.strip())),
             None,
         )
 
@@ -774,7 +777,7 @@ async def on_message(message: discord.Message):
                 "Pre-KVK Import ⚠️",
                 {
                     "Info": "No matching file found.",
-                    "Expected": "1198_prekvk.xlsx",
+                    "Expected": "1198_prekvk.xlsx or PreKvK_Rankings_*.xlsx",
                     "Channel": f"#{message.channel.name} ({message.channel.id})",
                     "Uploader": f"{message.author} ({message.author.id})",
                 },

--- a/docs/Codex_Task_Pack_Inventory_Phase_2_Materials.md
+++ b/docs/Codex_Task_Pack_Inventory_Phase_2_Materials.md
@@ -8,6 +8,88 @@ Phase 2 must extend the existing Inventory Image Import Module to support Rise o
 
 Use the existing task pack and Standard Development Initiation Statement as mandatory working context.
 
+## Implementation Wrap-Up
+
+Phase 2 Materials was implemented and validated in PR #57 against the mirror repository.
+
+Implemented capability:
+
+- Materials import is enabled for upload-first inventory flow.
+- Materials sessions support explicit multi-image upload via `Add Another Image`, up to 4 screenshots.
+- Materials import recognises choice chests and individual material icons for Animal Bone, Leather, Ebony, and Iron Ore.
+- Raw values are stored by material kind and rarity in `GovernorMaterialInventory`.
+- Legendary-equivalent calculations are implemented and used for review, reporting, and export.
+- Choice chests remain separate from fixed materials while contributing to the clearly labelled total.
+- Typed correction flow is implemented through Materials section selection and five-rarity modals.
+- Approval writes one logical import batch with material child rows.
+- `/myinventory` supports Materials output with KPI cards, trend graph, range controls, and `assets/materials_logo.png`.
+- `/export_inventory` includes Materials rows.
+- `/inventory_import_audit` supports Materials imports and Materials-related debug metadata.
+- Admin debug captures failed, rejected, cancelled, corrected, and low-confidence Materials paths.
+- Existing Resources and Speedups behaviour was preserved.
+
+Implementation files of note:
+
+- `inventory/material_calculations.py`
+- `inventory/material_service.py`
+- `inventory/dal/inventory_material_dal.py`
+- `inventory/inventory_service.py`
+- `inventory/reporting_service.py`
+- `inventory/report_image_renderer.py`
+- `inventory/export_service.py`
+- `services/vision_client.py`
+- `ui/views/inventory_views.py`
+- `ui/views/inventory_report_views.py`
+- `commands/inventory_cmds.py`
+- `sql/inventory_phase2_materials_schema.sql`
+- `sql/inventory_phase2_materials_status_schema.sql`
+- `assets/material_reference_sheet.png`
+- `assets/materials_logo.png`
+
+Issues found and resolved during smoke testing:
+
+- Initial Materials vision recognition needed heavy correction. The fix was to use the stronger fallback model first for Materials-hinted scans and include a Materials-only visual reference sheet generated from labelled training images.
+- Rarity detection was clarified to use icon tile background colour rather than detail-panel text or gold/yellow outer frame.
+- Advanced ebony was occasionally misclassified as leather; prompt guidance now distinguishes dark wood grain/plank bundles from tan/yellow hide or rolled sheets.
+- Duplicate values now report which duplicate was kept.
+- Conflicting values now report exactly which value was kept and which was ignored.
+- Older review messages are retired and disabled after `Add Another Image`, preventing stale approvals and duplicate/confusing import actions.
+- `Add Another Image` now defers the interaction immediately and sends follow-up guidance, fixing `Unknown interaction` failures after correction flows.
+- Materials significant-change checks were added. The gate now checks Choice Chests, Bone, Leather, Ebony, Iron, and Total Materials using the same 50% threshold as Resources and Speedups.
+- `/myinventory Materials` initially failed because the renderer passed `color=` to `_draw_kpi`; this was corrected to `delta_color=`.
+- `/myinventory Materials` now uses `assets/materials_logo.png` rather than the generic K98 logo.
+
+Manual OpenAI vision smoke results:
+
+- Prompt-only Materials training pass was insufficient.
+- Stronger model plus prompt improvements improved results but still left rarity/kind misses.
+- Materials reference sheet plus model/prompt changes produced 25 / 25 labelled training image matches for expected kind and rarity.
+- Full Materials import smoke over the supplied import screenshots returned valid Materials detections with nonzero rows.
+
+Validated commands during implementation:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_vision_client.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_material_calculations.py tests\test_inventory_upload_flow.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_service.py tests\test_inventory_report_image_renderer.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_ui_imports.py <expanded tests\test_inventory_*.py list>
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+Final local validation snapshot:
+
+- Full suite passed: 1196 passed, 8 skipped.
+- Targeted inventory/UI suite passed: 146 passed.
+- Pre-commit passed.
+- Architecture and deferred optimisation validators passed.
+- User smoke testing confirmed correction, add-another-image, approval, significant-change, and `/myinventory Materials` output flows.
+
 ## Scope Control
 
 ### In scope

--- a/docs/K98 Bot — Standard Development Initiation Statement.md
+++ b/docs/K98 Bot — Standard Development Initiation Statement.md
@@ -184,3 +184,22 @@ restart-safe
 test-backed
 explicit about refactor decisions
 structured for future optimisation batching
+
+If the task include SQL changes then:
+## Required SQL Validation
+
+Before implementation:
+
+1. Search the SQL repo:
+   C:\K98-bot-SQL-Server
+
+2. Validate:
+   - procedure dependencies
+   - table schemas
+   - expected output columns
+   - dynamic SQL targets
+   - ProcConfig usage
+
+3. If live SQL access fails:
+   - use the SQL repo as the authoritative source
+   - do NOT fall back to guessed schema

--- a/docs/prekvk_schema_standardisation_task_pack.md
+++ b/docs/prekvk_schema_standardisation_task_pack.md
@@ -1,0 +1,490 @@
+# Codex Task Pack — PreKvK Import Schema Standardisation & Reporting Retention
+
+## Task Summary
+
+The PreKvK ranking file format has changed. This task is not a simple importer patch: it is a schema standardisation and reporting compatibility task.
+
+The new workbook provides separate Stage I, Stage II, Stage III, and Total PreKvK points directly. The current implementation imports only a single cumulative points value and `prekvk_stats.py` derives phase rankings from scan-window deltas. The goal is to update the import and supporting SQL/model logic so `prekvk_stats.py` continues to return the same logical reporting blocks:
+
+- `overall`
+- `p1`
+- `p2`
+- `p3`
+
+…but now sourced from the new direct file columns rather than inferred scan-window deltas.
+
+## Required Reading
+
+Read these before making changes:
+
+1. `K98 Bot — Standard Development Initiation Statement.md`
+2. `K98 Bot — Project Engineering Standards.md`
+3. `K98 Bot — Coding Execution Guidelines.md`
+4. `K98 Bot — Testing Standards.md`
+5. `K98 Bot — Skills & Refactor Triggers.md`
+6. `K98 Bot — Deferred Optimisation Framework.md`
+7. Current implementation files:
+   - `prekvk_importer.py`
+   - `stats_alerts/prekvk_stats.py`
+   - `stats_alerts/embeds/prekvk.py`
+   - `DL_bot.py`
+   - `sql_schema/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql`
+   - `sql_schema/dbo.sp_ExcelOutput_ByKVK.StoredProcedure.sql`
+8. Example workbook:
+   - `/downloads/PreKvK_sample_file/PreKvK_Rankings_C13164_2026-05-08.xlsx`
+
+## Mandatory Working Method
+
+Follow the project initiation rules.
+
+Stop after Step 1 audit unless explicitly approved to continue.
+
+This task pack defines the intended scope, but Codex must still perform an audit first.
+
+---
+
+# Step 1 — Audit First
+
+## Audit Objectives
+
+Confirm:
+
+1. Exact new workbook schema.
+2. Existing importer assumptions.
+3. Existing SQL table shape for:
+   - `dbo.PreKvk_Scan`
+   - `dbo.PreKvk_Scores`
+   - any indexes/constraints/triggers
+4. Existing reporting expectations from:
+   - `stats_alerts/prekvk_stats.py`
+   - `stats_alerts/embeds/prekvk.py`
+5. How `DL_bot.py` routes PreKvK uploads.
+6. Whether existing tests cover PreKvK import/reporting.
+7. Whether old-format imports must remain compatible.
+
+## Known Starting Findings
+
+The new workbook appears to include:
+
+- `Rank`
+- `Name`
+- `Governor ID`
+- `KD`
+- `Stage I Points`
+- `Stage II Points`
+- `Stage III Points`
+- `Total Points`
+
+The current importer expects:
+
+- `GovernorID` or `governor_id`
+- `Name`
+- a single column beginning with `Prekvk`
+
+The current reporting helper returns:
+
+```python
+{
+    "overall": [],
+    "p1": [],
+    "p2": [],
+    "p3": [],
+}
+```
+
+That public shape must be retained.
+
+---
+
+# Scope
+
+## In Scope
+
+### Phase 1 — Import compatibility and canonical mapping
+
+Update PreKvK import to support the new workbook schema.
+
+Canonical fields should be:
+
+| Source Column | Canonical Field |
+|---|---|
+| Rank | SourceRank |
+| Name | GovernorName |
+| Governor ID | GovernorID |
+| KD | KingdomID |
+| Stage I Points | Stage1Points |
+| Stage II Points | Stage2Points |
+| Stage III Points | Stage3Points |
+| Total Points | TotalPoints |
+
+Importer must:
+
+- Accept the new sheet name, likely `Pre-KvK Rankings`.
+- Retain safe fallback behaviour for workbook sheet selection.
+- Validate required columns.
+- Validate `GovernorID`.
+- Validate duplicate `GovernorID` rows.
+- Convert points safely to integers.
+- Trim governor names.
+- Log import phase failures clearly.
+- Emit telemetry consistently with existing PreKvK import telemetry style.
+- Preserve hash-based duplicate file protection.
+- Preserve SQL headroom preflight behaviour from `DL_bot.py`.
+
+### Phase 2 — SQL storage standardisation
+
+Update SQL storage so PreKvK imported rows can store:
+
+- `KVK_NO`
+- `ScanID`
+- `GovernorID`
+- `GovernorName`
+- `KingdomID`
+- `SourceRank`
+- `Stage1Points`
+- `Stage2Points`
+- `Stage3Points`
+- `TotalPoints`
+
+Implementation options:
+
+1. Alter `dbo.PreKvk_Scores` to add new nullable columns, keeping existing `Points` populated as `TotalPoints`.
+2. Or create a replacement normalised table/view layer if that is cleaner.
+
+Preferred approach unless audit finds a blocker:
+
+- Add new columns to `dbo.PreKvk_Scores`.
+- Continue populating existing `Points` with `TotalPoints` for backward compatibility.
+- Add/update indexes to support:
+  - latest scan per KVK
+  - top total points
+  - top stage points
+  - governor lookup per KVK
+
+### Phase 3 — Ranking refresh logic
+
+Update `dbo.sp_Build_Prekvk_And_Honor_Rankings`.
+
+It must continue producing existing fields:
+
+- `MaxPreKvkPoints`
+- `PreKvk_Rank`
+
+It should also support direct stage values/ranks, either in `dbo.PreKvk_Scores_Ranked` or via a separate supporting object:
+
+- `Stage1Points`
+- `Stage1Rank`
+- `Stage2Points`
+- `Stage2Rank`
+- `Stage3Points`
+- `Stage3Rank`
+
+Rules:
+
+- Overall ranking uses `TotalPoints` / existing `Points`.
+- Stage rankings use direct stage columns.
+- Ranking should be per `KVK_NO`.
+- Tie-breaker should remain stable, using points desc then `GovernorID` asc unless there is a better existing project convention.
+- Honor ranking logic should not be changed unless required by dependency.
+
+### Phase 4 — Preserve `prekvk_stats.py` reporting contract
+
+Update `stats_alerts/prekvk_stats.py`.
+
+The function:
+
+```python
+load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict
+```
+
+must keep returning:
+
+```python
+{
+    "overall": [{"Name": str, "Points": int}, ...],
+    "p1": [{"Name": str, "Points": int}, ...],
+    "p2": [{"Name": str, "Points": int}, ...],
+    "p3": [{"Name": str, "Points": int}, ...],
+}
+```
+
+Mapping:
+
+- `overall` = Total Points / overall PreKvK score
+- `p1` = Stage I Points
+- `p2` = Stage II Points
+- `p3` = Stage III Points
+
+Do not require a new PreKvK report in this task.
+
+The existing embed should continue to work without changing its public behaviour, unless minor label fixes are needed.
+
+Fix any incorrect previous-KVK phase mapping discovered during audit.
+
+---
+
+# Explicitly Out of Scope
+
+## Phase 5 — KVK Excel output
+
+Do not change final KVK Excel output in this task.
+
+Do not add new PreKvK stage columns to `sp_ExcelOutput_ByKVK`.
+
+Do not change exported Google Sheet / Excel output shape.
+
+Existing `MaxPreKvkPoints` and `PreKvkRank` compatibility should remain if already used.
+
+## Separate Future Task — PreKvK report
+
+Do not build a new standalone PreKvK report in this task.
+
+Capture as deferred optimisation:
+
+- New PreKvK report command/output
+- Possible admin-facing import history
+- Possible historic comparison report
+- Possible per-stage Top N configurable report
+
+---
+
+# Files Likely to Modify
+
+## Python
+
+- `prekvk_importer.py`
+- `stats_alerts/prekvk_stats.py`
+- `stats_alerts/embeds/prekvk.py`
+- `DL_bot.py`
+
+## SQL
+
+- SQL migration/script for `dbo.PreKvk_Scores` schema changes
+- `sql_schema/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql`
+
+## Tests
+
+Add or update tests under:
+
+- `tests/`
+
+Possible test files:
+
+- `tests/test_prekvk_importer.py`
+- `tests/test_prekvk_stats.py`
+
+Do not rely on archived tests.
+
+---
+
+# Implementation Requirements
+
+## Importer
+
+Importer must support:
+
+1. New schema workbook.
+2. Clear validation errors.
+3. Duplicate GovernorID rejection.
+4. Hash duplicate skip.
+5. Empty/invalid workbook rejection.
+6. Numeric conversion for all stage and total point columns.
+7. Name trimming and null handling.
+8. Logging with phase names.
+9. Telemetry for:
+   - start
+   - success
+   - failed validation
+   - duplicate skip
+   - database failure
+
+## Upload routing
+
+Update `DL_bot.py` PreKvK file acceptance.
+
+Current exact filename matching is too strict.
+
+Accepted files should include:
+
+- `1198_prekvk.xlsx` for legacy/manual compatibility
+- `PreKvK_Rankings_*.xlsx`
+- Case-insensitive `.xlsx`
+
+Reject unrelated files clearly.
+
+## SQL
+
+SQL changes must be safe for existing data.
+
+Migration should:
+
+- Add nullable columns if missing.
+- Avoid destructive drops of core import data.
+- Preserve existing `Points` column as total score compatibility.
+- Add indexes conditionally.
+- Avoid breaking old rows where stage columns are null.
+
+Ranking procedure should:
+
+- Keep current overall ranking compatibility.
+- Add stage rankings without breaking downstream joins.
+- Avoid changing honor ranking behaviour.
+
+## Reporting
+
+`prekvk_stats.py` must:
+
+- Keep the same return contract.
+- Prefer direct stage columns.
+- Handle older rows with null stage columns gracefully.
+- Return empty lists rather than raising if data is missing.
+- Respect `limit`.
+- Use parameterised SQL.
+- Avoid direct SQL duplication where practical.
+
+---
+
+# Validation / Acceptance Criteria
+
+## Import acceptance
+
+Given the new workbook:
+
+- Import succeeds.
+- Rows imported count matches valid governor rows.
+- `GovernorID`, `GovernorName`, `KingdomID`, `SourceRank`, `Stage1Points`, `Stage2Points`, `Stage3Points`, and `TotalPoints` are stored.
+- Existing `Points` is populated with `TotalPoints`.
+
+## Reporting acceptance
+
+`load_prekvk_top3(kvk_no, 3)` returns:
+
+- `overall` from total points.
+- `p1` from Stage I points.
+- `p2` from Stage II points.
+- `p3` from Stage III points.
+
+Existing PreKvK embed remains functional.
+
+## Backward compatibility
+
+- Existing old-format PreKvK rows do not break reporting.
+- Existing `MaxPreKvkPoints` and `PreKvkRank` continue to exist.
+- Honor ranking remains unchanged.
+
+## Negative tests
+
+Must cover:
+
+- Missing required columns.
+- Duplicate GovernorID.
+- Empty workbook/no valid rows.
+- Non-numeric point values.
+- Duplicate file hash.
+- Unknown filename rejection in upload route, if route tests are practical.
+
+## Regression tests
+
+Must cover:
+
+- Existing `load_prekvk_top3` dictionary shape.
+- Limit handling.
+- Null stage value handling.
+- Old data compatibility where only `Points` exists.
+
+---
+
+# Testing Commands
+
+Use project-standard commands:
+
+```powershell
+cd C:\discord_file_downloader
+.\.venv\Scripts\Activate.ps1
+python -m pre_commit run -a
+python -m pytest -q tests
+git diff --check
+```
+
+Do not run pytest against archive folders.
+
+---
+
+# Deployment Notes
+
+Likely deployment order:
+
+1. Apply SQL schema migration.
+2. Deploy updated stored procedure:
+   - `dbo.sp_Build_Prekvk_And_Honor_Rankings`
+3. Deploy Python code.
+4. Restart bot via normal watchdog process.
+5. Upload new PreKvK workbook to configured PreKvK channel.
+6. Confirm:
+   - import success embed
+   - rows imported
+   - `prekvk_stats.py` output
+   - PreKvK stats embed refresh
+
+---
+
+# Deferred Optimisations
+
+## Deferred Optimisation
+- Area: PreKvK reporting
+- Type: feature
+- Description: Build a standalone PreKvK report using the new stage-level data.
+- Suggested Fix: Create a separate task for a PreKvK report command/embed once import/schema stabilisation is complete.
+- Impact: medium
+- Risk: low
+
+## Deferred Optimisation
+- Area: Import diagnostics
+- Type: observability
+- Description: Rejected/corrected import diagnostics are useful but not required for this schema update.
+- Suggested Fix: Add an admin-facing import history/diagnostics view covering accepted, rejected, duplicate, and failed PreKvK uploads.
+- Impact: medium
+- Risk: low
+
+## Deferred Optimisation
+- Area: Historic data migration
+- Type: data migration
+- Description: Historic PreKvK imports may only contain total points, not stage-level values.
+- Suggested Fix: Decide separately whether old imports should be backfilled, left as total-only, or marked as legacy.
+- Impact: low
+- Risk: medium
+
+## Deferred Optimisation
+- Area: Import routing architecture
+- Type: architecture
+- Description: `DL_bot.py` still contains direct upload-routing logic for PreKvK.
+- Suggested Fix: Move PreKvK upload route into a dedicated importer/router service in a future refactor.
+- Impact: medium
+- Risk: medium
+
+## Deferred Optimisation
+- Area: Configurable report limits
+- Type: feature
+- Description: `load_prekvk_top3` supports a limit, but reporting may later want configurable Top N values.
+- Suggested Fix: Add configurable PreKvK report limits only when the standalone report is built.
+- Impact: low
+- Risk: low
+
+---
+
+# Required Codex Output
+
+Codex must provide:
+
+1. Audit findings.
+2. Confirmed implementation plan.
+3. File manifest.
+4. SQL changes.
+5. Test plan.
+6. Deployment steps.
+7. Structured deferred optimisations.
+8. Codex review summary after implementation.
+
+Do not implement Phase 5.
+
+Do not create the standalone PreKvK report in this task.

--- a/prekvk_importer.py
+++ b/prekvk_importer.py
@@ -3,6 +3,7 @@ import hashlib
 import io
 import logging
 import os
+import re
 
 import pandas as pd
 import pyodbc
@@ -11,6 +12,143 @@ from file_utils import fetch_one_dict
 from sheet_importer import executemany_batched  # NEW: shared batching helper
 
 logger = logging.getLogger(__name__)
+
+
+NEW_PREKVK_SHEET_NAME = "pre-kvk rankings"
+
+
+def _normalize_column_name(value) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").strip().lower())
+
+
+def _columns_by_normalized_name(df: pd.DataFrame) -> dict[str, object]:
+    return {_normalize_column_name(c): c for c in df.columns}
+
+
+def _coerce_required_int_series(series: pd.Series, column_name: str) -> pd.Series:
+    values = pd.to_numeric(series, errors="coerce")
+    bad_mask = series.notna() & values.isna()
+    if bool(bad_mask.any()):
+        sample = ", ".join(str(x) for x in series.loc[bad_mask].head(5).tolist())
+        raise ValueError(f"Non-numeric value(s) in {column_name}: {sample}")
+    return values.fillna(0).astype(int)
+
+
+def _clean_governor_names(series: pd.Series) -> pd.Series:
+    try:
+        cleaned = series.where(series.notna(), "")
+    except Exception:
+        cleaned = pd.Series([""] * len(series), index=series.index)
+    cleaned = pd.Series(cleaned, index=series.index).astype(str).str.strip()
+    return cleaned.replace({"nan": "", "NaN": "", "None": "", "none": ""})
+
+
+def _read_prekvk_workbook(xlsx_bytes: bytes) -> pd.DataFrame:
+    try:
+        return pd.read_excel(io.BytesIO(xlsx_bytes), sheet_name="prekvk")
+    except Exception:
+        sheets = pd.read_excel(io.BytesIO(xlsx_bytes), sheet_name=None)
+        if not sheets:
+            raise ValueError("No sheets found in workbook")
+
+        pick = next(
+            (
+                name
+                for name in sheets.keys()
+                if str(name).strip().lower() in {"prekvk", NEW_PREKVK_SHEET_NAME}
+            ),
+            None,
+        )
+        return sheets[pick] if pick else next(iter(sheets.values()))
+
+
+def _normalize_prekvk_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    cols = _columns_by_normalized_name(df)
+
+    new_schema = {
+        "rank": "SourceRank",
+        "name": "GovernorName",
+        "governorid": "GovernorID",
+        "kd": "KingdomID",
+        "stageipoints": "Stage1Points",
+        "stageiipoints": "Stage2Points",
+        "stageiiipoints": "Stage3Points",
+        "totalpoints": "TotalPoints",
+    }
+
+    if all(key in cols for key in new_schema):
+        out = pd.DataFrame()
+        for source_key, canonical_name in new_schema.items():
+            out[canonical_name] = df[cols[source_key]]
+
+        out["GovernorID"] = pd.to_numeric(out["GovernorID"], errors="coerce").astype("Int64")
+        out["GovernorName"] = _clean_governor_names(out["GovernorName"])
+
+        for col in (
+            "KingdomID",
+            "SourceRank",
+            "Stage1Points",
+            "Stage2Points",
+            "Stage3Points",
+            "TotalPoints",
+        ):
+            out[col] = _coerce_required_int_series(out[col], col)
+
+        out["Points"] = out["TotalPoints"]
+        return out[
+            [
+                "GovernorID",
+                "GovernorName",
+                "KingdomID",
+                "SourceRank",
+                "Stage1Points",
+                "Stage2Points",
+                "Stage3Points",
+                "TotalPoints",
+                "Points",
+            ]
+        ]
+
+    gid_col = cols.get("governorid") or cols.get("governor_id") or "GovernorID"
+    name_col = cols.get("name") or "Name"
+    pts_col = None
+    for c in df.columns:
+        if str(c).strip().lower().startswith("prekvk"):
+            pts_col = c
+            break
+    pts_col = pts_col or "Prekvk Points"
+
+    required_cols = [gid_col, name_col, pts_col]
+    missing = [c for c in required_cols if c not in df.columns]
+    if missing:
+        found = ", ".join(str(c) for c in list(df.columns))
+        miss = ", ".join(str(c) for c in missing)
+        raise KeyError(f"Missing required column(s): {miss}. Found columns: {found}")
+
+    out = df[required_cols].copy()
+    out.columns = ["GovernorID", "GovernorName", "Points"]
+    out["GovernorID"] = pd.to_numeric(out["GovernorID"], errors="coerce").astype("Int64")
+    out["GovernorName"] = _clean_governor_names(out["GovernorName"])
+    out["Points"] = pd.to_numeric(out["Points"], errors="coerce").fillna(0).astype(int)
+    out["KingdomID"] = None
+    out["SourceRank"] = None
+    out["Stage1Points"] = None
+    out["Stage2Points"] = None
+    out["Stage3Points"] = None
+    out["TotalPoints"] = out["Points"]
+    return out[
+        [
+            "GovernorID",
+            "GovernorName",
+            "KingdomID",
+            "SourceRank",
+            "Stage1Points",
+            "Stage2Points",
+            "Stage3Points",
+            "TotalPoints",
+            "Points",
+        ]
+    ]
 
 
 def _conn():
@@ -70,52 +208,34 @@ def import_prekvk_bytes(
     try:
         phase = "read_excel"
         try:
-            df = pd.read_excel(io.BytesIO(xlsx_bytes), sheet_name="prekvk")
-        except Exception:
-            sheets = pd.read_excel(io.BytesIO(xlsx_bytes), sheet_name=None)
-            if not sheets:
-                logger.warning(
-                    "[PREKVK] import failed phase=%s kvk_no=%s file=%s: no sheets found",
-                    phase,
-                    kvk_no,
-                    filename,
-                )
-                _emit_telemetry(
-                    {
-                        "event": "prekvk_import_failed",
-                        "phase": phase,
-                        "kvk_no": kvk_no,
-                        "filename": filename,
-                        "bytes_len": bytes_len,
-                        "hash_prefix": hash_prefix,
-                        "error_type": "NoSheets",
-                        "error_text": "No sheets found in workbook",
-                    }
-                )
-                return (False, "No sheets found in workbook.", 0)
-
-            pick = next(
-                (name for name in sheets.keys() if str(name).strip().lower() == "prekvk"), None
+            df = _read_prekvk_workbook(xlsx_bytes)
+        except ValueError as e:
+            logger.warning(
+                "[PREKVK] import failed phase=%s kvk_no=%s file=%s: %s",
+                phase,
+                kvk_no,
+                filename,
+                str(e),
             )
-            df = sheets[pick] if pick else next(iter(sheets.values()))
+            _emit_telemetry(
+                {
+                    "event": "prekvk_import_failed",
+                    "phase": phase,
+                    "kvk_no": kvk_no,
+                    "filename": filename,
+                    "bytes_len": bytes_len,
+                    "hash_prefix": hash_prefix,
+                    "error_type": "NoSheets",
+                    "error_text": str(e),
+                }
+            )
+            return (False, f"{e}.", 0)
 
         phase = "normalize"
-        cols_lc = {str(c).strip().lower(): c for c in df.columns}
-        gid_col = cols_lc.get("governorid") or cols_lc.get("governor_id") or "GovernorID"
-        name_col = cols_lc.get("name") or "Name"
-        pts_col = None
-        for c in df.columns:
-            if str(c).strip().lower().startswith("prekvk"):
-                pts_col = c
-                break
-        pts_col = pts_col or "Prekvk Points"
-
-        required_cols = [gid_col, name_col, pts_col]
-        missing = [c for c in required_cols if c not in df.columns]
-        if missing:
-            found = ", ".join(str(c) for c in list(df.columns))
-            miss = ", ".join(str(c) for c in missing)
-            msg = f"Missing required column(s): {miss}. Found columns: {found}"
+        try:
+            out = _normalize_prekvk_dataframe(df)
+        except KeyError as e:
+            msg = str(e).strip("'")
 
             logger.warning(
                 "[PREKVK] import failed phase=%s kvk_no=%s file=%s: %s",
@@ -137,22 +257,28 @@ def import_prekvk_bytes(
                 }
             )
             return (False, msg, 0)
-
-        out = df[required_cols].copy()
-        out.columns = ["GovernorID", "GovernorName", "Points"]
-
-        out["GovernorID"] = pd.to_numeric(out["GovernorID"], errors="coerce").astype("Int64")
-
-        try:
-            out["GovernorName"] = out["GovernorName"].where(out["GovernorName"].notna(), "")
-        except Exception:
-            out["GovernorName"] = ""
-        out["GovernorName"] = out["GovernorName"].astype(str).str.strip()
-        out["GovernorName"] = out["GovernorName"].replace(
-            {"nan": "", "NaN": "", "None": "", "none": ""}
-        )
-
-        out["Points"] = pd.to_numeric(out["Points"], errors="coerce").fillna(0).astype(int)
+        except ValueError as e:
+            msg = str(e)
+            logger.warning(
+                "[PREKVK] import failed phase=%s kvk_no=%s file=%s: %s",
+                phase,
+                kvk_no,
+                filename,
+                msg,
+            )
+            _emit_telemetry(
+                {
+                    "event": "prekvk_import_failed",
+                    "phase": phase,
+                    "kvk_no": kvk_no,
+                    "filename": filename,
+                    "bytes_len": bytes_len,
+                    "hash_prefix": hash_prefix,
+                    "error_type": "InvalidNumericValue",
+                    "error_text": msg,
+                }
+            )
+            return (False, msg, 0)
 
         out = out.dropna(subset=["GovernorID"])
         if out.empty:
@@ -257,7 +383,19 @@ def import_prekvk_bytes(
 
                 phase = "db_insert_rows"
                 rows = [
-                    (kvk_no, scan_id, int(r.GovernorID), str(r.GovernorName)[:64], int(r.Points))
+                    (
+                        kvk_no,
+                        scan_id,
+                        int(r.GovernorID),
+                        str(r.GovernorName)[:64],
+                        int(r.Points),
+                        None if pd.isna(r.KingdomID) else int(r.KingdomID),
+                        None if pd.isna(r.SourceRank) else int(r.SourceRank),
+                        None if pd.isna(r.Stage1Points) else int(r.Stage1Points),
+                        None if pd.isna(r.Stage2Points) else int(r.Stage2Points),
+                        None if pd.isna(r.Stage3Points) else int(r.Stage3Points),
+                        None if pd.isna(r.TotalPoints) else int(r.TotalPoints),
+                    )
                     for r in out.itertuples(index=False)
                 ]
 
@@ -276,8 +414,20 @@ def import_prekvk_bytes(
                     cur,
                     conn,
                     """
-                    INSERT INTO dbo.PreKvk_Scores (KVK_NO, ScanID, GovernorID, GovernorName, Points)
-                    VALUES (?,?,?,?,?)
+                    INSERT INTO dbo.PreKvk_Scores (
+                        KVK_NO,
+                        ScanID,
+                        GovernorID,
+                        GovernorName,
+                        Points,
+                        KingdomID,
+                        SourceRank,
+                        Stage1Points,
+                        Stage2Points,
+                        Stage3Points,
+                        TotalPoints
+                    )
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     rows,
                     batch_size=batch_size,

--- a/sql/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql
+++ b/sql/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql
@@ -1,9 +1,12 @@
-﻿SET ANSI_NULLS ON
+SET ANSI_NULLS ON
+GO
 SET QUOTED_IDENTIFIER ON
+GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[sp_Build_Prekvk_And_Honor_Rankings]') AND type in (N'P', N'PC'))
 BEGIN
 EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[sp_Build_Prekvk_And_Honor_Rankings] AS'
 END
+GO
 ALTER PROCEDURE [dbo].[sp_Build_Prekvk_And_Honor_Rankings]
 WITH EXECUTE AS CALLER
 AS

--- a/sql/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql
+++ b/sql/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql
@@ -1,0 +1,154 @@
+﻿SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[sp_Build_Prekvk_And_Honor_Rankings]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [dbo].[sp_Build_Prekvk_And_Honor_Rankings] AS'
+END
+ALTER PROCEDURE [dbo].[sp_Build_Prekvk_And_Honor_Rankings]
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -------------------------------------------------------
+    -- 1) Build PreKvk_Scores_Ranked: per KVK, per Governor:
+    --    MaxPreKvkPoints (bigint), PreKvk_Rank (bigint),
+    --    direct stage points/ranks, KVK_NO, GovernorID,
+    --    GovernorName, ScanID, ScanTimestampUTC
+    -------------------------------------------------------
+    DROP TABLE IF EXISTS dbo.PreKvk_Scores_Ranked;
+
+    ;WITH MaxPerGov AS (
+        SELECT KVK_NO, GovernorID, MAX(Points) AS MaxPoints
+        FROM dbo.PreKvk_Scores
+        GROUP BY KVK_NO, GovernorID
+    ),
+    BestScans AS (
+        -- all rows where Points = MaxPoints (may be multiple scan entries)
+        SELECT p.KVK_NO,
+               p.GovernorID,
+               p.GovernorName,
+               p.Points,
+               p.Stage1Points,
+               p.Stage2Points,
+               p.Stage3Points,
+               p.ScanID
+        FROM dbo.PreKvk_Scores p
+        JOIN MaxPerGov m
+          ON p.KVK_NO = m.KVK_NO
+         AND p.GovernorID = m.GovernorID
+         AND p.Points = m.MaxPoints
+    ),
+    Picked AS (
+        -- pick a single ScanID when duplicates; capture GovName and ScanID
+        SELECT
+            b.KVK_NO,
+            b.GovernorID,
+            MAX(b.GovernorName) AS GovernorName,
+            CAST(MAX(b.Points) AS bigint) AS MaxPreKvkPoints,
+            CAST(MAX(b.Stage1Points) AS bigint) AS Stage1Points,
+            CAST(MAX(b.Stage2Points) AS bigint) AS Stage2Points,
+            CAST(MAX(b.Stage3Points) AS bigint) AS Stage3Points,
+            MIN(b.ScanID) AS ScanID
+        FROM BestScans b
+        GROUP BY b.KVK_NO, b.GovernorID
+    ),
+    WithTS AS (
+        -- attach ScanTimestampUTC from PreKvk_Scan
+        SELECT p.KVK_NO, p.GovernorID, p.GovernorName, p.MaxPreKvkPoints,
+               p.Stage1Points, p.Stage2Points, p.Stage3Points,
+               p.ScanID, s.ScanTimestampUTC
+        FROM Picked p
+        LEFT JOIN dbo.PreKvk_Scan s
+          ON s.KVK_NO = p.KVK_NO AND s.ScanID = p.ScanID
+    ),
+    Ranked AS (
+        SELECT w.*,
+               RANK() OVER (PARTITION BY w.KVK_NO ORDER BY w.MaxPreKvkPoints DESC, w.GovernorID ASC) AS PreRank,
+               RANK() OVER (PARTITION BY w.KVK_NO ORDER BY w.Stage1Points DESC, w.GovernorID ASC) AS Stage1RankRaw,
+               RANK() OVER (PARTITION BY w.KVK_NO ORDER BY w.Stage2Points DESC, w.GovernorID ASC) AS Stage2RankRaw,
+               RANK() OVER (PARTITION BY w.KVK_NO ORDER BY w.Stage3Points DESC, w.GovernorID ASC) AS Stage3RankRaw
+        FROM WithTS w
+    )
+    SELECT
+        KVK_NO,
+        GovernorID,
+        GovernorName,
+        MaxPreKvkPoints,
+        CAST(PreRank AS bigint) AS PreKvk_Rank,
+        Stage1Points,
+        CASE WHEN Stage1Points IS NULL THEN NULL ELSE CAST(Stage1RankRaw AS bigint) END AS Stage1Rank,
+        Stage2Points,
+        CASE WHEN Stage2Points IS NULL THEN NULL ELSE CAST(Stage2RankRaw AS bigint) END AS Stage2Rank,
+        Stage3Points,
+        CASE WHEN Stage3Points IS NULL THEN NULL ELSE CAST(Stage3RankRaw AS bigint) END AS Stage3Rank,
+        ScanID,
+        ScanTimestampUTC
+    INTO dbo.PreKvk_Scores_Ranked
+    FROM Ranked;
+
+    -- optional index for faster joins (GovernorID lookup & KVK lookup)
+    IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID(N'dbo.PreKvk_Scores_Ranked') AND name = N'IX_PreKvkScoresRanked_KvK_Gov')
+    BEGIN
+        CREATE NONCLUSTERED INDEX IX_PreKvkScoresRanked_KvK_Gov ON dbo.PreKvk_Scores_Ranked (KVK_NO, GovernorID) INCLUDE (MaxPreKvkPoints, PreKvk_Rank, Stage1Points, Stage1Rank, Stage2Points, Stage2Rank, Stage3Points, Stage3Rank, ScanID);
+    END
+
+    -------------------------------------------------------
+    -- 2) Build KVK_Honor_Ranked: per KVK, per Governor:
+    --    MaxHonorPoints (bigint), Honor_Rank (bigint),
+    --    KVK_NO, GovernorID, GovernorName, ScanID, ScanTimestampUTC
+    -------------------------------------------------------
+    DROP TABLE IF EXISTS dbo.KVK_Honor_Ranked;
+
+    ;WITH MaxHonorPerGov AS (
+        SELECT KVK_NO, GovernorID, MAX(HonorPoints) AS MaxHonor
+        FROM dbo.KVK_Honor_AllPlayers_Raw
+        GROUP BY KVK_NO, GovernorID
+    ),
+    BestHonorScans AS (
+        SELECT h.KVK_NO, h.GovernorID, h.GovernorName, h.HonorPoints, h.ScanID
+        FROM dbo.KVK_Honor_AllPlayers_Raw h
+        JOIN MaxHonorPerGov m
+          ON h.KVK_NO = m.KVK_NO
+         AND h.GovernorID = m.GovernorID
+         AND h.HonorPoints = m.MaxHonor
+    ),
+    PickedHonor AS (
+        SELECT
+            b.KVK_NO,
+            b.GovernorID,
+            MAX(b.GovernorName) AS GovernorName,
+            CAST(MAX(b.HonorPoints) AS bigint) AS MaxHonorPoints,
+            MIN(b.ScanID) AS ScanID
+        FROM BestHonorScans b
+        GROUP BY b.KVK_NO, b.GovernorID
+    ),
+    WithHonorTS AS (
+        SELECT p.KVK_NO, p.GovernorID, p.GovernorName, p.MaxHonorPoints,
+               p.ScanID, s.ScanTimestampUTC
+        FROM PickedHonor p
+        LEFT JOIN dbo.KVK_Honor_Scan s
+          ON s.KVK_NO = p.KVK_NO AND s.ScanID = p.ScanID
+    )
+    SELECT
+        KVK_NO,
+        GovernorID,
+        GovernorName,
+        MaxHonorPoints,
+        CAST(HonorRank AS bigint) AS Honor_Rank,
+        ScanID,
+        ScanTimestampUTC
+    INTO dbo.KVK_Honor_Ranked
+    FROM (
+        SELECT w.*,
+               RANK() OVER (PARTITION BY w.KVK_NO ORDER BY w.MaxHonorPoints DESC, w.GovernorID ASC) AS HonorRank
+        FROM WithHonorTS w
+    ) x;
+
+    IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID(N'dbo.KVK_Honor_Ranked') AND name = N'IX_KVKHonorRanked_KvK_Gov')
+    BEGIN
+        CREATE NONCLUSTERED INDEX IX_KVKHonorRanked_KvK_Gov ON dbo.KVK_Honor_Ranked (KVK_NO, GovernorID) INCLUDE (MaxHonorPoints, Honor_Rank, ScanID);
+    END
+
+    RETURN 0;
+END

--- a/sql/prekvk_schema_standardisation_schema.sql
+++ b/sql/prekvk_schema_standardisation_schema.sql
@@ -1,0 +1,56 @@
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'KingdomID') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [KingdomID] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'SourceRank') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [SourceRank] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'Stage1Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [Stage1Points] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'Stage2Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [Stage2Points] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'Stage3Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [Stage3Points] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores', N'TotalPoints') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores] ADD [TotalPoints] [int] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage1Points] [bigint] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Rank') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage1Rank] [bigint] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage2Points] [bigint] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Rank') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage2Rank] [bigint] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Points') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage3Points] [bigint] NULL
+
+IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Rank') IS NULL
+ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage3Rank] [bigint] NULL
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[PreKvk_Scores]') AND name = N'IX_PreKvk_Scores_KVK_Scan_Total')
+CREATE NONCLUSTERED INDEX [IX_PreKvk_Scores_KVK_Scan_Total] ON [dbo].[PreKvk_Scores]
+(
+    [KVK_NO] ASC,
+    [ScanID] ASC,
+    [TotalPoints] DESC,
+    [GovernorID] ASC
+)
+INCLUDE([GovernorName],[Points],[Stage1Points],[Stage2Points],[Stage3Points]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[PreKvk_Scores]') AND name = N'IX_PreKvk_Scores_KVK_Gov')
+CREATE NONCLUSTERED INDEX [IX_PreKvk_Scores_KVK_Gov] ON [dbo].[PreKvk_Scores]
+(
+    [KVK_NO] ASC,
+    [GovernorID] ASC
+)
+INCLUDE([ScanID],[GovernorName],[Points],[TotalPoints],[Stage1Points],[Stage2Points],[Stage3Points]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]

--- a/sql/prekvk_schema_standardisation_schema.sql
+++ b/sql/prekvk_schema_standardisation_schema.sql
@@ -19,22 +19,28 @@ ALTER TABLE [dbo].[PreKvk_Scores] ADD [Stage3Points] [int] NULL
 IF COL_LENGTH(N'dbo.PreKvk_Scores', N'TotalPoints') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores] ADD [TotalPoints] [int] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Points') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Points') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage1Points] [bigint] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Rank') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage1Rank') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage1Rank] [bigint] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Points') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Points') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage2Points] [bigint] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Rank') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage2Rank') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage2Rank] [bigint] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Points') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Points') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage3Points] [bigint] NULL
 
-IF COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Rank') IS NULL
+IF OBJECT_ID(N'dbo.PreKvk_Scores_Ranked', N'U') IS NOT NULL
+   AND COL_LENGTH(N'dbo.PreKvk_Scores_Ranked', N'Stage3Rank') IS NULL
 ALTER TABLE [dbo].[PreKvk_Scores_Ranked] ADD [Stage3Rank] [bigint] NULL
 
 IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[PreKvk_Scores]') AND name = N'IX_PreKvk_Scores_KVK_Scan_Total')

--- a/stats_alerts/embeds/prekvk.py
+++ b/stats_alerts/embeds/prekvk.py
@@ -247,12 +247,12 @@ async def send_prekvk_embed(
             )
             embed.add_field(
                 name="Marauder Forts - last kvk:",
-                value=_fmt_top_simple(prev_tops.get("p3", []), "pts", limit=1),
+                value=_fmt_top_simple(prev_tops.get("p2", []), "pts", limit=1),
                 inline=True,
             )
             embed.add_field(
                 name="Training -last kvk:",
-                value=_fmt_top_simple(prev_tops.get("p2", []), "pts", limit=1),
+                value=_fmt_top_simple(prev_tops.get("p3", []), "pts", limit=1),
                 inline=True,
             )
     except Exception:

--- a/stats_alerts/prekvk_stats.py
+++ b/stats_alerts/prekvk_stats.py
@@ -1,6 +1,6 @@
 # stats_alerts/prekvk_stats.py
 """
-Helpers to load Pre-KVK top lists (overall + per-phase deltas).
+Helpers to load Pre-KVK top lists (overall + direct stage values).
 
 Provides:
 - load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict[str, list[dict]]
@@ -35,7 +35,7 @@ def load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict:
             if lim <= 0:
                 lim = 1
 
-            # Overall (latest scan per KVK, top N)
+            # Overall (latest scan per KVK, top N).
             cur.execute(
                 f"""
                 WITH latest AS (
@@ -46,11 +46,14 @@ def load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict:
                       SELECT MAX(s2.ScanID) FROM dbo.PreKvk_Scan s2 WHERE s2.KVK_NO = s.KVK_NO
                     )
                 )
-                SELECT TOP ({lim}) sc.GovernorID, MAX(sc.GovernorName) AS Name, MAX(sc.Points) AS Points
+                SELECT TOP ({lim})
+                       sc.GovernorID,
+                       MAX(sc.GovernorName) AS Name,
+                       MAX(COALESCE(sc.TotalPoints, sc.Points)) AS Points
                 FROM dbo.PreKvk_Scores sc
                 JOIN latest l ON l.KVK_NO = sc.KVK_NO AND l.ScanID = sc.ScanID
                 GROUP BY sc.GovernorID
-                ORDER BY MAX(sc.Points) DESC, MAX(sc.GovernorName);
+                ORDER BY MAX(COALESCE(sc.TotalPoints, sc.Points)) DESC, sc.GovernorID ASC;
                 """,
                 (kvk_no,),
             )
@@ -65,54 +68,34 @@ def load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict:
                 for r in rows
             ]
 
-            # Phase helper
-            def _phase_top(phase: int, lim_phase: int) -> list[dict[str, Any]]:
+            def _stage_top(stage_column: str, lim_phase: int) -> list[dict[str, Any]]:
                 lim_p = int(lim_phase) if lim_phase is not None else 1
                 if lim_p <= 0:
                     lim_p = 1
-                # compute delta points for the phase (Baseline vs InWindow) and return top lim_p
+                if stage_column not in {"Stage1Points", "Stage2Points", "Stage3Points"}:
+                    return []
+
                 cur.execute(
                     f"""
-                    WITH W AS (
-                      SELECT StartUTC, EndUTC
-                      FROM dbo.PreKvk_Phases
-                      WHERE KVK_NO = ? AND Phase = ?
-                    ),
-                    B AS (
-                      SELECT sc.GovernorID,
-                             MAX(sc.Points) AS Baseline
-                      FROM dbo.PreKvk_Scores sc
-                      JOIN dbo.PreKvk_Scan s ON s.KVK_NO = sc.KVK_NO AND s.ScanID = sc.ScanID
-                      CROSS JOIN W
-                      WHERE sc.KVK_NO = ? AND s.ScanTimestampUTC < W.StartUTC
-                      GROUP BY sc.GovernorID
-                    ),
-                    P AS (
-                      SELECT sc.GovernorID,
-                             MAX(sc.Points) AS InWindow
-                      FROM dbo.PreKvk_Scores sc
-                      JOIN dbo.PreKvk_Scan s ON s.KVK_NO = sc.KVK_NO AND s.ScanID = sc.ScanID
-                      CROSS JOIN W
-                      WHERE sc.KVK_NO = ? AND s.ScanTimestampUTC BETWEEN W.StartUTC AND W.EndUTC
-                      GROUP BY sc.GovernorID
-                    ),
-                    Names AS (
-                      SELECT sc.GovernorID, MAX(sc.GovernorName) AS GovernorName
-                      FROM dbo.PreKvk_Scores sc
-                      JOIN dbo.PreKvk_Scan s ON s.KVK_NO = sc.KVK_NO AND s.ScanID = sc.ScanID
-                      WHERE sc.KVK_NO = ?
-                      GROUP BY sc.GovernorID
+                    WITH latest AS (
+                      SELECT s.KVK_NO, s.ScanID
+                      FROM dbo.PreKvk_Scan s
+                      WHERE s.KVK_NO = ?
+                        AND s.ScanID = (
+                          SELECT MAX(s2.ScanID) FROM dbo.PreKvk_Scan s2 WHERE s2.KVK_NO = s.KVK_NO
+                        )
                     )
-                    SELECT TOP ({lim_p}) COALESCE(p.GovernorID, b.GovernorID) AS GovernorID,
-                           COALESCE(n.GovernorName, CONVERT(varchar(20), COALESCE(p.GovernorID, b.GovernorID))) AS Name,
-                           MAX(COALESCE(p.InWindow, b.Baseline, 0)) - MAX(COALESCE(b.Baseline, 0)) AS Points
-                    FROM B b
-                    FULL JOIN P p ON p.GovernorID = b.GovernorID
-                    LEFT JOIN Names n ON n.GovernorID = COALESCE(p.GovernorID, b.GovernorID)
-                    GROUP BY COALESCE(p.GovernorID, b.GovernorID), COALESCE(n.GovernorName, CONVERT(varchar(20), COALESCE(p.GovernorID, b.GovernorID)))
-                    ORDER BY Points DESC, Name;
+                    SELECT TOP ({lim_p})
+                           sc.GovernorID,
+                           MAX(sc.GovernorName) AS Name,
+                           MAX(sc.{stage_column}) AS Points
+                    FROM dbo.PreKvk_Scores sc
+                    JOIN latest l ON l.KVK_NO = sc.KVK_NO AND l.ScanID = sc.ScanID
+                    WHERE sc.{stage_column} IS NOT NULL
+                    GROUP BY sc.GovernorID
+                    ORDER BY MAX(sc.{stage_column}) DESC, sc.GovernorID ASC;
                     """,
-                    (kvk_no, phase, kvk_no, kvk_no, kvk_no),
+                    (kvk_no,),
                 )
                 rows_p = _fetch_all_as_dicts(cur)
                 rows_p = rows_p[:lim_p]
@@ -121,9 +104,9 @@ def load_prekvk_top3(kvk_no: int, limit: int = 3) -> dict:
                     for r in rows_p
                 ]
 
-            out["p1"] = _phase_top(1, lim)
-            out["p2"] = _phase_top(2, lim)
-            out["p3"] = _phase_top(3, lim)
+            out["p1"] = _stage_top("Stage1Points", lim)
+            out["p2"] = _stage_top("Stage2Points", lim)
+            out["p3"] = _stage_top("Stage3Points", lim)
 
     except Exception:
         logger.exception("[PREKVK] Failed to load Pre-KVK Top lists")

--- a/tests/test_prekvk_importer.py
+++ b/tests/test_prekvk_importer.py
@@ -264,6 +264,99 @@ def test_governor_name_nan_becomes_empty_string(monkeypatch):
     assert inserted_rows[1][3] == ""
 
 
+def test_new_schema_import_maps_stage_columns(monkeypatch):
+    df = _fake_df_with_columns(
+        [
+            "Rank",
+            "Name",
+            "Governor ID",
+            "KD",
+            "Stage I Points",
+            "Stage II Points",
+            "Stage III Points",
+            "Total Points",
+        ],
+        [
+            {
+                "Rank": 1,
+                "Name": " Alice ",
+                "Governor ID": 123,
+                "KD": 1198,
+                "Stage I Points": 10,
+                "Stage II Points": 20,
+                "Stage III Points": 30,
+                "Total Points": 60,
+            }
+        ],
+    )
+    _patch_read_excel(monkeypatch, df, sheet_name_required=False)
+
+    cur = MockCursor()
+    conn = MockConn(cur)
+    _patch_conn(monkeypatch, cur, conn)
+    cur.queue_fetchone(None, columns=("x",))
+    cur.queue_fetchone((99,), columns=("ScanID",))
+
+    ok, msg, rows = pki.import_prekvk_bytes(
+        b"content-bytes",
+        "PreKvK_Rankings_C13164_2026-05-08.xlsx",
+        kvk_no=13,
+    )
+
+    assert ok is True
+    assert rows == 1
+    assert "scan 99" in msg
+
+    insert_sql, inserted_rows = cur.executemany_calls[0]
+    assert "KingdomID" in insert_sql
+    assert "Stage1Points" in insert_sql
+    assert inserted_rows[0] == (13, 99, 123, "Alice", 60, 1198, 1, 10, 20, 30, 60)
+
+
+def test_new_schema_non_numeric_points_are_rejected_before_db(monkeypatch):
+    df = _fake_df_with_columns(
+        [
+            "Rank",
+            "Name",
+            "Governor ID",
+            "KD",
+            "Stage I Points",
+            "Stage II Points",
+            "Stage III Points",
+            "Total Points",
+        ],
+        [
+            {
+                "Rank": 1,
+                "Name": "A",
+                "Governor ID": 123,
+                "KD": 1198,
+                "Stage I Points": "oops",
+                "Stage II Points": 20,
+                "Stage III Points": 30,
+                "Total Points": 60,
+            }
+        ],
+    )
+    _patch_read_excel(monkeypatch, df, sheet_name_required=False)
+
+    def fail_conn():
+        raise AssertionError("_conn() should not be called for invalid point values")
+
+    monkeypatch.setattr(pki, "_conn", fail_conn)
+
+    ok, msg, rows = pki.import_prekvk_bytes(
+        b"bytes",
+        "PreKvK_Rankings_C13164_2026-05-08.xlsx",
+        kvk_no=13,
+    )
+
+    assert ok is False
+    assert rows == 0
+    assert "Non-numeric value" in msg
+    assert "Stage1Points" in msg
+
+
 def test_duplicate_hash_skips_import(monkeypatch):
     """
     If SELECT 1 finds an existing hash, importer should skip without inserting.

--- a/tests/test_prekvk_stats.py
+++ b/tests/test_prekvk_stats.py
@@ -76,3 +76,74 @@ def test_load_prekvk_top3_limit_one(monkeypatch):
     assert len(out["overall"]) <= 1
     assert len(out["p1"]) <= 1
     assert out["overall"][0]["Name"] == "A"
+
+
+def test_load_prekvk_top3_queries_direct_stage_columns(monkeypatch):
+    overall = [{"Name": "A", "Points": 60}]
+    p1 = [{"Name": "A", "Points": 10}]
+    p2 = [{"Name": "B", "Points": 20}]
+    p3 = [{"Name": "C", "Points": 30}]
+    seq = [overall, p1, p2, p3]
+    executed = []
+
+    monkeypatch.setattr(prekvk_stats, "_fetch_all_as_dicts", lambda cur: seq.pop(0))
+
+    class DummyCursor:
+        def execute(self, sql, *args, **kwargs):
+            executed.append(str(sql))
+
+        def fetchall(self):
+            return []
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(prekvk_stats, "get_conn_with_retries", lambda: DummyConn())
+
+    out = prekvk_stats.load_prekvk_top3(15, limit=3)
+
+    assert out == {"overall": overall, "p1": p1, "p2": p2, "p3": p3}
+    assert "COALESCE(sc.TotalPoints, sc.Points)" in executed[0]
+    assert "Stage1Points" in executed[1]
+    assert "Stage2Points" in executed[2]
+    assert "Stage3Points" in executed[3]
+    assert all("PreKvk_Phases" not in sql for sql in executed)
+
+
+def test_load_prekvk_top3_old_rows_without_stage_values_return_empty_phases(monkeypatch):
+    overall = [{"Name": "Legacy", "Points": 50}]
+    seq = [overall, [], [], []]
+    monkeypatch.setattr(prekvk_stats, "_fetch_all_as_dicts", lambda cur: seq.pop(0))
+
+    class DummyCursor:
+        def execute(self, *args, **kwargs):
+            pass
+
+        def fetchall(self):
+            return []
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(prekvk_stats, "get_conn_with_retries", lambda: DummyConn())
+
+    out = prekvk_stats.load_prekvk_top3(15, limit=3)
+
+    assert out["overall"] == overall
+    assert out["p1"] == []
+    assert out["p2"] == []
+    assert out["p3"] == []


### PR DESCRIPTION
## Summary

Standardises the PreKvK import/reporting path for the new workbook schema with direct Stage I / II / III and Total Points columns, while preserving the existing reporting contract.

## Changes

- Supports the new `Pre-KvK Rankings` workbook schema and keeps legacy `1198_prekvk.xlsx` compatibility.
- Stores canonical PreKvK fields for source rank, kingdom, stage points, and total points while continuing to populate existing `Points` as the total score.
- Updates `load_prekvk_top3(kvk_no, limit)` to keep returning `overall`, `p1`, `p2`, and `p3`, now sourced from direct stage values.
- Adds `/sql/` deployment scripts for the PreKvK schema additions and ranked stored procedure deployment.
- Includes the updated docs/task pack and SQL-source-of-truth guidance.
- Fixes the previous-KVK PreKvK embed phase mapping for Forts and Training.

## SQL Deployment Notes

Apply in order:

1. `sql/prekvk_schema_standardisation_schema.sql`
2. `sql/dbo.sp_Build_Prekvk_And_Honor_Rankings.StoredProcedure.sql`
3. Deploy the Python bot changes and restart normally.

This PR does not change the final KVK Excel output procedure or output shape.

## Validation

```powershell
.\.venv\Scripts\python.exe -m pytest -q tests/test_prekvk_importer.py tests/test_prekvk_stats.py
.\.venv\Scripts\python.exe -m py_compile prekvk_importer.py stats_alerts\prekvk_stats.py stats_alerts\embeds\prekvk.py DL_bot.py tests\test_prekvk_importer.py tests\test_prekvk_stats.py
.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
.\.venv\Scripts\python.exe scripts\select_tests.py
git diff --cached --check
```

Focused pytest result: 21 passed.

`pre-commit run -a` could not complete locally because pre-commit/virtualenv cache writes hit Windows permission issues in user cache paths, and the redirected-cache rerun was interrupted after taking too long.

## Deferred Optimisations

- Align or retire `kvk/dal/kvk_stats_dal.py::fetch_prekvk_phase_list`, which still uses old scan-window delta SQL.
- Build a standalone PreKvK report in a separate task.
- Add admin-facing PreKvK import diagnostics/history in a separate task.