### PR TITLE
[codex] KVK_ALL Phase 4 recompute modernisation

### DIFF
--- a/docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md
+++ b/docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md
@@ -1,0 +1,54 @@
+# KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules
+
+## Purpose
+
+Phase 4 modernises recompute behaviour for the Full Data v2 workbook while preserving current export, Google Sheets, and Discord reporting contracts.
+
+The authoritative workbook tab is `Full Data`. `Basic Data` remains intentionally ignored.
+
+## Source-Of-Truth Decisions
+
+### Kill Points
+
+`kill_points_diff` is the Full Data v2 semantic source for cumulative kill points.
+
+`points_difference` is retained as the legacy compatibility field. Phase 4 recompute may use `points_difference` as a fallback when `kill_points_diff` is null so older staged rows remain compatible.
+
+The sample workbook shows `points_difference` and `kill_points_diff` matching across all inspected Full Data rows.
+
+### Healed Troops
+
+`healed_troops` is the Full Data v2 semantic source for cumulative healed troops displayed downstream.
+
+`max_units_healed_diff` is retained as the legacy compatibility field. Phase 4 recompute may use `max_units_healed_diff` as a fallback when `healed_troops` is null.
+
+The sample workbook shows `max_units_healed_difference`, `max_units_healed_diff`, and `healed_troops` matching across all inspected Full Data rows after numeric coercion.
+
+### Raw Min/Max Metrics
+
+Raw min/max metric columns are validation and reconciliation inputs in Phase 4, not replacements for established downstream output fields.
+
+Where legacy diff columns are present, recompute keeps the current downstream semantics. Raw min/max pairs may be used as fallback inputs only when the matching diff field is null and both endpoints are present.
+
+This applies to:
+
+- `min_kill_points` / `max_kill_points`
+- `min_dead` / `max_dead`
+- `min_units_healed` / `max_units_healed`
+- `min_kills_iv` / `max_kills_iv`
+- `min_kills_v` / `max_kills_v`
+- `min_max_contribute` / `max_max_contribute`
+- `min_cur_contribute` / `max_cur_contribute`
+
+### Contribution Metrics
+
+Contribution metrics are recomputed into internal windowed SQL outputs in Phase 4:
+
+- `max_contribute_gain`
+- `cur_contribute_gain`
+
+They are not added to Discord reporting display, Google Sheets tab names, or export result-set ordering in Phase 4. Reporting and export presentation changes remain assigned to later programme phases.
+
+## Performance Rule
+
+Phase 4 keeps the existing full-refresh recompute model but preserves the current batched delete for `KVK_Player_Windowed`, which is the largest output table. Any broader incremental recompute design remains outside Phase 4.

--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -25,6 +25,8 @@ Phase 1 is complete and deployed.
 
 Phase 2 is complete and deployed.
 
+Phase 3 is complete and deployed.
+
 Completed Phase 1 scope:
 
 strict Full Data workbook detection
@@ -54,9 +56,24 @@ deployment smoke confirmed DB columns and ingest metadata parameters exist
 
 Phase 2 did not change recompute formula behaviour, export result-set order, Google Sheets tabs, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
 
+Completed Phase 3 scope:
+
+kvk_all_importer.py reduced to a compatibility wrapper around service and DAL layers
+workbook parsing, Full Data selection, aliasing, schema validation, canonical mapping, coercion, and source metadata moved into kvk/services/kvk_all_import_service.py
+stage column ordering, SQL staging, stage schema preflight, ingest procedure call, recompute call, KVK timestamp precheck, diagnostic writing, and negative count reads moved into kvk/dal/kvk_all_import_dal.py
+Full Data v2 canonical mapping constants moved into kvk/schemas/kvk_all_schema.py
+structured schema and coercion failures preserved
+legacy import return dictionary shape preserved for DL_bot.py
+Phase 2 schema/source metadata staging and ingest parameters preserved
+unknown column reporting retained in schema metadata without changing Discord output
+focused tests added for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviours
+non-mutating workbook/service smoke validation completed against the uploaded sample workbook
+
+Phase 3 did not change SQL schema, recompute formulas, export result-set order, Google Sheets tab names, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
+
 Next phase:
 
-Phase 3 — Importer Service/DAL Refactor
+Phase 4 — Recompute Modernisation
 
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
@@ -484,6 +501,9 @@ read-only SQL metadata smoke confirming deployed columns and ingest metadata par
 
 No recompute, export, Google Sheets, Discord reporting display, admin command SQL extraction, or reporting DAL refactor changes were made in Phase 2.
 Phase 3 — Importer Service/DAL Refactor
+Status
+Complete and deployed.
+
 Goal
 Resolve importer architecture debt and support the full schema cleanly.
 
@@ -502,6 +522,48 @@ kvk_all_importer.py becomes a compatibility wrapper or thin entrypoint.
 SQL write logic lives in DAL.
 Schema mapping is metadata-driven.
 Tests cover mapping, coercion, validation, and DAL call shape.
+
+Completion Notes
+Implemented:
+
+kvk_all_importer.py
+kvk/schemas/kvk_all_schema.py
+kvk/services/kvk_all_import_service.py
+kvk/dal/kvk_all_import_dal.py
+tests/test_kvk_all_schema.py
+tests/test_kvk_all_import_service.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_importer.py
+
+Python delivery:
+
+kvk_all_importer.ingest_kvk_all_excel remains the compatibility entrypoint.
+Services and DAL do not depend on Discord types.
+Workbook schema validation and mapping are testable outside the Discord/upload path.
+SQL writes and stored procedure calls live in DAL code.
+Phase 1 strict Full Data validation remains intact.
+Basic Data remains intentionally ignored and is not used as fallback.
+Phase 2 SQL metadata and Full Data capacity fields continue to be staged and passed through.
+Existing legacy import return keys used by DL_bot.py remain compatible.
+Unknown column reporting is available in schema metadata without changing user-facing Discord output.
+
+Validation completed:
+
+python -m pytest -q tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py
+python -m black --check kvk_all_importer.py kvk\schemas\kvk_all_schema.py kvk\services\kvk_all_import_service.py kvk\dal\kvk_all_import_dal.py tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py
+python -m ruff check kvk_all_importer.py kvk\schemas\kvk_all_schema.py kvk\services\kvk_all_import_service.py kvk\dal\kvk_all_import_dal.py tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py
+python -m py_compile kvk_all_importer.py kvk\schemas\kvk_all_schema.py kvk\services\kvk_all_import_service.py kvk\dal\kvk_all_import_dal.py
+python scripts\validate_architecture_boundaries.py
+python scripts\validate_deferred_items.py
+python scripts\smoke_imports.py
+python scripts\validate_command_registration.py
+python -m pyright kvk_all_importer.py kvk\schemas\kvk_all_schema.py kvk\services\kvk_all_import_service.py kvk\dal\kvk_all_import_dal.py tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py
+non-mutating workbook/service smoke against downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Pyright completed with 0 errors and local dependency-resolution warnings for pandas, pytest, pyodbc, and numpy in the sandboxed invocation.
+
+No SQL, recompute formula, export, Google Sheets, Discord reporting display, admin command SQL extraction, or reporting DAL refactor changes were made in Phase 3.
+
 Phase 4 — Recompute Modernisation
 Goal
 Modernise recompute to support new metrics and reduce performance risk.

