### PR TITLE
[codex] harden KVK_ALL Phase 9 pipeline

### DIFF
--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -35,6 +35,8 @@ Phase 6 is complete and deployed.
 
 Phase 7 is complete and deployed.
 
+Phase 8 is complete and deployed.
+
 Completed Phase 1 scope:
 
 strict Full Data workbook detection
@@ -98,9 +100,28 @@ the unrelated /my_stats_export direct SQL finding was captured structurally in d
 
 Phase 7 did not change SQL schema, import behaviour, recompute semantics, export result-set contracts, Google Sheets tab names, Discord reporting display, Basic Data ingestion, summary tab ingestion, or Phase 5/6 service boundaries.
 
+Completed Phase 8 scope:
+
+KVK.KVK_AllPlayers_Stage gained an additive staged_at_utc retention marker for failed/stale stage row cleanup
+KVK.KVK_Ingest_Diagnostics was introduced for durable ingest diagnostic visibility
+KVK.sp_KVK_Ingest_Cleanup was introduced with dry-run default cleanup for stale stage rows, old ingest diagnostics, and old negative diagnostics
+default retention policy documented and implemented as 24 hours for staged rows, 90 days for ingest diagnostics, and 365 days for negative diagnostics
+cleanup refuses unsafe sub-1-hour or sub-1-day retention settings
+cleanup does not run automatically during deployment or import
+Python KVK_ALL ingest now records best-effort durable diagnostics for timestamp precheck rejections and ingest procedure failures where Phase 8 SQL is deployed
+diagnostic context includes schema/source metadata, source filename, file hash, uploader ID, staged row count, and error/context payload where available
+failed ingest procedure paths intentionally retain staged rows for inspection until explicit retention cleanup
+coercion validation failures include structured validation context without changing Discord-facing import output
+focused DAL/importer/SQL contract tests were added for diagnostic shape, best-effort diagnostic writes, retained failed stage rows, and cleanup SQL policy
+production deployment script added under sql/kvk_all_phase8_ingest_retention.sql
+production SQL smoke confirmed stage marker, diagnostics table, cleanup procedure, dry-run cleanup, and diagnostic insert visibility
+the KVK_ALL upload routing follow-up was captured structurally in docs/deferred_optimisations.md
+
+Phase 8 did not introduce Basic Data ingestion, summary tab ingestion, Discord reporting display changes, Google Sheets export contract changes, KVK export result-set changes, admin command redesign, automatic cleanup execution, or Phase 9 performance/restart hardening.
+
 Next phase:
 
-Phase 8 — Operational Cleanup & Retention
+Phase 9 — End-to-End Performance & Restart Safety Hardening
 
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
@@ -865,6 +886,9 @@ Smoke validation completed:
 No SQL schema changes, Google Sheets export contract changes, KVK export result-set changes, Discord reporting display changes, Basic Data ingestion, summary tab ingestion, operational retention cleanup, or end-to-end performance/restart hardening were included in Phase 7.
 
 Phase 8 — Operational Cleanup & Retention
+Status
+Complete and deployed.
+
 Goal
 Make ingest diagnostics and failed stage rows operationally safe.
 
@@ -884,6 +908,59 @@ Failed ingest diagnostics are inspectable.
 Old diagnostics can be cleaned safely.
 Cleanup does not remove active ingest tokens.
 Runbook notes exist.
+
+Completion Notes
+Implemented:
+
+sql/kvk_all_phase8_ingest_retention.sql
+kvk/dal/kvk_all_import_dal.py
+kvk_all_importer.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_importer.py
+tests/test_kvk_all_recompute_sql_contract.py
+docs/KVK_ALL Schema Modernisation — Phase 8 Initiation Statement.md
+
+SQL delivery:
+
+KVK.KVK_AllPlayers_Stage gained staged_at_utc with a sysutcdatetime() default and supporting age-based index.
+KVK.KVK_Ingest_Diagnostics was added for durable ingest diagnostic visibility.
+KVK.sp_KVK_Ingest_Cleanup was added with dry-run default cleanup.
+Default retention policy is 24 hours for staged rows, 90 days for ingest diagnostics, and 365 days for negative diagnostics.
+Cleanup validates retention values before deleting and does not run automatically during deployment.
+
+Python delivery:
+
+KVK_ALL timestamp precheck rejections record best-effort durable diagnostics where Phase 8 SQL is deployed.
+KVK_ALL ingest procedure failures record best-effort durable diagnostics while retaining staged rows for operator inspection.
+Diagnostic payloads include schema/source metadata, source filename, file hash, uploader ID, staged row count, error text, and context JSON where available.
+Coercion validation failures include structured validation context without changing Discord-facing import output.
+Diagnostic writes are best-effort and do not make imports fail harder if the Phase 8 SQL table is unavailable.
+
+Validation completed:
+
+python -m pytest -q tests
+python -m pytest -q tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_import_service.py tests/test_kvk_all_recompute_sql_contract.py
+python -m black --check kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py
+python -m ruff check kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py
+python -m py_compile kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py
+python -m pyright kvk/dal/kvk_all_import_dal.py kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_recompute_sql_contract.py
+python scripts/validate_architecture_boundaries.py
+python scripts/validate_deferred_items.py
+python scripts/select_tests.py
+python scripts/smoke_imports.py
+python scripts/validate_command_registration.py
+git diff --check
+
+Production smoke completed:
+
+staged_at_utc column exists on KVK.KVK_AllPlayers_Stage.
+KVK.KVK_Ingest_Diagnostics exists and accepts insert smoke rows.
+KVK.sp_KVK_Ingest_Cleanup exists.
+Dry-run cleanup returned stale counts without deleting rows.
+Diagnostic audit visibility was confirmed with a phase8_smoke row.
+
+No Discord reporting display changes, Google Sheets export contract changes, KVK export result-set changes, Basic Data ingestion, summary tab ingestion, automatic cleanup execution, or Phase 9 restart/performance hardening were included in Phase 8.
+
 Phase 9 — End-to-End Performance & Restart Safety Hardening
 Goal
 Final optimisation and validation pass.
