### PR TITLE
[codex] Refactor KVK_ALL importer layers

### DIFF
--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -23,6 +23,8 @@ Basic Data is out of scope and must not be used for ingestion, validation, or fa
 Programme Status
 Phase 1 is complete and deployed.
 
+Phase 2 is complete and deployed.
+
 Completed Phase 1 scope:
 
 strict Full Data workbook detection
@@ -36,9 +38,25 @@ focused tests cover valid schema, missing Full Data, missing required columns, a
 
 Phase 1 changed Python-side workbook validation only. No SQL schema, stored procedure, recompute, export, Google Sheets, or Discord reporting behaviour was changed.
 
+Completed Phase 2 scope:
+
+additive SQL capacity added for Full Data v2 fields
+nullable Full Data columns added to KVK.KVK_AllPlayers_Stage
+nullable Full Data columns added to KVK.KVK_AllPlayers_Raw
+schema/source metadata added to KVK.KVK_Scan
+KVK.sp_KVK_AllPlayers_Ingest updated additively with optional metadata parameters
+Full Data v2 fields are staged from Python without changing recompute/export/reporting contracts
+source metadata is staged and passed into ingest
+KVK_Ingest_Negatives can capture negative contribution deltas
+production deployment SQL script added under sql/
+focused schema/import contract tests added
+deployment smoke confirmed DB columns and ingest metadata parameters exist
+
+Phase 2 did not change recompute formula behaviour, export result-set order, Google Sheets tabs, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
+
 Next phase:
 
-Phase 2 — Additive SQL Schema Migration
+Phase 3 — Importer Service/DAL Refactor
 
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
@@ -131,11 +149,10 @@ Current importer:
 
 requires Full Data
 rejects fallback sheets
-maps only legacy/stage columns
-drops new contribution fields
-drops raw min/max metric families
+maps legacy fields and Phase 2 Full Data capacity fields into stage rows
+stages rank, raw min/max metric families, and contribution fields
 returns schema version in the import result
-does not persist source sheet metadata
+persists schema/source metadata through the SQL ingest flow
 does not warn on ignored known columns
 Current SQL Pipeline
 Reviewed SQL objects:
@@ -159,7 +176,7 @@ dbo.fn_KVK_Player_Aggregated
 dbo.fn_KVK_Kingdom_Aggregated
 dbo.fn_KVK_Camp_Aggregated
 KVK.vw_FightingDataset
-Current SQL supports legacy fields only:
+Current SQL supports legacy fields plus Phase 2 Full Data capacity fields:
 
 points_difference
 kill_points_diff
@@ -171,19 +188,35 @@ healed_troops
 kills_iv_diff
 kills_v_diff
 latest_power
+rank
+min_kill_points
+max_kill_points
+min_power_raw
+max_power_raw
+min_dead
+max_dead
+min_troop_power
+max_troop_power
+min_units_healed
+max_units_healed
+min_kills_iv
+max_kills_iv
+min_kills_v
+max_kills_v
+min_max_contribute
+max_max_contribute
+min_cur_contribute
+max_cur_contribute
+max_contribute_diff
+cur_contribute_diff
+schema_version
+source_sheet_name
+source_column_hash
+source_column_count
+source_row_count
+
 It does not support:
 
-rank
-raw min/max kill points
-raw min/max power
-raw min/max dead
-raw min/max troop power
-raw min/max healed
-max contribution metrics
-current contribution metrics
-schema version metadata
-source workbook metadata
-source sheet metadata
 summary tab reconciliation
 Current Export/Reporting Coupling
 gsheet_module.py currently assumes:
@@ -360,6 +393,9 @@ deferred item validation passed
 
 No SQL, export, recompute, or reporting changes were made in Phase 1.
 Phase 2 — Additive SQL Schema Migration
+Status
+Complete and deployed.
+
 Goal
 Add SQL capacity for the full workbook schema without breaking existing ingest/export behaviour.
 
@@ -409,6 +445,44 @@ Existing legacy import still works if required by compatibility tests.
 New Full Data fields are persisted.
 Ingest metadata is queryable.
 SQL scripts are additive and rollback-safe.
+
+Completion Notes
+Implemented:
+
+sql/kvk_all_phase2_full_data_capacity.sql
+kvk_all_importer.py
+tests/test_kvk_all_schema.py
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+
+SQL deployment delivered:
+
+nullable Full Data capacity columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data capacity columns on KVK.KVK_AllPlayers_Raw
+schema_version, source_sheet_name, source_column_hash, source_column_count, and source_row_count on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+raw persistence of rank, min/max metrics, contribution metrics, and source metadata
+negative diagnostics extended to max_contribute_diff and cur_contribute_diff
+
+Python delivery:
+
+Full Data v2 workbook columns are mapped into canonical stage column names.
+schema/source metadata is added to staged rows.
+ingest call passes schema/source metadata to SQL.
+legacy import return fields and user-facing import behaviour are preserved.
+
+Validation completed:
+
+python -m pytest -q tests\test_kvk_all_schema.py
+python scripts\validate_architecture_boundaries.py
+python scripts\validate_deferred_items.py
+python scripts\smoke_imports.py
+python scripts\validate_command_registration.py
+python -m black --check kvk_all_importer.py tests\test_kvk_all_schema.py
+python -m pyright kvk_all_importer.py tests\test_kvk_all_schema.py
+non-mutating workbook/importer smoke against downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+read-only SQL metadata smoke confirming deployed columns and ingest metadata parameters
+
+No recompute, export, Google Sheets, Discord reporting display, admin command SQL extraction, or reporting DAL refactor changes were made in Phase 2.
 Phase 3 — Importer Service/DAL Refactor
 Goal
 Resolve importer architecture debt and support the full schema cleanly.