--- a/docs/KVK_ALL Schema Modernisation — Phase 4 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 4 Initiation Statement.md
@@ -1,0 +1,177 @@
+KVK_ALL Schema Modernisation — Phase 4 Initiation Statement
+
+We are starting Phase 4 of the KVK_ALL Schema Modernisation programme.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
+
+Also read the uploaded workbook sample:
+
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, and migration scripts. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 2 is complete and deployed.
+
+Phase 2 delivered:
+
+additive SQL capacity for the KVK_ALL Full Data workbook schema
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Raw
+queryable schema/source metadata on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+Python staging support for rank, raw min/max metric families, contribution metrics, and source metadata
+focused schema/import SQL contract tests
+production deployment script under sql/kvk_all_phase2_full_data_capacity.sql
+non-mutating workbook/importer smoke validation
+read-only SQL metadata smoke validation after deployment
+
+Phase 3 is complete and deployed.
+
+Phase 3 delivered:
+
+kvk_all_importer.py reduced to a compatibility wrapper around service and DAL layers
+workbook parsing, Full Data selection, aliasing, schema validation, canonical mapping, coercion, and source metadata moved into kvk/services/kvk_all_import_service.py
+stage column ordering, SQL staging, stage schema preflight, ingest procedure call, recompute call, KVK timestamp precheck, diagnostic writing, and negative count reads moved into kvk/dal/kvk_all_import_dal.py
+Full Data v2 canonical mapping constants moved into kvk/schemas/kvk_all_schema.py
+structured schema and coercion failures preserved
+legacy import return dictionary shape preserved for DL_bot.py
+Phase 2 schema/source metadata staging and ingest parameters preserved
+unknown column reporting retained in schema metadata without changing Discord output
+focused tests added for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviours
+non-mutating workbook/service smoke validation completed against the uploaded sample workbook
+
+Phases 1 through 3 did not change recompute formula behaviour, export result-set order, Google Sheets tab names, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
+
+Phase 4 objective:
+
+Modernise KVK_ALL recompute behaviour to support the Full Data v2 schema where appropriate, decide and document source-of-truth metric rules, and reduce recompute performance risk while preserving existing downstream export, Google Sheets, and Discord reporting contracts.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data is out of scope and intentionally ignored.
+
+In scope:
+
+review current recompute SQL and downstream aggregate dependencies before implementation
+validate all recompute input columns against the SQL repo
+decide and document the source of truth for points_difference vs kill_points_diff
+decide and document the source of truth for max_units_healed_diff vs healed_troops
+decide and document the source of truth for raw min/max metric fields vs legacy diff fields
+evaluate whether contribution metrics should be recomputed into output tables in this phase
+add contribution recompute outputs if required and safe
+preserve existing KP, kills, deads, healed, DKP, baseline, kingdom, and camp outputs
+review current full-refresh recompute behaviour
+measure or smoke-check recompute performance risk where practical
+add additive SQL changes in the SQL repo if output table capacity or indexes are required
+add representative SQL contract or fixture-style tests where practical
+keep Python changes limited to any service/DAL contract adjustments needed for recompute support
+capture new out-of-scope findings structurally
+
+Likely SQL objects to review and possibly update:
+
+KVK.sp_KVK_Recompute_Windows
+KVK.KVK_Player_Windowed
+KVK.KVK_Kingdom_Windowed
+KVK.KVK_Camp_Windowed
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Player_Baseline
+KVK.KVK_Windows
+KVK.KVK_CampMap
+dbo.fn_KVK_Player_Aggregated
+dbo.fn_KVK_Kingdom_Aggregated
+dbo.fn_KVK_Camp_Aggregated
+KVK.vw_FightingDataset
+
+Likely Python modules to review, but not redesign unless required:
+
+kvk/dal/kvk_all_import_dal.py
+kvk/services/kvk_all_import_service.py
+kvk_all_importer.py
+gsheet_module.py
+stats_alerts/allkingdoms.py
+stats_alerts/embeds/kvk.py
+commands/stats_cmds.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_import_service.py
+
+Out of scope for Phase 4:
+
+new export result sets or export result-set reordering unless strictly required by recompute compatibility
+Google Sheets export changes
+Discord reporting display changes
+admin command SQL extraction
+reporting DAL refactor
+export contract decoupling
+summary tab ingestion
+Basic Data ingestion
+live ingest of production data as a test unless explicitly requested
+production promotion before local validation
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Preserve existing import behaviour and return shape.
+Do not change existing export tab names or result-set contracts in this phase unless explicitly approved.
+Do not change Discord embed/reporting output in this phase.
+Use additive, rollback-safe SQL changes only.
+Do not silently change metric semantics.
+Document source-of-truth decisions before changing formulas.
+Avoid embedded SQL in command/view layers.
+Prefer service and DAL boundaries.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact recompute SQL dependencies and downstream contracts.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 4 recompute modernisation.
+Run targeted validation.
+Stop after Phase 4 implementation, tests, and report.
+
+Acceptance criteria:
+
+Current recompute inputs and outputs are mapped against authoritative SQL definitions.
+Metric source-of-truth decisions are documented.
+Existing KP, kills, deads, healed, DKP, baseline, kingdom, and camp outputs remain stable.
+Contribution metrics are recomputed or explicitly excluded by documented rule.
+Any SQL changes are additive and rollback-safe.
+Export result-set order and Google Sheets tab names remain unchanged unless explicitly approved.
+Discord reporting display remains unchanged.
+Representative recompute tests or SQL contract validations cover changed formulas where practical.
+Performance risk is measured, smoke-checked, or explicitly documented.
+New deferred findings are captured structurally, but all known KVK_ALL/all-kingdom work remains assigned to later programme phases rather than left as final deferred debt.

--- a/sql/kvk_all_phase4_recompute_modernisation.sql
+++ b/sql/kvk_all_phase4_recompute_modernisation.sql
@@ -176,11 +176,27 @@ IF COL_LENGTH('KVK.KVK_Kingdom_Windowed', 'cur_contribute_gain') IS NULL
 BEGIN
 ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_KingdomWin_CurContrib] DEFAULT ((0)) WITH VALUES
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_MaxContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Kingdom_Windowed]')
+      AND c.name = N'max_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD CONSTRAINT [DF_KingdomWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_CurContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Kingdom_Windowed]')
+      AND c.name = N'cur_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD CONSTRAINT [DF_KingdomWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
 END

--- a/sql/kvk_all_phase4_recompute_modernisation.sql
+++ b/sql/kvk_all_phase4_recompute_modernisation.sql
@@ -56,11 +56,27 @@ IF COL_LENGTH('KVK.KVK_Player_Windowed', 'cur_contribute_gain') IS NULL
 BEGIN
 ALTER TABLE [KVK].[KVK_Player_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_PlayerWin_CurContrib] DEFAULT ((0)) WITH VALUES
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_PlayerWin_MaxContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]')
+      AND c.name = N'max_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Player_Windowed] ADD CONSTRAINT [DF_PlayerWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_PlayerWin_CurContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]')
+      AND c.name = N'cur_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Player_Windowed] ADD CONSTRAINT [DF_PlayerWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
 END