@@ -956,3 +1033,69 @@ Deferred Optimisations
 For this programme, Deferred Optimisations should usually be:
 
 None. Required optimisation item completed in this phase.
+
+Completion Notes
+
+Implemented:
+
+kvk/services/kvk_all_import_service.py
+kvk/dal/kvk_all_import_dal.py
+kvk_all_importer.py
+scripts/benchmark_kvk_all_phase9.py
+tests/test_kvk_all_import_service.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_importer.py
+docs/KVK_ALL Schema Modernisation — Phase 9 Initiation Statement.md
+
+Python delivery:
+
+KVK_ALL Full Data numeric and timestamp coercion was vectorised while preserving strict Full Data validation, Basic Data rejection, canonical staging columns, schema metadata, and legacy import return compatibility.
+Granular local timing fields were added for prepare, stage row preparation, stage insert, KVK_Details precheck, ingest procedure execution, recompute execution, and negative diagnostic counting.
+The existing Discord-facing import output was not changed; added timing fields are returned for diagnostics and future operator analysis.
+A read-only Phase 9 benchmark script was added under scripts/ for repeatable workbook parsing, coercion, metadata, full preparation, and stage-row preparation timing against local workbook samples.
+
+Performance baseline:
+
+Sample workbook:
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Workbook shape:
+Full Data, 5,000 rows, 43 columns, schema hash f885b1c7c5e36516697b05acbb0499a8969bb7571d3fc67546f7f9358124c7b8.
+
+Pre-change local baseline from Phase 9 audit:
+read_full_data_workbook median 1552.25ms
+coerce_full_data_frame median 1967.53ms
+attach_source_metadata median 1.44ms
+prepare_kvk_all_import total median 3642.55ms
+rows_for_stage median 79.91ms
+
+Post-change local baseline:
+read_full_data_workbook median 1637.91ms
+coerce_full_data_frame median 24.87ms
+attach_source_metadata median 6.30ms
+prepare_kvk_all_import total median 1616.97ms
+rows_for_stage median 72.25ms
+
+Live SQL timing notes:
+
+KVK.sp_KVK_AllPlayers_Ingest live timing was not run during local validation because it mutates KVK.KVK_Scan, KVK.KVK_AllPlayers_Raw, KVK.KVK_Player_Baseline, KVK.KVK_Ingest_Negatives, and clears staged rows.
+KVK.sp_KVK_Recompute_Windows live timing was not run during local validation because it deletes and rebuilds KVK windowed output tables for the target KVK.
+KVK.sp_KVK_Get_Exports / Google Sheets export posting was not run during local validation to avoid unintended live spreadsheet writes.
+The Python path now returns timing fields for the live ingest/recompute/export-adjacent phases when normal operator workflows run them.
+
+Restart and state assessment:
+
+Before stage insert, no critical KVK_ALL state exists only in process memory; retrying the upload is safe.
+After stage insert and before ingest procedure execution, staged rows are durable by IngestToken and inspectable until explicit Phase 8 retention cleanup.
+If KVK_Details timestamp precheck rejects an upload, the importer attempts targeted staged-row cleanup and records a best-effort durable diagnostic where Phase 8 SQL is deployed.
+If KVK.sp_KVK_AllPlayers_Ingest fails, SQL transaction rollback preserves staged rows for inspection and the Python DAL records a best-effort durable diagnostic.
+After ingest succeeds and before recompute completes, KVK.KVK_Scan and KVK.KVK_AllPlayers_Raw are durable and /kvk_recompute can rebuild windowed outputs.
+After recompute succeeds and before Google Sheets export completes, SQL outputs are durable and /kvk_export_all can be rerun.
+Automatic Google Sheets export remains an in-process convenience task; the recovery contract is the existing admin export command. Broader durable upload/export route extraction remains outside Phase 9 scope.
+Phase 8 cleanup remains dry-run by default and no staged rows or diagnostics are deleted automatically by the import path.
+
+Validation completed:
+
+python -m pytest -q tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_recompute_sql_contract.py tests/test_kvk_export_service.py tests/test_gsheet_module.py tests/test_kvk_admin_service.py tests/test_kvk_reporting_service.py
+
+No SQL schema changes, Discord reporting display changes, Google Sheets tab/spreadsheet changes, KVK export result-set changes, Basic Data ingestion, summary tab ingestion, automatic cleanup execution, live production import, live recompute, or live export posting were included in Phase 9.

