### PR TITLE
[codex] add kvk full data sql capacity

### DIFF
--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -20,6 +20,26 @@ Full Data
 
 Basic Data is out of scope and must not be used for ingestion, validation, or fallback behaviour. The additional rows in Basic Data are not required for the modernised pipeline.
 
+Programme Status
+Phase 1 is complete and deployed.
+
+Completed Phase 1 scope:
+
+strict Full Data workbook detection
+Full Data tab is required
+Basic Data is ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns are validated before legacy coercion
+schema version kvk_all_full_data_v2 is returned in import results
+structured validation errors are returned for schema failures
+focused tests cover valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 1 changed Python-side workbook validation only. No SQL schema, stored procedure, recompute, export, Google Sheets, or Discord reporting behaviour was changed.
+
+Next phase:
+
+Phase 2 — Additive SQL Schema Migration
+
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
 
@@ -109,12 +129,12 @@ DL_bot.py
       -> optional gsheet_module.run_kvk_proc_exports_with_alerts
 Current importer:
 
-prefers Full Data
-accepts fallback sheets
+requires Full Data
+rejects fallback sheets
 maps only legacy/stage columns
 drops new contribution fields
 drops raw min/max metric families
-does not persist schema version
+returns schema version in the import result
 does not persist source sheet metadata
 does not warn on ignored known columns
 Current SQL Pipeline
@@ -290,6 +310,9 @@ Reporting SQL should move out of stats_alerts/allkingdoms.py into DAL/service co
 
 Implementation Phases
 Phase 1 — Schema Detection & Validation
+Status
+Complete and deployed.
+
 Goal
 Introduce strict Full Data schema detection before changing SQL behaviour.
 
@@ -319,6 +342,23 @@ Importer only accepts Full Data.
 Basic Data is never used.
 Schema validation returns clear errors.
 Tests cover valid full schema, missing sheet, missing required columns, and ignored basic data.
+
+Completion Notes
+Implemented in Python only:
+
+kvk/schemas/kvk_all_schema.py
+kvk_all_importer.py
+tests/test_kvk_all_schema.py
+
+Validation completed:
+
+targeted schema tests passed
+import smoke passed
+command registration validation passed
+architecture boundary validation passed
+deferred item validation passed
+
+No SQL, export, recompute, or reporting changes were made in Phase 1.
 Phase 2 — Additive SQL Schema Migration
 Goal
 Add SQL capacity for the full workbook schema without breaking existing ingest/export behaviour.

--- a/docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
@@ -1,0 +1,142 @@
+KVK_ALL Schema Modernisation — Phase 2 Initiation Statement
+
+We are starting Phase 2 of the KVK_ALL Schema Modernisation programme.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+
+Also read the uploaded workbook sample:
+
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, and migration scripts. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 1 did not change SQL schema, SQL procedures, recompute, export, Google Sheets, or Discord reporting behaviour.
+
+Phase 2 objective:
+
+Add SQL capacity for the full KVK_ALL Full Data workbook schema without breaking existing ingest, recompute, export, Google Sheets, or Discord reporting behaviour.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data is out of scope and intentionally ignored.
+
+In scope:
+
+review SQL repo objects before implementation
+design additive SQL migration for Full Data fields
+add nullable columns to existing KVK stage/raw tables or introduce versioned v2 tables if justified
+update ingest stored procedure/stage flow additively
+persist schema/source metadata needed by the programme
+preserve existing legacy import/export/recompute compatibility
+add SQL scripts in the SQL repo using project naming standards
+add or update focused Python/SQL contract tests where practical
+capture new out-of-scope findings structurally
+
+Required persisted fields to support:
+
+rank
+min_kill_points
+max_kill_points
+min_power_raw
+max_power_raw
+min_dead
+max_dead
+min_troop_power
+max_troop_power
+min_units_healed
+max_units_healed
+min_kills_iv
+max_kills_iv
+min_kills_v
+max_kills_v
+min_max_contribute
+max_max_contribute
+min_cur_contribute
+max_cur_contribute
+max_contribute_diff
+cur_contribute_diff
+schema_version
+source_sheet_name
+source_column_hash
+source_column_count
+source_row_count
+
+Likely SQL objects to review/update:
+
+KVK.KVK_AllPlayers_Stage
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Scan or a new ingest metadata table
+KVK.sp_KVK_AllPlayers_Ingest
+KVK.KVK_Ingest_Negatives
+
+Out of scope for Phase 2:
+
+Discord reporting display changes
+Google Sheets export changes
+recompute formula redesign
+admin command SQL extraction
+reporting DAL refactor
+importer service/DAL refactor unless a minimal Python compatibility change is required for SQL contract tests
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Use additive, rollback-safe SQL changes.
+Do not make destructive SQL changes.
+Do not change existing export tab names or result-set contracts in this phase.
+Do not change Discord embed/reporting output in this phase.
+Preserve existing ingest behaviour for currently mapped legacy fields.
+Avoid embedded SQL in command/view layers.
+Prefer service and DAL boundaries where practical.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact SQL objects and Python touchpoints.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 2 additive SQL capacity.
+Run targeted validation.
+Stop after Phase 2 implementation, tests, and report.
+
+Acceptance criteria:
+
+existing legacy import path remains compatible
+new Full Data fields have additive SQL capacity
+ingest metadata is queryable
+SQL scripts are additive and rollback-safe
+no SQL/export/reporting behaviour outside Phase 2 is changed
+tests or validation cover the SQL contract and compatibility path where practical
+new deferred findings are captured structurally

--- a/kvk_all_importer.py
+++ b/kvk_all_importer.py
@@ -67,11 +67,57 @@ COLUMN_ALIASES = {
 }
 
 # 1) Define the exact stage order ONCE (top of file, near STAGE_INSERT_SQL)