--- a/sql/kvk_all_phase4_recompute_modernisation.sql
+++ b/sql/kvk_all_phase4_recompute_modernisation.sql
@@ -1,0 +1,833 @@
+﻿/*
+KVK_ALL Schema Modernisation - Phase 4 Recompute Modernisation
+
+Purpose:
+- Apply additive Full Data v2 recompute capacity to production.
+- Add internal contribution gain outputs to KVK windowed tables.
+- Update recompute source precedence while preserving export result-set order and Google Sheets tab names.
+
+Deployment notes:
+- Run against the production ROK_TRACKER database after mirror validation.
+- Script is idempotent for additive table columns and uses ALTER PROCEDURE for procedure bodies.
+- No destructive table changes are included.
+*/
+
+
+PRINT N'Applying KVK.KVK_Player_Windowed.Table.sql';
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND type in (N'U'))
+BEGIN
+CREATE TABLE [KVK].[KVK_Player_Windowed](
+	[KVK_NO] [int] NOT NULL,
+	[WindowName] [nvarchar](40) COLLATE Latin1_General_CI_AS NOT NULL,
+	[governor_id] [bigint] NOT NULL,
+	[name] [nvarchar](64) COLLATE Latin1_General_CI_AS NULL,
+	[kingdom] [int] NOT NULL,
+	[campid] [tinyint] NULL,
+	[kp_gain] [bigint] NOT NULL,
+	[kp_gain_recalc] [bigint] NOT NULL,
+	[kills_gain] [bigint] NOT NULL,
+	[t4_kills] [bigint] NOT NULL,
+	[t5_kills] [bigint] NOT NULL,
+	[kp_loss] [bigint] NOT NULL,
+	[healed_troops] [bigint] NOT NULL,
+	[deads] [bigint] NOT NULL,
+	[max_contribute_gain] [bigint] NOT NULL,
+	[cur_contribute_gain] [bigint] NOT NULL,
+	[starting_power] [bigint] NOT NULL,
+	[dkp] [float] NOT NULL,
+	[last_scan_id] [int] NOT NULL,
+	[computed_at_utc] [datetime2](0) NOT NULL,
+ CONSTRAINT [PK_KVK_Player_Windowed] PRIMARY KEY CLUSTERED
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC,
+	[governor_id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+END
+IF COL_LENGTH('KVK.KVK_Player_Windowed', 'max_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Player_Windowed] ADD [max_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_PlayerWin_MaxContrib] DEFAULT ((0)) WITH VALUES
+END
+IF COL_LENGTH('KVK.KVK_Player_Windowed', 'cur_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Player_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_PlayerWin_CurContrib] DEFAULT ((0)) WITH VALUES
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_PlayerWin_MaxContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Player_Windowed] ADD CONSTRAINT [DF_PlayerWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_PlayerWin_CurContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Player_Windowed] ADD CONSTRAINT [DF_PlayerWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
+END
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_KVK_Player_Windowed_KVK_NO_governor_id')
+CREATE NONCLUSTERED INDEX [IX_KVK_Player_Windowed_KVK_NO_governor_id] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC,
+	[governor_id] ASC
+)
+INCLUDE([kingdom],[starting_power]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_KVK_Player_Windowed_KVK_NO_Kingdom')
+CREATE NONCLUSTERED INDEX [IX_KVK_Player_Windowed_KVK_NO_Kingdom] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC,
+	[kingdom] ASC
+)
+INCLUDE([governor_id],[starting_power]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_KVK_Player_Windowed_KVK_NO_WindowName')
+CREATE NONCLUSTERED INDEX [IX_KVK_Player_Windowed_KVK_NO_WindowName] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC
+)
+INCLUDE([governor_id],[name],[kingdom],[campid],[t4_kills],[t5_kills],[deads],[starting_power]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_PlayerWin_Camp')
+CREATE NONCLUSTERED INDEX [IX_PlayerWin_Camp] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC,
+	[campid] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_PlayerWin_Delete_KVKNO')
+CREATE NONCLUSTERED INDEX [IX_PlayerWin_Delete_KVKNO] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Player_Windowed]') AND name = N'IX_PlayerWin_Kingdom')
+CREATE NONCLUSTERED INDEX [IX_PlayerWin_Kingdom] ON [KVK].[KVK_Player_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC,
+	[kingdom] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_PlayerWin_At]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Player_Windowed] ADD  CONSTRAINT [DF_PlayerWin_At]  DEFAULT (sysutcdatetime()) FOR [computed_at_utc]
+END
+
+
+
+GO
+
+
+PRINT N'Applying KVK.KVK_Kingdom_Windowed.Table.sql';
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Kingdom_Windowed]') AND type in (N'U'))
+BEGIN
+CREATE TABLE [KVK].[KVK_Kingdom_Windowed](
+	[KVK_NO] [int] NOT NULL,
+	[WindowName] [nvarchar](40) COLLATE Latin1_General_CI_AS NOT NULL,
+	[kingdom] [int] NOT NULL,
+	[kp_gain] [bigint] NOT NULL,
+	[kills_gain] [bigint] NOT NULL,
+	[t4_kills] [bigint] NOT NULL,
+	[t5_kills] [bigint] NOT NULL,
+	[kp_loss] [bigint] NOT NULL,
+	[healed_troops] [bigint] NOT NULL,
+	[deads] [bigint] NOT NULL,
+	[max_contribute_gain] [bigint] NOT NULL,
+	[cur_contribute_gain] [bigint] NOT NULL,
+	[dkp] [float] NOT NULL,
+	[last_scan_id] [int] NOT NULL,
+	[computed_at_utc] [datetime2](0) NOT NULL,
+	[campid] [int] NOT NULL,
+	[camp_name] [nvarchar](100) COLLATE Latin1_General_CI_AS NOT NULL,
+ CONSTRAINT [PK_KVK_Kingdom_Windowed] PRIMARY KEY CLUSTERED
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC,
+	[kingdom] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+END
+IF COL_LENGTH('KVK.KVK_Kingdom_Windowed', 'max_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD [max_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_KingdomWin_MaxContrib] DEFAULT ((0)) WITH VALUES
+END
+IF COL_LENGTH('KVK.KVK_Kingdom_Windowed', 'cur_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_KingdomWin_CurContrib] DEFAULT ((0)) WITH VALUES
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_MaxContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD CONSTRAINT [DF_KingdomWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_CurContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD CONSTRAINT [DF_KingdomWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
+END
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Kingdom_Windowed]') AND name = N'IX_KingWin_KVK')
+CREATE NONCLUSTERED INDEX [IX_KingWin_KVK] ON [KVK].[KVK_Kingdom_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Kingdom_Windowed]') AND name = N'IX_KVK_Kingdom_Windowed_KVK_NO_WindowName')
+CREATE NONCLUSTERED INDEX [IX_KVK_Kingdom_Windowed_KVK_NO_WindowName] ON [KVK].[KVK_Kingdom_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC
+)
+INCLUDE([kingdom],[t4_kills],[t5_kills],[deads]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingWin_At]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD  CONSTRAINT [DF_KingWin_At]  DEFAULT (sysutcdatetime()) FOR [computed_at_utc]
+END
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_campid]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD  CONSTRAINT [DF_KingdomWin_campid]  DEFAULT ((0)) FOR [campid]
+END
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_KingdomWin_campname]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Kingdom_Windowed] ADD  CONSTRAINT [DF_KingdomWin_campname]  DEFAULT (N'') FOR [camp_name]
+END
+
+
+
+GO
+
+
+PRINT N'Applying KVK.KVK_Camp_Windowed.Table.sql';
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Camp_Windowed]') AND type in (N'U'))
+BEGIN
+CREATE TABLE [KVK].[KVK_Camp_Windowed](
+	[KVK_NO] [int] NOT NULL,
+	[WindowName] [nvarchar](40) COLLATE Latin1_General_CI_AS NOT NULL,
+	[campid] [tinyint] NOT NULL,
+	[camp_name] [nvarchar](40) COLLATE Latin1_General_CI_AS NOT NULL,
+	[kp_gain] [bigint] NOT NULL,
+	[kills_gain] [bigint] NOT NULL,
+	[t4_kills] [bigint] NOT NULL,
+	[t5_kills] [bigint] NOT NULL,
+	[kp_loss] [bigint] NOT NULL,
+	[healed_troops] [bigint] NOT NULL,
+	[deads] [bigint] NOT NULL,
+	[max_contribute_gain] [bigint] NOT NULL,
+	[cur_contribute_gain] [bigint] NOT NULL,
+	[dkp] [float] NOT NULL,
+	[last_scan_id] [int] NOT NULL,
+	[computed_at_utc] [datetime2](0) NOT NULL,
+ CONSTRAINT [PK_KVK_Camp_Windowed] PRIMARY KEY CLUSTERED
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC,
+	[campid] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+END
+IF COL_LENGTH('KVK.KVK_Camp_Windowed', 'max_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD [max_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_CampWin_MaxContrib] DEFAULT ((0)) WITH VALUES
+END
+IF COL_LENGTH('KVK.KVK_Camp_Windowed', 'cur_contribute_gain') IS NULL
+BEGIN
+ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_CampWin_CurContrib] DEFAULT ((0)) WITH VALUES
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_CampWin_MaxContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD CONSTRAINT [DF_CampWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
+END
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_CampWin_CurContrib]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD CONSTRAINT [DF_CampWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
+END
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Camp_Windowed]') AND name = N'IX_CampWin_KVK')
+CREATE NONCLUSTERED INDEX [IX_CampWin_KVK] ON [KVK].[KVK_Camp_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+SET ANSI_PADDING ON
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Camp_Windowed]') AND name = N'IX_KVK_Camp_Windowed_KVK_NO_WindowName')
+CREATE NONCLUSTERED INDEX [IX_KVK_Camp_Windowed_KVK_NO_WindowName] ON [KVK].[KVK_Camp_Windowed]
+(
+	[KVK_NO] ASC,
+	[WindowName] ASC
+)
+INCLUDE([campid],[camp_name],[t4_kills],[t5_kills],[deads]) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_CampWin_At]') AND type = 'D')
+BEGIN
+ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD  CONSTRAINT [DF_CampWin_At]  DEFAULT (sysutcdatetime()) FOR [computed_at_utc]
+END
+
+
+
+GO
+
+
+PRINT N'Applying KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql';
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_Recompute_Windows]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Recompute_Windows] AS'
+END
+ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]
+	@KVK_NO [int]
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    ----------------------------------------------------------------
+    -- 0) Validations & setup
+    ----------------------------------------------------------------
+    IF @KVK_NO IS NULL
+        THROW 60001, 'KVK_NO is required.', 1;
+
+    DECLARE @MaxScanID INT;
+    SELECT @MaxScanID = MAX(ScanID)
+    FROM KVK.KVK_Scan WITH (READCOMMITTEDLOCK)
+    WHERE KVK_NO = @KVK_NO;
+
+    IF @MaxScanID IS NULL
+        THROW 60002, 'No scans exist for this KVK_NO.', 1;
+
+    DECLARE @X FLOAT, @Y FLOAT, @Z FLOAT;
+
+    SELECT TOP (1)
+        @X = WeightT4X, @Y = WeightT5Y, @Z = WeightDeadsZ
+    FROM KVK.KVK_DKPWeights WITH (READCOMMITTEDLOCK)
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY EffectiveFromUTC DESC;
+
+    IF @X IS NULL OR @Y IS NULL OR @Z IS NULL
+        THROW 60003, 'DKP weights not defined for this KVK.', 1;
+
+    ----------------------------------------------------------------
+    -- 1) Clear existing outputs for this KVK (full overwrite)
+	--    Keep Camp/Kingdom single-shot (small), batch Player (largest) for predictability.
+    ----------------------------------------------------------------
+    DELETE FROM KVK.KVK_Camp_Windowed    WHERE KVK_NO = @KVK_NO;
+    DELETE FROM KVK.KVK_Kingdom_Windowed WHERE KVK_NO = @KVK_NO;
+
+    DECLARE @DeleteBatchSize INT = 20000;
+
+    DECLARE @RowsDeleted INT;
+
+    WHILE 1 = 1
+    BEGIN
+        DELETE TOP (@DeleteBatchSize) p
+        FROM KVK.KVK_Player_Windowed p WITH (INDEX(PK_KVK_Player_Windowed), PAGLOCK)
+        WHERE p.KVK_NO = @KVK_NO;
+
+        SET @RowsDeleted = @@ROWCOUNT;
+
+        IF @RowsDeleted = 0 BREAK;
+        IF @RowsDeleted < @DeleteBatchSize BREAK; -- typically avoids one extra terminal no-op pass
+    END;
+
+    ----------------------------------------------------------------
+    -- 2) Baseline rows (validation view): zeros + fixed starting_power
+    ----------------------------------------------------------------
+    ;WITH base AS (
+        SELECT b.KVK_NO,
+               b.governor_id,
+               b.starting_power,
+               b.baseline_scan_id,
+               r.name,
+               r.kingdom
+        FROM KVK.KVK_Player_Baseline b
+        LEFT JOIN KVK.KVK_AllPlayers_Raw r
+               ON r.KVK_NO = b.KVK_NO
+              AND r.ScanID = b.baseline_scan_id
+              AND r.governor_id = b.governor_id
+        WHERE b.KVK_NO = @KVK_NO
+    ),
+    cm AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT  @KVK_NO, N'Baseline', b.governor_id, b.name, b.kingdom,
+            ISNULL(cm.CampID, 0),
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, b.starting_power, 0.0,
+            b.baseline_scan_id, SYSUTCDATETIME()
+    FROM base b
+    LEFT JOIN cm
+      ON cm.KVK_NO = b.KVK_NO AND cm.Kingdom = b.kingdom;
+
+    ----------------------------------------------------------------
+    -- 3) Windowed deltas (Start→End, End defaults to MaxScanID)
+    --    Window delta = End cumulative - Start cumulative
+    ----------------------------------------------------------------
+	;WITH W AS (
+		SELECT
+			RTRIM(w.WindowName) AS WindowName,
+			w.StartScanID,
+			-- Auto-cap EndScanID to max available scan (prevents future scan references)
+			CASE
+				WHEN w.EndScanID IS NULL THEN @MaxScanID
+				WHEN w.EndScanID > @MaxScanID THEN @MaxScanID  -- ← NEW: Safety cap
+				ELSE w.EndScanID
+			END AS EndScanID
+		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
+		WHERE w.KVK_NO = @KVK_NO
+		  AND w.StartScanID IS NOT NULL
+		  AND w.WindowName <> N'Baseline'
+	),
+    S AS (
+        SELECT
+            W.WindowName, W.StartScanID, W.EndScanID,
+            r.governor_id, r.name, r.kingdom,
+            COALESCE(r.kill_points_diff, r.points_difference, r.max_kill_points - r.min_kill_points, 0) AS kp_s,
+            COALESCE(r.kills_iv_diff, r.max_kills_iv - r.min_kills_iv, 0) AS t4_s,
+            COALESCE(r.kills_v_diff, r.max_kills_v - r.min_kills_v, 0) AS t5_s,
+            COALESCE(r.dead_diff, r.max_dead - r.min_dead, 0) AS deads_s,
+            COALESCE(r.healed_troops, r.max_units_healed_diff, r.max_units_healed - r.min_units_healed, 0) AS heals_s,
+            COALESCE(r.max_contribute_diff, r.max_max_contribute - r.min_max_contribute, 0) AS max_contrib_s,
+            COALESCE(r.cur_contribute_diff, r.max_cur_contribute - r.min_cur_contribute, 0) AS cur_contrib_s
+        FROM W
+        JOIN KVK.KVK_AllPlayers_Raw r
+          ON r.KVK_NO = @KVK_NO
+         AND r.ScanID = W.StartScanID
+    ),
+    E AS (
+        SELECT
+            W.WindowName, W.StartScanID, W.EndScanID,
+            r.governor_id, r.name, r.kingdom,
+            COALESCE(r.kill_points_diff, r.points_difference, r.max_kill_points - r.min_kill_points, 0) AS kp_e,
+            COALESCE(r.kills_iv_diff, r.max_kills_iv - r.min_kills_iv, 0) AS t4_e,
+            COALESCE(r.kills_v_diff, r.max_kills_v - r.min_kills_v, 0) AS t5_e,
+            COALESCE(r.dead_diff, r.max_dead - r.min_dead, 0) AS deads_e,
+            COALESCE(r.healed_troops, r.max_units_healed_diff, r.max_units_healed - r.min_units_healed, 0) AS heals_e,
+            COALESCE(r.max_contribute_diff, r.max_max_contribute - r.min_max_contribute, 0) AS max_contrib_e,
+            COALESCE(r.cur_contribute_diff, r.max_cur_contribute - r.min_cur_contribute, 0) AS cur_contrib_e
+        FROM W
+        JOIN KVK.KVK_AllPlayers_Raw r
+          ON r.KVK_NO = @KVK_NO
+         AND r.ScanID = W.EndScanID
+    ),
+    U AS (
+        -- Full outer join: include govs that appear in Start or End (defensive)
+        SELECT
+            COALESCE(S.WindowName, E.WindowName) AS WindowName,
+            COALESCE(S.StartScanID, E.StartScanID) AS StartScanID,
+            COALESCE(S.EndScanID,   E.EndScanID)   AS EndScanID,
+            COALESCE(S.governor_id, E.governor_id) AS governor_id,
+            COALESCE(E.name, S.name)               AS name,
+            COALESCE(E.kingdom, S.kingdom)         AS kingdom,
+            -- Deltas
+            ISNULL(E.kp_e,0)    - ISNULL(S.kp_s,0)    AS kp_gain,
+            (ISNULL(E.t4_e,0)+ISNULL(E.t5_e,0))
+          - (ISNULL(S.t4_s,0)+ISNULL(S.t5_s,0))       AS kills_gain,
+            ISNULL(E.t4_e,0)   - ISNULL(S.t4_s,0)     AS t4_kills,
+            ISNULL(E.t5_e,0)   - ISNULL(S.t5_s,0)     AS t5_kills,
+            ISNULL(E.heals_e,0)- ISNULL(S.heals_s,0)  AS healed_troops,
+            ISNULL(E.deads_e,0)- ISNULL(S.deads_s,0)  AS deads,
+            ISNULL(E.max_contrib_e,0)- ISNULL(S.max_contrib_s,0) AS max_contribute_gain,
+            ISNULL(E.cur_contrib_e,0)- ISNULL(S.cur_contrib_s,0) AS cur_contribute_gain
+        FROM S
+        FULL OUTER JOIN E
+          ON E.WindowName = S.WindowName
+         AND E.StartScanID = S.StartScanID
+         AND E.EndScanID   = S.EndScanID
+         AND E.governor_id = S.governor_id
+    ),
+    B AS (
+        SELECT b.governor_id, b.starting_power
+        FROM KVK.KVK_Player_Baseline b WITH (READCOMMITTEDLOCK)
+        WHERE b.KVK_NO = @KVK_NO
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        @KVK_NO,
+        RTRIM(U.WindowName),
+        U.governor_id,
+        U.name,
+        U.kingdom,
+        ISNULL(CM.CampID, 0) AS campid,
+        -- KP Gain (source-of-truth)
+        U.kp_gain,
+        -- KP Gain (recalc) = 10*T4 + 20*T5
+        (U.t4_kills * 10) + (U.t5_kills * 20) AS kp_gain_recalc,
+        U.kills_gain,
+        U.t4_kills,
+        U.t5_kills,
+        -- KP Loss = heals * 20
+        (U.healed_troops * 20) AS kp_loss,
+        U.healed_troops,
+        U.deads,
+        U.max_contribute_gain,
+        U.cur_contribute_gain,
+        ISNULL(B.starting_power, 0) AS starting_power,
+        CASE WHEN ISNULL(B.starting_power,0) > 0
+             THEN ((U.t4_kills * @X) + (U.t5_kills * @Y) + (U.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        U.EndScanID,
+        SYSUTCDATETIME()
+    FROM U
+    LEFT JOIN B  ON B.governor_id = U.governor_id
+    LEFT JOIN CM ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = U.kingdom;
+
+    ----------------------------------------------------------------
+    -- 4) Full KVK (Baseline→MaxScanID): use latest cumulative snapshot
+    ----------------------------------------------------------------
+    ;WITH E AS (
+        SELECT r.governor_id, r.name, r.kingdom,
+               COALESCE(r.kill_points_diff, r.points_difference, r.max_kill_points - r.min_kill_points, 0) AS kp,
+               COALESCE(r.kills_iv_diff, r.max_kills_iv - r.min_kills_iv, 0) AS t4,
+               COALESCE(r.kills_v_diff, r.max_kills_v - r.min_kills_v, 0) AS t5,
+               COALESCE(r.dead_diff, r.max_dead - r.min_dead, 0) AS deads,
+               COALESCE(r.healed_troops, r.max_units_healed_diff, r.max_units_healed - r.min_units_healed, 0) AS heals,
+               COALESCE(r.max_contribute_diff, r.max_max_contribute - r.min_max_contribute, 0) AS max_contribute_gain,
+               COALESCE(r.cur_contribute_diff, r.max_cur_contribute - r.min_cur_contribute, 0) AS cur_contribute_gain
+        FROM KVK.KVK_AllPlayers_Raw r WITH (READCOMMITTEDLOCK)
+        WHERE r.KVK_NO = @KVK_NO
+          AND r.ScanID = @MaxScanID
+    ),
+    B AS (
+        SELECT governor_id, starting_power
+        FROM KVK.KVK_Player_Baseline WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        @KVK_NO,
+        N'Full',
+        E.governor_id,
+        E.name,
+        E.kingdom,
+        ISNULL(CM.CampID, 0),
+        -- Full uses cumulative since baseline (End-only)
+        E.kp,
+        (E.t4 * 10) + (E.t5 * 20) AS kp_gain_recalc,
+        (E.t4 + E.t5)             AS kills_gain,
+        E.t4, E.t5,
+        (E.heals * 20)            AS kp_loss,
+        E.heals,
+        E.deads,
+        E.max_contribute_gain,
+        E.cur_contribute_gain,
+        ISNULL(B.starting_power, 0) AS starting_power,
+        CASE WHEN ISNULL(B.starting_power,0) > 0
+             THEN ((E.t4 * @X) + (E.t5 * @Y) + (E.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        @MaxScanID,
+        SYSUTCDATETIME()
+    FROM E
+    LEFT JOIN B  ON B.governor_id = E.governor_id
+    LEFT JOIN CM ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = E.kingdom;
+
+    ----------------------------------------------------------------
+    -- 5) Rollups (Kingdom & Camp) from Player_Windowed just written
+    ----------------------------------------------------------------
+    -- Kingdom
+    ;WITH P AS (
+		SELECT *
+		FROM KVK.KVK_Player_Windowed WITH (READCOMMITTEDLOCK)
+		WHERE KVK_NO = @KVK_NO
+	),
+	CM AS (
+		SELECT KVK_NO, Kingdom, CampID, CampName
+		FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+		WHERE KVK_NO = @KVK_NO
+	),
+	K AS (
+		SELECT
+			@KVK_NO AS KVK_NO,
+			p.WindowName,
+			p.kingdom,
+			ISNULL(cm.CampID, 0)        AS campid,
+			ISNULL(cm.CampName, N'')    AS camp_name,
+			SUM(p.kp_gain)              AS kp_gain,
+			SUM(p.kp_gain_recalc)       AS kp_gain_recalc, -- only used for DKP calc here
+			SUM(p.kills_gain)           AS kills_gain,
+			SUM(p.t4_kills)             AS t4_kills,
+			SUM(p.t5_kills)             AS t5_kills,
+			SUM(p.kp_loss)              AS kp_loss,
+			SUM(p.healed_troops)        AS healed_troops,
+			SUM(p.deads)                AS deads,
+			SUM(p.max_contribute_gain)  AS max_contribute_gain,
+			SUM(p.cur_contribute_gain)  AS cur_contribute_gain,
+			SUM(p.starting_power)       AS starting_power_sum,
+			MAX(p.last_scan_id)         AS last_scan_id
+		FROM P p
+		LEFT JOIN CM
+		  ON CM.KVK_NO = @KVK_NO
+		 AND CM.Kingdom = p.kingdom
+		GROUP BY p.WindowName, p.kingdom, ISNULL(cm.CampID, 0), ISNULL(cm.CampName, N'')
+	)
+	INSERT INTO KVK.KVK_Kingdom_Windowed
+	(
+		KVK_NO, WindowName, kingdom, campid, camp_name,
+		kp_gain, kills_gain, t4_kills, t5_kills,
+		kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain, dkp,
+		last_scan_id, computed_at_utc
+	)
+	SELECT
+		K.KVK_NO, K.WindowName, K.kingdom, K.campid, K.camp_name,
+		K.kp_gain, K.kills_gain, K.t4_kills, K.t5_kills,
+		K.kp_loss, K.healed_troops, K.deads, K.max_contribute_gain, K.cur_contribute_gain,
+		CASE WHEN K.starting_power_sum > 0
+			 THEN ((K.t4_kills * @X) + (K.t5_kills * @Y) + (K.deads * @Z))
+			 ELSE 0.0 END AS dkp,
+		K.last_scan_id,
+		SYSUTCDATETIME()
+	FROM K;
+
+    -- Camp
+    ;WITH P AS (
+        SELECT *
+        FROM KVK.KVK_Player_Windowed WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    C AS (
+        SELECT
+            @KVK_NO AS KVK_NO,
+            p.WindowName,
+            ISNULL(cm.CampID, 0)   AS campid,
+            ISNULL(cm.CampName, N'') AS camp_name,
+            SUM(p.kp_gain)         AS kp_gain,
+            SUM(p.kills_gain)      AS kills_gain,
+            SUM(p.t4_kills)        AS t4_kills,
+            SUM(p.t5_kills)        AS t5_kills,
+            SUM(p.kp_loss)         AS kp_loss,
+            SUM(p.healed_troops)   AS healed_troops,
+            SUM(p.deads)           AS deads,
+            SUM(p.max_contribute_gain) AS max_contribute_gain,
+            SUM(p.cur_contribute_gain) AS cur_contribute_gain,
+            SUM(p.starting_power)  AS starting_power_sum,
+            MAX(p.last_scan_id)    AS last_scan_id
+        FROM P p
+        LEFT JOIN CM
+          ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = p.kingdom
+        GROUP BY p.WindowName, ISNULL(cm.CampID, 0), ISNULL(cm.CampName, N'')
+    )
+    INSERT INTO KVK.KVK_Camp_Windowed
+    (
+        KVK_NO, WindowName, campid, camp_name,
+        kp_gain, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        C.KVK_NO, C.WindowName, C.campid, C.camp_name,
+        C.kp_gain, C.kills_gain, C.t4_kills, C.t5_kills,
+        C.kp_loss, C.healed_troops, C.deads, C.max_contribute_gain, C.cur_contribute_gain,
+        CASE WHEN C.starting_power_sum > 0
+             THEN ((C.t4_kills * @X) + (C.t5_kills * @Y) + (C.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        C.last_scan_id,
+        SYSUTCDATETIME()
+    FROM C;
+
+    RETURN 0;
+END
+
+
+
+GO
+
+
+PRINT N'Applying KVK.sp_KVK_Get_Exports.StoredProcedure.sql';
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_Get_Exports]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Get_Exports] AS'
+END
+ALTER PROCEDURE [KVK].[sp_KVK_Get_Exports]
+	@KVK_NO [int]
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    ----------------------------------------------------------------
+    -- 1) KVK_Scan_Log
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO,
+        ScanID,
+        ScanTimestampUTC,
+        SourceFileName,
+        Row_Count,               -- note: your column rename
+        ImportedAtUTC,
+        UploaderDiscordID
+    FROM KVK.KVK_Scan
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY ScanID;
+
+    ----------------------------------------------------------------
+    -- 2) KVK_Windows (effective end also shown)
+    ----------------------------------------------------------------
+    DECLARE @MaxScanID INT = (SELECT MAX(ScanID) FROM KVK.KVK_Scan WHERE KVK_NO=@KVK_NO);
+
+    SELECT
+        KVK_NO,
+        WindowName,
+        WindowSeq,
+        StartScanID,
+        EndScanID,
+        COALESCE(EndScanID, @MaxScanID) AS EffectiveEndScanID,
+        Notes,
+        UpdatedAtUTC
+    FROM KVK.KVK_Windows
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY ISNULL(WindowSeq, 255), WindowName;
+
+    ----------------------------------------------------------------
+    -- 3) KVK_DKP_Weights (latest first)
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO,
+        WeightT4X,
+        WeightT5Y,
+        WeightDeadsZ,
+        EffectiveFromUTC
+    FROM KVK.KVK_DKPWeights
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY EffectiveFromUTC DESC;
+
+    ----------------------------------------------------------------
+    -- 4) Player Windowed (all windows including Baseline/Full)
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, starting_power, dkp,
+        last_scan_id, computed_at_utc
+    FROM KVK.KVK_Player_Windowed
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY WindowName, dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 5) Kingdom Windowed
+    ----------------------------------------------------------------
+	SELECT
+		KVK_NO, WindowName, kingdom, campid, camp_name,
+		kp_gain, kills_gain, t4_kills, t5_kills,
+		kp_loss, healed_troops, deads, dkp,
+		last_scan_id, computed_at_utc
+	FROM KVK.KVK_Kingdom_Windowed
+	WHERE KVK_NO = @KVK_NO
+	ORDER BY WindowName, dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 6) Camp Windowed
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, WindowName, campid, camp_name,
+        kp_gain, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, dkp,
+        last_scan_id, computed_at_utc
+    FROM KVK.KVK_Camp_Windowed
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY WindowName, dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 7) Player Full
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, starting_power, dkp,
+        last_scan_id, computed_at_utc
+    FROM KVK.KVK_Player_Windowed
+    WHERE KVK_NO = @KVK_NO AND WindowName = N'Full'
+    ORDER BY dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 8) Kingdom Full
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, WindowName, kingdom, campid, camp_name,
+        kp_gain, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, dkp,
+        last_scan_id, computed_at_utc
+    FROM KVK.KVK_Kingdom_Windowed
+    WHERE KVK_NO = @KVK_NO AND WindowName = N'Full'
+    ORDER BY dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 9) Camp Full
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, WindowName, campid, camp_name,
+        kp_gain, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, dkp,
+        last_scan_id, computed_at_utc
+    FROM KVK.KVK_Camp_Windowed
+    WHERE KVK_NO = @KVK_NO AND WindowName = N'Full'
+    ORDER BY dkp DESC;
+
+    ----------------------------------------------------------------
+    -- 10) Negative Corrections (all for this KVK)
+    ----------------------------------------------------------------
+    SELECT
+        KVK_NO, ScanID, governor_id, name, kingdom, campid,
+        field_name, value, recorded_at_utc
+    FROM KVK.KVK_Ingest_Negatives
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY ScanID, governor_id, field_name;
+END
+
+
+
+GO

