### PR TITLE
[codex] Add KVK ingest retention diagnostics

### DIFF
--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -33,6 +33,8 @@ Phase 5 is complete and deployed.
 
 Phase 6 is complete and deployed.
 
+Phase 7 is complete and deployed.
+
 Completed Phase 1 scope:
 
 strict Full Data workbook detection
@@ -77,9 +79,28 @@ non-mutating workbook/service smoke validation completed against the uploaded sa
 
 Phase 3 did not change SQL schema, recompute formulas, export result-set order, Google Sheets tab names, Discord reporting display, admin command SQL ownership, or reporting DAL ownership.
 
+Completed Phase 7 scope:
+
+KVK admin SQL moved out of commands/stats_cmds.py for the Phase 7 in-scope admin workflows
+KVK admin data access added in kvk/dal/kvk_admin_dal.py
+KVK admin orchestration and command-facing result shaping added in kvk/services/kvk_admin_service.py
+/kvk_recompute delegates recompute execution through the KVK admin service and DAL
+/kvk_list_scans delegates recent scan loading and response table formatting through the KVK admin service and DAL
+/kvk_window_preview delegates window preview loading through the KVK admin service and DAL
+/kvk_export_all current-KVK resolution delegates through the KVK admin service and preserves existing Google Sheets export execution
+command names, permissions, defer/followup behaviour, output copy, and operator workflow were preserved
+SQL Server RowCount alias compatibility was fixed with [RowCount]
+window preview embed output was capped to Discord's 1024-character field limit with a truncation marker
+focused tests added for DAL/service result shape, command boundary handoff, SQL alias coverage, and window preview embed field limit
+local smoke confirmed /kvk_export_all completes successfully
+/kvk_window_preview smoke issues found during validation were fixed in follow-up PRs
+the unrelated /my_stats_export direct SQL finding was captured structurally in docs/deferred_optimisations.md
+
+Phase 7 did not change SQL schema, import behaviour, recompute semantics, export result-set contracts, Google Sheets tab names, Discord reporting display, Basic Data ingestion, summary tab ingestion, or Phase 5/6 service boundaries.
+
 Next phase:
 
-Phase 7 — Admin Command SQL Extraction
+Phase 8 — Operational Cleanup & Retention
 
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
@@ -773,6 +794,9 @@ Production deployment completed after local validation and smoke testing.
 
 No SQL schema changes, Google Sheets export contract changes, admin command SQL extraction, Basic Data ingestion, summary-tab ingestion, or unrelated rankings/history/personal KVK redesign were included in Phase 6.
 Phase 7 — Admin Command SQL Extraction
+Status
+Complete and deployed.
+
 Goal
 Remove KVK admin SQL from command modules.
 
@@ -795,6 +819,51 @@ Commands are thin.
 Direct SQL is removed from command handlers.
 Permission/defer/response behaviour remains unchanged.
 Tests cover service handoff and core service logic.
+
+Completion Notes
+Implemented:
+
+commands/stats_cmds.py
+kvk/dal/kvk_admin_dal.py
+kvk/services/kvk_admin_service.py
+tests/test_kvk_admin_service.py
+tests/test_stats_cmds.py
+docs/KVK_ALL Schema Modernisation — Phase 7 Initiation Statement.md
+
+Python delivery:
+
+KVK admin command SQL for recompute, recent scan listing, and window preview was moved out of commands/stats_cmds.py.
+KVK admin data access now lives in kvk/dal/kvk_admin_dal.py.
+KVK admin orchestration and command-facing result shaping now lives in kvk/services/kvk_admin_service.py.
+commands/stats_cmds.py remains responsible for Discord permissions, safe defer/followup flow, command inputs, and response rendering.
+/kvk_export_all keeps the existing Google Sheets export execution path and delegates current-KVK resolution through the KVK admin service.
+/kvk_export_all now reports export exceptions back to the operator instead of failing silently.
+/kvk_window_preview preserves the existing embed/table shape and caps the field value to Discord's 1024-character embed field limit, appending a truncation marker when needed.
+SQL Server compatibility for the window preview row-count alias was fixed by bracketing [RowCount].
+
+Validation completed:
+
+python -m pytest -q tests/test_kvk_admin_service.py tests/test_stats_cmds.py
+python -m pytest -q tests/test_kvk_admin_service.py tests/test_stats_cmds.py tests/test_stats_service.py tests/test_mykvkstats.py
+python -m black --check commands/stats_cmds.py kvk/dal/kvk_admin_dal.py kvk/services/kvk_admin_service.py tests/test_kvk_admin_service.py tests/test_stats_cmds.py
+python -m ruff check commands/stats_cmds.py kvk/dal/kvk_admin_dal.py kvk/services/kvk_admin_service.py tests/test_kvk_admin_service.py tests/test_stats_cmds.py
+python -m py_compile commands/stats_cmds.py kvk/dal/kvk_admin_dal.py kvk/services/kvk_admin_service.py tests/test_kvk_admin_service.py tests/test_stats_cmds.py
+python -m pyright kvk/dal/kvk_admin_dal.py kvk/services/kvk_admin_service.py tests/test_kvk_admin_service.py tests/test_stats_cmds.py
+python scripts/validate_architecture_boundaries.py
+python scripts/validate_deferred_items.py
+python scripts/select_tests.py
+python scripts/smoke_imports.py
+python scripts/validate_command_registration.py
+git diff --check
+
+Smoke validation completed:
+
+/kvk_export_all completed successfully after Phase 7 deployment.
+/kvk_window_preview initially surfaced a SQL Server RowCount alias issue; fixed in the Phase 7 follow-up hotfix.
+/kvk_window_preview then surfaced a Discord 1024-character embed field limit issue; fixed in the Phase 7 follow-up hotfix.
+
+No SQL schema changes, Google Sheets export contract changes, KVK export result-set changes, Discord reporting display changes, Basic Data ingestion, summary tab ingestion, operational retention cleanup, or end-to-end performance/restart hardening were included in Phase 7.
+
 Phase 8 — Operational Cleanup & Retention
 Goal
 Make ingest diagnostics and failed stage rows operationally safe.