--- a/docs/KVK_ALL Schema Modernisation — Phase 9 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 9 Initiation Statement.md
@@ -1,0 +1,299 @@
+KVK_ALL Schema Modernisation — Phase 9 Initiation Statement
+
+We are starting Phase 9 of the KVK_ALL Schema Modernisation programme.
+
+Important local documentation note:
+
+The Phase 8 completion update to docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md and this Phase 9 initiation statement were created locally after Phase 8 was completed and deployed.
+
+Do not amend the Phase 8 PR for these documentation updates.
+
+These local documentation changes must be included in the next PR opened for Phase 9.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 4 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md
+docs/KVK_ALL Schema Modernisation — Phase 5 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 6 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 7 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 8 Initiation Statement.md
+
+Also read the uploaded workbook sample:
+
+downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, aggregate functions, diagnostic tables, retention scripts, migration scripts, and performance-sensitive query plans. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 2 is complete and deployed.
+
+Phase 2 delivered:
+
+additive SQL capacity for the KVK_ALL Full Data workbook schema
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Raw
+queryable schema/source metadata on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+Python staging support for rank, raw min/max metric families, contribution metrics, and source metadata
+focused schema/import SQL contract tests
+production deployment script under sql/kvk_all_phase2_full_data_capacity.sql
+non-mutating workbook/importer smoke validation
+read-only SQL metadata smoke validation after deployment
+
+Phase 3 is complete and deployed.
+
+Phase 3 delivered:
+
+kvk_all_importer.py reduced to a compatibility wrapper around service and DAL layers
+workbook parsing, Full Data selection, aliasing, schema validation, canonical mapping, coercion, and source metadata moved into kvk/services/kvk_all_import_service.py
+stage column ordering, SQL staging, stage schema preflight, ingest procedure call, recompute call, KVK timestamp precheck, diagnostic writing, and negative count reads moved into kvk/dal/kvk_all_import_dal.py
+Full Data v2 canonical mapping constants moved into kvk/schemas/kvk_all_schema.py
+structured schema and coercion failures preserved
+legacy import return dictionary shape preserved for DL_bot.py
+Phase 2 schema/source metadata staging and ingest parameters preserved
+unknown column reporting retained in schema metadata without changing Discord output
+focused tests added for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviours
+non-mutating workbook/service smoke validation completed against the uploaded sample workbook
+
+Phase 4 is complete and deployed.
+
+Phase 4 delivered:
+
+metric source-of-truth rules documented for kill points, healed troops, raw min/max metric fields, and contribution metrics
+Full Data v2 recompute precedence implemented for kill points using kill_points_diff with legacy/raw fallback
+Full Data v2 recompute precedence implemented for healed troops using healed_troops with legacy/raw fallback
+raw min/max fields retained as validation/reconciliation inputs and fallback inputs rather than replacing stable output semantics
+additive max_contribute_gain and cur_contribute_gain outputs on KVK.KVK_Player_Windowed, KVK.KVK_Kingdom_Windowed, and KVK.KVK_Camp_Windowed
+KVK.sp_KVK_Recompute_Windows updated to populate contribution gains while preserving existing KP, kills, deads, healed, DKP, baseline, kingdom, and camp outputs
+KVK.sp_KVK_Get_Exports kept at 10 result sets and adjusted to keep Full export output columns explicit
+Google Sheets tab names and Discord reporting display unchanged
+production replication script added under sql/kvk_all_phase4_recompute_modernisation.sql
+focused SQL contract tests added for source precedence, additive contribution columns, export contract preservation, and production SQL script coverage
+
+Phase 5 is complete and deployed.
+
+Phase 5 delivered:
+
+stable named KVK export sections for KVK.sp_KVK_Get_Exports outputs
+legacy positional export compatibility retained while current callers migrate
+primary KVK Google Sheets export binding moved away from fragile fixed DataFrame index assumptions
+additional PASS, ALTAR, GREATZIG, and comparison spreadsheet generation updated to use named export-section binding
+compatible extra SQL result sets can be ignored when all required export sections are present
+existing primary spreadsheet tab names preserved
+existing additional spreadsheet names and tab names preserved
+ALL_WINDOW_COMPARISON tab names preserved with no new contribution comparison tabs
+max_contribute_gain and cur_contribute_gain exported in existing player, kingdom, and camp windowed/full export sections
+KVK.sp_KVK_Get_Exports kept at 10 result sets with existing section order preserved
+local production deployment script added under sql/kvk_all_phase5_export_contract_decoupling.sql
+focused tests added for named binding, backward compatibility, compatible extra result sets, missing-section failures, tab-name stability, and contribution export behaviour
+read-only SQL smoke confirmed the applied procedure contract
+Google Sheets smoke confirmed stable primary/additional/comparison tab behaviour
+production promotion completed after validation
+
+Phase 6 is complete and deployed.
+
+Phase 6 delivered:
+
+KVK all-kingdom reporting SQL moved out of stats_alerts/allkingdoms.py
+reporting data access moved into kvk/dal/kvk_reporting_dal.py
+reporting block orchestration and row shaping moved into kvk/services/kvk_reporting_service.py
+stats_alerts/allkingdoms.py preserved as a thin compatibility wrapper around load_allkingdom_blocks(kvk_no)
+existing Discord embed display, field names, links, titles, Top 5 layout, and truncation behaviour preserved
+max_contribute_gain and cur_contribute_gain made available in structured reporting rows where SQL supports them
+contribution metrics intentionally not displayed in Discord embeds
+focused tests added for reporting block shape, SQL placement, contribution availability, embed compatibility, and truncation stability
+read-only SQL smoke confirmed structured reporting block availability
+Discord test embed smoke confirmed existing display remained stable
+production deployment completed after validation
+
+Phase 7 is complete and deployed.
+
+Phase 7 delivered:
+
+KVK admin command SQL moved out of commands/stats_cmds.py for recompute, scan listing, and window preview workflows
+KVK admin data access moved into kvk/dal/kvk_admin_dal.py
+KVK admin orchestration and command-facing result shaping moved into kvk/services/kvk_admin_service.py
+commands/stats_cmds.py preserved command names, permissions, defer/followup flow, output copy, export behaviour, and operator workflow
+/kvk_export_all current-KVK resolution moved through the KVK admin service while preserving existing Google Sheets export execution
+/kvk_export_all exception reporting hardened so export failures are visible to the operator
+/kvk_window_preview SQL Server RowCount alias compatibility fixed
+/kvk_window_preview output capped to Discord's 1024-character embed field limit with a truncation marker
+focused tests added for DAL/service result shape, command boundary handoff, SQL alias coverage, and embed field limit behaviour
+/kvk_export_all smoke completed successfully
+/kvk_window_preview smoke issues were fixed in Phase 7 follow-up hotfixes
+
+Phase 8 is complete and deployed.
+
+Phase 8 delivered:
+
+KVK.KVK_AllPlayers_Stage gained staged_at_utc with default and supporting age-based index
+KVK.KVK_Ingest_Diagnostics was introduced for durable ingest diagnostic visibility
+KVK.sp_KVK_Ingest_Cleanup was introduced with dry-run default cleanup
+default retention policy is 24 hours for staged rows, 90 days for ingest diagnostics, and 365 days for negative diagnostics
+cleanup validates retention values and does not run automatically during deployment or import
+timestamp precheck rejections and ingest procedure failures record best-effort durable diagnostics where Phase 8 SQL is deployed
+diagnostic context includes schema/source metadata, source filename, file hash, uploader ID, staged row count, error text, and context JSON where available
+ingest procedure failure paths retain staged rows for operator inspection until explicit retention cleanup
+coercion validation failures include structured validation context without changing Discord-facing import output
+focused tests added for diagnostic shape, best-effort diagnostic writes, retained failed stage rows, and cleanup SQL policy
+production deployment script added under sql/kvk_all_phase8_ingest_retention.sql
+production smoke confirmed stage marker, diagnostics table, cleanup procedure, dry-run cleanup, and diagnostic insert visibility
+
+Phases 1 through 8 did not introduce Basic Data ingestion, summary tab ingestion, Discord contribution display, incompatible Google Sheets tab/spreadsheet changes, KVK export result-set changes, unrelated admin command redesign, or automatic cleanup execution.
+
+Phase 9 objective:
+
+Perform the final end-to-end performance and restart-safety hardening pass for the modernised KVK_ALL pipeline while preserving established import, recompute, export, Google Sheets, Discord reporting, admin command, and operational diagnostic contracts.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data remains out of scope and intentionally ignored.
+
+In scope:
+
+review the full KVK_ALL import-to-export flow before implementation
+validate all referenced stage, raw, scan, diagnostic, recompute, export, reporting, and admin objects against the SQL repo
+benchmark workbook parsing and schema validation time using the uploaded sample workbook
+benchmark stage row preparation and stage insert behaviour where practical
+benchmark KVK.sp_KVK_AllPlayers_Ingest execution or document why live timing is not safe in the current environment
+benchmark KVK.sp_KVK_Recompute_Windows execution or document why live timing is not safe in the current environment
+benchmark KVK.sp_KVK_Get_Exports / Google Sheets export path where practical without posting unintended live output
+review transaction log impact and current SQL log headroom safeguards
+validate restart/failure behaviour during upload, workbook parse, stage insert, ingest procedure execution, recompute, export, and diagnostic cleanup
+verify no critical KVK_ALL import state exists only in process memory without durable recovery or clear retry semantics
+review failed stage row and diagnostic retention behaviour after Phase 8 deployment
+identify and fix small PR-sized restart/performance risks where low risk and clearly in scope
+capture any larger out-of-scope findings structurally
+include the local Phase 8 task-pack update and this Phase 9 initiation statement in the next PR
+
+Likely SQL objects to review:
+
+KVK.KVK_AllPlayers_Stage
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Scan
+KVK.KVK_Ingest_Negatives
+KVK.KVK_Ingest_Diagnostics
+KVK.sp_KVK_AllPlayers_Ingest
+KVK.sp_KVK_Recompute_Windows
+KVK.sp_KVK_Get_Exports
+KVK.sp_KVK_Ingest_Cleanup
+KVK.KVK_Player_Windowed
+KVK.KVK_Kingdom_Windowed
+KVK.KVK_Camp_Windowed
+KVK.KVK_Player_Baseline
+KVK.KVK_Windows
+KVK.KVK_DKPWeights
+KVK.KVK_CampMap
+dbo.KVK_Details
+dbo.fn_KVK_Player_Aggregated
+dbo.fn_KVK_Kingdom_Aggregated
+dbo.fn_KVK_Camp_Aggregated
+KVK.vw_FightingDataset
+
+Likely Python modules to review and possibly update:
+
+kvk/dal/kvk_all_import_dal.py
+kvk/services/kvk_all_import_service.py
+kvk_all_importer.py
+DL_bot.py
+kvk/services/kvk_export_service.py
+gsheet_module.py
+kvk/dal/kvk_admin_dal.py
+kvk/services/kvk_admin_service.py
+kvk/dal/kvk_reporting_dal.py
+kvk/services/kvk_reporting_service.py
+stats_alerts/allkingdoms.py
+stats_alerts/embeds/kvk.py
+tests/test_kvk_all_import_dal.py
+tests/test_kvk_all_import_service.py
+tests/test_kvk_all_importer.py
+tests/test_kvk_all_recompute_sql_contract.py
+tests/test_kvk_export_service.py
+tests/test_gsheet_module.py
+tests/test_kvk_admin_service.py
+tests/test_kvk_reporting_service.py
+scripts/
+sql/
+
+Out of scope for Phase 9:
+
+Discord reporting display changes
+new contribution fields in Discord embeds
+Google Sheets tab or spreadsheet name changes
+KVK export result-set changes
+Basic Data ingestion
+summary tab ingestion
+new live production imports, recomputes, exports, cleanup deletes, or reporting posts unless explicitly requested
+production promotion before local validation
+rewriting unrelated stats, rankings, history, reporting, personal KVK, or admin command flows
+large cross-module KVK_ALL upload-route extraction unless explicitly approved as a separate task
+new analytics features beyond final hardening and validation
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Preserve existing import behaviour and return shape.
+Preserve existing Google Sheets export behaviour.
+Preserve existing Discord embed/reporting output.
+Do not silently change metric semantics.
+Do not silently change diagnostic retention semantics.
+Do not delete diagnostics or staged rows without explicit approval and dry-run review.
+Avoid embedded SQL in command/view/presentation layers.
+Prefer service and DAL boundaries.
+Use additive, rollback-safe SQL changes only if SQL changes become necessary.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact performance, restart, state, and operational risks.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 9 final hardening work.
+Run targeted validation.
+Stop after Phase 9 implementation, tests, and report.
+
+Acceptance criteria:
+
+Performance baseline is recorded for workbook parse, staging, ingest, recompute, and export where practical.
+Restart and failure-mode risks are documented or fixed for upload, stage insert, ingest, recompute, export, and cleanup.
+No critical KVK_ALL state exists only in process memory without clear recovery or retry behaviour.
+Phase 8 diagnostics and retention behaviour remain safe and inspectable.
+Existing import, recompute, export, Google Sheets, admin command, and Discord reporting behaviour remains stable.
+No Basic Data or summary tab ingestion is introduced.
+No incompatible Google Sheets or export result-set changes are introduced.
+Tests or validation cover any changed behaviour.
+New deferred findings are captured structurally.
+The programme is migration-ready, or any remaining blocker is explicitly documented with owner, risk, and next action.

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -295,13 +295,10 @@ def ingest_prepared_import(
     uploader_id: int,
     scan_ts_utc: dt.datetime,
 ) -> dict[str, Any]:
-    stage_rows_started = time.perf_counter()
     df = prepared.dataframe
     staged_rows = prepared.staged_rows
     sheet_name = prepared.sheet_name
     schema_metadata = prepared.schema_metadata
-    stage_rows = rows_for_stage("", df)
-    stage_rows_ms = (time.perf_counter() - stage_rows_started) * 1000.0
 
     cur = con.cursor()
     enable_fast_executemany(cur)
@@ -330,9 +327,11 @@ def ingest_prepared_import(
             }
 
     token = str(uuid.uuid4())
-    stage_insert_rows = [(token, *row[1:]) for row in stage_rows]
+    stage_rows_started = time.perf_counter()
+    stage_rows = rows_for_stage(token, df)
+    stage_rows_ms = (time.perf_counter() - stage_rows_started) * 1000.0
     stage_insert_started = time.perf_counter()
-    cur.executemany(STAGE_INSERT_SQL, stage_insert_rows)
+    cur.executemany(STAGE_INSERT_SQL, stage_rows)
     con.commit()
     stage_insert_ms = (time.perf_counter() - stage_insert_started) * 1000.0
 

--- a/kvk/dal/kvk_all_import_dal.py
+++ b/kvk/dal/kvk_all_import_dal.py
@@ -295,10 +295,13 @@ def ingest_prepared_import(
     uploader_id: int,
     scan_ts_utc: dt.datetime,
 ) -> dict[str, Any]:
+    stage_rows_started = time.perf_counter()
     df = prepared.dataframe
     staged_rows = prepared.staged_rows
     sheet_name = prepared.sheet_name
     schema_metadata = prepared.schema_metadata
+    stage_rows = rows_for_stage("", df)
+    stage_rows_ms = (time.perf_counter() - stage_rows_started) * 1000.0
 
     cur = con.cursor()
     enable_fast_executemany(cur)
@@ -327,8 +330,11 @@ def ingest_prepared_import(
             }
 
     token = str(uuid.uuid4())
-    cur.executemany(STAGE_INSERT_SQL, rows_for_stage(token, df))
+    stage_insert_rows = [(token, *row[1:]) for row in stage_rows]
+    stage_insert_started = time.perf_counter()
+    cur.executemany(STAGE_INSERT_SQL, stage_insert_rows)
     con.commit()
+    stage_insert_ms = (time.perf_counter() - stage_insert_started) * 1000.0
 
     logger.info("[KVK] Final stage col order: %s", STAGE_COL_ORDER)
     logger.info("[KVK] DF col order now: %s", list(df.columns))
@@ -339,7 +345,9 @@ def ingest_prepared_import(
     scan_ts_utc = ensure_aware_utc(scan_ts_utc)
     scan_ts_naive = scan_ts_utc.replace(tzinfo=None)
 
+    precheck_started = time.perf_counter()
     if not scan_ts_within_kvk_details(con, scan_ts_naive):
+        precheck_ms = (time.perf_counter() - precheck_started) * 1000.0
         cleanup_failed = False
         cleanup_error: str | None = None
         try:
@@ -355,6 +363,9 @@ def ingest_prepared_import(
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,
             "staged_rows": staged_rows,
+            "stage_rows_ms": stage_rows_ms,
+            "stage_insert_ms": stage_insert_ms,
+            "precheck_ms": precheck_ms,
             "schema": schema_metadata,
             "sample_row": {},
             "cleanup_failed": cleanup_failed,
@@ -402,7 +413,11 @@ def ingest_prepared_import(
             "cleanup_failed": cleanup_failed,
             "cleanup_error": cleanup_error,
             "diagnostic_id": diagnostic_id,
+            "stage_rows_ms": stage_rows_ms,
+            "stage_insert_ms": stage_insert_ms,
+            "precheck_ms": precheck_ms,
         }
+    precheck_ms = (time.perf_counter() - precheck_started) * 1000.0
 
     cur = con.cursor()
     ingest_started = time.perf_counter()
@@ -432,6 +447,9 @@ def ingest_prepared_import(
             "scan_ts_naive": str(scan_ts_naive),
             "source_filename": source_filename,
             "staged_rows": staged_rows,
+            "stage_rows_ms": stage_rows_ms,
+            "stage_insert_ms": stage_insert_ms,
+            "precheck_ms": precheck_ms,
             "ingest_ms": ingest_ms,
             "schema": schema_metadata,
             "stage_retention": "staged rows are retained for inspection until Phase 8 cleanup",
@@ -469,8 +487,10 @@ def ingest_prepared_import(
     recompute_ms = (time.perf_counter() - recompute_started) * 1000.0
 
     cur = con.cursor()
+    negative_count_started = time.perf_counter()
     cur.execute(NEGATIVE_COUNT_SQL, (kvk_no, scan_id))
     negative_value = _first_scalar(cur)
+    negative_count_ms = (time.perf_counter() - negative_count_started) * 1000.0
     negatives = int(negative_value) if negative_value is not None else 0
 
     return {
@@ -479,8 +499,12 @@ def ingest_prepared_import(
         "row_count": int(row_count),
         "negatives": negatives,
         "staged_rows": staged_rows,
+        "stage_rows_ms": stage_rows_ms,
+        "stage_insert_ms": stage_insert_ms,
+        "precheck_ms": precheck_ms,
         "ingest_ms": ingest_ms,
         "recompute_ms": recompute_ms,
+        "negative_count_ms": negative_count_ms,
         "proc_ms": ingest_ms,
         "sheet": sheet_name,
         "schema_version": SCHEMA_VERSION,

--- a/kvk/services/kvk_all_import_service.py
+++ b/kvk/services/kvk_all_import_service.py
@@ -138,7 +138,21 @@ def _as_dt(value: Any) -> Any:
 def _numeric_series(df: pd.DataFrame, column: str) -> pd.Series:
     if column not in df.columns:
         return pd.Series([None] * len(df), index=df.index, dtype=object)
-    return pd.to_numeric(df[column], errors="coerce").astype(object)
+
+    source = df[column]
+    numeric = pd.to_numeric(source, errors="coerce")
+
+    string_mask = source.map(lambda value: isinstance(value, str))
+    integer_literal_mask = source.astype(str).str.strip().str.fullmatch(r"[+-]?\d+")
+    invalid_string_mask = string_mask & source.notna() & ~integer_literal_mask.fillna(False)
+
+    numeric = numeric.mask(invalid_string_mask)
+    numeric = numeric.mask(numeric.notna() & (numeric % 1 != 0))
+
+    result = pd.Series([None] * len(df), index=df.index, dtype=object)
+    valid_mask = numeric.notna()
+    result.loc[valid_mask] = numeric.loc[valid_mask].astype("Int64").astype(object)
+    return result
 
 
 def _datetime_series(df: pd.DataFrame, column: str) -> pd.Series:

--- a/kvk/services/kvk_all_import_service.py
+++ b/kvk/services/kvk_all_import_service.py
@@ -135,6 +135,24 @@ def _as_dt(value: Any) -> Any:
         return None
 
 
+def _numeric_series(df: pd.DataFrame, column: str) -> pd.Series:
+    if column not in df.columns:
+        return pd.Series([None] * len(df), index=df.index, dtype=object)
+    return pd.to_numeric(df[column], errors="coerce").astype(object)
+
+
+def _datetime_series(df: pd.DataFrame, column: str) -> pd.Series:
+    if column not in df.columns:
+        return pd.Series([None] * len(df), index=df.index, dtype=object)
+
+    values = pd.to_datetime(df[column], errors="coerce", utc=True)
+    return pd.Series(
+        [None if pd.isna(value) else ensure_aware_utc(value.to_pydatetime()) for value in values],
+        index=df.index,
+        dtype=object,
+    )
+
+
 def coerce_full_data_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Map Full Data v2 workbook columns into the canonical stage contract."""
     missing = [column for column in REQUIRED_MIN_COLUMNS if column not in df.columns]
@@ -142,19 +160,19 @@ def coerce_full_data_frame(df: pd.DataFrame) -> pd.DataFrame:
         raise ValueError(f"Missing required column(s): {', '.join(missing)}")
 
     out = pd.DataFrame()
-    out["governor_id"] = df["governor_id"].map(_as_int)
+    out["governor_id"] = _numeric_series(df, "governor_id")
     out["name"] = df["name"].map(_as_str) if "name" in df.columns else None
-    out["kingdom"] = df["kingdom"].map(_as_int)
-    out["campid"] = df.get("campid").map(_as_int) if "campid" in df.columns else None
+    out["kingdom"] = _numeric_series(df, "kingdom")
+    out["campid"] = _numeric_series(df, "campid")
 
     for source_col, target_col in FULL_DATA_NUMERIC_COLUMN_MAP.items():
-        out[target_col] = df[source_col].map(_as_int) if source_col in df.columns else None
+        out[target_col] = _numeric_series(df, source_col)
 
     for column in LEGACY_STAGE_NUMERIC_COLUMNS:
-        out[column] = df[column].map(_as_int) if column in df.columns else None
+        out[column] = _numeric_series(df, column)
 
-    out["first_updateUTC"] = df.get("first_updateUTC", pd.Series([None] * len(df))).map(_as_dt)
-    out["last_updateUTC"] = df.get("last_updateUTC", pd.Series([None] * len(df))).map(_as_dt)
+    out["first_updateUTC"] = _datetime_series(df, "first_updateUTC")
+    out["last_updateUTC"] = _datetime_series(df, "last_updateUTC")
 
     if out["governor_id"].isna().any() or out["kingdom"].isna().any():
         raise ValueError("One or more rows missing governor_id or kingdom after coercion.")

--- a/kvk_all_importer.py
+++ b/kvk_all_importer.py
@@ -58,7 +58,9 @@ def ingest_kvk_all_excel(
     """
     started = time.perf_counter()
     try:
+        prepare_started = time.perf_counter()
         prepared = prepare_kvk_all_import(content, source_filename)
+        prepare_ms = (time.perf_counter() - prepare_started) * 1000.0
     except KvkAllSchemaValidationError as exc:
         logger.info("[KVK] Import schema validation failed for %s: %s", source_filename, exc)
         return {
@@ -124,6 +126,7 @@ def ingest_kvk_all_excel(
         except Exception:
             pass
 
+    result.setdefault("prepare_ms", prepare_ms)
     result.setdefault("duration_s", round(time.perf_counter() - started, 2))
     return result
 

--- a/scripts/benchmark_kvk_all_phase9.py
+++ b/scripts/benchmark_kvk_all_phase9.py
@@ -1,0 +1,133 @@
+"""Read-only Phase 9 benchmark for the KVK_ALL Full Data workbook path."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+import json
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Any, TypeVar
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from kvk.dal.kvk_all_import_dal import rows_for_stage
+from kvk.services.kvk_all_import_service import (
+    attach_source_metadata,
+    coerce_full_data_frame,
+    prepare_kvk_all_import,
+    read_full_data_workbook,
+)
+
+T = TypeVar("T")
+
+DEFAULT_SAMPLE = Path("downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx")
+
+
+def _time_call(
+    fn: Callable[..., T],
+    *args: Any,
+    repeats: int,
+    **kwargs: Any,
+) -> tuple[T, list[float]]:
+    values: list[float] = []
+    result: T | None = None
+    for _ in range(repeats):
+        started = time.perf_counter()
+        result = fn(*args, **kwargs)
+        values.append((time.perf_counter() - started) * 1000.0)
+    if result is None:
+        raise RuntimeError("benchmark function returned no result")
+    return result, values
+
+
+def _stats(values: list[float]) -> dict[str, Any]:
+    return {
+        "runs_ms": [round(value, 2) for value in values],
+        "median_ms": round(statistics.median(values), 2),
+        "min_ms": round(min(values), 2),
+        "max_ms": round(max(values), 2),
+    }
+
+
+def benchmark_workbook(path: Path, *, repeats: int) -> dict[str, Any]:
+    content = path.read_bytes()
+    workbook = pd.ExcelFile(path)
+
+    raw_tuple, read_ms = _time_call(
+        read_full_data_workbook,
+        content,
+        path.name,
+        repeats=repeats,
+    )
+    raw_df, sheet_name, schema_metadata = raw_tuple
+    coerced, coerce_ms = _time_call(coerce_full_data_frame, raw_df, repeats=repeats)
+    _, metadata_ms = _time_call(
+        attach_source_metadata,
+        coerced,
+        sheet_name=sheet_name,
+        schema_metadata=schema_metadata,
+        repeats=repeats,
+    )
+    prepared, prepare_ms = _time_call(
+        prepare_kvk_all_import,
+        content,
+        path.name,
+        repeats=repeats,
+    )
+    _, rows_ms = _time_call(
+        rows_for_stage,
+        "00000000-0000-0000-0000-000000000000",
+        prepared.dataframe,
+        repeats=repeats,
+    )
+
+    return {
+        "sample": str(path),
+        "file_bytes": len(content),
+        "sheets": workbook.sheet_names,
+        "full_data_rows": int(raw_df.shape[0]),
+        "full_data_columns": int(raw_df.shape[1]),
+        "schema": schema_metadata,
+        "prepared_columns": len(prepared.dataframe.columns),
+        "timings": {
+            "read_full_data_workbook": _stats(read_ms),
+            "coerce_full_data_frame": _stats(coerce_ms),
+            "attach_source_metadata": _stats(metadata_ms),
+            "prepare_kvk_all_import_total": _stats(prepare_ms),
+            "rows_for_stage": _stats(rows_ms),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark the read-only KVK_ALL Full Data workbook preparation path.",
+    )
+    parser.add_argument(
+        "workbook",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_SAMPLE,
+        help="Path to a KVK_ALL workbook sample.",
+    )
+    parser.add_argument("--repeats", type=int, default=5, help="Number of benchmark repeats.")
+    args = parser.parse_args()
+
+    if args.repeats < 1:
+        raise SystemExit("--repeats must be at least 1")
+    if not args.workbook.exists():
+        raise SystemExit(f"Workbook not found: {args.workbook}")
+
+    print(json.dumps(benchmark_workbook(args.workbook, repeats=args.repeats), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kvk_all_import_dal.py
+++ b/tests/test_kvk_all_import_dal.py
@@ -132,6 +132,12 @@ def test_ingest_prepared_import_call_shape(monkeypatch) -> None:
     assert result["scan_id"] == 2
     assert result["negatives"] == 3
     assert result["success"] is True
+    assert result["stage_rows_ms"] >= 0
+    assert result["stage_insert_ms"] >= 0
+    assert result["precheck_ms"] >= 0
+    assert result["ingest_ms"] >= 0
+    assert result["recompute_ms"] >= 0
+    assert result["negative_count_ms"] >= 0
     assert connection.commit_calls == 3
 
 
@@ -155,6 +161,9 @@ def test_ingest_prepared_import_cleans_stage_rows_when_precheck_fails(monkeypatc
     assert result["success"] is False
     assert result["cleanup_failed"] is False
     assert result["cleanup_error"] is None
+    assert result["stage_rows_ms"] >= 0
+    assert result["stage_insert_ms"] >= 0
+    assert result["precheck_ms"] >= 0
     diagnostic_cursor = connection.cursors[1]
     assert diagnostic_cursor.executed[0][0] == dal.INSERT_INGEST_DIAGNOSTIC_SQL
     diagnostic_params = cast(tuple[Any, ...], diagnostic_cursor.executed[0][1])

--- a/tests/test_kvk_all_import_service.py
+++ b/tests/test_kvk_all_import_service.py
@@ -53,6 +53,36 @@ def test_prepare_maps_full_data_columns_and_metadata() -> None:
     assert prepared.schema_metadata["unknown_columns"] == []
 
 
+def test_coerce_full_data_frame_vectorised_path_preserves_invalid_row_detection() -> None:
+    full_data = _full_data_df()
+    full_data["governor_id"] = full_data["governor_id"].astype(object)
+    full_data.loc[0, "governor_id"] = "not-a-number"
+
+    with pytest.raises(ValueError) as exc:
+        service.coerce_full_data_frame(full_data)
+
+    assert str(exc.value) == "One or more rows missing governor_id or kingdom after coercion."
+
+
+def test_coerce_full_data_frame_vectorised_path_preserves_numeric_and_datetime_values() -> None:
+    full_data = _full_data_df()
+    full_data["governor_id"] = full_data["governor_id"].astype(object)
+    full_data["kingdom"] = full_data["kingdom"].astype(object)
+    full_data["rank"] = full_data["rank"].astype(object)
+    full_data.loc[0, "governor_id"] = "123"
+    full_data.loc[0, "kingdom"] = "1198"
+    full_data.loc[0, "rank"] = "7"
+    full_data.loc[0, "first_updateUTC"] = "2026-05-08 01:00:00"
+
+    coerced = service.coerce_full_data_frame(full_data)
+    row = coerced.iloc[0]
+
+    assert int(row["governor_id"]) == 123
+    assert int(row["kingdom"]) == 1198
+    assert int(row["rank"]) == 7
+    assert row["first_updateUTC"].tzinfo is not None
+
+
 def test_read_full_data_workbook_preserves_unknown_column_reporting() -> None:
     full_data = _full_data_df()
     full_data["future_metric"] = 99

--- a/tests/test_kvk_all_importer.py
+++ b/tests/test_kvk_all_importer.py
@@ -53,8 +53,12 @@ def test_wrapper_preserves_success_return_shape(monkeypatch) -> None:
         "row_count": 1,
         "negatives": 0,
         "staged_rows": 1,
+        "stage_rows_ms": 2.0,
+        "stage_insert_ms": 4.0,
+        "precheck_ms": 1.0,
         "ingest_ms": 12.0,
         "recompute_ms": 3.0,
+        "negative_count_ms": 1.0,
         "proc_ms": 12.0,
         "sheet": "Full Data",
         "schema_version": SCHEMA_VERSION,
@@ -93,6 +97,8 @@ def test_wrapper_preserves_success_return_shape(monkeypatch) -> None:
     assert result["success"] is True
     assert result["kvk_no"] == 13
     assert result["proc_ms"] == 12.0
+    assert result["prepare_ms"] >= 0
+    assert result["stage_insert_ms"] == 4.0
     assert result["duration_s"] >= 0
     assert connection.closed is True
 


### PR DESCRIPTION
## Summary

Implements the Phase 9 end-to-end performance and restart-safety hardening pass for the modernised KVK_ALL pipeline.

## Changes

- Vectorises KVK_ALL Full Data numeric and timestamp coercion while preserving strict Full Data validation and Basic Data rejection.
- Adds granular import timing fields for prepare, stage row preparation, stage insert, KVK_Details precheck, ingest procedure execution, recompute execution, and negative-count read.
- Adds `scripts/benchmark_kvk_all_phase9.py` for repeatable read-only workbook preparation benchmarks.
- Updates focused importer/DAL/service tests for timing fields and coercion behaviour.
- Includes the local Phase 8 task-pack completion update plus the Phase 9 initiation statement in this PR, per programme instructions.
- Records Phase 9 performance baseline and restart/failure-mode assessment in the full optimisation task pack.

## Performance Baseline

Using `downloads/kvk_all_sample_file/1086045_05_08_2026,_02_21_38_AM.xlsx`:

- Full Data shape: 5,000 rows, 43 columns.
- Coercion median improved from about `1967.53ms` to `24.87ms`.
- Full local workbook preparation median improved from about `3642.55ms` to `1616.97ms`.
- Stage row preparation median: `72.25ms`.

## Restart / Safety Notes

- No Basic Data or summary-tab ingestion was introduced.
- No SQL schema, export result-set, Google Sheets tab, Discord reporting display, automatic cleanup, live import, live recompute, or live spreadsheet posting changes were made.
- Existing recovery semantics remain: staged rows are durable by token, ingest failures retain staged rows and diagnostics where Phase 8 SQL exists, recompute can be rerun via `/kvk_recompute`, and export can be rerun via `/kvk_export_all`.
- Live timing for mutating ingest/recompute procedures was not run locally to avoid unintended production mutations.

## Validation

- `python -m pytest -q tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_recompute_sql_contract.py tests/test_kvk_export_service.py tests/test_gsheet_module.py tests/test_kvk_admin_service.py tests/test_kvk_reporting_service.py`
- `python scripts/benchmark_kvk_all_phase9.py --repeats 5`
- `python -m black --check kvk/services/kvk_all_import_service.py kvk/dal/kvk_all_import_dal.py kvk_all_importer.py scripts/benchmark_kvk_all_phase9.py tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py`
- `python -m ruff check kvk/services/kvk_all_import_service.py kvk/dal/kvk_all_import_dal.py kvk_all_importer.py scripts/benchmark_kvk_all_phase9.py tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py`
- `python -m py_compile kvk/services/kvk_all_import_service.py kvk/dal/kvk_all_import_dal.py kvk_all_importer.py scripts/benchmark_kvk_all_phase9.py tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py`
- `python -m pyright kvk/services/kvk_all_import_service.py kvk/dal/kvk_all_import_dal.py kvk_all_importer.py scripts/benchmark_kvk_all_phase9.py tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py` (`0 errors`, dependency-resolution warnings only)
- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `git diff --check`
- `python -m pytest -q tests` (`1266 passed, 8 skipped`)

## Deferred Optimisations

No new Phase 9 blocker was introduced. The broader durable KVK_ALL upload/export route extraction remains outside Phase 9 scope and is already captured in `docs/deferred_optimisations.md`.