--- a/sql/kvk_all_phase4_recompute_modernisation.sql
+++ b/sql/kvk_all_phase4_recompute_modernisation.sql
@@ -276,11 +276,27 @@ IF COL_LENGTH('KVK.KVK_Camp_Windowed', 'cur_contribute_gain') IS NULL
 BEGIN
 ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD [cur_contribute_gain] [bigint] NOT NULL CONSTRAINT [DF_CampWin_CurContrib] DEFAULT ((0)) WITH VALUES
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_CampWin_MaxContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Camp_Windowed]')
+      AND c.name = N'max_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD CONSTRAINT [DF_CampWin_MaxContrib] DEFAULT ((0)) FOR [max_contribute_gain]
 END
-IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[DF_CampWin_CurContrib]') AND type = 'D')
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_Camp_Windowed]')
+      AND c.name = N'cur_contribute_gain'
+)
 BEGIN
 ALTER TABLE [KVK].[KVK_Camp_Windowed] ADD CONSTRAINT [DF_CampWin_CurContrib] DEFAULT ((0)) FOR [cur_contribute_gain]
 END

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -6,13 +6,28 @@ import re
 
 import pytest
 
-SQL_REPO = Path(os.environ.get("K98_SQL_REPO", r"C:\K98-bot-SQL-Server"))
+K98_SQL_REPO_ENV = os.environ.get("K98_SQL_REPO")
+SQL_REPO = Path(K98_SQL_REPO_ENV) if K98_SQL_REPO_ENV else Path(r"C:\K98-bot-SQL-Server")
 SQL_SCHEMA = SQL_REPO / "sql_schema"