--- a/docs/KVK_ALL Schema Modernisation — Phase 8 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 8 Initiation Statement.md
@@ -1,0 +1,263 @@
+KVK_ALL Schema Modernisation — Phase 8 Initiation Statement
+
+We are starting Phase 8 of the KVK_ALL Schema Modernisation programme.
+
+Important local documentation note:
+
+The Phase 7 completion update to docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md and this Phase 8 initiation statement were created locally after Phase 7 was completed and deployed.
+
+Do not amend the Phase 7 PR or Phase 7 follow-up hotfix PR for these documentation updates.
+
+These local documentation changes must be included in the next PR opened for Phase 8.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 4 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md
+docs/KVK_ALL Schema Modernisation — Phase 5 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 6 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 7 Initiation Statement.md
+
+Also read the uploaded workbook sample:
+
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, aggregate functions, diagnostic tables, retention scripts, and migration scripts. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 2 is complete and deployed.
+
+Phase 2 delivered:
+
+additive SQL capacity for the KVK_ALL Full Data workbook schema
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Raw
+queryable schema/source metadata on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+Python staging support for rank, raw min/max metric families, contribution metrics, and source metadata
+focused schema/import SQL contract tests
+production deployment script under sql/kvk_all_phase2_full_data_capacity.sql
+non-mutating workbook/importer smoke validation
+read-only SQL metadata smoke validation after deployment
+
+Phase 3 is complete and deployed.
+
+Phase 3 delivered:
+
+kvk_all_importer.py reduced to a compatibility wrapper around service and DAL layers
+workbook parsing, Full Data selection, aliasing, schema validation, canonical mapping, coercion, and source metadata moved into kvk/services/kvk_all_import_service.py
+stage column ordering, SQL staging, stage schema preflight, ingest procedure call, recompute call, KVK timestamp precheck, diagnostic writing, and negative count reads moved into kvk/dal/kvk_all_import_dal.py
+Full Data v2 canonical mapping constants moved into kvk/schemas/kvk_all_schema.py
+structured schema and coercion failures preserved
+legacy import return dictionary shape preserved for DL_bot.py
+Phase 2 schema/source metadata staging and ingest parameters preserved
+unknown column reporting retained in schema metadata without changing Discord output
+focused tests added for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviours
+non-mutating workbook/service smoke validation completed against the uploaded sample workbook
+
+Phase 4 is complete and deployed.
+
+Phase 4 delivered:
+
+metric source-of-truth rules documented for kill points, healed troops, raw min/max metric fields, and contribution metrics
+Full Data v2 recompute precedence implemented for kill points using kill_points_diff with legacy/raw fallback
+Full Data v2 recompute precedence implemented for healed troops using healed_troops with legacy/raw fallback
+raw min/max fields retained as validation/reconciliation inputs and fallback inputs rather than replacing stable output semantics
+additive max_contribute_gain and cur_contribute_gain outputs on KVK.KVK_Player_Windowed, KVK.KVK_Kingdom_Windowed, and KVK.KVK_Camp_Windowed
+KVK.sp_KVK_Recompute_Windows updated to populate contribution gains while preserving existing KP, kills, deads, healed, DKP, baseline, kingdom, and camp outputs
+KVK.sp_KVK_Get_Exports kept at 10 result sets and adjusted to keep Full export output columns explicit
+Google Sheets tab names and Discord reporting display unchanged
+production replication script added under sql/kvk_all_phase4_recompute_modernisation.sql
+focused SQL contract tests added for source precedence, additive contribution columns, export contract preservation, and production SQL script coverage
+
+Phase 5 is complete and deployed.
+
+Phase 5 delivered:
+
+stable named KVK export sections for KVK.sp_KVK_Get_Exports outputs
+legacy positional export compatibility retained while current callers migrate
+primary KVK Google Sheets export binding moved away from fragile fixed DataFrame index assumptions
+additional PASS, ALTAR, GREATZIG, and comparison spreadsheet generation updated to use named export-section binding
+compatible extra SQL result sets can be ignored when all required export sections are present
+existing primary spreadsheet tab names preserved
+existing additional spreadsheet names and tab names preserved
+ALL_WINDOW_COMPARISON tab names preserved with no new contribution comparison tabs
+max_contribute_gain and cur_contribute_gain exported in existing player, kingdom, and camp windowed/full export sections
+KVK.sp_KVK_Get_Exports kept at 10 result sets with existing section order preserved
+local production deployment script added under sql/kvk_all_phase5_export_contract_decoupling.sql
+focused tests added for named binding, backward compatibility, compatible extra result sets, missing-section failures, tab-name stability, and contribution export behaviour
+read-only SQL smoke confirmed the applied procedure contract
+Google Sheets smoke confirmed stable primary/additional/comparison tab behaviour
+production promotion completed after validation
+
+Phase 6 is complete and deployed.
+
+Phase 6 delivered:
+
+KVK all-kingdom reporting SQL moved out of stats_alerts/allkingdoms.py
+reporting data access moved into kvk/dal/kvk_reporting_dal.py
+reporting block orchestration and row shaping moved into kvk/services/kvk_reporting_service.py
+stats_alerts/allkingdoms.py preserved as a thin compatibility wrapper around load_allkingdom_blocks(kvk_no)
+existing Discord embed display, field names, links, titles, Top 5 layout, and truncation behaviour preserved
+max_contribute_gain and cur_contribute_gain made available in structured reporting rows where SQL supports them
+contribution metrics intentionally not displayed in Discord embeds
+focused tests added for reporting block shape, SQL placement, contribution availability, embed compatibility, and truncation stability
+read-only SQL smoke confirmed structured reporting block availability
+Discord test embed smoke confirmed existing display remained stable
+production deployment completed after validation
+
+Phase 7 is complete and deployed.
+
+Phase 7 delivered:
+
+KVK admin command SQL moved out of commands/stats_cmds.py for recompute, scan listing, and window preview workflows
+KVK admin data access moved into kvk/dal/kvk_admin_dal.py
+KVK admin orchestration and command-facing result shaping moved into kvk/services/kvk_admin_service.py
+commands/stats_cmds.py preserved command names, permissions, defer/followup flow, output copy, export behaviour, and operator workflow
+/kvk_export_all current-KVK resolution moved through the KVK admin service while preserving existing Google Sheets export execution
+/kvk_export_all exception reporting hardened so export failures are visible to the operator
+/kvk_window_preview SQL Server RowCount alias compatibility fixed
+/kvk_window_preview output capped to Discord's 1024-character embed field limit with a truncation marker
+focused tests added for DAL/service result shape, command boundary handoff, SQL alias coverage, and embed field limit behaviour
+/kvk_export_all smoke completed successfully
+/kvk_window_preview smoke issues were fixed in Phase 7 follow-up hotfixes
+
+Phases 1 through 7 did not introduce Basic Data ingestion, summary tab ingestion, Discord contribution display, incompatible Google Sheets tab/spreadsheet changes, KVK export result-set changes, or unrelated admin command redesign.
+
+Phase 8 objective:
+
+Make KVK_ALL ingest diagnostics and failed stage rows operationally safe by defining retention, cleanup, and audit visibility for diagnostic data while preserving import, recompute, export, reporting, and admin command behaviour.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data remains out of scope and intentionally ignored.
+
+In scope:
+
+review current KVK ingest diagnostic and staging failure behaviour before implementation
+validate all referenced diagnostic, stage, ingest, scan, and metadata objects against the SQL repo
+define a retention policy for failed stage rows and diagnostic records
+add cleanup capability for stale failed stage rows or diagnostics if needed
+ensure cleanup does not remove active ingest tokens or recent actionable diagnostics
+make ingest audit visibility clearer where practical
+include schema/source metadata in diagnostics where supported by existing Phase 2/3 metadata
+include failed column validation context where practical without changing Discord import output unless required for error clarity
+avoid unbounded growth of diagnostic data
+keep changes PR-sized and rollback-safe
+add focused tests or validation for retention/cleanup selection logic and diagnostic shape where practical
+capture new out-of-scope findings structurally
+include the local Phase 7 task-pack update and this Phase 8 initiation statement in the next PR
+
+Likely SQL objects to review:
+
+KVK.KVK_AllPlayers_Stage
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Scan
+KVK.KVK_Ingest_Negatives
+KVK.sp_KVK_AllPlayers_Ingest
+dbo.KVK_Details
+any KVK.KVK_Ingest_* diagnostic objects or scripts found in the SQL repo
+
+Likely Python modules to review and possibly update:
+
+kvk/dal/kvk_all_import_dal.py
+kvk/services/kvk_all_import_service.py
+kvk_all_importer.py
+DL_bot.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_import_service.py
+tests/test_kvk_all_importer.py
+scripts/
+sql/
+
+Likely modules to review for downstream contract awareness, but not redesign unless required:
+
+commands/stats_cmds.py
+kvk/dal/kvk_admin_dal.py
+kvk/services/kvk_admin_service.py
+kvk/services/kvk_export_service.py
+kvk/dal/kvk_reporting_dal.py
+kvk/services/kvk_reporting_service.py
+gsheet_module.py
+stats_alerts/allkingdoms.py
+stats_alerts/embeds/kvk.py
+
+Out of scope for Phase 8:
+
+Discord reporting display changes
+new contribution fields in Discord embeds
+Google Sheets export contract changes
+KVK export result-set changes
+Basic Data ingestion
+summary tab ingestion
+admin command SQL extraction beyond Phase 7 follow-up fixes
+new live production imports, recomputes, exports, cleanup, or reporting posts unless explicitly requested
+production promotion before local validation
+rewriting unrelated stats, rankings, history, reporting, personal KVK, or admin command flows
+end-to-end performance and restart hardening assigned to Phase 9
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Preserve existing import behaviour and return shape.
+Preserve existing Google Sheets export behaviour.
+Preserve existing Discord embed/reporting output.
+Do not silently change diagnostic retention semantics.
+Do not delete diagnostics or staged rows without a clear retention rule.
+Avoid embedded SQL in command/view/presentation layers.
+Prefer service and DAL boundaries.
+Use additive, rollback-safe SQL changes only if SQL changes become necessary.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact diagnostic/staging data dependencies and retention risks.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 8 operational cleanup and retention work.
+Run targeted validation.
+Stop after Phase 8 implementation, tests, and report.
+
+Acceptance criteria:
+
+Failed ingest diagnostics are inspectable.
+Old diagnostics or failed staged rows can be cleaned safely according to a documented rule.
+Cleanup does not remove active ingest tokens or recent actionable diagnostics.
+Diagnostic context includes schema/source metadata where supported by the current pipeline.
+Failed column validation context is preserved or improved where practical.
+Existing import, recompute, export, Google Sheets, admin command, and Discord reporting behaviour remains stable.
+No Basic Data or summary tab ingestion is introduced.
+Tests or validation cover retention/cleanup selection and diagnostic shape where practical.
+New deferred findings are captured structurally, but all known KVK_ALL work remains assigned to later programme phases rather than left as final deferred debt.

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -42,3 +42,12 @@
 - Impact: medium
 - Risk: medium
 - Dependencies: Future stats command cleanup; preserve existing Excel/CSV/Google Sheets-compatible output copy and file workflow.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` KVK_ALL upload routing
+- Type: architecture
+- Description: KVK_ALL upload routing still lives in the legacy root bot listener with attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling mixed together.
+- Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to Phase 9.

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -117,6 +117,18 @@ CALL_INGEST_SQL = """
 RECOMPUTE_SQL = "EXEC KVK.sp_KVK_Recompute_Windows @KVK_NO=?;"
 NEGATIVE_COUNT_SQL = "SELECT COUNT(*) FROM KVK.KVK_Ingest_Negatives WHERE KVK_NO=? AND ScanID=?;"
 DELETE_STAGED_TOKEN_SQL = "DELETE FROM KVK.KVK_AllPlayers_Stage WHERE IngestToken=?;"
+INSERT_INGEST_DIAGNOSTIC_SQL = """
+ INSERT INTO KVK.KVK_Ingest_Diagnostics
+ (
+   DiagnosticStatus, DiagnosticType, IngestToken, KVK_NO, ScanID,
+   SourceFileName, FileHashSha256, UploaderDiscordID,
+   SchemaVersion, SourceSheetName, SourceColumnHash,
+   SourceColumnCount, SourceRowCount, StagedRowCount,
+   ErrorText, ContextJson
+ )
+ OUTPUT INSERTED.DiagnosticID
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+ """
 
 
 def connect_sql_server(
@@ -177,6 +189,76 @@ def write_ingest_diag(token: str, note: str, context: dict[str, Any]) -> str | N
         return filename
     except Exception:
         logger.exception("Failed to write ingest diagnostic file")
+        return None
+
+
+def record_ingest_diagnostic(
+    con: pyodbc.Connection,
+    *,
+    status: str,
+    diagnostic_type: str,
+    ingest_token: str | None = None,
+    kvk_no: int | None = None,
+    scan_id: int | None = None,
+    source_filename: str | None = None,
+    file_hash_hex: str | None = None,
+    uploader_id: int | None = None,
+    schema_metadata: dict[str, Any] | None = None,
+    sheet_name: str | None = None,
+    staged_rows: int | None = None,
+    error_text: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> int | None:
+    """Best-effort durable KVK ingest diagnostic write.
+
+    Phase 8 SQL may not be deployed everywhere at the same time as Python, so
+    diagnostic write failures are intentionally logged and suppressed.
+    """
+    metadata = schema_metadata or {}
+    context_payload = json.dumps(context or {}, ensure_ascii=False, default=str)
+    try:
+        cur = con.cursor()
+        cur.execute(
+            INSERT_INGEST_DIAGNOSTIC_SQL,
+            (
+                status,
+                diagnostic_type[:64],
+                ingest_token,
+                kvk_no,
+                scan_id,
+                source_filename[:255] if source_filename else None,
+                file_hash_hex[:64] if file_hash_hex else None,
+                int(uploader_id) if uploader_id is not None else None,
+                str(metadata.get("schema_version") or SCHEMA_VERSION)[:64],
+                str(sheet_name or metadata.get("sheet_name") or "")[:128] or None,
+                str(metadata.get("column_hash") or "")[:64] or None,
+                metadata.get("column_count"),
+                metadata.get("row_count") or metadata.get("source_row_count") or staged_rows,
+                staged_rows,
+                str(error_text or "")[:1000] or None,
+                context_payload,
+            ),
+        )
+        row = cur.fetchone()
+        con.commit()
+        diagnostic_id = int(row[0]) if row and row[0] is not None else None
+        logger.info(
+            "[KVK] ingest diagnostic recorded id=%s status=%s type=%s token=%s file=%s",
+            diagnostic_id,
+            status,
+            diagnostic_type,
+            ingest_token,
+            source_filename,
+        )
+        return diagnostic_id
+    except Exception:
+        logger.exception(
+            "[KVK] failed to record ingest diagnostic status=%s type=%s token=%s file=%s",
+            status,
+            diagnostic_type,
+            ingest_token,
+            source_filename,
+        )
         return None
 
 
@@ -253,6 +335,7 @@ def ingest_prepared_import(
     logger.info("[KVK] DF col order now: %s", list(df.columns))
 
     file_hash = hashlib.sha256(content).digest()
+    file_hash_hex = hashlib.sha256(content).hexdigest()
     scan_ts_utc = ensure_aware_utc(scan_ts_utc)
     scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
 
@@ -272,6 +355,7 @@ def ingest_prepared_import(
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,
             "staged_rows": staged_rows,
+            "schema": schema_metadata,
             "sample_row": {},
             "cleanup_failed": cleanup_failed,
         }
@@ -283,6 +367,20 @@ def ingest_prepared_import(
         except Exception:
             pass
         diag = write_ingest_diag(token, "scan timestamp outside KVK_Details ranges", context)
+        diagnostic_id = record_ingest_diagnostic(
+            con,
+            status="rejected",
+            diagnostic_type="scan_timestamp_outside_kvk_details",
+            ingest_token=token,
+            source_filename=source_filename,
+            file_hash_hex=file_hash_hex,
+            uploader_id=uploader_id,
+            schema_metadata=schema_metadata,
+            sheet_name=sheet_name,
+            staged_rows=staged_rows,
+            error_text="Scan timestamp outside KVK_Details ranges.",
+            context=context,
+        )
         message = (
             f"Scan timestamp {scan_ts_naive!s} does not fall within any configured "
             f"KVK_Details range. Diagnostic: {diag}"
@@ -295,29 +393,56 @@ def ingest_prepared_import(
             "offending_scan_ts": str(scan_ts_naive),
             "cleanup_failed": cleanup_failed,
             "cleanup_error": cleanup_error,
+            "diagnostic_id": diagnostic_id,
         }
 
     cur = con.cursor()
     ingest_started = time.perf_counter()
-    cur.execute(
-        CALL_INGEST_SQL,
-        (
-            token,
-            scan_ts_naive,
-            source_filename,
-            file_hash,
-            int(uploader_id),
-            schema_metadata.get("schema_version") or SCHEMA_VERSION,
-            sheet_name,
-            schema_metadata.get("column_hash"),
-            schema_metadata.get("column_count"),
-            staged_rows,
-        ),
-    )
-    rows = cur.fetchall()
-    ingest_ms = (time.perf_counter() - ingest_started) * 1000.0
-    if not rows:
-        raise RuntimeError("Ingest returned no outputs.")
+    try:
+        cur.execute(
+            CALL_INGEST_SQL,
+            (
+                token,
+                scan_ts_naive,
+                source_filename,
+                file_hash,
+                int(uploader_id),
+                schema_metadata.get("schema_version") or SCHEMA_VERSION,
+                sheet_name,
+                schema_metadata.get("column_hash"),
+                schema_metadata.get("column_count"),
+                staged_rows,
+            ),
+        )
+        rows = cur.fetchall()
+        ingest_ms = (time.perf_counter() - ingest_started) * 1000.0
+        if not rows:
+            raise RuntimeError("Ingest returned no outputs.")
+    except Exception as exc:
+        ingest_ms = (time.perf_counter() - ingest_started) * 1000.0
+        context = {
+            "scan_ts_naive": str(scan_ts_naive),
+            "source_filename": source_filename,
+            "staged_rows": staged_rows,
+            "ingest_ms": ingest_ms,
+            "schema": schema_metadata,
+            "stage_retention": "staged rows are retained for inspection until Phase 8 cleanup",
+        }
+        record_ingest_diagnostic(
+            con,
+            status="failed",
+            diagnostic_type="ingest_procedure_failed",
+            ingest_token=token,
+            source_filename=source_filename,
+            file_hash_hex=file_hash_hex,
+            uploader_id=uploader_id,
+            schema_metadata=schema_metadata,
+            sheet_name=sheet_name,
+            staged_rows=staged_rows,
+            error_text=f"{type(exc).__name__}: {exc}",
+            context=context,
+        )
+        raise
     kvk_no, scan_id, row_count = rows[0]
     con.commit()
 

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -334,8 +334,9 @@ def ingest_prepared_import(
     logger.info("[KVK] Final stage col order: %s", STAGE_COL_ORDER)
     logger.info("[KVK] DF col order now: %s", list(df.columns))
 
-    file_hash = hashlib.sha256(content).digest()
-    file_hash_hex = hashlib.sha256(content).hexdigest()
+    file_hash_obj = hashlib.sha256(content)
+    file_hash = file_hash_obj.digest()
+    file_hash_hex = file_hash_obj.hexdigest()
     scan_ts_utc = ensure_aware_utc(scan_ts_utc)
     scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
 

--- a/kvk_all_importer.py
+++ b/kvk_all_importer.py
@@ -76,6 +76,13 @@ def ingest_kvk_all_excel(
             "sheet": exc.sheet_name,
             "schema_version": SCHEMA_VERSION,
             "schema": exc.schema_metadata,
+            "validation_error": {
+                "code": "full_data_coercion_failed",
+                "message": str(exc),
+                "schema_version": SCHEMA_VERSION,
+                "sheet_name": exc.sheet_name,
+                "schema": exc.schema_metadata,
+            },
         }
     except ValueError as exc:
         logger.info("[KVK] Import failed for %s: %s", source_filename, exc)

--- a/sql/kvk_all_phase8_ingest_retention.sql
+++ b/sql/kvk_all_phase8_ingest_retention.sql
@@ -35,9 +35,12 @@ END
 
 IF NOT EXISTS (
     SELECT 1
-    FROM sys.objects
-    WHERE object_id = OBJECT_ID(N'[KVK].[DF_KVK_AllPlayers_Stage_StagedAtUTC]')
-      AND type = 'D'
+    FROM sys.default_constraints dc
+    INNER JOIN sys.columns c
+        ON c.object_id = dc.parent_object_id
+       AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID(N'[KVK].[KVK_AllPlayers_Stage]')
+      AND c.name = N'staged_at_utc'
 )
 BEGIN
     ALTER TABLE [KVK].[KVK_AllPlayers_Stage]

--- a/sql/kvk_all_phase8_ingest_retention.sql
+++ b/sql/kvk_all_phase8_ingest_retention.sql
@@ -1,0 +1,246 @@
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+GO
+
+/*
+KVK_ALL Schema Modernisation - Phase 8 Ingest Diagnostics & Retention
+
+Purpose:
+- Add durable ingest diagnostic visibility for failed/rejected KVK_ALL imports.
+- Add an age-based cleanup path for stale staged rows and old diagnostics.
+- Preserve current ingest, recompute, export, Google Sheets, admin command, and Discord behaviour.
+
+Retention policy:
+- Staged rows are transient and may be cleaned after 24 hours by default.
+- Ingest diagnostics are retained for 90 days by default.
+- Negative correction diagnostics are retained for 365 days by default.
+- Cleanup defaults to dry-run and refuses sub-1-hour stage retention.
+*/
+
+IF OBJECT_ID(N'[KVK].[KVK_AllPlayers_Stage]', N'U') IS NULL
+    THROW 51001, 'Required table KVK.KVK_AllPlayers_Stage does not exist.', 1;
+
+IF OBJECT_ID(N'[KVK].[KVK_Ingest_Negatives]', N'U') IS NULL
+    THROW 51002, 'Required table KVK.KVK_Ingest_Negatives does not exist.', 1;
+
+PRINT N'Applying KVK.KVK_AllPlayers_Stage staged_at_utc retention marker';
+
+IF COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'staged_at_utc') IS NULL
+BEGIN
+    ALTER TABLE [KVK].[KVK_AllPlayers_Stage]
+    ADD [staged_at_utc] [datetime2](0) NOT NULL
+        CONSTRAINT [DF_KVK_AllPlayers_Stage_StagedAtUTC] DEFAULT (sysutcdatetime())
+        WITH VALUES;
+END
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.objects
+    WHERE object_id = OBJECT_ID(N'[KVK].[DF_KVK_AllPlayers_Stage_StagedAtUTC]')
+      AND type = 'D'
+)
+BEGIN
+    ALTER TABLE [KVK].[KVK_AllPlayers_Stage]
+    ADD CONSTRAINT [DF_KVK_AllPlayers_Stage_StagedAtUTC]
+    DEFAULT (sysutcdatetime()) FOR [staged_at_utc];
+END
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'[KVK].[KVK_AllPlayers_Stage]')
+      AND name = N'IX_KVK_AllPlayers_Stage_StagedAt'
+)
+CREATE NONCLUSTERED INDEX [IX_KVK_AllPlayers_Stage_StagedAt]
+ON [KVK].[KVK_AllPlayers_Stage] ([staged_at_utc] ASC)
+INCLUDE ([IngestToken]);
+
+PRINT N'Applying KVK.KVK_Ingest_Diagnostics';
+
+IF OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]', N'U') IS NULL
+BEGIN
+CREATE TABLE [KVK].[KVK_Ingest_Diagnostics](
+    [DiagnosticID] [bigint] IDENTITY(1,1) NOT NULL,
+    [CreatedUTC] [datetime2](0) NOT NULL,
+    [DiagnosticStatus] [varchar](20) COLLATE Latin1_General_CI_AS NOT NULL,
+    [DiagnosticType] [nvarchar](64) COLLATE Latin1_General_CI_AS NOT NULL,
+    [IngestToken] [uniqueidentifier] NULL,
+    [KVK_NO] [int] NULL,
+    [ScanID] [int] NULL,
+    [SourceFileName] [nvarchar](255) COLLATE Latin1_General_CI_AS NULL,
+    [FileHashSha256] [char](64) COLLATE Latin1_General_CI_AS NULL,
+    [UploaderDiscordID] [bigint] NULL,
+    [SchemaVersion] [nvarchar](64) COLLATE Latin1_General_CI_AS NULL,
+    [SourceSheetName] [nvarchar](128) COLLATE Latin1_General_CI_AS NULL,
+    [SourceColumnHash] [char](64) COLLATE Latin1_General_CI_AS NULL,
+    [SourceColumnCount] [int] NULL,
+    [SourceRowCount] [int] NULL,
+    [StagedRowCount] [int] NULL,
+    [ErrorText] [nvarchar](1000) COLLATE Latin1_General_CI_AS NULL,
+    [ContextJson] [nvarchar](max) COLLATE Latin1_General_CI_AS NULL,
+ CONSTRAINT [PK_KVK_Ingest_Diagnostics] PRIMARY KEY CLUSTERED
+(
+    [DiagnosticID] ASC
+) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF,
+        ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF)
+);
+END
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.objects
+    WHERE object_id = OBJECT_ID(N'[KVK].[DF_KVK_IngestDiag_CreatedUTC]')
+      AND type = 'D'
+)
+BEGIN
+    ALTER TABLE [KVK].[KVK_Ingest_Diagnostics]
+    ADD CONSTRAINT [DF_KVK_IngestDiag_CreatedUTC]
+    DEFAULT (sysutcdatetime()) FOR [CreatedUTC];
+END
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.check_constraints
+    WHERE object_id = OBJECT_ID(N'[KVK].[CK_KVK_IngestDiag_Status]')
+      AND parent_object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+)
+ALTER TABLE [KVK].[KVK_Ingest_Diagnostics] WITH CHECK
+ADD CONSTRAINT [CK_KVK_IngestDiag_Status]
+CHECK ([DiagnosticStatus] IN ('failed', 'rejected', 'cleanup'));
+
+IF EXISTS (
+    SELECT 1
+    FROM sys.check_constraints
+    WHERE object_id = OBJECT_ID(N'[KVK].[CK_KVK_IngestDiag_Status]')
+      AND parent_object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+)
+ALTER TABLE [KVK].[KVK_Ingest_Diagnostics] CHECK CONSTRAINT [CK_KVK_IngestDiag_Status];
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+      AND name = N'IX_KVK_IngestDiag_Status_Created'
+)
+CREATE NONCLUSTERED INDEX [IX_KVK_IngestDiag_Status_Created]
+ON [KVK].[KVK_Ingest_Diagnostics] ([DiagnosticStatus] ASC, [CreatedUTC] DESC)
+INCLUDE ([DiagnosticType], [KVK_NO], [ScanID], [SourceFileName], [SchemaVersion], [SourceSheetName]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+      AND name = N'IX_KVK_IngestDiag_Token'
+)
+CREATE NONCLUSTERED INDEX [IX_KVK_IngestDiag_Token]
+ON [KVK].[KVK_Ingest_Diagnostics] ([IngestToken] ASC, [CreatedUTC] DESC)
+INCLUDE ([DiagnosticStatus], [DiagnosticType], [SourceFileName], [StagedRowCount]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+      AND name = N'IX_KVK_IngestDiag_KVK_Scan'
+)
+CREATE NONCLUSTERED INDEX [IX_KVK_IngestDiag_KVK_Scan]
+ON [KVK].[KVK_Ingest_Diagnostics] ([KVK_NO] ASC, [ScanID] ASC, [CreatedUTC] DESC)
+INCLUDE ([DiagnosticStatus], [DiagnosticType], [SourceFileName]);
+
+PRINT N'Applying KVK.sp_KVK_Ingest_Cleanup';
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.objects
+    WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_Ingest_Cleanup]')
+      AND type in (N'P', N'PC')
+)
+BEGIN
+    EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Ingest_Cleanup] AS';
+END
+GO
+
+ALTER PROCEDURE [KVK].[sp_KVK_Ingest_Cleanup]
+    @StageRetentionHours [int] = 24,
+    @DiagnosticRetentionDays [int] = 90,
+    @NegativeRetentionDays [int] = 365,
+    @DryRun [bit] = 1,
+    @NowUTC [datetime2](0) = NULL
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF @StageRetentionHours IS NULL OR @StageRetentionHours < 1
+        THROW 51010, 'Stage retention must be at least 1 hour.', 1;
+    IF @DiagnosticRetentionDays IS NULL OR @DiagnosticRetentionDays < 1
+        THROW 51011, 'Diagnostic retention must be at least 1 day.', 1;
+    IF @NegativeRetentionDays IS NULL OR @NegativeRetentionDays < 1
+        THROW 51012, 'Negative diagnostic retention must be at least 1 day.', 1;
+
+    DECLARE @EffectiveNow datetime2(0) = COALESCE(@NowUTC, SYSUTCDATETIME());
+    DECLARE @StageCutoff datetime2(0) = DATEADD(hour, -@StageRetentionHours, @EffectiveNow);
+    DECLARE @DiagnosticCutoff datetime2(0) = DATEADD(day, -@DiagnosticRetentionDays, @EffectiveNow);
+    DECLARE @NegativeCutoff datetime2(0) = DATEADD(day, -@NegativeRetentionDays, @EffectiveNow);
+
+    DECLARE @StageRows int = (
+        SELECT COUNT(*)
+        FROM KVK.KVK_AllPlayers_Stage WITH (READCOMMITTEDLOCK)
+        WHERE staged_at_utc < @StageCutoff
+    );
+    DECLARE @DiagnosticRows int = (
+        SELECT COUNT(*)
+        FROM KVK.KVK_Ingest_Diagnostics WITH (READCOMMITTEDLOCK)
+        WHERE CreatedUTC < @DiagnosticCutoff
+    );
+    DECLARE @NegativeRows int = (
+        SELECT COUNT(*)
+        FROM KVK.KVK_Ingest_Negatives WITH (READCOMMITTEDLOCK)
+        WHERE recorded_at_utc < @NegativeCutoff
+    );
+
+    IF @DryRun = 0
+    BEGIN
+        BEGIN TRANSACTION;
+
+        DELETE FROM KVK.KVK_AllPlayers_Stage
+        WHERE staged_at_utc < @StageCutoff;
+        SET @StageRows = @@ROWCOUNT;
+
+        DELETE FROM KVK.KVK_Ingest_Diagnostics
+        WHERE CreatedUTC < @DiagnosticCutoff;
+        SET @DiagnosticRows = @@ROWCOUNT;
+
+        DELETE FROM KVK.KVK_Ingest_Negatives
+        WHERE recorded_at_utc < @NegativeCutoff;
+        SET @NegativeRows = @@ROWCOUNT;
+
+        INSERT INTO KVK.KVK_Ingest_Diagnostics
+        (
+            DiagnosticStatus, DiagnosticType, ErrorText, ContextJson
+        )
+        VALUES
+        (
+            'cleanup',
+            N'retention_cleanup',
+            N'KVK ingest retention cleanup completed.',
+            CONCAT(
+                N'{"stage_retention_hours":', @StageRetentionHours,
+                N',"diagnostic_retention_days":', @DiagnosticRetentionDays,
+                N',"negative_retention_days":', @NegativeRetentionDays,
+                N',"stage_rows_deleted":', @StageRows,
+                N',"diagnostic_rows_deleted":', @DiagnosticRows,
+                N',"negative_rows_deleted":', @NegativeRows,
+                N'}'
+            )
+        );
+
+        COMMIT TRANSACTION;
+    END
+
+    SELECT
+        CAST(@DryRun AS bit) AS DryRun,
+        @StageCutoff AS StageCutoffUTC,
+        @DiagnosticCutoff AS DiagnosticCutoffUTC,
+        @NegativeCutoff AS NegativeCutoffUTC,
+        @StageRows AS StaleStageRows,
+        @DiagnosticRows AS StaleDiagnosticRows,
+        @NegativeRows AS StaleNegativeRows;
+END
+GO

--- a/sql/kvk_all_phase8_ingest_retention.sql
+++ b/sql/kvk_all_phase8_ingest_retention.sql
@@ -90,9 +90,14 @@ CREATE TABLE [KVK].[KVK_Ingest_Diagnostics](
 END
 
 IF NOT EXISTS (
-    SELECT 1 FROM sys.objects
-    WHERE object_id = OBJECT_ID(N'[KVK].[DF_KVK_IngestDiag_CreatedUTC]')
-      AND type = 'D'
+    SELECT 1
+    FROM sys.columns c
+    LEFT JOIN sys.default_constraints dc
+        ON dc.parent_object_id = c.object_id
+       AND dc.parent_column_id = c.column_id
+    WHERE c.object_id = OBJECT_ID(N'[KVK].[KVK_Ingest_Diagnostics]')
+      AND c.name = N'CreatedUTC'
+      AND dc.object_id IS NOT NULL
 )
 BEGIN
     ALTER TABLE [KVK].[KVK_Ingest_Diagnostics]

--- a/tests/test_kvk_all_import_dal.py
+++ b/tests/test_kvk_all_import_dal.py
@@ -57,6 +57,8 @@ class MockCursor:
             self.description = [("COUNT",)]
             self._fetchall = []
             self._fetchone = (3,)
+        elif sql == dal.INSERT_INGEST_DIAGNOSTIC_SQL:
+            self._fetchone = (42,)
         return self
 
     def executemany(self, sql: str, rows):
@@ -153,4 +155,86 @@ def test_ingest_prepared_import_cleans_stage_rows_when_precheck_fails(monkeypatc
     assert result["success"] is False
     assert result["cleanup_failed"] is False
     assert result["cleanup_error"] is None
-    assert connection.commit_calls == 2
+    diagnostic_cursor = connection.cursors[1]
+    assert diagnostic_cursor.executed[0][0] == dal.INSERT_INGEST_DIAGNOSTIC_SQL
+    diagnostic_params = cast(tuple[Any, ...], diagnostic_cursor.executed[0][1])
+    assert diagnostic_params[0] == "rejected"
+    assert diagnostic_params[1] == "scan_timestamp_outside_kvk_details"
+    assert diagnostic_params[2] == "token-2"
+    assert diagnostic_params[5] == "kvk.xlsx"
+    assert diagnostic_params[8] == SCHEMA_VERSION
+    assert diagnostic_params[9] == "Full Data"
+    assert diagnostic_params[12] == 1
+    assert diagnostic_params[13] == 1
+    assert result["diagnostic_id"] == 42
+    assert connection.commit_calls == 3
+
+
+def test_record_ingest_diagnostic_is_best_effort() -> None:
+    class FailingConnection:
+        def cursor(self):
+            raise RuntimeError("diagnostic table missing")
+
+    result = dal.record_ingest_diagnostic(
+        FailingConnection(),  # type: ignore[arg-type]
+        status="failed",
+        diagnostic_type="unit_test",
+        source_filename="kvk.xlsx",
+        error_text="boom",
+    )
+
+    assert result is None
+
+
+def test_ingest_prepared_import_records_proc_failure_and_keeps_stage_rows(
+    monkeypatch,
+) -> None:
+    class FailingIngestCursor(MockCursor):
+        def execute(self, sql: str, params=None):
+            if sql == dal.CALL_INGEST_SQL:
+                self.executed.append((sql, params))
+                raise RuntimeError("stored procedure failed")
+            return super().execute(sql, params)
+
+    class FailureConnection(MockConnection):
+        def cursor(self) -> MockCursor:
+            if len(self.cursors) == 1:
+                cursor: MockCursor = FailingIngestCursor()
+            else:
+                cursor = MockCursor()
+            self.cursors.append(cursor)
+            return cursor
+
+    connection = FailureConnection()
+    monkeypatch.setattr(dal, "scan_ts_within_kvk_details", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(dal.uuid, "uuid4", lambda: "token-3")
+
+    try:
+        dal.ingest_prepared_import(
+            con=connection,
+            prepared=_prepared_frame(),
+            content=b"abc",
+            source_filename="kvk.xlsx",
+            uploader_id=999,
+            scan_ts_utc=dt.datetime(2026, 5, 8, 1, 0, tzinfo=dt.UTC),
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "stored procedure failed"
+    else:  # pragma: no cover - defensive guard
+        raise AssertionError("expected ingest failure")
+
+    stage_cursor = connection.cursors[0]
+    ingest_cursor = connection.cursors[1]
+    diagnostic_cursor = connection.cursors[2]
+
+    assert stage_cursor.executemany_calls[0][0] == dal.STAGE_INSERT_SQL
+    assert ingest_cursor.executed[0][0] == dal.CALL_INGEST_SQL
+    assert (dal.DELETE_STAGED_TOKEN_SQL, "token-3") not in stage_cursor.executed
+    assert diagnostic_cursor.executed[0][0] == dal.INSERT_INGEST_DIAGNOSTIC_SQL
+    diagnostic_params = cast(tuple[Any, ...], diagnostic_cursor.executed[0][1])
+    assert diagnostic_params[0] == "failed"
+    assert diagnostic_params[1] == "ingest_procedure_failed"
+    assert diagnostic_params[2] == "token-3"
+    assert diagnostic_params[12] == 1
+    assert diagnostic_params[13] == 1
+    assert "RuntimeError: stored procedure failed" in str(diagnostic_params[14])

--- a/tests/test_kvk_all_importer.py
+++ b/tests/test_kvk_all_importer.py
@@ -95,3 +95,25 @@ def test_wrapper_preserves_success_return_shape(monkeypatch) -> None:
     assert result["proc_ms"] == 12.0
     assert result["duration_s"] >= 0
     assert connection.closed is True
+
+
+def test_wrapper_returns_coercion_validation_context_without_db_connection() -> None:
+    full_data = _full_data_df()
+    full_data.loc[0, "governor_id"] = None
+
+    result = importer.ingest_kvk_all_excel(
+        content=_xlsx_bytes({"Full Data": full_data}),
+        source_filename="kvk.xlsx",
+        uploader_id=123,
+        scan_ts_utc=dt.datetime(2026, 5, 8, tzinfo=dt.UTC),
+        server="unused",
+        database="unused",
+        username="unused",
+        password="unused",
+    )
+
+    assert result["success"] is False
+    assert result["sheet"] == "Full Data"
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["validation_error"]["code"] == "full_data_coercion_failed"
+    assert result["validation_error"]["schema"]["schema_version"] == SCHEMA_VERSION

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -182,3 +182,74 @@ def test_phase5_prod_sql_script_contains_export_contract_changes() -> None:
 
     for token in required_tokens:
         assert token in script
+
+
+def test_phase8_sql_repo_contains_diagnostic_and_cleanup_contract() -> None:
+    stage_sql = _sql_file("KVK.KVK_AllPlayers_Stage.Table.sql")
+    diagnostics_sql = _sql_file("KVK.KVK_Ingest_Diagnostics.Table.sql")
+    cleanup_sql = _sql_file("KVK.sp_KVK_Ingest_Cleanup.StoredProcedure.sql")
+
+    assert "[staged_at_utc] [datetime2](0) NOT NULL" in stage_sql
+    assert "DF_KVK_AllPlayers_Stage_StagedAtUTC" in stage_sql
+    assert "IX_KVK_AllPlayers_Stage_StagedAt" in stage_sql
+    assert "INCLUDE([IngestToken])" in stage_sql
+
+    for token in (
+        "CREATE TABLE [KVK].[KVK_Ingest_Diagnostics]",
+        "[DiagnosticStatus] [varchar](20)",
+        "[DiagnosticType] [nvarchar](64)",
+        "[IngestToken] [uniqueidentifier] NULL",
+        "[SchemaVersion] [nvarchar](64)",
+        "[SourceSheetName] [nvarchar](128)",
+        "[SourceColumnHash] [char](64)",
+        "[ContextJson] [nvarchar](max)",
+        "CK_KVK_IngestDiag_Status",
+        "IX_KVK_IngestDiag_Status_Created",
+        "IX_KVK_IngestDiag_Token",
+    ):
+        assert token in diagnostics_sql
+
+    compact_cleanup = _compact(cleanup_sql)
+    for token in (
+        "ALTER PROCEDURE [KVK].[sp_KVK_Ingest_Cleanup]",
+        "@StageRetentionHours [int] = 24",
+        "@DiagnosticRetentionDays [int] = 90",
+        "@NegativeRetentionDays [int] = 365",
+        "@DryRun [bit] = 1",
+        "THROW 51010, 'Stage retention must be at least 1 hour.', 1",
+        "WHERE staged_at_utc < @StageCutoff",
+        "WHERE CreatedUTC < @DiagnosticCutoff",
+        "WHERE recorded_at_utc < @NegativeCutoff",
+        "DiagnosticStatus, DiagnosticType, ErrorText, ContextJson",
+        "StaleStageRows",
+        "StaleDiagnosticRows",
+        "StaleNegativeRows",
+    ):
+        assert _compact(token) in compact_cleanup
+
+
+def test_phase8_prod_sql_script_contains_retention_objects_and_policy() -> None:
+    script = Path("sql/kvk_all_phase8_ingest_retention.sql").read_text(encoding="utf-8-sig")
+    compact = _compact(script)
+
+    required_tokens = [
+        "KVK_ALL Schema Modernisation - Phase 8 Ingest Diagnostics & Retention",
+        "IF OBJECT_ID(N'[KVK].[KVK_AllPlayers_Stage]', N'U') IS NULL",
+        "COL_LENGTH('KVK.KVK_AllPlayers_Stage', 'staged_at_utc')",
+        "CREATE TABLE [KVK].[KVK_Ingest_Diagnostics]",
+        "CK_KVK_IngestDiag_Status",
+        "IX_KVK_IngestDiag_Status_Created",
+        "IX_KVK_IngestDiag_Token",
+        "ALTER PROCEDURE [KVK].[sp_KVK_Ingest_Cleanup]",
+        "@StageRetentionHours [int] = 24",
+        "@DiagnosticRetentionDays [int] = 90",
+        "@NegativeRetentionDays [int] = 365",
+        "@DryRun [bit] = 1",
+        "WHERE staged_at_utc < @StageCutoff",
+        "WHERE CreatedUTC < @DiagnosticCutoff",
+        "WHERE recorded_at_utc < @NegativeCutoff",
+        "GO",
+    ]
+
+    for token in required_tokens:
+        assert _compact(token) in compact


### PR DESCRIPTION
## Summary

Adds Phase 8 operational safety for KVK_ALL ingest diagnostics and failed stage rows.

## Changes

- Adds `sql/kvk_all_phase8_ingest_retention.sql` for prod deployment.
- Adds a `staged_at_utc` retention marker to `KVK.KVK_AllPlayers_Stage` in the deployment script.
- Adds durable `KVK.KVK_Ingest_Diagnostics` audit storage in the deployment script.
- Adds `KVK.sp_KVK_Ingest_Cleanup` with dry-run default cleanup for stale staged rows, old ingest diagnostics, and old negative diagnostics.
- Records best-effort durable diagnostics for rejected timestamp precheck failures and ingest procedure failures.
- Preserves existing Discord import output, import return shape, recompute, export, Google Sheets, admin, and reporting behavior.
- Includes the local Phase 7 task-pack update and Phase 8 initiation statement as requested.

## SQL Deployment Note

The Phase 8 SQL script is additive and intended to apply the required prod DB additions:

- validates required base tables exist before applying changes
- adds `KVK.KVK_AllPlayers_Stage.staged_at_utc` with `sysutcdatetime()` default and `WITH VALUES`
- creates `IX_KVK_AllPlayers_Stage_StagedAt` for age-based stale-stage cleanup
- creates `KVK.KVK_Ingest_Diagnostics` with status/type/token/schema/source metadata/error/context fields
- creates diagnostic indexes for status/date, ingest token, and KVK/Scan lookups
- creates or alters `KVK.sp_KVK_Ingest_Cleanup`
- defaults cleanup to dry-run (`@DryRun = 1`)
- defaults retention to 24 hours for staged rows, 90 days for ingest diagnostics, and 365 days for negative diagnostics
- refuses retention values below 1 hour/day

No destructive cleanup runs automatically from Python or the deployment script.

## Validation

- `python -m pytest -q tests` -> 1263 passed, 8 skipped
- `python -m pytest -q tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_import_service.py tests/test_kvk_all_recompute_sql_contract.py` -> 32 passed
- `python -m black --check kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py`
- `python -m ruff check kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py`
- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `python -m pyright kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py` -> 0 errors, dependency-resolution warnings only
- `git diff --check`

## Deferred Optimisations

Captured in `docs/deferred_optimisations.md`:

- KVK_ALL upload routing still lives in `DL_bot.py`; defer route/service extraction to a later phase while preserving current Discord output and auto-export behavior.

## Risk / Rollback

Rollback is straightforward from the Python side because diagnostic writes are best-effort and suppressed if the Phase 8 SQL table is unavailable. SQL changes are additive. Cleanup is opt-in and dry-run by default.