### PR TITLE
[codex] Cap KVK window preview embed field

### DIFF
--- a/kvk/services/kvk_admin_service.py
+++ b/kvk/services/kvk_admin_service.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from kvk.dal import kvk_admin_dal
 
+DISCORD_EMBED_FIELD_VALUE_LIMIT = 1024
+
 
 @dataclass(frozen=True)
 class KvkRecomputeResult:
@@ -105,7 +107,7 @@ def format_window_preview_table(result: KvkWindowPreviewResult) -> str:
         end = _format_timestamp(row.get("EndTS"))
         lines.append(f"{name:20} {start:>16} {end:>16}")
 
-    return "```\n" + "\n".join(lines[:400]) + "\n```"
+    return _bounded_code_block(lines, max_chars=DISCORD_EMBED_FIELD_VALUE_LIMIT)
 
 
 def _format_timestamp(value: Any) -> str:
@@ -115,3 +117,31 @@ def _format_timestamp(value: Any) -> str:
         return value.strftime("%d %b %H:%M")
     except Exception:
         return "—"
+
+
+def _bounded_code_block(lines: list[str], *, max_chars: int) -> str:
+    prefix = "```\n"
+    suffix = "\n```"
+    truncation_line = "... truncated ..."
+    body_limit = max_chars - len(prefix) - len(suffix)
+
+    body = "\n".join(lines)
+    if len(body) <= body_limit:
+        return prefix + body + suffix
+
+    selected: list[str] = []
+    for index, line in enumerate(lines):
+        has_more = index < len(lines) - 1
+        candidate_lines = [*selected, line]
+        if has_more:
+            candidate_lines.append(truncation_line)
+        if len("\n".join(candidate_lines)) > body_limit:
+            break
+        selected.append(line)
+
+    if not selected:
+        selected = [truncation_line[:body_limit]]
+    elif len(selected) < len(lines):
+        selected.append(truncation_line)
+
+    return prefix + "\n".join(selected) + suffix

--- a/kvk/services/kvk_admin_service.py
+++ b/kvk/services/kvk_admin_service.py
@@ -123,7 +123,12 @@ def _bounded_code_block(lines: list[str], *, max_chars: int) -> str:
     prefix = "```\n"
     suffix = "\n```"
     truncation_line = "... truncated ..."
-    body_limit = max_chars - len(prefix) - len(suffix)
+    overhead = len(prefix) + len(suffix)
+    if max_chars < overhead:
+        raise ValueError(
+            f"max_chars must be at least {overhead} to fit the code block fences"
+        )
+    body_limit = max_chars - overhead
 
     body = "\n".join(lines)
     if len(body) <= body_limit:

--- a/kvk/services/kvk_admin_service.py
+++ b/kvk/services/kvk_admin_service.py
@@ -125,9 +125,7 @@ def _bounded_code_block(lines: list[str], *, max_chars: int) -> str:
     truncation_line = "... truncated ..."
     overhead = len(prefix) + len(suffix)
     if max_chars < overhead:
-        raise ValueError(
-            f"max_chars must be at least {overhead} to fit the code block fences"
-        )
+        raise ValueError(f"max_chars must be at least {overhead} to fit the code block fences")
     body_limit = max_chars - overhead
 
     body = "\n".join(lines)

--- a/tests/test_kvk_admin_service.py
+++ b/tests/test_kvk_admin_service.py
@@ -113,7 +113,7 @@ def test_window_preview_table_respects_discord_field_limit() -> None:
 
     table = kvk_admin_service.format_window_preview_table(result)
 
-    assert len(table) <= 1024
+    assert len(table) <= kvk_admin_service.DISCORD_EMBED_FIELD_VALUE_LIMIT
     assert table.startswith("```\n")
     assert table.endswith("\n```")
     assert "... truncated ..." in table

--- a/tests/test_kvk_admin_service.py
+++ b/tests/test_kvk_admin_service.py
@@ -89,3 +89,31 @@ def test_load_window_preview_detects_bad_ranges_and_formats_table(monkeypatch) -
     assert "Pass 4" in table
     assert "Full" in table
     assert "open" in table
+
+
+def test_window_preview_table_respects_discord_field_limit() -> None:
+    rows = [
+        {
+            "WindowName": f"Window {index:03d}",
+            "StartScanID": index,
+            "EndScanID": index + 1,
+            "StartTS": datetime(2026, 5, 1, 1, 0),
+            "EndTS": datetime(2026, 5, 1, 2, 0),
+            "NumScans": 2,
+            "RowCount": 1000 + index,
+        }
+        for index in range(80)
+    ]
+    result = kvk_admin_service.KvkWindowPreviewResult(
+        kvk_no=13,
+        rows=rows,
+        bad_ranges=[],
+        generated_at_utc=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+
+    table = kvk_admin_service.format_window_preview_table(result)
+
+    assert len(table) <= 1024
+    assert table.startswith("```\n")
+    assert table.endswith("\n```")
+    assert "... truncated ..." in table


### PR DESCRIPTION
## Summary

Fixes `/kvk_window_preview` failing when the generated preview table exceeds Discord's 1024-character embed field limit.

## Changes

- Adds a bounded code-block formatter for the KVK window preview table.
- Preserves the existing monospace table shape and appends `... truncated ...` when not all rows fit.
- Adds regression coverage to ensure the formatted field value stays within Discord's limit.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_admin_service.py tests/test_stats_cmds.py`
- `.\.venv\Scripts\python.exe -m black --check kvk\services\kvk_admin_service.py tests\test_kvk_admin_service.py`
- `.\.venv\Scripts\python.exe -m ruff check kvk\services\kvk_admin_service.py tests\test_kvk_admin_service.py`
- `.\.venv\Scripts\python.exe -m pyright kvk\services\kvk_admin_service.py tests\test_kvk_admin_service.py`

## Notes

No SQL, export, Google Sheets, reporting display, or command permission changes are included.