+
+
+def _running_in_ci() -> bool:
+    return any(
+        os.environ.get(name)
+        for name in ("CI", "GITHUB_ACTIONS", "BUILD_BUILDID", "TF_BUILD")
+    )
 
 
 def _sql_file(name: str) -> str:
     path = SQL_SCHEMA / name
     if not path.exists():
+        if _running_in_ci():
+            if not K98_SQL_REPO_ENV:
+                pytest.fail(
+                    "K98_SQL_REPO must be set in CI so SQL contract tests run against "
+                    f"the external SQL repository; missing expected file: {path}"
+                )
+            pytest.fail(f"SQL repo file not available in CI: {path}")
         pytest.skip(f"SQL repo file not available: {path}")
     return path.read_text(encoding="utf-8")
 

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -33,7 +33,21 @@ def _sql_file(name: str) -> str:
 
 
 def _compact(sql: str) -> str:
-    return re.sub(r"\s+", " ", sql)
+    """Collapse whitespace and normalise spacing around SQL operators/punctuation.
+
+    * Collapses all whitespace runs to a single space.
+    * Strips spaces around ``-``, ``+``, and ``,`` (arithmetic operators / argument
+      separators), so ``a - b`` and ``a-b`` are treated identically.
+    * Strips the space *after* ``(`` and *before* ``)`` so that
+      ``COALESCE( x, y )`` normalises to ``COALESCE(x,y)`` while
+      ``func(…) AS alias`` is unaffected (space after ``)`` is preserved).
+    * ``*`` is intentionally excluded so that ``SELECT *`` detection still works.
+    """
+    sql = re.sub(r"\s+", " ", sql)
+    sql = re.sub(r" *([-+,]) *", r"\1", sql)
+    sql = re.sub(r"\( *", "(", sql)
+    sql = re.sub(r" *\)", ")", sql)
+    return sql.strip()
 
 
 def test_phase4_metric_source_rules_are_documented() -> None:
@@ -80,7 +94,7 @@ def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
     ]
 
     for expression in expected_source_expressions:
-        assert expression in sql
+        assert _compact(expression) in sql
 
 
 def test_recompute_populates_contribution_outputs_and_rollups() -> None:
@@ -97,7 +111,7 @@ def test_recompute_populates_contribution_outputs_and_rollups() -> None:
     ]
 
     for token in required_tokens:
-        assert token in sql
+        assert _compact(token) in sql
 
 
 def test_export_contract_keeps_ten_result_sets_and_no_full_select_star() -> None:

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -13,8 +13,7 @@ SQL_SCHEMA = SQL_REPO / "sql_schema"
 
 def _running_in_ci() -> bool:
     return any(
-        os.environ.get(name)
-        for name in ("CI", "GITHUB_ACTIONS", "BUILD_BUILDID", "TF_BUILD")
+        os.environ.get(name) for name in ("CI", "GITHUB_ACTIONS", "BUILD_BUILDID", "TF_BUILD")
     )
 
 
@@ -79,8 +78,6 @@ def test_windowed_tables_add_contribution_columns_additively() -> None:
         sql = _sql_file(file_name)
         assert "[max_contribute_gain] [bigint] NOT NULL" in sql
         assert "[cur_contribute_gain] [bigint] NOT NULL" in sql