+FULL_DATA_NUMERIC_COLUMN_MAP = {
+    "rank": "rank",
+    "minkill_points": "min_kill_points",
+    "maxkill_points": "max_kill_points",
+    "minpower": "min_power_raw",
+    "maxpower": "max_power_raw",
+    "mindead": "min_dead",
+    "maxdead": "max_dead",
+    "mintroop_power": "min_troop_power",
+    "maxtroop_power": "max_troop_power",
+    "minmax_units_healed": "min_units_healed",
+    "maxmax_units_healed": "max_units_healed",
+    "minkills_iv": "min_kills_iv",
+    "maxkills_iv": "max_kills_iv",
+    "minkills_v": "min_kills_v",
+    "maxkills_v": "max_kills_v",
+    "max_contribute_min": "min_max_contribute",
+    "max_contribute_max": "max_max_contribute",
+    "cur_contribute_min": "min_cur_contribute",
+    "cur_contribute_max": "max_cur_contribute",
+    "max_contribute_diff": "max_contribute_diff",
+    "cur_contribute_diff": "cur_contribute_diff",
+}
+
+# 1) Define the exact stage order ONCE (top of file, near STAGE_INSERT_SQL)
 STAGE_COL_ORDER = [
     "governor_id",
     "name",
     "kingdom",
     "campid",
+    "rank",
+    "min_kill_points",
+    "max_kill_points",
+    "min_power_raw",
+    "max_power_raw",
+    "min_dead",
+    "max_dead",
+    "min_troop_power",
+    "max_troop_power",
+    "min_units_healed",
+    "max_units_healed",
+    "min_kills_iv",
+    "max_kills_iv",
+    "min_kills_v",
+    "max_kills_v",
+    "min_max_contribute",
+    "max_max_contribute",
+    "min_cur_contribute",
+    "max_cur_contribute",
+    "max_contribute_diff",
+    "cur_contribute_diff",
     "min_points",
     "max_points",
     "points_difference",
@@ -90,6 +136,11 @@ STAGE_COL_ORDER = [
     "kills_iv_diff",
     "kills_v_diff",
     "subscription_level",
+    "schema_version",
+    "source_sheet_name",
+    "source_column_hash",
+    "source_column_count",
+    "source_row_count",
 ]
 
 
@@ -138,14 +189,12 @@ def _get_negatives_count(cn, kvk_no: int, scan_id: int) -> int:
         return int(val) if val is not None else 0
 
 
-STAGE_INSERT_SQL = """
+STAGE_INSERT_COLUMNS = ["IngestToken", *STAGE_COL_ORDER]
+
+STAGE_INSERT_SQL = f"""
  INSERT INTO KVK.KVK_AllPlayers_Stage (
-   IngestToken, governor_id, name, kingdom, campid,
-   min_points, max_points, points_difference, min_power, max_power, power_difference,
-   first_updateUTC, last_updateUTC,
-   latest_power, kill_points_diff, power_diff, dead_diff, troop_power_diff,
-   max_units_healed_diff, healed_troops, kills_iv_diff, kills_v_diff, subscription_level
- ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+   {", ".join(f"[{column}]" for column in STAGE_INSERT_COLUMNS)}
+ ) VALUES ({",".join("?" for _ in STAGE_INSERT_COLUMNS)})
  """
 
 CALL_INGEST_SQL = """
@@ -156,6 +205,11 @@ CALL_INGEST_SQL = """
    @SourceFileName=?,
    @FileHash=?,
    @UploaderDiscordID=?,
+   @SchemaVersion=?,
+   @SourceSheetName=?,
+   @SourceColumnHash=?,
+   @SourceColumnCount=?,
+   @SourceRowCount=?,
    @OutKVK_NO=@kvk OUTPUT,
    @OutScanID=@scan OUTPUT,
    @OutRowCount=@rows OUTPUT;
@@ -269,6 +323,12 @@ def _coerce(df: pd.DataFrame) -> pd.DataFrame:
     out["kingdom"] = df["kingdom"].map(as_int)
     out["campid"] = df.get("campid").map(as_int) if "campid" in df.columns else None
 
+    for source_col, target_col in FULL_DATA_NUMERIC_COLUMN_MAP.items():
+        if source_col in df.columns:
+            out[target_col] = df[source_col].map(as_int)
+        else:
+            out[target_col] = None
+
     # Numerics (optional if missing)
     for c in [
         "min_points",
@@ -301,6 +361,23 @@ def _coerce(df: pd.DataFrame) -> pd.DataFrame:
     if out["governor_id"].isna().any() or out["kingdom"].isna().any():
         raise ValueError("One or more rows missing governor_id or kingdom after coercion.")
     return out
+
+
+def _with_source_metadata(
+    df: pd.DataFrame,
+    *,
+    sheet_name: str,
+    schema_metadata: dict[str, Any],
+) -> pd.DataFrame:
+    df = df.copy()
+    df["schema_version"] = str(schema_metadata.get("schema_version") or KVK_ALL_SCHEMA_VERSION)[:64]
+    df["source_sheet_name"] = str(sheet_name)[:128]
+    column_hash = schema_metadata.get("column_hash")
+    df["source_column_hash"] = str(column_hash)[:64] if column_hash else None
+    column_count = schema_metadata.get("column_count")
+    df["source_column_count"] = int(column_count) if column_count is not None else None
+    df["source_row_count"] = int(df.shape[0])
+    return df
 
 
 # 2) Replace _rows_for_stage with an order-safe version
@@ -436,6 +513,7 @@ def ingest_kvk_all_excel(
             "schema_version": KVK_ALL_SCHEMA_VERSION,
             "schema": schema_metadata,
         }
+    df = _with_source_metadata(df, sheet_name=sheet_name, schema_metadata=schema_metadata)
 
     if df.empty:
         logger.info("[KVK] Import failed for %s: No rows found in uploaded file.", source_filename)
@@ -515,7 +593,19 @@ def ingest_kvk_all_excel(
         cur = con.cursor()
         t_ingest0 = time.perf_counter()
         cur.execute(
-            CALL_INGEST_SQL, (token, scan_ts_naive, source_filename, file_hash, int(uploader_id))
+            CALL_INGEST_SQL,
+            (
+                token,
+                scan_ts_naive,
+                source_filename,
+                file_hash,
+                int(uploader_id),
+                schema_metadata.get("schema_version") or KVK_ALL_SCHEMA_VERSION,
+                sheet_name,
+                schema_metadata.get("column_hash"),
+                schema_metadata.get("column_count"),
+                staged_rows,
+            ),
         )
         res = cur.fetchall()
         ingest_ms = (time.perf_counter() - t_ingest0) * 1000.0

--- a/sql/kvk_all_phase2_full_data_capacity.sql
+++ b/sql/kvk_all_phase2_full_data_capacity.sql
@@ -1,0 +1,276 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+/*
+KVK_ALL Schema Modernisation - Phase 2 additive SQL capacity.
+
+Deployment notes:
+- Additive only: nullable columns and a backward-compatible stored procedure signature.
+- Existing export/recompute/reporting result-set contracts are intentionally unchanged.
+- Rollback, if required, should prefer deploying the prior stored procedure definition.
+  Dropping added columns is intentionally not included because it can destroy ingested data.
+*/
+
+IF OBJECT_ID(N'[KVK].[KVK_AllPlayers_Stage]', N'U') IS NULL
+    THROW 51001, 'Required table KVK.KVK_AllPlayers_Stage does not exist.', 1;
+IF OBJECT_ID(N'[KVK].[KVK_AllPlayers_Raw]', N'U') IS NULL
+    THROW 51002, 'Required table KVK.KVK_AllPlayers_Raw does not exist.', 1;
+IF OBJECT_ID(N'[KVK].[KVK_Scan]', N'U') IS NULL
+    THROW 51003, 'Required table KVK.KVK_Scan does not exist.', 1;
+GO
+
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'rank') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [rank] [int] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_kill_points') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_kill_points] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_kill_points') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_kill_points] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_power_raw') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_power_raw] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_power_raw') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_power_raw] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_dead') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_dead] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_dead') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_dead] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_troop_power') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_troop_power] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_troop_power') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_troop_power] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_units_healed') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_units_healed] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_units_healed') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_units_healed] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_kills_iv') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_kills_iv] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_kills_iv') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_kills_iv] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_kills_v') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_kills_v] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_kills_v') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_kills_v] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_max_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_max_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_max_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_max_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'min_cur_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [min_cur_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_cur_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_cur_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'max_contribute_diff') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [max_contribute_diff] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'cur_contribute_diff') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [cur_contribute_diff] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'schema_version') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [schema_version] [nvarchar](64) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'source_sheet_name') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [source_sheet_name] [nvarchar](128) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'source_column_hash') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [source_column_hash] [char](64) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'source_column_count') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [source_column_count] [int] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'source_row_count') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Stage] ADD [source_row_count] [int] NULL;
+GO
+
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'rank') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [rank] [int] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_kill_points') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_kill_points] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_kill_points') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_kill_points] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_power_raw') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_power_raw] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_power_raw') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_power_raw] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_dead') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_dead] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_dead') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_dead] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_troop_power') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_troop_power] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_troop_power') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_troop_power] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_units_healed') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_units_healed] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_units_healed') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_units_healed] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_kills_iv') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_kills_iv] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_kills_iv') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_kills_iv] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_kills_v') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_kills_v] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_kills_v') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_kills_v] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_max_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_max_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_max_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_max_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'min_cur_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [min_cur_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_cur_contribute') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_cur_contribute] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'max_contribute_diff') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [max_contribute_diff] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'cur_contribute_diff') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [cur_contribute_diff] [bigint] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'schema_version') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [schema_version] [nvarchar](64) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'source_sheet_name') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [source_sheet_name] [nvarchar](128) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'source_column_hash') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [source_column_hash] [char](64) NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'source_column_count') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [source_column_count] [int] NULL;
+IF COL_LENGTH('KVK.KVK_AllPlayers_Raw', 'source_row_count') IS NULL ALTER TABLE [KVK].[KVK_AllPlayers_Raw] ADD [source_row_count] [int] NULL;
+GO
+
+IF COL_LENGTH('KVK.KVK_Scan', 'schema_version') IS NULL ALTER TABLE [KVK].[KVK_Scan] ADD [schema_version] [nvarchar](64) NULL;
+IF COL_LENGTH('KVK.KVK_Scan', 'source_sheet_name') IS NULL ALTER TABLE [KVK].[KVK_Scan] ADD [source_sheet_name] [nvarchar](128) NULL;
+IF COL_LENGTH('KVK.KVK_Scan', 'source_column_hash') IS NULL ALTER TABLE [KVK].[KVK_Scan] ADD [source_column_hash] [char](64) NULL;
+IF COL_LENGTH('KVK.KVK_Scan', 'source_column_count') IS NULL ALTER TABLE [KVK].[KVK_Scan] ADD [source_column_count] [int] NULL;
+IF COL_LENGTH('KVK.KVK_Scan', 'source_row_count') IS NULL ALTER TABLE [KVK].[KVK_Scan] ADD [source_row_count] [int] NULL;
+GO
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_AllPlayers_Ingest]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_AllPlayers_Ingest] AS'
+END
+GO
+
+ALTER PROCEDURE [KVK].[sp_KVK_AllPlayers_Ingest]
+    @IngestToken [uniqueidentifier],
+    @ScanTimestampUTC [datetime2](0),
+    @SourceFileName [nvarchar](255),
+    @FileHash [varbinary](32),
+    @UploaderDiscordID [bigint] = NULL,
+    @OutKVK_NO [int] OUTPUT,
+    @OutScanID [int] OUTPUT,
+    @OutRowCount [int] OUTPUT,
+    @SchemaVersion [nvarchar](64) = NULL,
+    @SourceSheetName [nvarchar](128) = NULL,
+    @SourceColumnHash [char](64) = NULL,
+    @SourceColumnCount [int] = NULL,
+    @SourceRowCount [int] = NULL
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    BEGIN TRY
+        IF @IngestToken IS NULL
+            THROW 50001, 'IngestToken is required.', 1;
+        IF @ScanTimestampUTC IS NULL
+            THROW 50002, 'ScanTimestampUTC is required.', 1;
+        IF @FileHash IS NULL OR DATALENGTH(@FileHash) = 0
+            THROW 50003, 'FileHash is required (use SHA-256).', 1;
+
+        SELECT @OutRowCount = COUNT(*)
+        FROM KVK.KVK_AllPlayers_Stage WITH (READCOMMITTEDLOCK)
+        WHERE IngestToken = @IngestToken;
+
+        IF @OutRowCount IS NULL OR @OutRowCount = 0
+            THROW 50004, 'No staged rows found for IngestToken.', 1;
+
+        SELECT TOP (1)
+            @SchemaVersion = COALESCE(@SchemaVersion, s.schema_version),
+            @SourceSheetName = COALESCE(@SourceSheetName, s.source_sheet_name),
+            @SourceColumnHash = COALESCE(@SourceColumnHash, s.source_column_hash),
+            @SourceColumnCount = COALESCE(@SourceColumnCount, s.source_column_count),
+            @SourceRowCount = COALESCE(@SourceRowCount, s.source_row_count)
+        FROM KVK.KVK_AllPlayers_Stage AS s WITH (READCOMMITTEDLOCK)
+        WHERE s.IngestToken = @IngestToken
+        ORDER BY s.row_no;
+
+        SET @SourceRowCount = COALESCE(@SourceRowCount, @OutRowCount);
+
+        DECLARE @KVK_NO INT;
+
+        SELECT TOP(1) @KVK_NO = d.KVK_NO
+        FROM dbo.KVK_Details AS d WITH (READCOMMITTEDLOCK)
+        WHERE @ScanTimestampUTC >= d.KVK_REGISTRATION_DATE
+          AND @ScanTimestampUTC <= d.KVK_END_DATE
+        ORDER BY d.KVK_NO DESC;
+
+        IF @KVK_NO IS NULL
+            THROW 50005, 'Scan timestamp does not fall within any KVK_Details range.', 1;
+
+        IF EXISTS (
+            SELECT 1
+            FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
+            WHERE KVK_NO = @KVK_NO
+              AND ScanTimestampUTC = @ScanTimestampUTC
+              AND FileHash = @FileHash
+        )
+        BEGIN
+            THROW 50006, 'Duplicate ingest: same KVK, ScanTimestamp, and FileHash already exists.', 1;
+        END
+
+        DECLARE @ScanID INT;
+
+        SELECT @ScanID = ISNULL(MAX(ScanID), 0) + 1
+        FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
+        WHERE KVK_NO = @KVK_NO;
+
+        INSERT INTO KVK.KVK_Scan
+        (
+            KVK_NO, ScanID, ScanTimestampUTC, SourceFileName, FileHash,
+            Row_Count, ImportedAtUTC, UploaderDiscordID,
+            schema_version, source_sheet_name, source_column_hash,
+            source_column_count, source_row_count
+        )
+        VALUES
+        (
+            @KVK_NO, @ScanID, @ScanTimestampUTC, @SourceFileName, @FileHash,
+            @OutRowCount, SYSUTCDATETIME(), @UploaderDiscordID,
+            @SchemaVersion, @SourceSheetName, @SourceColumnHash,
+            @SourceColumnCount, @SourceRowCount
+        );
+
+        INSERT INTO KVK.KVK_AllPlayers_Raw
+        (
+            KVK_NO, ScanID, governor_id, [name], kingdom, campid,
+            [rank], min_kill_points, max_kill_points, min_power_raw, max_power_raw,
+            min_dead, max_dead, min_troop_power, max_troop_power,
+            min_units_healed, max_units_healed, min_kills_iv, max_kills_iv,
+            min_kills_v, max_kills_v, min_max_contribute, max_max_contribute,
+            min_cur_contribute, max_cur_contribute, max_contribute_diff,
+            cur_contribute_diff,
+            min_points, max_points, points_difference,
+            min_power, max_power, power_difference,
+            first_updateUTC, last_updateUTC,
+            latest_power, kill_points_diff, power_diff,
+            dead_diff, troop_power_diff, max_units_healed_diff, healed_troops,
+            kills_iv_diff, kills_v_diff, subscription_level,
+            schema_version, source_sheet_name, source_column_hash,
+            source_column_count, source_row_count
+        )
+        SELECT
+            @KVK_NO, @ScanID,
+            s.governor_id, s.[name], s.kingdom, s.campid,
+            s.[rank], s.min_kill_points, s.max_kill_points, s.min_power_raw, s.max_power_raw,
+            s.min_dead, s.max_dead, s.min_troop_power, s.max_troop_power,
+            s.min_units_healed, s.max_units_healed, s.min_kills_iv, s.max_kills_iv,
+            s.min_kills_v, s.max_kills_v, s.min_max_contribute, s.max_max_contribute,
+            s.min_cur_contribute, s.max_cur_contribute, s.max_contribute_diff,
+            s.cur_contribute_diff,
+            s.min_points, s.max_points, s.points_difference,
+            s.min_power, s.max_power, s.power_difference,
+            s.first_updateUTC, s.last_updateUTC,
+            s.latest_power, s.kill_points_diff, s.power_diff,
+            s.dead_diff, s.troop_power_diff, s.max_units_healed_diff, s.healed_troops,
+            s.kills_iv_diff, s.kills_v_diff, s.subscription_level,
+            COALESCE(s.schema_version, @SchemaVersion),
+            COALESCE(s.source_sheet_name, @SourceSheetName),
+            COALESCE(s.source_column_hash, @SourceColumnHash),
+            COALESCE(s.source_column_count, @SourceColumnCount),
+            COALESCE(s.source_row_count, @SourceRowCount)
+        FROM KVK.KVK_AllPlayers_Stage AS s
+        WHERE s.IngestToken = @IngestToken;
+
+        INSERT INTO KVK.KVK_Player_Baseline (KVK_NO, governor_id, baseline_scan_id, starting_power)
+        SELECT DISTINCT
+            @KVK_NO, s.governor_id, @ScanID, ISNULL(s.max_power, 0)
+        FROM KVK.KVK_AllPlayers_Stage AS s
+        LEFT JOIN KVK.KVK_Player_Baseline AS b
+               ON b.KVK_NO = @KVK_NO AND b.governor_id = s.governor_id
+        WHERE s.IngestToken = @IngestToken
+          AND b.governor_id IS NULL;
+
+        INSERT INTO KVK.KVK_Ingest_Negatives
+        (
+            KVK_NO, ScanID, governor_id, [name], kingdom, campid, field_name, [value], recorded_at_utc
+        )
+        SELECT
+            @KVK_NO, @ScanID, x.governor_id, x.[name], x.kingdom, x.campid, v.field_name, v.val, SYSUTCDATETIME()
+        FROM
+        (
+            SELECT s.governor_id, s.[name], s.kingdom, s.campid,
+                   s.points_difference, s.kills_iv_diff, s.kills_v_diff,
+                   s.dead_diff, s.max_units_healed_diff,
+                   s.max_contribute_diff, s.cur_contribute_diff
+            FROM KVK.KVK_AllPlayers_Stage AS s
+            WHERE s.IngestToken = @IngestToken
+        ) AS x
+        CROSS APPLY
+        (
+            VALUES
+              (N'points_difference',      x.points_difference),
+              (N'kills_iv_diff',          x.kills_iv_diff),
+              (N'kills_v_diff',           x.kills_v_diff),
+              (N'dead_diff',              x.dead_diff),
+              (N'max_units_healed_diff',  x.max_units_healed_diff),
+              (N'max_contribute_diff',    x.max_contribute_diff),
+              (N'cur_contribute_diff',    x.cur_contribute_diff)
+        ) AS v(field_name, val)
+        WHERE v.val IS NOT NULL AND v.val < 0;
+
+        DELETE FROM KVK.KVK_AllPlayers_Stage WHERE IngestToken = @IngestToken;
+
+        SET @OutKVK_NO = @KVK_NO;
+        SET @OutScanID = @ScanID;
+
+        RETURN 0;
+    END TRY
+    BEGIN CATCH
+        DECLARE @msg NVARCHAR(4000) = CONCAT(
+            'Ingest failed (token=', CONVERT(VARCHAR(36), @IngestToken), '): ',
+            ERROR_MESSAGE()
+        );
+        THROW 50010, @msg, 1;
+    END CATCH
+END
+GO

--- a/sql/kvk_all_phase2_full_data_capacity.sql
+++ b/sql/kvk_all_phase2_full_data_capacity.sql
@@ -148,37 +148,48 @@ BEGIN
         IF @KVK_NO IS NULL
             THROW 50005, 'Scan timestamp does not fall within any KVK_Details range.', 1;
 
-        IF EXISTS (
-            SELECT 1
-            FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
-            WHERE KVK_NO = @KVK_NO
-              AND ScanTimestampUTC = @ScanTimestampUTC
-              AND FileHash = @FileHash
-        )
-        BEGIN
-            THROW 50006, 'Duplicate ingest: same KVK, ScanTimestamp, and FileHash already exists.', 1;
-        END
-
         DECLARE @ScanID INT;
 
-        SELECT @ScanID = ISNULL(MAX(ScanID), 0) + 1
-        FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
-        WHERE KVK_NO = @KVK_NO;
+        BEGIN TRY
+            BEGIN TRANSACTION;
 
-        INSERT INTO KVK.KVK_Scan
-        (
-            KVK_NO, ScanID, ScanTimestampUTC, SourceFileName, FileHash,
-            Row_Count, ImportedAtUTC, UploaderDiscordID,
-            schema_version, source_sheet_name, source_column_hash,
-            source_column_count, source_row_count
-        )
-        VALUES
-        (
-            @KVK_NO, @ScanID, @ScanTimestampUTC, @SourceFileName, @FileHash,
-            @OutRowCount, SYSUTCDATETIME(), @UploaderDiscordID,
-            @SchemaVersion, @SourceSheetName, @SourceColumnHash,
-            @SourceColumnCount, @SourceRowCount
-        );
+            IF EXISTS (
+                SELECT 1
+                FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
+                WHERE KVK_NO = @KVK_NO
+                  AND ScanTimestampUTC = @ScanTimestampUTC
+                  AND FileHash = @FileHash
+            )
+            BEGIN
+                THROW 50006, 'Duplicate ingest: same KVK, ScanTimestamp, and FileHash already exists.', 1;
+            END
+
+            SELECT @ScanID = ISNULL(MAX(ScanID), 0) + 1
+            FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
+            WHERE KVK_NO = @KVK_NO;
+
+            INSERT INTO KVK.KVK_Scan
+            (
+                KVK_NO, ScanID, ScanTimestampUTC, SourceFileName, FileHash,
+                Row_Count, ImportedAtUTC, UploaderDiscordID,
+                schema_version, source_sheet_name, source_column_hash,
+                source_column_count, source_row_count
+            )
+            VALUES
+            (
+                @KVK_NO, @ScanID, @ScanTimestampUTC, @SourceFileName, @FileHash,
+                @OutRowCount, SYSUTCDATETIME(), @UploaderDiscordID,
+                @SchemaVersion, @SourceSheetName, @SourceColumnHash,
+                @SourceColumnCount, @SourceRowCount
+            );
+
+            COMMIT TRANSACTION;
+        END TRY
+        BEGIN CATCH
+            IF @@TRANCOUNT > 0
+                ROLLBACK TRANSACTION;
+            THROW;
+        END CATCH;
 
         INSERT INTO KVK.KVK_AllPlayers_Raw
         (

--- a/sql/kvk_all_phase2_full_data_capacity.sql
+++ b/sql/kvk_all_phase2_full_data_capacity.sql
@@ -153,6 +153,8 @@ BEGIN
         BEGIN TRY
             BEGIN TRANSACTION;
 
+            -- Duplicate-ingest guard: UPDLOCK/HOLDLOCK remain active for the
+            -- lifetime of this transaction, serialising concurrent callers.
             IF EXISTS (
                 SELECT 1
                 FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
@@ -164,6 +166,7 @@ BEGIN
                 THROW 50006, 'Duplicate ingest: same KVK, ScanTimestamp, and FileHash already exists.', 1;
             END
 
+            -- ScanID allocation: serialised by the same transaction/lock scope above.
             SELECT @ScanID = ISNULL(MAX(ScanID), 0) + 1
             FROM KVK.KVK_Scan WITH (UPDLOCK, HOLDLOCK)
             WHERE KVK_NO = @KVK_NO;
@@ -183,6 +186,86 @@ BEGIN
                 @SourceColumnCount, @SourceRowCount
             );
 
+            INSERT INTO KVK.KVK_AllPlayers_Raw
+            (
+                KVK_NO, ScanID, governor_id, [name], kingdom, campid,
+                [rank], min_kill_points, max_kill_points, min_power_raw, max_power_raw,
+                min_dead, max_dead, min_troop_power, max_troop_power,
+                min_units_healed, max_units_healed, min_kills_iv, max_kills_iv,
+                min_kills_v, max_kills_v, min_max_contribute, max_max_contribute,
+                min_cur_contribute, max_cur_contribute, max_contribute_diff,
+                cur_contribute_diff,
+                min_points, max_points, points_difference,
+                min_power, max_power, power_difference,
+                first_updateUTC, last_updateUTC,
+                latest_power, kill_points_diff, power_diff,
+                dead_diff, troop_power_diff, max_units_healed_diff, healed_troops,
+                kills_iv_diff, kills_v_diff, subscription_level,
+                schema_version, source_sheet_name, source_column_hash,
+                source_column_count, source_row_count
+            )
+            SELECT
+                @KVK_NO, @ScanID,
+                s.governor_id, s.[name], s.kingdom, s.campid,
+                s.[rank], s.min_kill_points, s.max_kill_points, s.min_power_raw, s.max_power_raw,
+                s.min_dead, s.max_dead, s.min_troop_power, s.max_troop_power,
+                s.min_units_healed, s.max_units_healed, s.min_kills_iv, s.max_kills_iv,
+                s.min_kills_v, s.max_kills_v, s.min_max_contribute, s.max_max_contribute,
+                s.min_cur_contribute, s.max_cur_contribute, s.max_contribute_diff,
+                s.cur_contribute_diff,
+                s.min_points, s.max_points, s.points_difference,
+                s.min_power, s.max_power, s.power_difference,
+                s.first_updateUTC, s.last_updateUTC,
+                s.latest_power, s.kill_points_diff, s.power_diff,
+                s.dead_diff, s.troop_power_diff, s.max_units_healed_diff, s.healed_troops,
+                s.kills_iv_diff, s.kills_v_diff, s.subscription_level,
+                COALESCE(s.schema_version, @SchemaVersion),
+                COALESCE(s.source_sheet_name, @SourceSheetName),
+                COALESCE(s.source_column_hash, @SourceColumnHash),
+                COALESCE(s.source_column_count, @SourceColumnCount),
+                COALESCE(s.source_row_count, @SourceRowCount)
+            FROM KVK.KVK_AllPlayers_Stage AS s
+            WHERE s.IngestToken = @IngestToken;
+
+            INSERT INTO KVK.KVK_Player_Baseline (KVK_NO, governor_id, baseline_scan_id, starting_power)
+            SELECT DISTINCT
+                @KVK_NO, s.governor_id, @ScanID, ISNULL(s.max_power, 0)
+            FROM KVK.KVK_AllPlayers_Stage AS s
+            LEFT JOIN KVK.KVK_Player_Baseline AS b
+                   ON b.KVK_NO = @KVK_NO AND b.governor_id = s.governor_id
+            WHERE s.IngestToken = @IngestToken
+              AND b.governor_id IS NULL;
+
+            INSERT INTO KVK.KVK_Ingest_Negatives
+            (
+                KVK_NO, ScanID, governor_id, [name], kingdom, campid, field_name, [value], recorded_at_utc
+            )
+            SELECT
+                @KVK_NO, @ScanID, x.governor_id, x.[name], x.kingdom, x.campid, v.field_name, v.val, SYSUTCDATETIME()
+            FROM
+            (
+                SELECT s.governor_id, s.[name], s.kingdom, s.campid,
+                       s.points_difference, s.kills_iv_diff, s.kills_v_diff,
+                       s.dead_diff, s.max_units_healed_diff,
+                       s.max_contribute_diff, s.cur_contribute_diff
+                FROM KVK.KVK_AllPlayers_Stage AS s
+                WHERE s.IngestToken = @IngestToken
+            ) AS x
+            CROSS APPLY
+            (
+                VALUES
+                  (N'points_difference',      x.points_difference),
+                  (N'kills_iv_diff',          x.kills_iv_diff),
+                  (N'kills_v_diff',           x.kills_v_diff),
+                  (N'dead_diff',              x.dead_diff),
+                  (N'max_units_healed_diff',  x.max_units_healed_diff),
+                  (N'max_contribute_diff',    x.max_contribute_diff),
+                  (N'cur_contribute_diff',    x.cur_contribute_diff)
+            ) AS v(field_name, val)
+            WHERE v.val IS NOT NULL AND v.val < 0;
+
+            DELETE FROM KVK.KVK_AllPlayers_Stage WHERE IngestToken = @IngestToken;
+
             COMMIT TRANSACTION;
         END TRY
         BEGIN CATCH
@@ -190,86 +273,6 @@ BEGIN
                 ROLLBACK TRANSACTION;
             THROW;
         END CATCH;
-
-        INSERT INTO KVK.KVK_AllPlayers_Raw
-        (
-            KVK_NO, ScanID, governor_id, [name], kingdom, campid,
-            [rank], min_kill_points, max_kill_points, min_power_raw, max_power_raw,
-            min_dead, max_dead, min_troop_power, max_troop_power,
-            min_units_healed, max_units_healed, min_kills_iv, max_kills_iv,
-            min_kills_v, max_kills_v, min_max_contribute, max_max_contribute,
-            min_cur_contribute, max_cur_contribute, max_contribute_diff,
-            cur_contribute_diff,
-            min_points, max_points, points_difference,
-            min_power, max_power, power_difference,
-            first_updateUTC, last_updateUTC,
-            latest_power, kill_points_diff, power_diff,
-            dead_diff, troop_power_diff, max_units_healed_diff, healed_troops,
-            kills_iv_diff, kills_v_diff, subscription_level,
-            schema_version, source_sheet_name, source_column_hash,
-            source_column_count, source_row_count
-        )
-        SELECT
-            @KVK_NO, @ScanID,
-            s.governor_id, s.[name], s.kingdom, s.campid,
-            s.[rank], s.min_kill_points, s.max_kill_points, s.min_power_raw, s.max_power_raw,
-            s.min_dead, s.max_dead, s.min_troop_power, s.max_troop_power,
-            s.min_units_healed, s.max_units_healed, s.min_kills_iv, s.max_kills_iv,
-            s.min_kills_v, s.max_kills_v, s.min_max_contribute, s.max_max_contribute,
-            s.min_cur_contribute, s.max_cur_contribute, s.max_contribute_diff,
-            s.cur_contribute_diff,
-            s.min_points, s.max_points, s.points_difference,
-            s.min_power, s.max_power, s.power_difference,
-            s.first_updateUTC, s.last_updateUTC,
-            s.latest_power, s.kill_points_diff, s.power_diff,
-            s.dead_diff, s.troop_power_diff, s.max_units_healed_diff, s.healed_troops,
-            s.kills_iv_diff, s.kills_v_diff, s.subscription_level,
-            COALESCE(s.schema_version, @SchemaVersion),
-            COALESCE(s.source_sheet_name, @SourceSheetName),
-            COALESCE(s.source_column_hash, @SourceColumnHash),
-            COALESCE(s.source_column_count, @SourceColumnCount),
-            COALESCE(s.source_row_count, @SourceRowCount)
-        FROM KVK.KVK_AllPlayers_Stage AS s
-        WHERE s.IngestToken = @IngestToken;
-
-        INSERT INTO KVK.KVK_Player_Baseline (KVK_NO, governor_id, baseline_scan_id, starting_power)
-        SELECT DISTINCT
-            @KVK_NO, s.governor_id, @ScanID, ISNULL(s.max_power, 0)
-        FROM KVK.KVK_AllPlayers_Stage AS s
-        LEFT JOIN KVK.KVK_Player_Baseline AS b
-               ON b.KVK_NO = @KVK_NO AND b.governor_id = s.governor_id
-        WHERE s.IngestToken = @IngestToken
-          AND b.governor_id IS NULL;
-
-        INSERT INTO KVK.KVK_Ingest_Negatives
-        (
-            KVK_NO, ScanID, governor_id, [name], kingdom, campid, field_name, [value], recorded_at_utc
-        )
-        SELECT
-            @KVK_NO, @ScanID, x.governor_id, x.[name], x.kingdom, x.campid, v.field_name, v.val, SYSUTCDATETIME()
-        FROM
-        (
-            SELECT s.governor_id, s.[name], s.kingdom, s.campid,
-                   s.points_difference, s.kills_iv_diff, s.kills_v_diff,
-                   s.dead_diff, s.max_units_healed_diff,
-                   s.max_contribute_diff, s.cur_contribute_diff
-            FROM KVK.KVK_AllPlayers_Stage AS s
-            WHERE s.IngestToken = @IngestToken
-        ) AS x
-        CROSS APPLY
-        (
-            VALUES
-              (N'points_difference',      x.points_difference),
-              (N'kills_iv_diff',          x.kills_iv_diff),
-              (N'kills_v_diff',           x.kills_v_diff),
-              (N'dead_diff',              x.dead_diff),
-              (N'max_units_healed_diff',  x.max_units_healed_diff),
-              (N'max_contribute_diff',    x.max_contribute_diff),
-              (N'cur_contribute_diff',    x.cur_contribute_diff)
-        ) AS v(field_name, val)
-        WHERE v.val IS NOT NULL AND v.val < 0;
-
-        DELETE FROM KVK.KVK_AllPlayers_Stage WHERE IngestToken = @IngestToken;
 
         SET @OutKVK_NO = @KVK_NO;
         SET @OutScanID = @ScanID;

--- a/tests/test_kvk_all_schema.py
+++ b/tests/test_kvk_all_schema.py
@@ -24,7 +24,7 @@ def _xlsx_bytes(sheets: dict[str, pd.DataFrame]) -> bytes:
 
 
 def _full_data_df() -> pd.DataFrame:
-    row = {column: 1 for column in EXPECTED_FULL_DATA_COLUMNS}
+    row: dict[str, object] = {column: 1 for column in EXPECTED_FULL_DATA_COLUMNS}
     row.update(
         {
             "name": "Test Governor",
@@ -82,6 +82,100 @@ def test_read_excel_uses_full_data_and_ignores_basic_data() -> None:
     assert schema["column_count"] == len(EXPECTED_FULL_DATA_COLUMNS)
     assert df.loc[0, "name"] == "Test Governor"
     assert "first_updateUTC" in df.columns
+
+
+def test_coerce_maps_full_data_v2_columns_to_additive_stage_columns() -> None:
+    full_data = _full_data_df()
+    full_data.loc[0, "rank"] = 7
+    full_data.loc[0, "minkill_points"] = 111
+    full_data.loc[0, "maxkill_points"] = 222
+    full_data.loc[0, "minpower"] = 333
+    full_data.loc[0, "maxpower"] = 444
+    full_data.loc[0, "max_contribute_min"] = 555
+    full_data.loc[0, "max_contribute_max"] = 666
+    full_data.loc[0, "cur_contribute_min"] = 777
+    full_data.loc[0, "cur_contribute_max"] = 888
+    full_data.loc[0, "max_contribute_diff"] = 999
+    full_data.loc[0, "cur_contribute_diff"] = 1000
+
+    coerced = importer._coerce(full_data)
+
+    assert coerced.loc[0, "rank"] == 7
+    assert coerced.loc[0, "min_kill_points"] == 111
+    assert coerced.loc[0, "max_kill_points"] == 222
+    assert coerced.loc[0, "min_power_raw"] == 333
+    assert coerced.loc[0, "max_power_raw"] == 444
+    assert coerced.loc[0, "min_max_contribute"] == 555
+    assert coerced.loc[0, "max_max_contribute"] == 666
+    assert coerced.loc[0, "min_cur_contribute"] == 777
+    assert coerced.loc[0, "max_cur_contribute"] == 888
+    assert coerced.loc[0, "max_contribute_diff"] == 999
+    assert coerced.loc[0, "cur_contribute_diff"] == 1000
+
+
+def test_stage_insert_contract_includes_phase2_columns_and_metadata() -> None:
+    required = {
+        "rank",
+        "min_kill_points",
+        "max_kill_points",
+        "min_power_raw",
+        "max_power_raw",
+        "min_dead",
+        "max_dead",
+        "min_troop_power",
+        "max_troop_power",
+        "min_units_healed",
+        "max_units_healed",
+        "min_kills_iv",
+        "max_kills_iv",
+        "min_kills_v",
+        "max_kills_v",
+        "min_max_contribute",
+        "max_max_contribute",
+        "min_cur_contribute",
+        "max_cur_contribute",
+        "max_contribute_diff",
+        "cur_contribute_diff",
+        "schema_version",
+        "source_sheet_name",
+        "source_column_hash",
+        "source_column_count",
+        "source_row_count",
+    }
+
+    assert required.issubset(set(importer.STAGE_COL_ORDER))
+    assert importer.STAGE_INSERT_SQL.count("?") == len(importer.STAGE_INSERT_COLUMNS)
+
+
+def test_rows_for_stage_include_source_metadata_values() -> None:
+    schema = validate_full_data_columns(EXPECTED_FULL_DATA_COLUMNS, sheet_name=FULL_DATA_SHEET_NAME)
+    coerced = importer._coerce(_full_data_df())
+    enriched = importer._with_source_metadata(
+        coerced,
+        sheet_name=FULL_DATA_SHEET_NAME,
+        schema_metadata=schema.to_dict(),
+    )
+
+    row = importer._rows_for_stage("token-1", enriched)[0]
+    values = dict(zip(["IngestToken", *importer.STAGE_COL_ORDER], row, strict=True))
+
+    assert values["IngestToken"] == "token-1"
+    assert values["schema_version"] == SCHEMA_VERSION
+    assert values["source_sheet_name"] == FULL_DATA_SHEET_NAME
+    assert values["source_column_hash"] == schema.column_hash
+    assert values["source_column_count"] == len(EXPECTED_FULL_DATA_COLUMNS)
+    assert values["source_row_count"] == 1
+
+
+def test_ingest_call_contract_passes_phase2_metadata_parameters() -> None:
+    for parameter_name in [
+        "@SchemaVersion=?",
+        "@SourceSheetName=?",
+        "@SourceColumnHash=?",
+        "@SourceColumnCount=?",
+        "@SourceRowCount=?",
+    ]:
+        assert parameter_name in importer.CALL_INGEST_SQL
 
 
 def test_read_excel_rejects_missing_full_data_without_sheet_fallback() -> None:


### PR DESCRIPTION
## Summary

Adds Phase 2 additive SQL capacity for the KVK_ALL Full Data workbook schema while preserving the existing ingest/recompute/export/reporting behaviour.

## Changes

- Extends `kvk_all_importer.py` to stage Full Data v2 rank, raw min/max metric families, contribution fields, and schema/source metadata.
- Adds `sql/kvk_all_phase2_full_data_capacity.sql` for prod DB deployment of additive nullable columns and a backward-compatible `KVK.sp_KVK_AllPlayers_Ingest` update.
- Updates focused KVK schema tests to cover additive stage field mapping, source metadata propagation, and ingest proc parameter contract.
- Includes updated docs for the Full Optimisation Task Pack and Phase 2 Initiation Statement.

## Compatibility

- Existing legacy import fields remain staged and ingested.
- Recompute, export result-set ordering, Google Sheets output, and Discord reporting output are intentionally unchanged in this phase.
- SQL script is additive and avoids destructive rollback steps.

## Validation

- `python -m pytest -q tests\test_kvk_all_schema.py`
- `python scripts\validate_architecture_boundaries.py`
- `python scripts\validate_deferred_items.py`
- `python scripts\smoke_imports.py`
- `python scripts\validate_command_registration.py`
- `python -m black --check kvk_all_importer.py tests\test_kvk_all_schema.py`
- `python -m pyright kvk_all_importer.py tests\test_kvk_all_schema.py` (0 errors; local third-party import warnings only)

## Deployment Note

Apply `sql/kvk_all_phase2_full_data_capacity.sql` to the production database before deploying the Python importer changes that write the new stage columns.