--- a/docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
@@ -1,0 +1,151 @@
+KVK_ALL Schema Modernisation — Phase 3 Initiation Statement
+
+We are starting Phase 3 of the KVK_ALL Schema Modernisation programme.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+
+Also read the uploaded workbook sample:
+
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, and migration scripts. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 2 is complete and deployed.
+
+Phase 2 delivered:
+
+additive SQL capacity for the KVK_ALL Full Data workbook schema
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Raw
+queryable schema/source metadata on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+Python staging support for rank, raw min/max metric families, contribution metrics, and source metadata
+focused schema/import SQL contract tests
+production deployment script under sql/kvk_all_phase2_full_data_capacity.sql
+non-mutating workbook/importer smoke validation
+read-only SQL metadata smoke validation after deployment
+
+Phase 2 did not change recompute formula behaviour, export result-set order, Google Sheets tab names, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
+
+Phase 3 objective:
+
+Refactor the KVK_ALL importer into clear schema, service, and DAL boundaries while preserving the existing user-facing import behaviour and the Phase 2 SQL contract.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data is out of scope and intentionally ignored.
+
+In scope:
+
+review current importer and SQL contract before implementation
+extract workbook parsing and schema validation from kvk_all_importer.py into the KVK schema/service layer
+extract Full Data v2 canonical column mapping and coercion into testable schema or service code
+extract SQL staging, ingest procedure calls, recompute calls, and negative count reads into a DAL module
+keep Discord objects out of services and DAL
+preserve kvk_all_importer.ingest_kvk_all_excel as a compatibility wrapper or thin entrypoint
+preserve existing return dictionary keys used by DL_bot.py
+preserve structured validation errors introduced in Phase 1
+preserve Phase 2 schema/source metadata persistence
+include unknown/dropped column reporting where practical without changing user-facing Discord output
+add structured import result types internally if useful
+add focused tests for mapping, coercion, validation, DAL call shape, and wrapper compatibility
+capture new out-of-scope findings structurally
+
+Likely Python modules to create or update:
+
+kvk_all_importer.py
+kvk/schemas/kvk_all_schema.py
+kvk/services/kvk_all_import_service.py
+kvk/dal/kvk_all_import_dal.py
+tests/test_kvk_all_schema.py
+tests/test_kvk_all_import_service.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_importer.py
+
+Likely SQL objects to validate, but not redesign in this phase:
+
+KVK.KVK_AllPlayers_Stage
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Scan
+KVK.sp_KVK_AllPlayers_Ingest
+KVK.KVK_Ingest_Negatives
+KVK.sp_KVK_Recompute_Windows
+
+Out of scope for Phase 3:
+
+new SQL schema changes unless a Phase 2 compatibility bug is discovered
+recompute formula redesign
+new export result sets or export result-set reordering
+Google Sheets export changes
+Discord reporting display changes
+admin command SQL extraction
+reporting DAL refactor
+summary tab ingestion
+Basic Data ingestion
+live ingest of production data as a test unless explicitly requested
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Preserve existing import behaviour and return shape.
+Do not change existing export tab names or result-set contracts in this phase.
+Do not change Discord embed/reporting output in this phase.
+Avoid embedded SQL in command/view layers.
+Prefer service and DAL boundaries.
+Do not silently drop Phase 2 fields from the staging contract.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact Python touchpoints and SQL contract dependencies.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 3 importer service/DAL refactor.
+Run targeted validation.
+Stop after Phase 3 implementation, tests, and report.
+
+Acceptance criteria:
+
+kvk_all_importer.py is a thin compatibility entrypoint or substantially reduced wrapper.
+Workbook schema validation and mapping are testable outside the Discord/upload path.
+SQL writes and stored procedure calls live in DAL code rather than importer orchestration.
+Services and DAL do not depend on Discord types.
+Phase 1 strict Full Data validation remains intact.
+Phase 2 SQL metadata and Full Data capacity fields continue to be staged and passed through.
+Existing legacy import path remains compatible.
+Existing recompute, export, Google Sheets, and Discord reporting behaviour is unchanged.
+Tests cover schema mapping, coercion, DAL call shape, wrapper compatibility, and validation failures where practical.
+New deferred findings are captured structurally, but all known KVK_ALL/all-kingdom work remains assigned to later programme phases rather than left as final deferred debt.

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -116,6 +116,7 @@ CALL_INGEST_SQL = """
 
 RECOMPUTE_SQL = "EXEC KVK.sp_KVK_Recompute_Windows @KVK_NO=?;"
 NEGATIVE_COUNT_SQL = "SELECT COUNT(*) FROM KVK.KVK_Ingest_Negatives WHERE KVK_NO=? AND ScanID=?;"
+DELETE_STAGED_TOKEN_SQL = "DELETE FROM KVK.KVK_AllPlayers_Stage WHERE IngestToken=?;"
 
 
 def connect_sql_server(
@@ -256,6 +257,11 @@ def ingest_prepared_import(
     scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
 
     if not scan_ts_within_kvk_details(con, scan_ts_naive):
+        try:
+            cur.execute(DELETE_STAGED_TOKEN_SQL, token)
+            con.commit()
+        except Exception:
+            logger.exception("[KVK] Failed to clean staged rows for token %s after pre-check failure.", token)
         context: dict[str, Any] = {
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -264,7 +264,7 @@ def ingest_prepared_import(
             con.commit()
         except Exception as exc:
             cleanup_failed = True
-            cleanup_error = f"{type(exc).__name__}: {exc}"
+            cleanup_error = f"token={token} {type(exc).__name__}: {exc}"
             logger.exception("[KVK] Failed to clean staged rows for token %s after pre-check failure.", token)
         context: dict[str, Any] = {
             "scan_ts_naive": str(scan_ts_naive),

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -257,17 +257,24 @@ def ingest_prepared_import(
     scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
 
     if not scan_ts_within_kvk_details(con, scan_ts_naive):
+        cleanup_failed = False
+        cleanup_error: str | None = None
         try:
             cur.execute(DELETE_STAGED_TOKEN_SQL, token)
             con.commit()
-        except Exception:
+        except Exception as exc:
+            cleanup_failed = True
+            cleanup_error = f"{type(exc).__name__}: {exc}"
             logger.exception("[KVK] Failed to clean staged rows for token %s after pre-check failure.", token)
         context: dict[str, Any] = {
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,
             "staged_rows": staged_rows,
             "sample_row": {},
+            "cleanup_failed": cleanup_failed,
         }
+        if cleanup_error:
+            context["cleanup_error"] = cleanup_error
         try:
             sample = df.iloc[0].to_dict()
             context["sample_row"] = {key: str(value) for key, value in sample.items()}
@@ -284,6 +291,8 @@ def ingest_prepared_import(
             "error": message,
             "sheet": sheet_name,
             "offending_scan_ts": str(scan_ts_naive),
+            "cleanup_failed": cleanup_failed,
+            "cleanup_error": cleanup_error,
         }
 
     cur = con.cursor()

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -265,7 +265,9 @@ def ingest_prepared_import(
         except Exception as exc:
             cleanup_failed = True
             cleanup_error = f"token={token} {type(exc).__name__}: {exc}"
-            logger.exception("[KVK] Failed to clean staged rows for token %s after pre-check failure.", token)
+            logger.exception(
+                "[KVK] Failed to clean staged rows for token %s after pre-check failure.", token
+            )
         context: dict[str, Any] = {
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -1,0 +1,331 @@
+"""Data-access workflow for KVK_ALL Full Data imports."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import logging
+import os
+import time
+from typing import Any
+import uuid
+
+import pandas as pd
+import pyodbc
+
+from file_utils import fetch_one_dict
+from kvk.schemas.kvk_all_schema import FULL_DATA_NUMERIC_COLUMN_MAP, SCHEMA_VERSION
+from kvk.services.kvk_all_import_service import KvkAllPreparedImport
+from utils import ensure_aware_utc
+
+logger = logging.getLogger(__name__)
+
+STAGE_COL_ORDER = [
+    "governor_id",
+    "name",
+    "kingdom",
+    "campid",
+    "rank",
+    "min_kill_points",
+    "max_kill_points",
+    "min_power_raw",
+    "max_power_raw",
+    "min_dead",
+    "max_dead",
+    "min_troop_power",
+    "max_troop_power",
+    "min_units_healed",
+    "max_units_healed",
+    "min_kills_iv",
+    "max_kills_iv",
+    "min_kills_v",
+    "max_kills_v",
+    "min_max_contribute",
+    "max_max_contribute",
+    "min_cur_contribute",
+    "max_cur_contribute",
+    "max_contribute_diff",
+    "cur_contribute_diff",
+    "min_points",
+    "max_points",
+    "points_difference",
+    "min_power",
+    "max_power",
+    "power_difference",
+    "first_updateUTC",
+    "last_updateUTC",
+    "latest_power",
+    "kill_points_diff",
+    "power_diff",
+    "dead_diff",
+    "troop_power_diff",
+    "max_units_healed_diff",
+    "healed_troops",
+    "kills_iv_diff",
+    "kills_v_diff",
+    "subscription_level",
+    "schema_version",
+    "source_sheet_name",
+    "source_column_hash",
+    "source_column_count",
+    "source_row_count",
+]
+
+STAGE_PHASE2_REQUIRED_COLUMNS = (
+    *FULL_DATA_NUMERIC_COLUMN_MAP.values(),
+    "schema_version",
+    "source_sheet_name",
+    "source_column_hash",
+    "source_column_count",
+    "source_row_count",
+)
+
+STAGE_SCHEMA_COLUMNS_SQL = """
+ SELECT c.name
+ FROM sys.columns AS c
+ WHERE c.object_id = OBJECT_ID(N'KVK.KVK_AllPlayers_Stage')
+ """
+
+STAGE_INSERT_COLUMNS = ["IngestToken", *STAGE_COL_ORDER]
+
+STAGE_INSERT_SQL = f"""
+ INSERT INTO KVK.KVK_AllPlayers_Stage (
+   {", ".join(f"[{column}]" for column in STAGE_INSERT_COLUMNS)}
+ ) VALUES ({",".join("?" for _ in STAGE_INSERT_COLUMNS)})
+ """
+
+CALL_INGEST_SQL = """
+ DECLARE @kvk INT, @scan INT, @rows INT;
+ EXEC KVK.sp_KVK_AllPlayers_Ingest
+   @IngestToken=?,
+   @ScanTimestampUTC=?,
+   @SourceFileName=?,
+   @FileHash=?,
+   @UploaderDiscordID=?,
+   @SchemaVersion=?,
+   @SourceSheetName=?,
+   @SourceColumnHash=?,
+   @SourceColumnCount=?,
+   @SourceRowCount=?,
+   @OutKVK_NO=@kvk OUTPUT,
+   @OutScanID=@scan OUTPUT,
+   @OutRowCount=@rows OUTPUT;
+ SELECT @kvk AS KVK_NO, @scan AS ScanID, @rows AS RowImported;
+ """
+
+RECOMPUTE_SQL = "EXEC KVK.sp_KVK_Recompute_Windows @KVK_NO=?;"
+NEGATIVE_COUNT_SQL = "SELECT COUNT(*) FROM KVK.KVK_Ingest_Negatives WHERE KVK_NO=? AND ScanID=?;"
+
+
+def connect_sql_server(
+    *, server: str, database: str, username: str, password: str
+) -> pyodbc.Connection:
+    return pyodbc.connect(
+        "DRIVER={ODBC Driver 17 for SQL Server};"
+        f"SERVER={server};DATABASE={database};UID={username};PWD={password}"
+    )
+
+
+def enable_fast_executemany(cur: Any) -> bool:
+    try:
+        cur.fast_executemany = True
+        return bool(getattr(cur, "fast_executemany", False))
+    except Exception:
+        return False
+
+
+def rows_for_stage(token: str, df: pd.DataFrame) -> list[tuple[Any, ...]]:
+    df2 = df.reindex(columns=STAGE_COL_ORDER)
+    logger.info("[KVK] DF staged col order: %s", list(df2.columns))
+
+    def _noneify(value: Any) -> Any:
+        try:
+            import numpy as np
+
+            if isinstance(value, np.floating) and np.isnan(value):
+                return None
+        except Exception:
+            pass
+        return None if pd.isna(value) else value
+
+    return [
+        (token, *(tuple(_noneify(value) for value in row)))
+        for row in df2.itertuples(index=False, name=None)
+    ]
+
+
+def missing_stage_columns(cur: Any, required_columns: tuple[str, ...]) -> list[str]:
+    cur.execute(STAGE_SCHEMA_COLUMNS_SQL)
+    available_columns = {row[0] for row in cur.fetchall() if row and row[0]}
+    return [column for column in required_columns if column not in available_columns]
+
+
+def write_ingest_diag(token: str, note: str, context: dict[str, Any]) -> str | None:
+    try:
+        diag_dir = os.path.join(os.getcwd(), "data", "ingest_diagnostics")
+        os.makedirs(diag_dir, exist_ok=True)
+        filename = os.path.join(diag_dir, f"kvk_ingest_diag_{token}.json")
+        payload = {
+            "timestamp": dt.datetime.utcnow().isoformat(),
+            "note": note,
+            "context": context,
+        }
+        with open(filename, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, default=str)
+        return filename
+    except Exception:
+        logger.exception("Failed to write ingest diagnostic file")
+        return None
+
+
+def scan_ts_within_kvk_details(con: pyodbc.Connection, scan_ts_naive: dt.datetime) -> bool:
+    try:
+        cur = con.cursor()
+        cur.execute(
+            """
+            SELECT TOP(1) 1
+            FROM dbo.KVK_Details AS d WITH (READCOMMITTEDLOCK)
+            WHERE ? >= d.KVK_REGISTRATION_DATE
+              AND ? <= d.KVK_END_DATE
+            """,
+            (scan_ts_naive, scan_ts_naive),
+        )
+        return bool(cur.fetchone())
+    except Exception:
+        logger.exception("[KVK] Pre-check using KVK_Details failed (allowing ingest).")
+        return True
+
+
+def _first_scalar(cursor: Any) -> Any:
+    row = fetch_one_dict(cursor)
+    if not row:
+        return None
+    return next(iter(row.values()))
+
+
+def ingest_prepared_import(
+    *,
+    con: pyodbc.Connection,
+    prepared: KvkAllPreparedImport,
+    content: bytes,
+    source_filename: str,
+    uploader_id: int,
+    scan_ts_utc: dt.datetime,
+) -> dict[str, Any]:
+    df = prepared.dataframe
+    staged_rows = prepared.staged_rows
+    sheet_name = prepared.sheet_name
+    schema_metadata = prepared.schema_metadata
+
+    cur = con.cursor()
+    enable_fast_executemany(cur)
+
+    try:
+        missing_columns = missing_stage_columns(cur, STAGE_PHASE2_REQUIRED_COLUMNS)
+    except Exception:
+        logger.exception("[KVK] Stage schema preflight failed; continuing with staged insert.")
+    else:
+        if missing_columns:
+            migration_file = "sql/kvk_all_phase2_full_data_capacity.sql"
+            message = (
+                "KVK.KVK_AllPlayers_Stage is missing required phase-2 columns: "
+                f"{', '.join(missing_columns)}. Apply {migration_file} before "
+                "deploying this importer."
+            )
+            logger.warning("[KVK] %s", message)
+            return {
+                "success": False,
+                "error": message,
+                "sheet": sheet_name,
+                "schema_version": SCHEMA_VERSION,
+                "schema": schema_metadata,
+                "missing_stage_columns": missing_columns,
+                "required_sql_migration": migration_file,
+            }
+
+    token = str(uuid.uuid4())
+    cur.executemany(STAGE_INSERT_SQL, rows_for_stage(token, df))
+    con.commit()
+
+    logger.info("[KVK] Final stage col order: %s", STAGE_COL_ORDER)
+    logger.info("[KVK] DF col order now: %s", list(df.columns))
+
+    file_hash = hashlib.sha256(content).digest()
+    scan_ts_utc = ensure_aware_utc(scan_ts_utc)
+    scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
+
+    if not scan_ts_within_kvk_details(con, scan_ts_naive):
+        context: dict[str, Any] = {
+            "scan_ts_naive": str(scan_ts_naive),
+            "source_filename": source_filename,
+            "staged_rows": staged_rows,
+            "sample_row": {},
+        }
+        try:
+            sample = df.iloc[0].to_dict()
+            context["sample_row"] = {key: str(value) for key, value in sample.items()}
+        except Exception:
+            pass
+        diag = write_ingest_diag(token, "scan timestamp outside KVK_Details ranges", context)
+        message = (
+            f"Scan timestamp {scan_ts_naive!s} does not fall within any configured "
+            f"KVK_Details range. Diagnostic: {diag}"
+        )
+        logger.info("[KVK] Pre-check FAILED for %s: %s", source_filename, message)
+        return {
+            "success": False,
+            "error": message,
+            "sheet": sheet_name,
+            "offending_scan_ts": str(scan_ts_naive),
+        }
+
+    cur = con.cursor()
+    ingest_started = time.perf_counter()
+    cur.execute(
+        CALL_INGEST_SQL,
+        (
+            token,
+            scan_ts_naive,
+            source_filename,
+            file_hash,
+            int(uploader_id),
+            schema_metadata.get("schema_version") or SCHEMA_VERSION,
+            sheet_name,
+            schema_metadata.get("column_hash"),
+            schema_metadata.get("column_count"),
+            staged_rows,
+        ),
+    )
+    rows = cur.fetchall()
+    ingest_ms = (time.perf_counter() - ingest_started) * 1000.0
+    if not rows:
+        raise RuntimeError("Ingest returned no outputs.")
+    kvk_no, scan_id, row_count = rows[0]
+    con.commit()
+
+    cur = con.cursor()
+    recompute_started = time.perf_counter()
+    cur.execute(RECOMPUTE_SQL, kvk_no)
+    con.commit()
+    recompute_ms = (time.perf_counter() - recompute_started) * 1000.0
+
+    cur = con.cursor()
+    cur.execute(NEGATIVE_COUNT_SQL, (kvk_no, scan_id))
+    negative_value = _first_scalar(cur)
+    negatives = int(negative_value) if negative_value is not None else 0
+
+    return {
+        "kvk_no": int(kvk_no),
+        "scan_id": int(scan_id),
+        "row_count": int(row_count),
+        "negatives": negatives,
+        "staged_rows": staged_rows,
+        "ingest_ms": ingest_ms,
+        "recompute_ms": recompute_ms,
+        "proc_ms": ingest_ms,
+        "sheet": sheet_name,
+        "schema_version": SCHEMA_VERSION,
+        "schema": schema_metadata,
+        "success": True,
+    }