-        assert "COL_LENGTH" in sql
-        assert "WITH VALUES" in sql
 
 
 def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
@@ -155,6 +152,10 @@ def test_phase4_prod_sql_script_contains_all_changed_sql_objects() -> None:
         "ALTER PROCEDURE [KVK].[sp_KVK_Get_Exports]",
         "max_contribute_gain",
         "cur_contribute_gain",
+        "COL_LENGTH('KVK.KVK_Player_Windowed', 'max_contribute_gain')",
+        "COL_LENGTH('KVK.KVK_Kingdom_Windowed', 'max_contribute_gain')",
+        "COL_LENGTH('KVK.KVK_Camp_Windowed', 'max_contribute_gain')",
+        "WITH VALUES",
         "GO",
     ]
 

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+
+import pytest
+
+SQL_REPO = Path(os.environ.get("K98_SQL_REPO", r"C:\K98-bot-SQL-Server"))
+SQL_SCHEMA = SQL_REPO / "sql_schema"
+
+
+def _sql_file(name: str) -> str:
+    path = SQL_SCHEMA / name
+    if not path.exists():
+        pytest.skip(f"SQL repo file not available: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _compact(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql)
+
+
+def test_phase4_metric_source_rules_are_documented() -> None:
+    doc = Path("docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md")
+    text = doc.read_text(encoding="utf-8")
+
+    required_tokens = [
+        "`kill_points_diff` is the Full Data v2 semantic source",
+        "`points_difference` is retained as the legacy compatibility field",
+        "`healed_troops` is the Full Data v2 semantic source",
+        "`max_units_healed_diff` is retained as the legacy compatibility field",
+        "`max_contribute_gain`",
+        "`cur_contribute_gain`",
+        "They are not added to Discord reporting display, Google Sheets tab names, or export result-set ordering",
+    ]
+
+    for token in required_tokens:
+        assert token in text
+
+
+def test_windowed_tables_add_contribution_columns_additively() -> None:
+    table_files = [
+        "KVK.KVK_Player_Windowed.Table.sql",
+        "KVK.KVK_Kingdom_Windowed.Table.sql",
+        "KVK.KVK_Camp_Windowed.Table.sql",
+    ]
+
+    for file_name in table_files:
+        sql = _sql_file(file_name)
+        assert "[max_contribute_gain] [bigint] NOT NULL" in sql
+        assert "[cur_contribute_gain] [bigint] NOT NULL" in sql
+        assert "COL_LENGTH" in sql
+        assert "WITH VALUES" in sql
+
+
+def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
+    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+
+    expected_source_expressions = [
+        "COALESCE(r.kill_points_diff, r.points_difference, r.max_kill_points - r.min_kill_points, 0)",
+        "COALESCE(r.healed_troops, r.max_units_healed_diff, r.max_units_healed - r.min_units_healed, 0)",
+        "COALESCE(r.max_contribute_diff, r.max_max_contribute - r.min_max_contribute, 0)",
+        "COALESCE(r.cur_contribute_diff, r.max_cur_contribute - r.min_cur_contribute, 0)",
+    ]
+
+    for expression in expected_source_expressions:
+        assert expression in sql
+
+
+def test_recompute_populates_contribution_outputs_and_rollups() -> None:
+    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+
+    required_tokens = [
+        "max_contribute_gain, cur_contribute_gain",
+        "ISNULL(E.max_contrib_e,0)- ISNULL(S.max_contrib_s,0) AS max_contribute_gain",
+        "ISNULL(E.cur_contrib_e,0)- ISNULL(S.cur_contrib_s,0) AS cur_contribute_gain",
+        "SUM(p.max_contribute_gain) AS max_contribute_gain",
+        "SUM(p.cur_contribute_gain) AS cur_contribute_gain",
+        "K.max_contribute_gain, K.cur_contribute_gain",
+        "C.max_contribute_gain, C.cur_contribute_gain",
+    ]
+
+    for token in required_tokens:
+        assert token in sql
+
+
+def test_export_contract_keeps_ten_result_sets_and_no_full_select_star() -> None:
+    sql = _sql_file("KVK.sp_KVK_Get_Exports.StoredProcedure.sql")
+    compact = _compact(sql)
+
+    for section in range(1, 11):
+        assert f"-- {section})" in sql
+    assert "-- 11)" not in sql
+    assert "SELECT * FROM KVK.KVK_Player_Windowed" not in compact
+    assert "SELECT * FROM KVK.KVK_Kingdom_Windowed" not in compact
+    assert "SELECT * FROM KVK.KVK_Camp_Windowed" not in compact
+
+    tabs = Path("gsheet_module.py").read_text(encoding="utf-8")
+    for tab in (
+        "KVK_Scan_Log",
+        "KVK_Windows",
+        "KVK_DKP_Weights",
+        "KVK_Player_Windowed",
+        "KVK_Kingdom_Windowed",
+        "KVK_Camp_Windowed",
+        "KVK_Player_Full",
+        "KVK_Kingdom_Full",
+        "KVK_Camp_Full",
+        "KVK_Ingest_Negatives",
+    ):
+        assert f'"{tab}"' in tabs
+
+
+def test_phase4_prod_sql_script_contains_all_changed_sql_objects() -> None:
+    script = Path("sql/kvk_all_phase4_recompute_modernisation.sql").read_text(encoding="utf-8-sig")
+
+    required_tokens = [
+        "KVK_ALL Schema Modernisation - Phase 4 Recompute Modernisation",
+        "KVK.KVK_Player_Windowed.Table.sql",
+        "KVK.KVK_Kingdom_Windowed.Table.sql",
+        "KVK.KVK_Camp_Windowed.Table.sql",
+        "KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql",
+        "KVK.sp_KVK_Get_Exports.StoredProcedure.sql",
+        "ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]",
+        "ALTER PROCEDURE [KVK].[sp_KVK_Get_Exports]",
+        "max_contribute_gain",
+        "cur_contribute_gain",
+        "GO",
+    ]
+
+    for token in required_tokens:
+        assert token in script


### PR DESCRIPTION
## Summary

Implements the KVK_ALL Schema Modernisation Phase 4 PR package for the bot mirror.

## Changes

- Adds the Phase 4 initiation statement and metric source-of-truth rules documentation.
- Updates the full optimisation task pack with Phase 3 completion status and Phase 4 as the next programme phase.
- Adds `sql/kvk_all_phase4_recompute_modernisation.sql`, a production deployment script generated from the authoritative SQL repo changes.
- Adds SQL contract tests covering source precedence, additive contribution outputs, export result-set preservation, and deployment-script coverage.

## SQL Deployment Notes

The `/sql/` script is intended to replicate the Phase 4 SQL changes into production after local validation. It includes additive windowed-table contribution columns and altered recompute/export procedures while preserving export result-set order and Google Sheets tab names.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_all_recompute_sql_contract.py tests\test_kvk_all_schema.py tests\test_kvk_all_import_service.py tests\test_kvk_all_import_dal.py tests\test_kvk_all_importer.py` -> 26 passed
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py` -> passed
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py` -> passed
- `.\.venv\Scripts\python.exe scripts\select_tests.py` -> passed
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py` -> passed
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py` -> passed
- `.\.venv\Scripts\python.exe -m pytest -q tests` -> 1240 passed, 8 skipped
- `.\.venv\Scripts\python.exe -m ruff check tests\test_kvk_all_recompute_sql_contract.py` -> passed

## Deferred Optimisations

Existing later-phase items remain out of scope for this PR: export contract decoupling, reporting DAL extraction, and admin command SQL extraction.