--- a/kvk/schemas/kvk_all_schema.py
+++ b/kvk/schemas/kvk_all_schema.py
@@ -56,6 +56,92 @@ EXPECTED_FULL_DATA_COLUMNS = (
     "healed_troops",
 )
 
+FULL_DATA_NUMERIC_COLUMN_MAP = {
+    "rank": "rank",
+    "minkill_points": "min_kill_points",
+    "maxkill_points": "max_kill_points",
+    "minpower": "min_power_raw",
+    "maxpower": "max_power_raw",
+    "mindead": "min_dead",
+    "maxdead": "max_dead",
+    "mintroop_power": "min_troop_power",
+    "maxtroop_power": "max_troop_power",
+    "minmax_units_healed": "min_units_healed",
+    "maxmax_units_healed": "max_units_healed",
+    "minkills_iv": "min_kills_iv",
+    "maxkills_iv": "max_kills_iv",
+    "minkills_v": "min_kills_v",
+    "maxkills_v": "max_kills_v",
+    "max_contribute_min": "min_max_contribute",
+    "max_contribute_max": "max_max_contribute",
+    "cur_contribute_min": "min_cur_contribute",
+    "cur_contribute_max": "max_cur_contribute",
+    "max_contribute_diff": "max_contribute_diff",
+    "cur_contribute_diff": "cur_contribute_diff",
+}
+
+LEGACY_STAGE_NUMERIC_COLUMNS = (
+    "min_points",
+    "max_points",
+    "points_difference",
+    "min_power",
+    "max_power",
+    "power_difference",
+    "latest_power",
+    "kill_points_diff",
+    "power_diff",
+    "dead_diff",
+    "troop_power_diff",
+    "max_units_healed_diff",
+    "healed_troops",
+    "kills_iv_diff",
+    "kills_v_diff",
+    "subscription_level",
+)
+
+REQUIRED_MIN_COLUMNS = (
+    "governor_id",
+    "kingdom",
+    "max_power",
+    "points_difference",
+    "kills_iv_diff",
+    "kills_v_diff",
+    "dead_diff",
+    "max_units_healed_diff",
+)
+
+COLUMN_ALIASES = {
+    "first_updateUTC": (
+        "first_updateutc",
+        "first_update",
+        "first update",
+        "firstupdated",
+        "first_updated",
+    ),
+    "last_updateUTC": (
+        "last_updateutc",
+        "last_update",
+        "last update",
+        "lastupdated",
+        "last_updated",
+    ),
+    "kills_iv_diff": ("kills_iv_diff", "kills iv diff", "t4_kills", "t4 kills", "t4"),
+    "kills_v_diff": ("kills_v_diff", "kills v diff", "t5_kills", "t5 kills", "t5"),
+    "max_units_healed_diff": (
+        "max_units_healed_diff",
+        "max units healed diff",
+        "healed_units_diff",
+        "healed units",
+    ),
+    "dead_diff": ("dead_diff", "deads", "dead", "deads_diff"),
+    "points_difference": (
+        "points_difference",
+        "kill_points_diff",
+        "kill points difference",
+        "kp_diff",
+    ),
+}
+
 
 def normalize_sheet_name(value: str) -> str:
     return "".join(str(value).strip().lower().replace("_", " ").split())

--- a/kvk/services/__init__.py
+++ b/kvk/services/__init__.py
@@ -1,0 +1,2 @@
+"""KVK service-layer modules."""
+

--- a/kvk/services/__init__.py
+++ b/kvk/services/__init__.py
@@ -1,2 +1,1 @@
 """KVK service-layer modules."""
-

--- a/kvk/services/kvk_all_import_service.py
+++ b/kvk/services/kvk_all_import_service.py
@@ -48,7 +48,7 @@ def _alias_key(value: str) -> str:
 
 def apply_column_aliases(df: pd.DataFrame) -> pd.DataFrame:
     """Apply legacy-compatible aliases before strict Full Data schema validation."""
-    if df is None or df.empty:
+    if df is None:
         return df
 
     lookup = {_alias_key(column): column for column in df.columns}

--- a/kvk/services/kvk_all_import_service.py
+++ b/kvk/services/kvk_all_import_service.py
@@ -1,0 +1,200 @@
+"""Workbook parsing and canonical mapping for KVK_ALL Full Data imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+import logging
+from typing import Any
+
+import pandas as pd
+
+from kvk.schemas.kvk_all_schema import (
+    COLUMN_ALIASES,
+    FULL_DATA_NUMERIC_COLUMN_MAP,
+    LEGACY_STAGE_NUMERIC_COLUMNS,
+    REQUIRED_MIN_COLUMNS,
+    SCHEMA_VERSION,
+    KvkAllSchemaValidationError,
+    select_full_data_sheet,
+    validate_full_data_columns,
+)
+from utils import ensure_aware_utc
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KvkAllPreparedImport:
+    dataframe: pd.DataFrame
+    sheet_name: str
+    schema_metadata: dict[str, Any]
+
+    @property
+    def staged_rows(self) -> int:
+        return int(self.dataframe.shape[0])
+
+
+class KvkAllImportPreparationError(ValueError):
+    def __init__(self, message: str, *, sheet_name: str, schema_metadata: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.sheet_name = sheet_name
+        self.schema_metadata = schema_metadata
+
+
+def _alias_key(value: str) -> str:
+    return "".join(str(value).strip().lower().replace("_", " ").split())
+
+
+def apply_column_aliases(df: pd.DataFrame) -> pd.DataFrame:
+    """Apply legacy-compatible aliases before strict Full Data schema validation."""
+    if df is None or df.empty:
+        return df
+
+    lookup = {_alias_key(column): column for column in df.columns}
+    renames: dict[str, str] = {}
+    for canonical, variants in COLUMN_ALIASES.items():
+        if canonical in df.columns:
+            continue
+        for variant in variants:
+            original = lookup.get(_alias_key(variant))
+            if original:
+                renames[original] = canonical
+                break
+
+    if not renames:
+        return df
+
+    logger.info("[KVK] Header aliases applied: %s", renames)
+    return df.rename(columns=renames)
+
+
+def read_full_data_workbook(
+    content: bytes,
+    source_filename: str | None = None,
+) -> tuple[pd.DataFrame, str, dict[str, Any]]:
+    """
+    Read the authoritative KVK_ALL Full Data sheet and return raw frame plus schema metadata.
+
+    Basic Data and fallback sheet selection are intentionally rejected for KVK_ALL imports.
+    """
+    if not content:
+        raise ValueError("Empty file content")
+
+    if source_filename and source_filename.lower().endswith(".csv"):
+        raise KvkAllSchemaValidationError(
+            code="unsupported_kvk_all_file_type",
+            message="KVK_ALL imports require an Excel workbook containing the 'Full Data' sheet.",
+        )
+
+    try:
+        xl = pd.ExcelFile(BytesIO(content))
+    except Exception as exc:
+        raise ValueError(f"Failed to open Excel file: {exc}") from exc
+
+    sheet_names = xl.sheet_names or []
+    if not sheet_names:
+        raise ValueError("Excel file contains no sheets")
+
+    chosen_sheet = select_full_data_sheet(sheet_names)
+
+    try:
+        df = xl.parse(chosen_sheet)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse sheet '{chosen_sheet}': {exc}") from exc
+
+    if df is None:
+        raise ValueError("Parsed sheet is empty or invalid")
+
+    df.columns = [str(column).strip() for column in df.columns]
+    df = apply_column_aliases(df)
+    schema_result = validate_full_data_columns(df.columns, sheet_name=chosen_sheet)
+    logger.info("[KVK] Read sheet '%s' from uploaded file %s", chosen_sheet, source_filename)
+    return df, chosen_sheet, schema_result.to_dict()
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _as_str(value: Any) -> str | None:
+    return None if pd.isna(value) else str(value)[:64]
+
+
+def _as_dt(value: Any) -> Any:
+    if pd.isna(value):
+        return None
+    try:
+        if isinstance(value, pd.Timestamp):
+            return ensure_aware_utc(value.to_pydatetime())
+        return ensure_aware_utc(pd.to_datetime(value, errors="coerce").to_pydatetime())
+    except Exception:
+        return None
+
+
+def coerce_full_data_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Map Full Data v2 workbook columns into the canonical stage contract."""
+    missing = [column for column in REQUIRED_MIN_COLUMNS if column not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required column(s): {', '.join(missing)}")
+
+    out = pd.DataFrame()
+    out["governor_id"] = df["governor_id"].map(_as_int)
+    out["name"] = df["name"].map(_as_str) if "name" in df.columns else None
+    out["kingdom"] = df["kingdom"].map(_as_int)
+    out["campid"] = df.get("campid").map(_as_int) if "campid" in df.columns else None
+
+    for source_col, target_col in FULL_DATA_NUMERIC_COLUMN_MAP.items():
+        out[target_col] = df[source_col].map(_as_int) if source_col in df.columns else None
+
+    for column in LEGACY_STAGE_NUMERIC_COLUMNS:
+        out[column] = df[column].map(_as_int) if column in df.columns else None
+
+    out["first_updateUTC"] = df.get("first_updateUTC", pd.Series([None] * len(df))).map(_as_dt)
+    out["last_updateUTC"] = df.get("last_updateUTC", pd.Series([None] * len(df))).map(_as_dt)
+
+    if out["governor_id"].isna().any() or out["kingdom"].isna().any():
+        raise ValueError("One or more rows missing governor_id or kingdom after coercion.")
+    return out
+
+
+def attach_source_metadata(
+    df: pd.DataFrame,
+    *,
+    sheet_name: str,
+    schema_metadata: dict[str, Any],
+) -> pd.DataFrame:
+    df = df.copy()
+    df["schema_version"] = str(schema_metadata.get("schema_version") or SCHEMA_VERSION)[:64]
+    df["source_sheet_name"] = str(sheet_name)[:128]
+    column_hash = schema_metadata.get("column_hash")
+    df["source_column_hash"] = str(column_hash)[:64] if column_hash else None
+    column_count = schema_metadata.get("column_count")
+    df["source_column_count"] = int(column_count) if column_count is not None else None
+    df["source_row_count"] = int(df.shape[0])
+    return df
+
+
+def prepare_kvk_all_import(content: bytes, source_filename: str) -> KvkAllPreparedImport:
+    df_raw, sheet_name, schema_metadata = read_full_data_workbook(content, source_filename)
+    try:
+        coerced = coerce_full_data_frame(df_raw)
+    except ValueError as exc:
+        raise KvkAllImportPreparationError(
+            str(exc),
+            sheet_name=sheet_name,
+            schema_metadata=schema_metadata,
+        ) from exc
+    enriched = attach_source_metadata(
+        coerced,
+        sheet_name=sheet_name,
+        schema_metadata=schema_metadata,
+    )
+    return KvkAllPreparedImport(
+        dataframe=enriched,
+        sheet_name=sheet_name,
+        schema_metadata=schema_metadata,
+    )

--- a/kvk_all_importer.py
+++ b/kvk_all_importer.py
@@ -2,18 +2,9 @@
 from __future__ import annotations
 
 import datetime as dt
-import hashlib
-from io import BytesIO
-import json
 import logging
-import os
 import time
 from typing import Any
-
-logger = logging.getLogger(__name__)
-
-import pandas as pd
-import pyodbc
 
 from constants import (
     CREDENTIALS_FILE,
@@ -23,458 +14,29 @@ from constants import (
     SERVER,
     USERNAME,
 )
-from file_utils import fetch_one_dict
 from gsheet_module import run_kvk_proc_exports_with_alerts
-from kvk.schemas.kvk_all_schema import (
-    SCHEMA_VERSION as KVK_ALL_SCHEMA_VERSION,
-    KvkAllSchemaValidationError,
-    select_full_data_sheet,
-    validate_full_data_columns,
-)
-from utils import ensure_aware_utc
-
-COLUMN_ALIASES = {
-    # canonical -> acceptable variants (case/space/underscore insensitive)
-    "first_updateUTC": [
-        "first_updateutc",
-        "first_update",
-        "first update",
-        "firstupdated",
-        "first_updated",
-    ],
-    "last_updateUTC": [
-        "last_updateutc",
-        "last_update",
-        "last update",
-        "lastupdated",
-        "last_updated",
-    ],
-    "kills_iv_diff": ["kills_iv_diff", "kills iv diff", "t4_kills", "t4 kills", "t4"],
-    "kills_v_diff": ["kills_v_diff", "kills v diff", "t5_kills", "t5 kills", "t5"],
-    "max_units_healed_diff": [
-        "max_units_healed_diff",
-        "max units healed diff",
-        "healed_units_diff",
-        "healed units",
-    ],
-    "dead_diff": ["dead_diff", "deads", "dead", "deads_diff"],
-    "points_difference": [
-        "points_difference",
-        "kill_points_diff",
-        "kill points difference",
-        "kp_diff",
-    ],
-}
-
-# 1) Define the exact stage order ONCE (top of file, near STAGE_INSERT_SQL)
-FULL_DATA_NUMERIC_COLUMN_MAP = {
-    "rank": "rank",
-    "minkill_points": "min_kill_points",
-    "maxkill_points": "max_kill_points",
-    "minpower": "min_power_raw",
-    "maxpower": "max_power_raw",
-    "mindead": "min_dead",
-    "maxdead": "max_dead",
-    "mintroop_power": "min_troop_power",
-    "maxtroop_power": "max_troop_power",
-    "minmax_units_healed": "min_units_healed",
-    "maxmax_units_healed": "max_units_healed",
-    "minkills_iv": "min_kills_iv",
-    "maxkills_iv": "max_kills_iv",
-    "minkills_v": "min_kills_v",
-    "maxkills_v": "max_kills_v",
-    "max_contribute_min": "min_max_contribute",
-    "max_contribute_max": "max_max_contribute",
-    "cur_contribute_min": "min_cur_contribute",
-    "cur_contribute_max": "max_cur_contribute",
-    "max_contribute_diff": "max_contribute_diff",
-    "cur_contribute_diff": "cur_contribute_diff",
-}
-
-# 1) Define the exact stage order ONCE (top of file, near STAGE_INSERT_SQL)
-STAGE_COL_ORDER = [
-    "governor_id",
-    "name",
-    "kingdom",
-    "campid",
-    "rank",
-    "min_kill_points",
-    "max_kill_points",
-    "min_power_raw",
-    "max_power_raw",
-    "min_dead",
-    "max_dead",
-    "min_troop_power",
-    "max_troop_power",
-    "min_units_healed",
-    "max_units_healed",
-    "min_kills_iv",
-    "max_kills_iv",
-    "min_kills_v",
-    "max_kills_v",
-    "min_max_contribute",
-    "max_max_contribute",
-    "min_cur_contribute",
-    "max_cur_contribute",
-    "max_contribute_diff",
-    "cur_contribute_diff",
-    "min_points",
-    "max_points",
-    "points_difference",
-    "min_power",
-    "max_power",
-    "power_difference",
-    "first_updateUTC",
-    "last_updateUTC",
-    "latest_power",
-    "kill_points_diff",
-    "power_diff",
-    "dead_diff",
-    "troop_power_diff",
-    "max_units_healed_diff",
-    "healed_troops",
-    "kills_iv_diff",
-    "kills_v_diff",
-    "subscription_level",
-    "schema_version",
-    "source_sheet_name",
-    "source_column_hash",
-    "source_column_count",
-    "source_row_count",
-]
-
-STAGE_PHASE2_REQUIRED_COLUMNS = (
-    *FULL_DATA_NUMERIC_COLUMN_MAP.values(),
-    "schema_version",
-    "source_sheet_name",
-    "source_column_hash",
-    "source_column_count",
-    "source_row_count",
+from kvk.dal import kvk_all_import_dal
+from kvk.schemas.kvk_all_schema import SCHEMA_VERSION, KvkAllSchemaValidationError
+from kvk.services import kvk_all_import_service
+from kvk.services.kvk_all_import_service import (
+    KvkAllImportPreparationError,
+    prepare_kvk_all_import,
 )
 
-STAGE_SCHEMA_COLUMNS_SQL = """
- SELECT c.name
- FROM sys.columns AS c
- WHERE c.object_id = OBJECT_ID(N'KVK.KVK_AllPlayers_Stage')
- """
+logger = logging.getLogger(__name__)
 
-
-def _apply_aliases(df: pd.DataFrame) -> pd.DataFrame:
-    if df is None or df.empty:
-        return df
-
-    # Trim and build lookup (lower, no spaces/underscores)
-    def norm(s: str) -> str:
-        return "".join(str(s).strip().lower().replace("_", " ").split())
-
-    lookup = {norm(c): c for c in df.columns}
-    renames = {}
-    for canonical, variants in COLUMN_ALIASES.items():
-        if canonical in df.columns:
-            continue
-        for v in variants:
-            key = norm(v)
-            if key in lookup:
-                renames[lookup[key]] = canonical
-                break
-    if renames:
-        df = df.rename(columns=renames)
-        try:
-            logger.info("[KVK] Header aliases applied: %s", renames)
-        except Exception:
-            pass
-    return df
-
-
-def _get_negatives_count(cn, kvk_no: int, scan_id: int) -> int:
-    with cn.cursor() as c:
-        c.execute(
-            """
-            SELECT COUNT(*)
-            FROM KVK.KVK_Ingest_Negatives
-            WHERE KVK_NO = ? AND ScanID = ?
-        """,
-            (kvk_no, scan_id),
-        )
-        rd = fetch_one_dict(c)
-        # return first column value, or 0 if missing - use next(iter(...)) instead of single-element slice
-        if not rd:
-            return 0
-        val = next(iter(rd.values()))
-        return int(val) if val is not None else 0
-
-
-STAGE_INSERT_COLUMNS = ["IngestToken", *STAGE_COL_ORDER]
-
-STAGE_INSERT_SQL = f"""
- INSERT INTO KVK.KVK_AllPlayers_Stage (
-   {", ".join(f"[{column}]" for column in STAGE_INSERT_COLUMNS)}
- ) VALUES ({",".join("?" for _ in STAGE_INSERT_COLUMNS)})
- """
-
-CALL_INGEST_SQL = """
- DECLARE @kvk INT, @scan INT, @rows INT;
- EXEC KVK.sp_KVK_AllPlayers_Ingest
-   @IngestToken=?,
-   @ScanTimestampUTC=?,
-   @SourceFileName=?,
-   @FileHash=?,
-   @UploaderDiscordID=?,
-   @SchemaVersion=?,
-   @SourceSheetName=?,
-   @SourceColumnHash=?,
-   @SourceColumnCount=?,
-   @SourceRowCount=?,
-   @OutKVK_NO=@kvk OUTPUT,
-   @OutScanID=@scan OUTPUT,
-   @OutRowCount=@rows OUTPUT;
- SELECT @kvk AS KVK_NO, @scan AS ScanID, @rows AS RowImported;
- """
-
-RECOMPUTE_SQL = "EXEC KVK.sp_KVK_Recompute_Windows @KVK_NO=?;"
-NEGATIVE_COUNT_SQL = "SELECT COUNT(*) FROM KVK.KVK_Ingest_Negatives WHERE KVK_NO=? AND ScanID=?;"
-
-REQUIRED_MIN_COLS = [
-    "governor_id",
-    "kingdom",
-    "max_power",  # needed to fix Baseline starting_power
-    "points_difference",  # KP source-of-truth (will be aliased if file uses kill_points_diff)
-    "kills_iv_diff",  # T4
-    "kills_v_diff",  # T5
-    "dead_diff",
-    "max_units_healed_diff",
-]
-
-
-def _enable_fast_executemany(cur) -> bool:
-    try:
-        cur.fast_executemany = True
-        return bool(getattr(cur, "fast_executemany", False))
-    except Exception:
-        return False
-
-
-def _read_excel(
-    content: bytes, source_filename: str | None = None
-) -> tuple[pd.DataFrame, str, dict[str, Any]]:
-    """
-    Read a KVK_ALL workbook and return the DataFrame, sheet name, and schema metadata.
-
-    KVK_ALL imports now require the authoritative "Full Data" tab. Basic Data and
-    fallback sheet selection are intentionally rejected before legacy field coercion.
-    """
-    if not content:
-        raise ValueError("Empty file content")
-
-    # KVK_ALL phase 1 accepts only the authoritative workbook schema.
-    if source_filename and source_filename.lower().endswith(".csv"):
-        raise KvkAllSchemaValidationError(
-            code="unsupported_kvk_all_file_type",
-            message="KVK_ALL imports require an Excel workbook containing the 'Full Data' sheet.",
-        )
-
-    # Otherwise handle Excel workbooks and try to pick the "Full Data" sheet
-    try:
-        xl = pd.ExcelFile(BytesIO(content))
-    except Exception as e:
-        raise ValueError(f"Failed to open Excel file: {e}")
-
-    sheet_names = xl.sheet_names or []
-    if not sheet_names:
-        raise ValueError("Excel file contains no sheets")
-
-    chosen_sheet = select_full_data_sheet(sheet_names)
-
-    # Full Data is mandatory; select_full_data_sheet raises if it is absent.
-
-    try:
-        df = xl.parse(chosen_sheet)
-    except Exception as e:
-        raise ValueError(f"Failed to parse sheet '{chosen_sheet}': {e}")
-
-    if df is None:
-        raise ValueError("Parsed sheet is empty or invalid")
-
-    df.columns = [str(c).strip() for c in df.columns]
-    df = _apply_aliases(df)
-    schema_result = validate_full_data_columns(df.columns, sheet_name=chosen_sheet)
-    try:
-        logger.info("[KVK] Read sheet '%s' from uploaded file %s", chosen_sheet, source_filename)
-    except Exception:
-        pass
-    return df, chosen_sheet, schema_result.to_dict()
-
-
-def _coerce(df: pd.DataFrame) -> pd.DataFrame:
-    # Validate minimal set
-    missing = [c for c in REQUIRED_MIN_COLS if c not in df.columns]
-    if missing:
-        raise ValueError(f"Missing required column(s): {', '.join(missing)}")
-
-    def as_int(x):
-        try:
-            return int(x)
-        except Exception:
-            return None
-
-    def as_str(x):
-        return None if pd.isna(x) else str(x)[:64]
-
-    def as_dt(x):
-        if pd.isna(x):
-            return None
-        try:
-            # produce timezone-aware UTC datetimes in memory for consistent arithmetic
-            if isinstance(x, pd.Timestamp):
-                return ensure_aware_utc(x.to_pydatetime())
-            return ensure_aware_utc(pd.to_datetime(x, errors="coerce").to_pydatetime())
-        except Exception:
-            return None
-
-    out = pd.DataFrame()
-    # Common fields
-    out["governor_id"] = df["governor_id"].map(as_int)
-    out["name"] = df["name"].map(as_str) if "name" in df.columns else None
-    out["kingdom"] = df["kingdom"].map(as_int)
-    out["campid"] = df.get("campid").map(as_int) if "campid" in df.columns else None
-
-    for source_col, target_col in FULL_DATA_NUMERIC_COLUMN_MAP.items():
-        if source_col in df.columns:
-            out[target_col] = df[source_col].map(as_int)
-        else:
-            out[target_col] = None
-
-    # Numerics (optional if missing)
-    for c in [
-        "min_points",
-        "max_points",
-        "points_difference",
-        "min_power",
-        "max_power",
-        "power_difference",
-        "latest_power",
-        "kill_points_diff",
-        "power_diff",
-        "dead_diff",
-        "troop_power_diff",
-        "max_units_healed_diff",
-        "healed_troops",
-        "kills_iv_diff",
-        "kills_v_diff",
-        "subscription_level",
-    ]:
-        if c in df.columns:
-            out[c] = df[c].map(as_int)
-        else:
-            out[c] = None
-
-    # Optional datetimes (support either first_updateUTC/last_updateUTC or absent)
-    out["first_updateUTC"] = df.get("first_updateUTC", pd.Series([None] * len(df))).map(as_dt)
-    out["last_updateUTC"] = df.get("last_updateUTC", pd.Series([None] * len(df))).map(as_dt)
-
-    # Final sanity: at least governor_id + kingdom present
-    if out["governor_id"].isna().any() or out["kingdom"].isna().any():
-        raise ValueError("One or more rows missing governor_id or kingdom after coercion.")
-    return out
-
-
-def _with_source_metadata(
-    df: pd.DataFrame,
-    *,
-    sheet_name: str,
-    schema_metadata: dict[str, Any],
-) -> pd.DataFrame:
-    df = df.copy()
-    df["schema_version"] = str(schema_metadata.get("schema_version") or KVK_ALL_SCHEMA_VERSION)[:64]
-    df["source_sheet_name"] = str(sheet_name)[:128]
-    column_hash = schema_metadata.get("column_hash")
-    df["source_column_hash"] = str(column_hash)[:64] if column_hash else None
-    column_count = schema_metadata.get("column_count")
-    df["source_column_count"] = int(column_count) if column_count is not None else None
-    df["source_row_count"] = int(df.shape[0])
-    return df
-
-
-# 2) Replace _rows_for_stage with an order-safe version
-def _rows_for_stage(token: str, df: pd.DataFrame) -> list[tuple]:
-    df2 = df.reindex(columns=STAGE_COL_ORDER)
-    try:
-        logger.info("[KVK] DF staged col order: %s", list(df2.columns))
-    except Exception:
-        pass
-
-    # Convert pandas NA/NaT to None row-by-row (so pyodbc is happy)
-    def _noneify(x):
-        # also handle numpy types cleanly
-        try:
-            import numpy as np
-
-            if isinstance(x, (np.floating,)) and (np.isnan(x)):
-                return None
-        except Exception:
-            pass
-        return None if pd.isna(x) else x
-
-    rows = []
-    for row in df2.itertuples(index=False, name=None):
-        cleaned = tuple(_noneify(v) for v in row)
-        rows.append((token, *cleaned))
-    return rows
-
-
-def _missing_stage_columns(cur, required_columns: tuple[str, ...]) -> list[str]:
-    cur.execute(STAGE_SCHEMA_COLUMNS_SQL)
-    available_columns = {row[0] for row in cur.fetchall() if row and row[0]}
-    return [column for column in required_columns if column not in available_columns]
-
-
-def _write_ingest_diag(token: str, note: str, context: dict):
-    try:
-        DIAG_DIR = os.path.join(os.getcwd(), "data", "ingest_diagnostics")
-        os.makedirs(DIAG_DIR, exist_ok=True)
-        fname = os.path.join(DIAG_DIR, f"kvk_ingest_diag_{token}.json")
-        payload = {"timestamp": dt.datetime.utcnow().isoformat(), "note": note, "context": context}
-        with open(fname, "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2, default=str)
-        return fname
-    except Exception:
-        try:
-            logger.exception("Failed to write ingest diagnostic file")
-        except Exception:
-            pass
-        return None
-
-
-def _scan_ts_within_kvk_details(con: pyodbc.Connection, scan_ts_naive: dt.datetime) -> bool:
-    """
-    Pre-check using the same logic as the stored procedure:
-      SELECT TOP(1) d.KVK_NO FROM dbo.KVK_Details AS d
-      WHERE @ScanTimestampUTC >= d.KVK_REGISTRATION_DATE
-        AND @ScanTimestampUTC <= d.KVK_END_DATE
-
-    Returns True if a match is found (scan timestamp falls within a KVK_Details range).
-    Conservative: on any unexpected error return True to avoid blocking ingestion in environments
-    where the schema differs.
-    """
-    try:
-        cur = con.cursor()
-        # Use the exact column names used by the stored proc for the range check
-        sql = """
-            SELECT TOP(1) 1
-            FROM dbo.KVK_Details AS d WITH (READCOMMITTEDLOCK)
-            WHERE ? >= d.KVK_REGISTRATION_DATE
-              AND ? <= d.KVK_END_DATE
-        """
-        cur.execute(sql, (scan_ts_naive, scan_ts_naive))
-        row = cur.fetchone()
-        return bool(row)
-    except Exception:
-        # If anything goes wrong (missing table/cols, permission issue), log at debug and allow ingest.
-        try:
-            logger.exception("[KVK] Pre-check using KVK_Details failed (allowing ingest).")
-        except Exception:
-            pass
-        return True
+# Compatibility exports for older tests/tools that imported importer internals.
+STAGE_COL_ORDER = kvk_all_import_dal.STAGE_COL_ORDER
+STAGE_INSERT_COLUMNS = kvk_all_import_dal.STAGE_INSERT_COLUMNS
+STAGE_INSERT_SQL = kvk_all_import_dal.STAGE_INSERT_SQL
+STAGE_PHASE2_REQUIRED_COLUMNS = kvk_all_import_dal.STAGE_PHASE2_REQUIRED_COLUMNS
+CALL_INGEST_SQL = kvk_all_import_dal.CALL_INGEST_SQL
+RECOMPUTE_SQL = kvk_all_import_dal.RECOMPUTE_SQL
+NEGATIVE_COUNT_SQL = kvk_all_import_dal.NEGATIVE_COUNT_SQL
+_read_excel = kvk_all_import_service.read_full_data_workbook
+_coerce = kvk_all_import_service.coerce_full_data_frame
+_with_source_metadata = kvk_all_import_service.attach_source_metadata
+_rows_for_stage = kvk_all_import_dal.rows_for_stage
 
 
 def ingest_kvk_all_excel(
@@ -489,223 +51,80 @@ def ingest_kvk_all_excel(
     password: str,
 ) -> dict[str, Any]:
     """
-    Returns:
-      {
-        "kvk_no": int,
-        "scan_id": int,
-        "row_count": int,
-        "negatives": int,
-        "duration_s": float,
-        # NEW
-        "staged_rows": int,
-        "ingest_ms": float,
-        "recompute_ms": float,
-        "proc_ms": float,          # alias of ingest_ms for backward compat
-        "sheet": str,              # sheet name or "CSV"
-        "success": bool,           # explicit success flag
-      }
-    For expected validation failures returns {"success": False, "error": "<message>"} instead of raising.
-    Unexpected exceptions still propagate (so callers/logging can capture tracebacks).
+    Compatibility wrapper for the KVK_ALL Full Data import pipeline.
+
+    Expected validation failures return structured dictionaries. Unexpected database
+    or runtime failures still propagate so callers can log tracebacks.
     """
-    t0 = time.perf_counter()
+    started = time.perf_counter()
     try:
-        df_raw, sheet_name, schema_metadata = _read_excel(content, source_filename)
-    except KvkAllSchemaValidationError as e:
-        logger.info("[KVK] Import schema validation failed for %s: %s", source_filename, e)
+        prepared = prepare_kvk_all_import(content, source_filename)
+    except KvkAllSchemaValidationError as exc:
+        logger.info("[KVK] Import schema validation failed for %s: %s", source_filename, exc)
         return {
             "success": False,
-            "error": str(e),
-            "sheet": e.sheet_name,
-            "schema_version": e.schema_version,
-            "validation_error": e.to_dict(),
+            "error": str(exc),
+            "sheet": exc.sheet_name,
+            "schema_version": exc.schema_version,
+            "validation_error": exc.to_dict(),
         }
-    except Exception:
-        raise
-
-    # Catch known validation errors from coercion and surface as structured failure
-    try:
-        df = _coerce(df_raw)
-    except ValueError as e:
-        logger.info("[KVK] Import failed for %s: %s", source_filename, e)
+    except KvkAllImportPreparationError as exc:
+        logger.info("[KVK] Import failed for %s: %s", source_filename, exc)
         return {
             "success": False,
-            "error": str(e),
-            "sheet": sheet_name,
-            "schema_version": KVK_ALL_SCHEMA_VERSION,
-            "schema": schema_metadata,
+            "error": str(exc),
+            "sheet": exc.sheet_name,
+            "schema_version": SCHEMA_VERSION,
+            "schema": exc.schema_metadata,
         }
-    df = _with_source_metadata(df, sheet_name=sheet_name, schema_metadata=schema_metadata)
+    except ValueError as exc:
+        logger.info("[KVK] Import failed for %s: %s", source_filename, exc)
+        return {
+            "success": False,
+            "error": str(exc),
+            "sheet": "Full Data",
+            "schema_version": SCHEMA_VERSION,
+        }
 
-    if df.empty:
+    if prepared.dataframe.empty:
         logger.info("[KVK] Import failed for %s: No rows found in uploaded file.", source_filename)
         return {
             "success": False,
             "error": "No rows found in uploaded file.",
-            "sheet": sheet_name,
-            "schema_version": KVK_ALL_SCHEMA_VERSION,
-            "schema": schema_metadata,
+            "sheet": prepared.sheet_name,
+            "schema_version": SCHEMA_VERSION,
+            "schema": prepared.schema_metadata,
         }
 
-    staged_rows = int(df.shape[0])  # <= count AFTER coercion/cleanup
-
-    con = pyodbc.connect(
-        f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={server};DATABASE={database};UID={username};PWD={password}"
+    con = kvk_all_import_dal.connect_sql_server(
+        server=server,
+        database=database,
+        username=username,
+        password=password,
     )
     try:
-        cur = con.cursor()
-        _enable_fast_executemany(cur)
-
-        try:
-            missing_stage_columns = _missing_stage_columns(cur, STAGE_PHASE2_REQUIRED_COLUMNS)
-        except Exception:
-            logger.exception("[KVK] Stage schema preflight failed; continuing with staged insert.")
-        else:
-            if missing_stage_columns:
-                migration_file = "sql/kvk_all_phase2_full_data_capacity.sql"
-                message = (
-                    "KVK.KVK_AllPlayers_Stage is missing required phase-2 columns: "
-                    f"{', '.join(missing_stage_columns)}. Apply {migration_file} before "
-                    "deploying this importer."
-                )
-                logger.warning("[KVK] %s", message)
-                return {
-                    "success": False,
-                    "error": message,
-                    "sheet": sheet_name,
-                    "schema_version": KVK_ALL_SCHEMA_VERSION,
-                    "schema": schema_metadata,
-                    "missing_stage_columns": missing_stage_columns,
-                    "required_sql_migration": migration_file,
-                }
-
-        import uuid
-
-        token = str(uuid.uuid4())
-
-        # Stage rows
-        cur.executemany(STAGE_INSERT_SQL, _rows_for_stage(token, df))
-        con.commit()
-
-        logger.info("[KVK] Final stage col order: %s", STAGE_COL_ORDER)
-        logger.info("[KVK] DF col order now: %s", list(df.columns))
-
-        # Hash
-        file_hash = hashlib.sha256(content).digest()
-
-        # Normalize scan_ts_utc to aware UTC internally, then strip tzinfo for the legacy proc
-        scan_ts_utc = ensure_aware_utc(scan_ts_utc)
-        scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
-
-        # NEW: Pre-check whether provided scan timestamp falls into any KVK_Details range,
-        # using the same column names/logic as the stored procedure.
-        try:
-            ok = _scan_ts_within_kvk_details(con, scan_ts_naive)
-        except Exception as e:
-            # defensive: if pre-check raises, allow ingest but log
-            logger.exception("[KVK] Pre-check errored (allowing ingest): %s", e)
-            ok = True
-
-        if not ok:
-            # Write diagnostic with clear message and context; return structured failure (no traceback)
-            context = {
-                "scan_ts_naive": str(scan_ts_naive),
-                "source_filename": source_filename,
-                "staged_rows": staged_rows,
-                "sample_row": {},
-            }
-            try:
-                # include a small sample row for context
-                sample = df.iloc[0].to_dict()
-                for k, v in sample.items():
-                    try:
-                        context["sample_row"][k] = str(v)
-                    except Exception:
-                        context["sample_row"][k] = repr(v)
-            except Exception:
-                pass
-            diag = _write_ingest_diag(token, "scan timestamp outside KVK_Details ranges", context)
-            msg = f"Scan timestamp {scan_ts_naive!s} does not fall within any configured KVK_Details range. Diagnostic: {diag}"
-            logger.info("[KVK] Pre-check FAILED for %s: %s", source_filename, msg)
-            return {
-                "success": False,
-                "error": msg,
-                "sheet": sheet_name,
-                "offending_scan_ts": str(scan_ts_naive),
-            }
-
-        # Commit ingest (TIMED)
-        cur = con.cursor()
-        t_ingest0 = time.perf_counter()
-        cur.execute(
-            CALL_INGEST_SQL,
-            (
-                token,
-                scan_ts_naive,
-                source_filename,
-                file_hash,
-                int(uploader_id),
-                schema_metadata.get("schema_version") or KVK_ALL_SCHEMA_VERSION,
-                sheet_name,
-                schema_metadata.get("column_hash"),
-                schema_metadata.get("column_count"),
-                staged_rows,
-            ),
+        result = kvk_all_import_dal.ingest_prepared_import(
+            con=con,
+            prepared=prepared,
+            content=content,
+            source_filename=source_filename,
+            uploader_id=uploader_id,
+            scan_ts_utc=scan_ts_utc,
         )
-        res = cur.fetchall()
-        ingest_ms = (time.perf_counter() - t_ingest0) * 1000.0
-        if not res:
-            raise RuntimeError("Ingest returned no outputs.")
-        kvk_no, scan_id, row_count = res[0]
-        con.commit()
-
-        # Recompute windows (current KVK only) - TIMED
-        cur = con.cursor()
-        t_recompute0 = time.perf_counter()
-        cur.execute(RECOMPUTE_SQL, kvk_no)
-        con.commit()
-        recompute_ms = (time.perf_counter() - t_recompute0) * 1000.0
-
-        # Negative corrections count for this scan
-        cur = con.cursor()
-        cur.execute(NEGATIVE_COUNT_SQL, (kvk_no, scan_id))
-        _row = fetch_one_dict(cur)
-        if _row:
-            first_val = next(iter(_row.values()))
-            negatives = int(first_val) if first_val is not None else 0
-        else:
-            negatives = 0
-
-        duration_s = round(time.perf_counter() - t0, 2)
-
-        return {
-            "kvk_no": int(kvk_no),
-            "scan_id": int(scan_id),
-            "row_count": int(row_count),
-            "negatives": negatives,
-            "duration_s": duration_s,
-            # NEW health metrics
-            "staged_rows": staged_rows,
-            "ingest_ms": ingest_ms,
-            "recompute_ms": recompute_ms,
-            "proc_ms": ingest_ms,  # alias to keep existing callers happy
-            "sheet": sheet_name,
-            "schema_version": KVK_ALL_SCHEMA_VERSION,
-            "schema": schema_metadata,
-            "success": True,
-        }
     finally:
         try:
             con.close()
         except Exception:
             pass
 
+    result.setdefault("duration_s", round(time.perf_counter() - started, 2))
+    return result
+
 
 async def _auto_export_kvk(kvk_no: int, notify_channel, bot_loop):
     try:
-        # Local import to avoid module-level cycles
         from file_utils import run_blocking_in_thread
 
-        # Run the (blocking) export in a worker thread with telemetry
         ok = await run_blocking_in_thread(
             run_kvk_proc_exports_with_alerts,
             SERVER,
@@ -721,10 +140,13 @@ async def _auto_export_kvk(kvk_no: int, notify_channel, bot_loop):
             meta={"kvk_no": kvk_no},
         )
         if ok and notify_channel:
-            await notify_channel.send(f"📤 Export complete: **KVK {kvk_no} → {KVK_SHEET_NAME}**")
-    except Exception as e:
+            await notify_channel.send(
+                f"\U0001f4e4 Export complete: **KVK {kvk_no} \u2192 {KVK_SHEET_NAME}**"
+            )
+    except Exception as exc:
         logger.exception("[KVK_EXPORT] Auto-export crashed")
         if notify_channel:
             await notify_channel.send(
-                f"⚠️ Export failed for **KVK {kvk_no}**: `{type(e).__name__}: {e}`"
+                f"\u26a0\ufe0f Export failed for **KVK {kvk_no}**: "
+                f"`{type(exc).__name__}: {exc}`"
             )

--- a/tests/test_kvk_all_import_dal.py
+++ b/tests/test_kvk_all_import_dal.py
@@ -131,3 +131,24 @@ def test_ingest_prepared_import_call_shape(monkeypatch) -> None:
     assert result["negatives"] == 3
     assert result["success"] is True
     assert connection.commit_calls == 3
+
+
+def test_ingest_prepared_import_cleans_stage_rows_when_precheck_fails(monkeypatch) -> None:
+    connection = MockConnection()
+    monkeypatch.setattr(dal, "scan_ts_within_kvk_details", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(dal.uuid, "uuid4", lambda: "token-2")
+
+    result = dal.ingest_prepared_import(
+        con=connection,
+        prepared=_prepared_frame(),
+        content=b"abc",
+        source_filename="kvk.xlsx",
+        uploader_id=999,
+        scan_ts_utc=dt.datetime(2026, 5, 8, 1, 0, tzinfo=dt.UTC),
+    )
+
+    stage_cursor = connection.cursors[0]
+    assert stage_cursor.executemany_calls[0][0] == dal.STAGE_INSERT_SQL
+    assert (dal.DELETE_STAGED_TOKEN_SQL, "token-2") in stage_cursor.executed
+    assert result["success"] is False
+    assert connection.commit_calls == 2

--- a/tests/test_kvk_all_import_dal.py
+++ b/tests/test_kvk_all_import_dal.py
@@ -151,4 +151,6 @@ def test_ingest_prepared_import_cleans_stage_rows_when_precheck_fails(monkeypatc
     assert stage_cursor.executemany_calls[0][0] == dal.STAGE_INSERT_SQL
     assert (dal.DELETE_STAGED_TOKEN_SQL, "token-2") in stage_cursor.executed
     assert result["success"] is False
+    assert result["cleanup_failed"] is False
+    assert result["cleanup_error"] is None
     assert connection.commit_calls == 2

--- a/tests/test_kvk_all_import_dal.py
+++ b/tests/test_kvk_all_import_dal.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, cast
+
+import pandas as pd
+
+from kvk.dal import kvk_all_import_dal as dal
+from kvk.schemas.kvk_all_schema import (
+    EXPECTED_FULL_DATA_COLUMNS,
+    SCHEMA_VERSION,
+    validate_full_data_columns,
+)
+from kvk.services.kvk_all_import_service import KvkAllPreparedImport
+
+
+def _prepared_frame() -> KvkAllPreparedImport:
+    schema = validate_full_data_columns(
+        EXPECTED_FULL_DATA_COLUMNS, sheet_name="Full Data"
+    ).to_dict()
+    row: dict[str, Any] = {column: 1 for column in dal.STAGE_COL_ORDER}
+    row.update(
+        {
+            "governor_id": 123,
+            "name": "Test Governor",
+            "kingdom": 98,
+            "schema_version": SCHEMA_VERSION,
+            "source_sheet_name": "Full Data",
+            "source_column_hash": schema["column_hash"],
+            "source_column_count": schema["column_count"],
+            "source_row_count": 1,
+        }
+    )
+    return KvkAllPreparedImport(
+        dataframe=pd.DataFrame([row]),
+        sheet_name="Full Data",
+        schema_metadata=schema,
+    )
+
+
+class MockCursor:
+    def __init__(self) -> None:
+        self.fast_executemany = False
+        self.executed: list[tuple[str, object]] = []
+        self.executemany_calls: list[tuple[str, list[tuple[object, ...]]]] = []
+        self._fetchall: list[tuple[object, ...]] = []
+        self._fetchone: tuple[object, ...] | None = (1,)
+        self.description = [("COUNT",)]
+
+    def execute(self, sql: str, params=None):
+        self.executed.append((sql, params))
+        if sql == dal.STAGE_SCHEMA_COLUMNS_SQL:
+            self._fetchall = [(column,) for column in dal.STAGE_INSERT_COLUMNS]
+        elif sql == dal.CALL_INGEST_SQL:
+            self._fetchall = [(13, 2, 1)]
+        elif sql == dal.NEGATIVE_COUNT_SQL:
+            self.description = [("COUNT",)]
+            self._fetchall = []
+            self._fetchone = (3,)
+        return self
+
+    def executemany(self, sql: str, rows):
+        self.executemany_calls.append((sql, list(rows)))
+
+    def fetchall(self):
+        return self._fetchall
+
+    def fetchone(self):
+        return self._fetchone
+
+
+class MockConnection:
+    def __init__(self) -> None:
+        self.cursors: list[MockCursor] = []
+        self.commit_calls = 0
+
+    def cursor(self) -> MockCursor:
+        cursor = MockCursor()
+        self.cursors.append(cursor)
+        return cursor
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+
+def test_rows_for_stage_uses_declared_column_order() -> None:
+    prepared = _prepared_frame()
+
+    row = dal.rows_for_stage("token-1", prepared.dataframe)[0]
+    values = dict(zip(["IngestToken", *dal.STAGE_COL_ORDER], row, strict=True))
+
+    assert values["IngestToken"] == "token-1"
+    assert values["governor_id"] == 123
+    assert values["schema_version"] == SCHEMA_VERSION
+    assert len(row) == len(dal.STAGE_INSERT_COLUMNS)
+
+
+def test_ingest_prepared_import_call_shape(monkeypatch) -> None:
+    connection = MockConnection()
+    monkeypatch.setattr(dal, "scan_ts_within_kvk_details", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(dal.uuid, "uuid4", lambda: "token-1")
+
+    result = dal.ingest_prepared_import(
+        con=connection,
+        prepared=_prepared_frame(),
+        content=b"abc",
+        source_filename="kvk.xlsx",
+        uploader_id=999,
+        scan_ts_utc=dt.datetime(2026, 5, 8, 1, 0, tzinfo=dt.UTC),
+    )
+
+    stage_cursor = connection.cursors[0]
+    ingest_cursor = connection.cursors[1]
+    recompute_cursor = connection.cursors[2]
+    negative_cursor = connection.cursors[3]
+
+    assert stage_cursor.executemany_calls[0][0] == dal.STAGE_INSERT_SQL
+    assert ingest_cursor.executed[0][0] == dal.CALL_INGEST_SQL
+    params = cast(tuple[Any, ...], ingest_cursor.executed[0][1])
+    assert params[0] == "token-1"
+    assert params[2] == "kvk.xlsx"
+    assert params[4] == 999
+    assert params[5] == SCHEMA_VERSION
+    assert params[6] == "Full Data"
+    assert params[8] == len(EXPECTED_FULL_DATA_COLUMNS)
+    assert params[9] == 1
+    assert recompute_cursor.executed[0] == (dal.RECOMPUTE_SQL, 13)
+    assert negative_cursor.executed[0] == (dal.NEGATIVE_COUNT_SQL, (13, 2))
+    assert result["kvk_no"] == 13
+    assert result["scan_id"] == 2
+    assert result["negatives"] == 3
+    assert result["success"] is True
+    assert connection.commit_calls == 3

--- a/tests/test_kvk_all_import_service.py
+++ b/tests/test_kvk_all_import_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import pandas as pd
+import pytest
+
+from kvk.schemas.kvk_all_schema import EXPECTED_FULL_DATA_COLUMNS, SCHEMA_VERSION
+from kvk.services import kvk_all_import_service as service
+
+
+def _xlsx_bytes(sheets: dict[str, pd.DataFrame]) -> bytes:
+    bio = BytesIO()
+    with pd.ExcelWriter(bio, engine="openpyxl") as writer:
+        for sheet_name, df in sheets.items():
+            df.to_excel(writer, sheet_name=sheet_name, index=False)
+    return bio.getvalue()
+
+
+def _full_data_df() -> pd.DataFrame:
+    row: dict[str, object] = {column: 1 for column in EXPECTED_FULL_DATA_COLUMNS}
+    row.update(
+        {
+            "name": "Test Governor",
+            "first_updateUTC": "2026-05-08 01:00:00",
+            "last_updateUTC": "2026-05-08 02:00:00",
+        }
+    )
+    return pd.DataFrame([row], columns=list(EXPECTED_FULL_DATA_COLUMNS))
+
+
+def test_prepare_maps_full_data_columns_and_metadata() -> None:
+    full_data = _full_data_df()
+    full_data.loc[0, "rank"] = 7
+    full_data.loc[0, "minkill_points"] = 111
+    full_data.loc[0, "maxkill_points"] = 222
+    full_data.loc[0, "max_contribute_min"] = 333
+    full_data.loc[0, "cur_contribute_diff"] = 444
+
+    prepared = service.prepare_kvk_all_import(_xlsx_bytes({"Full Data": full_data}), "kvk.xlsx")
+    row = prepared.dataframe.iloc[0]
+
+    assert prepared.sheet_name == "Full Data"
+    assert prepared.staged_rows == 1
+    assert row["rank"] == 7
+    assert row["min_kill_points"] == 111
+    assert row["max_kill_points"] == 222
+    assert row["min_max_contribute"] == 333
+    assert row["cur_contribute_diff"] == 444
+    assert row["schema_version"] == SCHEMA_VERSION
+    assert row["source_sheet_name"] == "Full Data"
+    assert row["source_column_count"] == len(EXPECTED_FULL_DATA_COLUMNS)
+    assert prepared.schema_metadata["unknown_columns"] == []
+
+
+def test_read_full_data_workbook_preserves_unknown_column_reporting() -> None:
+    full_data = _full_data_df()
+    full_data["future_metric"] = 99
+
+    df, sheet_name, schema = service.read_full_data_workbook(
+        _xlsx_bytes({"Full Data": full_data}),
+        "kvk.xlsx",
+    )
+
+    assert sheet_name == "Full Data"
+    assert "future_metric" in df.columns
+    assert schema["unknown_columns"] == ["future_metric"]
+
+
+def test_prepare_wraps_coercion_failures_with_sheet_and_schema() -> None:
+    full_data = _full_data_df()
+    full_data.loc[0, "governor_id"] = None
+
+    with pytest.raises(service.KvkAllImportPreparationError) as exc:
+        service.prepare_kvk_all_import(_xlsx_bytes({"Full Data": full_data}), "kvk.xlsx")
+
+    assert str(exc.value) == "One or more rows missing governor_id or kingdom after coercion."
+    assert exc.value.sheet_name == "Full Data"
+    assert exc.value.schema_metadata["schema_version"] == SCHEMA_VERSION

--- a/tests/test_kvk_all_importer.py
+++ b/tests/test_kvk_all_importer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import datetime as dt
+from io import BytesIO
+
+import pandas as pd
+
+from kvk.schemas.kvk_all_schema import EXPECTED_FULL_DATA_COLUMNS, SCHEMA_VERSION
+import kvk_all_importer as importer
+
+
+def _xlsx_bytes(sheets: dict[str, pd.DataFrame]) -> bytes:
+    bio = BytesIO()
+    with pd.ExcelWriter(bio, engine="openpyxl") as writer:
+        for sheet_name, df in sheets.items():
+            df.to_excel(writer, sheet_name=sheet_name, index=False)
+    return bio.getvalue()
+
+
+def _full_data_df() -> pd.DataFrame:
+    row: dict[str, object] = {column: 1 for column in EXPECTED_FULL_DATA_COLUMNS}
+    row.update(
+        {
+            "name": "Test Governor",
+            "first_updateUTC": "2026-05-08 01:00:00",
+            "last_updateUTC": "2026-05-08 02:00:00",
+        }
+    )
+    return pd.DataFrame([row], columns=list(EXPECTED_FULL_DATA_COLUMNS))
+
+
+def test_wrapper_returns_schema_validation_error_without_db_connection() -> None:
+    result = importer.ingest_kvk_all_excel(
+        content=_xlsx_bytes({"Basic Data": pd.DataFrame([{"governor_id": 1}])}),
+        source_filename="kvk.xlsx",
+        uploader_id=123,
+        scan_ts_utc=dt.datetime(2026, 5, 8, tzinfo=dt.UTC),
+        server="unused",
+        database="unused",
+        username="unused",
+        password="unused",
+    )
+
+    assert result["success"] is False
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["validation_error"]["code"] == "missing_full_data_sheet"
+
+
+def test_wrapper_preserves_success_return_shape(monkeypatch) -> None:
+    expected = {
+        "kvk_no": 13,
+        "scan_id": 2,
+        "row_count": 1,
+        "negatives": 0,
+        "staged_rows": 1,
+        "ingest_ms": 12.0,
+        "recompute_ms": 3.0,
+        "proc_ms": 12.0,
+        "sheet": "Full Data",
+        "schema_version": SCHEMA_VERSION,
+        "schema": {"schema_version": SCHEMA_VERSION},
+        "success": True,
+    }
+
+    class MockConnection:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    connection = MockConnection()
+    monkeypatch.setattr(
+        importer.kvk_all_import_dal, "connect_sql_server", lambda **_kwargs: connection
+    )
+    monkeypatch.setattr(
+        importer.kvk_all_import_dal,
+        "ingest_prepared_import",
+        lambda **_kwargs: expected.copy(),
+    )
+
+    result = importer.ingest_kvk_all_excel(
+        content=_xlsx_bytes({"Full Data": _full_data_df()}),
+        source_filename="kvk.xlsx",
+        uploader_id=123,
+        scan_ts_utc=dt.datetime(2026, 5, 8, tzinfo=dt.UTC),
+        server="unused",
+        database="unused",
+        username="unused",
+        password="unused",
+    )
+
+    assert result["success"] is True
+    assert result["kvk_no"] == 13
+    assert result["proc_ms"] == 12.0
+    assert result["duration_s"] >= 0
+    assert connection.closed is True

--- a/tests/test_kvk_all_schema.py
+++ b/tests/test_kvk_all_schema.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import pandas as pd
 import pytest
 
+from kvk.dal import kvk_all_import_dal
 from kvk.schemas.kvk_all_schema import (
     EXPECTED_FULL_DATA_COLUMNS,
     FULL_DATA_SHEET_NAME,
@@ -287,7 +288,7 @@ def test_ingest_returns_migration_order_error_when_stage_schema_is_outdated(
             self.closed = True
 
     connection = MockConnection()
-    monkeypatch.setattr(importer.pyodbc, "connect", lambda *_args, **_kwargs: connection)
+    monkeypatch.setattr(kvk_all_import_dal.pyodbc, "connect", lambda *_args, **_kwargs: connection)
 
     result = importer.ingest_kvk_all_excel(
         content=content,


### PR DESCRIPTION
## Summary

Refactors the KVK_ALL Phase 3 importer into clear schema, service, and DAL boundaries while preserving the existing `kvk_all_importer.ingest_kvk_all_excel` compatibility entrypoint and return shape.

## Changes

- Moved Full Data workbook parsing, aliasing, schema validation, canonical v2 mapping, coercion, and source metadata enrichment into `kvk/services/kvk_all_import_service.py`.
- Moved stage insert SQL, ingest procedure call, recompute call, KVK timestamp precheck, diagnostics, and negative count reads into `kvk/dal/kvk_all_import_dal.py`.
- Kept Phase 1 strict Full Data validation and Phase 2 metadata/staging contract intact.
- Preserved compatibility exports in `kvk_all_importer.py` for older tests/tools while reducing the importer to wrapper orchestration.
- Added focused tests for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviour.

## Validation

- `python -m pytest -q tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py` — 19 passed
- `python -m black --check ...` — passed
- `python -m ruff check ...` — passed
- `python -m py_compile ...` — passed
- `python scripts\validate_architecture_boundaries.py` — passed
- `python scripts\validate_deferred_items.py` — passed
- `python scripts\smoke_imports.py` — passed
- `python scripts\validate_command_registration.py` — passed
- `python -m pyright ...` — 0 errors, with local dependency-resolution warnings for pandas/pytest/pyodbc/numpy

## SQL / Behaviour Notes

No SQL files were changed. Existing recompute, export result-set order, Google Sheets output, Discord reporting display, and `DL_bot.py` import behaviour are intended to remain unchanged.

## Deferred Optimisations

None newly captured for Phase 3. Later KVK_ALL programme items remain assigned to later phases.