### PR TITLE
[codex] fix KVK Full Data v2 recompute windows

### DIFF
--- a/docs/KVK_ALL Schema Modernisation - Phase 10 Metric Source Correction.md
+++ b/docs/KVK_ALL Schema Modernisation - Phase 10 Metric Source Correction.md
@@ -1,0 +1,58 @@
+# KVK_ALL Schema Modernisation - Phase 10 Metric Source Correction
+
+## Purpose
+
+Phase 10 corrects the Full Data v2 recompute source rules after production smoke showed
+zero diff fields masking changed cumulative endpoint values across scans.
+
+The authoritative workbook tab remains `Full Data`. `Basic Data` remains intentionally
+ignored.
+
+## Corrected Source-Of-Truth Decisions
+
+### Configured Windows
+
+For `kvk_all_full_data_v2` rows, configured windows such as Pass 4 use cumulative
+endpoint deltas across the configured scan range:
+
+- `max_kill_points`
+- `max_kills_iv`
+- `max_kills_v`
+- `max_dead`
+- `max_units_healed`
+- `max_max_contribute`
+- `max_cur_contribute`
+
+For example, Pass 4 `kp_gain` is `End.max_kill_points - Start.max_kill_points`
+when both endpoint values are available.
+
+Legacy diff fields remain fallback inputs for older rows where the endpoint columns are
+not available:
+
+- `kill_points_diff` / `points_difference`
+- `kills_iv_diff`
+- `kills_v_diff`
+- `dead_diff`
+- `healed_troops` / `max_units_healed_diff`
+- `max_contribute_diff`
+- `cur_contribute_diff`
+
+Zero diff fields are not authoritative for Full Data v2 configured windows when
+cumulative endpoints are present.
+
+### Baseline
+
+`Baseline` output rows remain validation rows with zero gains and fixed
+`starting_power`.
+
+### Full
+
+`Full` output rows represent baseline-to-latest values. For Full Data v2 rows, `Full`
+uses the player's baseline scan endpoint and latest scan endpoint when both are
+available. If endpoint values are unavailable, the legacy latest-snapshot diff fields
+remain the compatibility fallback.
+
+## Compatibility
+
+Older 22-column Full Data workbooks do not contain raw endpoint families. Those rows
+continue to use legacy diff fields, preserving existing pre-v2 recompute semantics.

--- a/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+++ b/docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
@@ -37,6 +37,8 @@ Phase 7 is complete and deployed.
 
 Phase 8 is complete and deployed.
 
+Phase 9 is complete and deployed.
+
 Completed Phase 1 scope:
 
 strict Full Data workbook detection
@@ -121,7 +123,7 @@ Phase 8 did not introduce Basic Data ingestion, summary tab ingestion, Discord r
 
 Next phase:
 
-Phase 9 — End-to-End Performance & Restart Safety Hardening
+Phase 10 — Full Run Diagnostics, Output Correctness & Recompute Bug Fixing
 
 Completion Rule
 This work is not complete until all items previously identified as deferred optimisations are implemented or explicitly resolved inside this programme.
@@ -962,6 +964,9 @@ Diagnostic audit visibility was confirmed with a phase8_smoke row.
 No Discord reporting display changes, Google Sheets export contract changes, KVK export result-set changes, Basic Data ingestion, summary tab ingestion, automatic cleanup execution, or Phase 9 restart/performance hardening were included in Phase 8.
 
 Phase 9 — End-to-End Performance & Restart Safety Hardening
+Status
+Complete and deployed.
+
 Goal
 Final optimisation and validation pass.
 
@@ -1099,3 +1104,68 @@ Validation completed:
 python -m pytest -q tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_recompute_sql_contract.py tests/test_kvk_export_service.py tests/test_gsheet_module.py tests/test_kvk_admin_service.py tests/test_kvk_reporting_service.py
 
 No SQL schema changes, Discord reporting display changes, Google Sheets tab/spreadsheet changes, KVK export result-set changes, Basic Data ingestion, summary tab ingestion, automatic cleanup execution, live production import, live recompute, or live export posting were included in Phase 9.
+
+Production smoke completed after deployment:
+
+Four KVK_ALL Full Data workbooks were uploaded and ingested for KVK 15:
+
+Scan 1: 1086045_05_08_2026_02_21_38_AM.xlsx, 5,000 rows.
+Scan 2: 1086045_05_09_2026_02_13_52_PM.xlsx, 5,000 rows.
+Scan 3: 1086045_05_10_2026_10_06_04_PM.xlsx, 5,000 rows.
+Scan 4: 1086045_05_11_2026_10_00_41_AM.xlsx, 5,000 rows.
+
+KVK.KVK_Scan confirmed all four scans with schema_version kvk_all_full_data_v2 and source_sheet_name Full Data.
+KVK.KVK_AllPlayers_Raw confirmed 20,000 rows for KVK 15, matching 4 scans x 5,000 rows.
+KVK.KVK_Ingest_Diagnostics contained only the prior phase8_smoke diagnostic and no failed/rejected diagnostics from these uploads.
+SQL log headroom checks passed before each ingest with reuse_wait=NOTHING and low log usage.
+Google Sheets auto-export completed and updated PASS4 and ALL_WINDOW_COMPARISON outputs without changing established tab names.
+
+Phase 9 deployment smoke also surfaced a Phase 10 correctness finding:
+
+Full Data v2 recompute window calculations can incorrectly return zero gains when diff fields such as kill_points_diff and points_difference are present but zero while raw cumulative endpoint fields change across scans. Example: governor_id 45227155 has max_kill_points increasing from 3,380,153,250 at Scan 2 to 3,478,156,090 at Scan 3, so Pass 4 kp_gain should be 98,002,840, but current KVK.sp_KVK_Recompute_Windows output shows zero. This is assigned to Phase 10.
+
+Phase 10 — Full Run Diagnostics, Output Correctness & Recompute Bug Fixing
+Goal
+Run a full end-to-end diagnostic correctness pass using consecutive real workbook samples, validate all SQL outputs and spreadsheet/export calculations, and fix discovered recompute/window correctness bugs while preserving the established Phase 1-9 import, export, Google Sheets, Discord reporting, admin command, and diagnostic contracts.
+
+In Scope
+Use the deployed KVK 15 sample scans from 8 May, 9 May, 10 May, and 11 May 2026 as the primary diagnostic dataset.
+Validate KVK.KVK_Scan, KVK.KVK_AllPlayers_Raw, KVK.KVK_Windows, KVK.KVK_Player_Windowed, KVK.KVK_Kingdom_Windowed, KVK.KVK_Camp_Windowed, KVK.KVK_Player_Baseline, KVK.KVK_Ingest_Negatives, KVK.KVK_Ingest_Diagnostics, and KVK export result sets against expected sample-derived calculations.
+Validate source-of-truth semantics for Full Data v2 cumulative endpoint columns versus diff columns.
+Fix KVK.sp_KVK_Recompute_Windows so Full Data v2 window calculations use the correct endpoint deltas when diff columns are zero or non-authoritative.
+Validate player, kingdom, and camp rollups after recompute.
+Validate Baseline, Full, Pass 4, and any configured future windows using sample-derived expected values.
+Validate KVK.sp_KVK_Get_Exports result-set shape and values after recompute fixes.
+Validate Google Sheets output values where practical without changing spreadsheet names, tab names, or result-set contracts.
+Add diagnostic SQL scripts or Python scripts where useful for repeatable comparison of raw scans to recompute outputs.
+Add SQL contract tests and/or fixture-style tests for the discovered zero-diff/nonzero-endpoint bug.
+Capture any larger analytics or redesign findings structurally.
+
+Known Phase 10 Bug In Scope
+Area: KVK.sp_KVK_Recompute_Windows
+Description: Full Data v2 scans can persist diff fields as zero while raw cumulative endpoint fields such as max_kill_points, max_kills_iv, max_kills_v, max_dead, max_units_healed, and contribution endpoint fields move between scans. Current recompute precedence can select the zero diff value before using raw endpoint fields, producing zero window gains.
+Expected Fix: For schema_version kvk_all_full_data_v2, compute window deltas from raw cumulative endpoint fields across StartScanID and EndScanID where those fields are available. Preserve legacy compatibility for older rows that depend on diff fields.
+Example: KVK 15, governor_id 45227155, Pass 4 window StartScanID=2 and EndScanID=3 should produce kp_gain 98,002,840 from max_kill_points delta.
+
+Out of Scope
+Basic Data ingestion.
+Summary tab ingestion.
+Discord reporting display changes unless explicitly approved as a bug fix.
+New contribution fields in Discord embeds.
+Google Sheets spreadsheet or tab name changes.
+KVK export result-set count/order changes unless explicitly approved.
+Unrelated stats, rankings, history, reporting, personal KVK, or admin command redesign.
+Large upload-route extraction from DL_bot.py unless separately approved.
+Automatic diagnostic cleanup deletes without explicit dry-run review.
+Production promotion before local validation.
+
+Acceptance Criteria
+Full Data v2 ingest remains stable for the sample workbooks.
+Expected sample-derived player window values match KVK.KVK_Player_Windowed for representative players, including the known governor_id 45227155 Pass 4 kp_gain case.
+Kingdom and camp rollups match player-windowed sums.
+Baseline and Full outputs have documented and validated semantics.
+Export result sets remain at 10 and preserve existing section meanings.
+Google Sheets tab names and spreadsheet names remain stable.
+No Basic Data or summary tab ingestion is introduced.
+Tests or repeatable diagnostic scripts cover changed recompute behaviour.
+Any remaining correctness blocker is explicitly documented with owner, risk, and next action.

--- a/docs/KVK_ALL Schema Modernisation — Phase 10 Initiation Statement.md
+++ b/docs/KVK_ALL Schema Modernisation — Phase 10 Initiation Statement.md
@@ -1,0 +1,320 @@
+KVK_ALL Schema Modernisation — Phase 10 Initiation Statement
+
+We are starting Phase 10 of the KVK_ALL Schema Modernisation programme.
+
+Important local documentation note:
+
+The Phase 9 completion update to docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md and this Phase 10 initiation statement were created locally after Phase 9 was completed, deployed, and smoke-tested.
+
+Do not amend the Phase 9 PR for these documentation updates.
+
+These local documentation changes must be included in the next PR opened for Phase 10.
+
+Before implementation, read all required repository documents and the full task pack:
+
+README-DEV.md
+docs/K98 Bot — Standard Development Initiation Statement.md
+docs/K98 Bot — Project Engineering Standards.md
+docs/K98 Bot — Coding Execution Guidelines.md
+docs/K98 Bot — Testing Standards.md
+docs/K98 Bot — Skills & Refactor Triggers.md
+docs/k98 Bot — Deferred Optimisation Framework.md
+docs/K98 Bot Deferred Optimisation Scoring Model.md
+docs/K98 Bot Codex Task Pack Generator.md
+docs/KVK_ALL Schema Modernisation — Full Optimisation Task Pack.md
+docs/KVK_ALL Schema Modernisation — Audit & Migration Planning Task Pack.md
+docs/KVK_ALL Schema Modernisation — Phase 2 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 3 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 4 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md
+docs/KVK_ALL Schema Modernisation — Phase 5 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 6 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 7 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 8 Initiation Statement.md
+docs/KVK_ALL Schema Modernisation — Phase 9 Initiation Statement.md
+
+Also use the deployed KVK 15 sample workbook set:
+
+1086045_05_08_2026_02_21_38_AM.xlsx
+1086045_05_09_2026_02_13_52_PM.xlsx
+1086045_05_10_2026_10_06_04_PM.xlsx
+1086045_05_11_2026_10_00_41_AM.xlsx
+
+Authoritative SQL repository:
+
+C:\K98-bot-SQL-Server
+
+The SQL repo is authoritative for table names, column names, stored procedures, indexes, views, ProcConfig usage, staging tables, output tables, aggregate functions, diagnostic tables, retention scripts, migration scripts, and performance-sensitive query plans. Do not infer schema purely from Python usage if SQL definitions exist.
+
+Phase 1 is complete and deployed.
+
+Phase 1 delivered:
+
+strict Full Data workbook detection
+Full Data tab required
+Basic Data ignored and never used as fallback
+fallback-to-second-sheet behaviour removed for KVK_ALL imports
+all expected Full Data columns validated before legacy coercion
+schema version kvk_all_full_data_v2 returned in import results
+structured validation errors for schema failures
+focused schema tests for valid schema, missing Full Data, missing required columns, and Basic Data ignored
+
+Phase 2 is complete and deployed.
+
+Phase 2 delivered:
+
+additive SQL capacity for the KVK_ALL Full Data workbook schema
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Stage
+nullable Full Data v2 columns on KVK.KVK_AllPlayers_Raw
+queryable schema/source metadata on KVK.KVK_Scan
+backward-compatible optional metadata parameters on KVK.sp_KVK_AllPlayers_Ingest
+Python staging support for rank, raw min/max metric families, contribution metrics, and source metadata
+focused schema/import SQL contract tests
+production deployment script under sql/kvk_all_phase2_full_data_capacity.sql
+non-mutating workbook/importer smoke validation
+read-only SQL metadata smoke validation after deployment
+
+Phase 3 is complete and deployed.
+
+Phase 3 delivered:
+
+kvk_all_importer.py reduced to a compatibility wrapper around service and DAL layers
+workbook parsing, Full Data selection, aliasing, schema validation, canonical mapping, coercion, and source metadata moved into kvk/services/kvk_all_import_service.py
+stage column ordering, SQL staging, stage schema preflight, ingest procedure call, recompute call, KVK timestamp precheck, diagnostic writing, and negative count reads moved into kvk/dal/kvk_all_import_dal.py
+Full Data v2 canonical mapping constants moved into kvk/schemas/kvk_all_schema.py
+structured schema and coercion failures preserved
+legacy import return dictionary shape preserved for DL_bot.py
+Phase 2 schema/source metadata staging and ingest parameters preserved
+unknown column reporting retained in schema metadata without changing Discord output
+focused tests added for service mapping/validation, DAL call shape, wrapper compatibility, and existing schema behaviours
+non-mutating workbook/service smoke validation completed against the uploaded sample workbook
+
+Phase 4 is complete and deployed.
+
+Phase 4 delivered:
+
+metric source-of-truth rules documented for kill points, healed troops, raw min/max metric fields, and contribution metrics
+Full Data v2 recompute precedence implemented for kill points using kill_points_diff with legacy/raw fallback
+Full Data v2 recompute precedence implemented for healed troops using healed_troops with legacy/raw fallback
+raw min/max fields retained as validation/reconciliation inputs and fallback inputs rather than replacing stable output semantics
+additive max_contribute_gain and cur_contribute_gain outputs on KVK.KVK_Player_Windowed, KVK.KVK_Kingdom_Windowed, and KVK.KVK_Camp_Windowed
+KVK.sp_KVK_Recompute_Windows updated to populate contribution gains while preserving existing KP, kills, deads, healed, DKP, baseline, kingdom, and camp outputs
+KVK.sp_KVK_Get_Exports kept at 10 result sets and adjusted to keep Full export output columns explicit
+Google Sheets tab names and Discord reporting display unchanged
+production replication script added under sql/kvk_all_phase4_recompute_modernisation.sql
+focused SQL contract tests added for source precedence, additive contribution columns, export contract preservation, and production SQL script coverage
+
+Phase 5 is complete and deployed.
+
+Phase 5 delivered:
+
+stable named KVK export sections for KVK.sp_KVK_Get_Exports outputs
+legacy positional export compatibility retained while current callers migrate
+primary KVK Google Sheets export binding moved away from fragile fixed DataFrame index assumptions
+additional PASS, ALTAR, GREATZIG, and comparison spreadsheet generation updated to use named export-section binding
+compatible extra SQL result sets can be ignored when all required export sections are present
+existing primary spreadsheet tab names preserved
+existing additional spreadsheet names and tab names preserved
+ALL_WINDOW_COMPARISON tab names preserved with no new contribution comparison tabs
+max_contribute_gain and cur_contribute_gain exported in existing player, kingdom, and camp windowed/full export sections
+KVK.sp_KVK_Get_Exports kept at 10 result sets with existing section order preserved
+local production deployment script added under sql/kvk_all_phase5_export_contract_decoupling.sql
+focused tests added for named binding, backward compatibility, compatible extra result sets, missing-section failures, tab-name stability, and contribution export behaviour
+read-only SQL smoke confirmed the applied procedure contract
+Google Sheets smoke confirmed stable primary/additional/comparison tab behaviour
+production promotion completed after validation
+
+Phase 6 is complete and deployed.
+
+Phase 6 delivered:
+
+KVK all-kingdom reporting SQL moved out of stats_alerts/allkingdoms.py
+reporting data access moved into kvk/dal/kvk_reporting_dal.py
+reporting block orchestration and row shaping moved into kvk/services/kvk_reporting_service.py
+stats_alerts/allkingdoms.py preserved as a thin compatibility wrapper around load_allkingdom_blocks(kvk_no)
+existing Discord embed display, field names, links, titles, Top 5 layout, and truncation behaviour preserved
+max_contribute_gain and cur_contribute_gain made available in structured reporting rows where SQL supports them
+contribution metrics intentionally not displayed in Discord embeds
+focused tests added for reporting block shape, SQL placement, contribution availability, embed compatibility, and truncation stability
+read-only SQL smoke confirmed structured reporting block availability
+Discord test embed smoke confirmed existing display remained stable
+production deployment completed after validation
+
+Phase 7 is complete and deployed.
+
+Phase 7 delivered:
+
+KVK admin command SQL moved out of commands/stats_cmds.py for recompute, scan listing, and window preview workflows
+KVK admin data access moved into kvk/dal/kvk_admin_dal.py
+KVK admin orchestration and command-facing result shaping moved into kvk/services/kvk_admin_service.py
+commands/stats_cmds.py preserved command names, permissions, defer/followup flow, output copy, export behaviour, and operator workflow
+/kvk_export_all current-KVK resolution moved through the KVK admin service while preserving existing Google Sheets export execution
+/kvk_export_all exception reporting hardened so export failures are visible to the operator
+/kvk_window_preview SQL Server RowCount alias compatibility fixed
+/kvk_window_preview output capped to Discord's 1024-character embed field limit with a truncation marker
+focused tests added for DAL/service result shape, command boundary handoff, SQL alias coverage, and embed field limit behaviour
+/kvk_export_all smoke completed successfully
+/kvk_window_preview smoke issues were fixed in Phase 7 follow-up hotfixes
+
+Phase 8 is complete and deployed.
+
+Phase 8 delivered:
+
+KVK.KVK_AllPlayers_Stage gained staged_at_utc with default and supporting age-based index
+KVK.KVK_Ingest_Diagnostics was introduced for durable ingest diagnostic visibility
+KVK.sp_KVK_Ingest_Cleanup was introduced with dry-run default cleanup
+default retention policy is 24 hours for staged rows, 90 days for ingest diagnostics, and 365 days for negative diagnostics
+cleanup validates retention values and does not run automatically during deployment or import
+timestamp precheck rejections and ingest procedure failures record best-effort durable diagnostics where Phase 8 SQL is deployed
+diagnostic context includes schema/source metadata, source filename, file hash, uploader ID, staged row count, error text, and context JSON where available
+ingest procedure failure paths retain staged rows for operator inspection until explicit retention cleanup
+coercion validation failures include structured validation context without changing Discord-facing import output
+focused tests added for diagnostic shape, best-effort diagnostic writes, retained failed stage rows, and cleanup SQL policy
+production deployment script added under sql/kvk_all_phase8_ingest_retention.sql
+production smoke confirmed stage marker, diagnostics table, cleanup procedure, dry-run cleanup, and diagnostic insert visibility
+
+Phase 9 is complete and deployed.
+
+Phase 9 delivered:
+
+KVK_ALL Full Data numeric and timestamp coercion was vectorised while preserving strict Full Data validation, Basic Data rejection, canonical staging columns, schema metadata, and legacy import return compatibility
+granular local timing fields were added for prepare, stage row preparation, stage insert, KVK_Details precheck, ingest procedure execution, recompute execution, and negative diagnostic counting
+read-only benchmark script added under scripts/benchmark_kvk_all_phase9.py
+performance baseline recorded against the 8 May workbook sample
+production smoke confirmed four KVK 15 Full Data scans ingested successfully with 20,000 raw rows and no failed/rejected ingest diagnostics
+Google Sheets auto-export completed and updated established PASS4 and comparison outputs
+Phase 9 smoke surfaced a recompute/window correctness bug assigned to Phase 10
+
+Phases 1 through 9 did not introduce Basic Data ingestion, summary tab ingestion, Discord contribution display, incompatible Google Sheets tab/spreadsheet changes, KVK export result-set changes, unrelated admin command redesign, or automatic cleanup execution.
+
+Phase 10 objective:
+
+Run a full end-to-end diagnostic correctness pass using consecutive real workbook samples, validate all SQL outputs and spreadsheet/export calculations, and fix discovered recompute/window correctness bugs while preserving established import, recompute, export, Google Sheets, Discord reporting, admin command, and operational diagnostic contracts.
+
+Authoritative workbook tab:
+
+Full Data only.
+
+Do not use Basic Data as fallback. Basic Data remains out of scope and intentionally ignored.
+
+In scope:
+
+review the full KVK_ALL import-to-export flow before implementation
+validate all referenced raw, scan, window, baseline, diagnostic, recompute, export, reporting, and admin objects against the SQL repo
+use the four deployed KVK 15 sample scans as the primary correctness dataset
+create or run a full diagnostic suite that compares raw scan endpoint values to recompute outputs
+validate Baseline, Full, Pass 4, and future configured window semantics
+validate KVK_Player_Windowed, KVK_Kingdom_Windowed, and KVK_Camp_Windowed values against sample-derived expected calculations
+validate KVK.sp_KVK_Get_Exports output values and shape after recompute fixes
+validate Google Sheets output values where practical without posting unintended live output unless explicitly approved
+fix the discovered Full Data v2 recompute bug where zero diff fields mask changed raw cumulative endpoint values
+add focused SQL contract tests and/or diagnostic fixture tests for changed recompute behaviour
+preserve existing import behaviour and return shape
+preserve existing Google Sheets tab names and spreadsheet names
+preserve existing Discord reporting display
+capture any larger out-of-scope findings structurally
+include the local Phase 9 task-pack update and this Phase 10 initiation statement in the next PR
+
+Known bug in scope:
+
+KVK.sp_KVK_Recompute_Windows currently can produce zero Full Data v2 window gains when diff fields such as kill_points_diff and points_difference are present but zero while raw cumulative endpoint fields move across scans.
+
+Example from production smoke:
+
+KVK 15
+Window Pass 4
+StartScanID 2
+EndScanID 3
+governor_id 45227155
+Scan 2 max_kill_points 3,380,153,250
+Scan 3 max_kill_points 3,478,156,090
+Expected Pass 4 kp_gain 98,002,840
+Observed Pass 4 kp_gain 0
+
+Likely SQL objects to review and possibly update:
+
+KVK.KVK_AllPlayers_Raw
+KVK.KVK_Scan
+KVK.KVK_Player_Windowed
+KVK.KVK_Kingdom_Windowed
+KVK.KVK_Camp_Windowed
+KVK.KVK_Player_Baseline
+KVK.KVK_Windows
+KVK.KVK_DKPWeights
+KVK.KVK_CampMap
+KVK.KVK_Ingest_Negatives
+KVK.KVK_Ingest_Diagnostics
+KVK.sp_KVK_Recompute_Windows
+KVK.sp_KVK_Get_Exports
+dbo.fn_KVK_Player_Aggregated
+dbo.fn_KVK_Kingdom_Aggregated
+dbo.fn_KVK_Camp_Aggregated
+KVK.vw_FightingDataset
+
+Likely Python modules to review and possibly update:
+
+kvk/dal/kvk_all_import_dal.py
+kvk/services/kvk_all_import_service.py
+kvk_all_importer.py
+kvk/services/kvk_export_service.py
+gsheet_module.py
+kvk/dal/kvk_admin_dal.py
+kvk/services/kvk_admin_service.py
+tests/test_kvk_all_recompute_sql_contract.py
+tests/test_kvk_export_service.py
+tests/test_gsheet_module.py
+scripts/
+sql/
+
+Out of scope for Phase 10:
+
+Discord reporting display changes unless explicitly approved as a bug fix
+new contribution fields in Discord embeds
+Google Sheets tab or spreadsheet name changes
+KVK export result-set count/order changes unless explicitly approved
+Basic Data ingestion
+summary tab ingestion
+new live production imports, recomputes, exports, cleanup deletes, or reporting posts unless explicitly requested
+production promotion before local validation
+rewriting unrelated stats, rankings, history, reporting, personal KVK, or admin command flows
+large cross-module KVK_ALL upload-route extraction unless explicitly approved as a separate task
+new analytics features beyond diagnostic correctness and bug fixing
+
+Important constraints:
+
+Keep changes PR-sized and focused.
+Preserve existing import behaviour and return shape.
+Preserve existing Google Sheets export behaviour.
+Preserve existing Discord embed/reporting output.
+Do not silently change metric semantics.
+Document source-of-truth decisions before changing formulas.
+Validate all schema and procedure assumptions against the SQL repo first.
+Avoid embedded SQL in command/view/presentation layers.
+Prefer service and DAL boundaries.
+Use additive, rollback-safe SQL changes only if SQL changes become necessary.
+Do not delete diagnostics or staged rows without explicit approval and dry-run review.
+Run targeted tests and validation where practical.
+
+Expected workflow:
+
+Step 1 must be review/scope only unless explicitly told otherwise.
+Search and validate SQL repo definitions first.
+Identify exact correctness risks, recompute formula issues, output-shape dependencies, and diagnostic strategy.
+Present an implementation plan before code if not explicitly asked to implement in one pass.
+Implement only Phase 10 full-run diagnostics and correctness bug fixes.
+Run targeted validation.
+Stop after Phase 10 implementation, tests, and report.
+
+Acceptance criteria:
+
+Full Data v2 ingest remains stable for the deployed sample workbook set.
+Sample-derived expected player window values match KVK.KVK_Player_Windowed for representative players, including governor_id 45227155 Pass 4 kp_gain.
+Kingdom and camp rollups match player-windowed sums.
+Baseline and Full output semantics are documented and validated.
+KVK.sp_KVK_Get_Exports remains at 10 result sets unless an explicit contract change is approved.
+Existing Google Sheets tab names and spreadsheet names remain stable.
+No Basic Data or summary tab ingestion is introduced.
+No incompatible Google Sheets or export result-set changes are introduced.
+Tests or repeatable diagnostic scripts cover changed recompute behaviour.
+New deferred findings are captured structurally.
+The programme is full-run correctness-ready, or any remaining blocker is explicitly documented with owner, risk, and next action.

--- a/scripts/diagnose_kvk_all_phase10.py
+++ b/scripts/diagnose_kvk_all_phase10.py
@@ -97,22 +97,22 @@ def _governor_window(
             "error": "Governor missing from start or end scan",
         }
 
-    start = rows.loc[start_scan]
-    end = rows.loc[end_scan]
+    start = rows.loc[[start_scan]]
+    end = rows.loc[[end_scan]]
     expected: dict[str, int] = {}
     legacy_diff_delta: dict[str, int] = {}
     for name, endpoint_col, diff_col in METRICS:
-        expected[name] = int(pd.to_numeric(end[endpoint_col], errors="coerce")) - int(
-            pd.to_numeric(start[endpoint_col], errors="coerce")
+        expected[name] = int(
+            (_int_series(end, endpoint_col) - _int_series(start, endpoint_col)).iloc[0]
         )
-        legacy_diff_delta[name] = int(pd.to_numeric(end[diff_col], errors="coerce")) - int(
-            pd.to_numeric(start[diff_col], errors="coerce")
+        legacy_diff_delta[name] = int(
+            (_int_series(end, diff_col) - _int_series(start, diff_col)).iloc[0]
         )
 
     return {
         "governor_id": governor_id,
-        "name": str(end.get("name", "")),
-        "kingdom": int(end.get("kingdom", 0)),
+        "name": str(end["name"].iloc[0] if "name" in end.columns else ""),
+        "kingdom": int(_int_series(end, "kingdom").iloc[0]),
         "start_scan": start_scan,
         "end_scan": end_scan,
         "expected_endpoint_delta": expected,

--- a/scripts/diagnose_kvk_all_phase10.py
+++ b/scripts/diagnose_kvk_all_phase10.py
@@ -37,6 +37,26 @@ def _int_series(df: pd.DataFrame, column: str) -> pd.Series:
     return pd.to_numeric(df[column], errors="coerce").fillna(0).astype("Int64")
 
 
+def _single_row_int(df: pd.DataFrame, column: str) -> int:
+    value = _int_series(df, column).iloc[0]
+    if pd.isna(value):
+        return 0
+    return int(value)
+
+
+def _single_row_str(df: pd.DataFrame, column: str) -> str:
+    if column not in df.columns:
+        return ""
+    value = df[column].iloc[0]
+    if pd.isna(value):
+        return ""
+    return str(value)
+
+
+def _window_delta(end_df: pd.DataFrame, start_df: pd.DataFrame, column: str) -> int:
+    return _single_row_int(end_df, column) - _single_row_int(start_df, column)
+
+
 def _load_prepared_samples(paths: list[Path]) -> pd.DataFrame:
     frames: list[pd.DataFrame] = []
     for scan_id, path in enumerate(paths, start=1):
@@ -102,17 +122,13 @@ def _governor_window(
     expected: dict[str, int] = {}
     legacy_diff_delta: dict[str, int] = {}
     for name, endpoint_col, diff_col in METRICS:
-        expected[name] = int(
-            (_int_series(end, endpoint_col) - _int_series(start, endpoint_col)).iloc[0]
-        )
-        legacy_diff_delta[name] = int(
-            (_int_series(end, diff_col) - _int_series(start, diff_col)).iloc[0]
-        )
+        expected[name] = _window_delta(end, start, endpoint_col)
+        legacy_diff_delta[name] = _window_delta(end, start, diff_col)
 
     return {
         "governor_id": governor_id,
-        "name": str(end["name"].iloc[0] if "name" in end.columns else ""),
-        "kingdom": int(_int_series(end, "kingdom").iloc[0]),
+        "name": _single_row_str(end, "name"),
+        "kingdom": _single_row_int(end, "kingdom"),
         "start_scan": start_scan,
         "end_scan": end_scan,
         "expected_endpoint_delta": expected,

--- a/scripts/diagnose_kvk_all_phase10.py
+++ b/scripts/diagnose_kvk_all_phase10.py
@@ -1,0 +1,206 @@
+"""Read-only Phase 10 diagnostics for KVK_ALL Full Data v2 window correctness."""
+
+from __future__ import annotations
+
+import argparse
+from itertools import pairwise
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from kvk.services.kvk_all_import_service import prepare_kvk_all_import
+
+DEFAULT_SAMPLE_DIR = Path("downloads/kvk_all_sample_file")
+DEFAULT_PATTERN = "1086045_05_*.xlsx"
+
+METRICS: tuple[tuple[str, str, str], ...] = (
+    ("kp_gain", "max_kill_points", "kill_points_diff"),
+    ("t4_kills", "max_kills_iv", "kills_iv_diff"),
+    ("t5_kills", "max_kills_v", "kills_v_diff"),
+    ("deads", "max_dead", "dead_diff"),
+    ("healed_troops", "max_units_healed", "healed_troops"),
+    ("max_contribute_gain", "max_max_contribute", "max_contribute_diff"),
+    ("cur_contribute_gain", "max_cur_contribute", "cur_contribute_diff"),
+)
+
+
+def _int_series(df: pd.DataFrame, column: str) -> pd.Series:
+    if column not in df.columns:
+        return pd.Series([0] * len(df), index=df.index, dtype="Int64")
+    return pd.to_numeric(df[column], errors="coerce").fillna(0).astype("Int64")
+
+
+def _load_prepared_samples(paths: list[Path]) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+    for scan_id, path in enumerate(paths, start=1):
+        prepared = prepare_kvk_all_import(path.read_bytes(), source_filename=path.name)
+        df = prepared.dataframe.copy()
+        df["ScanID"] = scan_id
+        df["source_file"] = path.name
+        frames.append(df)
+    if not frames:
+        raise ValueError("No workbook samples were provided")
+    return pd.concat(frames, ignore_index=True)
+
+
+def _pair_summary(all_scans: pd.DataFrame, start_scan: int, end_scan: int) -> dict[str, Any]:
+    start = all_scans[all_scans["ScanID"] == start_scan].set_index("governor_id")
+    end = all_scans[all_scans["ScanID"] == end_scan].set_index("governor_id")
+    common = start.index.intersection(end.index)
+
+    metrics: dict[str, Any] = {}
+    for name, endpoint_col, diff_col in METRICS:
+        endpoint_delta = _int_series(end.loc[common], endpoint_col) - _int_series(
+            start.loc[common], endpoint_col
+        )
+        diff_delta = _int_series(end.loc[common], diff_col) - _int_series(
+            start.loc[common], diff_col
+        )
+        metrics[name] = {
+            "endpoint_delta_sum": int(endpoint_delta.sum()),
+            "diff_delta_sum": int(diff_delta.sum()),
+            "masked_nonzero_endpoint_zero_diff_rows": int(
+                ((endpoint_delta != 0) & (diff_delta == 0)).sum()
+            ),
+            "endpoint_diff_mismatch_rows": int((endpoint_delta != diff_delta).sum()),
+        }
+
+    return {
+        "start_scan": start_scan,
+        "end_scan": end_scan,
+        "common_governors": int(len(common)),
+        "start_only_governors": int(len(start.index.difference(end.index))),
+        "end_only_governors": int(len(end.index.difference(start.index))),
+        "metrics": metrics,
+    }
+
+
+def _governor_window(
+    all_scans: pd.DataFrame,
+    governor_id: int,
+    start_scan: int,
+    end_scan: int,
+) -> dict[str, Any]:
+    rows = all_scans[all_scans["governor_id"] == governor_id].set_index("ScanID")
+    if start_scan not in rows.index or end_scan not in rows.index:
+        return {
+            "governor_id": governor_id,
+            "start_scan": start_scan,
+            "end_scan": end_scan,
+            "error": "Governor missing from start or end scan",
+        }
+
+    start = rows.loc[start_scan]
+    end = rows.loc[end_scan]
+    expected: dict[str, int] = {}
+    legacy_diff_delta: dict[str, int] = {}
+    for name, endpoint_col, diff_col in METRICS:
+        expected[name] = int(pd.to_numeric(end[endpoint_col], errors="coerce")) - int(
+            pd.to_numeric(start[endpoint_col], errors="coerce")
+        )
+        legacy_diff_delta[name] = int(pd.to_numeric(end[diff_col], errors="coerce")) - int(
+            pd.to_numeric(start[diff_col], errors="coerce")
+        )
+
+    return {
+        "governor_id": governor_id,
+        "name": str(end.get("name", "")),
+        "kingdom": int(end.get("kingdom", 0)),
+        "start_scan": start_scan,
+        "end_scan": end_scan,
+        "expected_endpoint_delta": expected,
+        "legacy_diff_delta": legacy_diff_delta,
+    }
+
+
+def diagnose(
+    paths: list[Path],
+    *,
+    known_governor_id: int,
+    known_start_scan: int,
+    known_end_scan: int,
+) -> dict[str, Any]:
+    all_scans = _load_prepared_samples(paths)
+    scan_ids = sorted(int(value) for value in all_scans["ScanID"].unique())
+
+    return {
+        "workbooks": [
+            {
+                "scan_id": index,
+                "path": str(path),
+                "file_bytes": path.stat().st_size,
+            }
+            for index, path in enumerate(paths, start=1)
+        ],
+        "rows_by_scan": {
+            str(scan_id): int((all_scans["ScanID"] == scan_id).sum()) for scan_id in scan_ids
+        },
+        "pair_summaries": [
+            _pair_summary(all_scans, start_scan, end_scan)
+            for start_scan, end_scan in pairwise(scan_ids)
+        ],
+        "full_span_summary": _pair_summary(all_scans, scan_ids[0], scan_ids[-1]),
+        "known_governor": _governor_window(
+            all_scans,
+            known_governor_id,
+            known_start_scan,
+            known_end_scan,
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Derive expected KVK_ALL Full Data v2 endpoint deltas from consecutive workbook "
+            "samples without mutating SQL or posting Google Sheets output."
+        )
+    )
+    parser.add_argument(
+        "--sample-dir",
+        type=Path,
+        default=DEFAULT_SAMPLE_DIR,
+        help="Directory containing the consecutive KVK_ALL sample workbooks.",
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_PATTERN,
+        help="Glob pattern used inside --sample-dir.",
+    )
+    parser.add_argument(
+        "--known-governor-id",
+        type=int,
+        default=45227155,
+        help="Governor ID to include as a representative regression case.",
+    )
+    parser.add_argument("--known-start-scan", type=int, default=2)
+    parser.add_argument("--known-end-scan", type=int, default=3)
+    args = parser.parse_args()
+
+    paths = sorted(args.sample_dir.glob(args.pattern))
+    if not paths:
+        raise SystemExit(f"No workbooks matched {args.sample_dir / args.pattern}")
+
+    print(
+        json.dumps(
+            diagnose(
+                paths,
+                known_governor_id=args.known_governor_id,
+                known_start_scan=args.known_start_scan,
+                known_end_scan=args.known_end_scan,
+            ),
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sql/kvk_all_phase10_recompute_correctness.sql
+++ b/sql/kvk_all_phase10_recompute_correctness.sql
@@ -17,7 +17,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_Recompute_Windows]') AND type in (N'P', N'PC'))
 BEGIN
-EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Recompute_Windows] AS' 
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Recompute_Windows] AS'
 END
 GO
 ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]
@@ -129,12 +129,12 @@ BEGIN
 				WHEN w.EndScanID > @MaxScanID THEN @MaxScanID  -- ← NEW: Safety cap
 				ELSE w.EndScanID
 			END AS EndScanID
- 		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
- 		WHERE w.KVK_NO = @KVK_NO
- 		  AND w.StartScanID IS NOT NULL
+		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
+		WHERE w.KVK_NO = @KVK_NO
+		  AND w.StartScanID IS NOT NULL
 		  AND w.StartScanID <= @MaxScanID
- 		  AND w.WindowName <> N'Baseline'
- 	),
+		  AND w.WindowName <> N'Baseline'
+	),
     S AS (
         SELECT
             W.WindowName, W.StartScanID, W.EndScanID,
@@ -493,10 +493,4 @@ BEGIN
 
     RETURN 0;
 END
-
-
-
-
-
 GO
-

--- a/sql/kvk_all_phase10_recompute_correctness.sql
+++ b/sql/kvk_all_phase10_recompute_correctness.sql
@@ -129,11 +129,12 @@ BEGIN
 				WHEN w.EndScanID > @MaxScanID THEN @MaxScanID  -- ← NEW: Safety cap
 				ELSE w.EndScanID
 			END AS EndScanID
-		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
-		WHERE w.KVK_NO = @KVK_NO
-		  AND w.StartScanID IS NOT NULL
-		  AND w.WindowName <> N'Baseline'
-	),
+ 		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
+ 		WHERE w.KVK_NO = @KVK_NO
+ 		  AND w.StartScanID IS NOT NULL
+		  AND w.StartScanID <= @MaxScanID
+ 		  AND w.WindowName <> N'Baseline'
+ 	),
     S AS (
         SELECT
             W.WindowName, W.StartScanID, W.EndScanID,
@@ -498,5 +499,4 @@ END
 
 
 GO
-
 

--- a/sql/kvk_all_phase10_recompute_correctness.sql
+++ b/sql/kvk_all_phase10_recompute_correctness.sql
@@ -1,0 +1,502 @@
+﻿/*
+KVK_ALL Schema Modernisation - Phase 10 Recompute Correctness
+
+Purpose:
+- Fix Full Data v2 configured-window gains when zero diff fields mask moving cumulative endpoints.
+- Preserve legacy diff-field compatibility for older KVK_ALL rows without endpoint columns.
+- Preserve existing export result-set count/order, Google Sheets tabs, and Discord reporting display.
+
+Rollback:
+- Redeploy the previous KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql definition.
+*/
+
+PRINT N'Applying KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql';
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[KVK].[sp_KVK_Recompute_Windows]') AND type in (N'P', N'PC'))
+BEGIN
+EXEC dbo.sp_executesql @statement = N'CREATE PROCEDURE [KVK].[sp_KVK_Recompute_Windows] AS' 
+END
+GO
+ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]
+	@KVK_NO [int]
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    ----------------------------------------------------------------
+    -- 0) Validations & setup
+    ----------------------------------------------------------------
+    IF @KVK_NO IS NULL
+        THROW 60001, 'KVK_NO is required.', 1;
+
+    DECLARE @MaxScanID INT;
+    SELECT @MaxScanID = MAX(ScanID)
+    FROM KVK.KVK_Scan WITH (READCOMMITTEDLOCK)
+    WHERE KVK_NO = @KVK_NO;
+
+    IF @MaxScanID IS NULL
+        THROW 60002, 'No scans exist for this KVK_NO.', 1;
+
+    DECLARE @X FLOAT, @Y FLOAT, @Z FLOAT;
+
+    SELECT TOP (1)
+        @X = WeightT4X, @Y = WeightT5Y, @Z = WeightDeadsZ
+    FROM KVK.KVK_DKPWeights WITH (READCOMMITTEDLOCK)
+    WHERE KVK_NO = @KVK_NO
+    ORDER BY EffectiveFromUTC DESC;
+
+    IF @X IS NULL OR @Y IS NULL OR @Z IS NULL
+        THROW 60003, 'DKP weights not defined for this KVK.', 1;
+
+    ----------------------------------------------------------------
+    -- 1) Clear existing outputs for this KVK (full overwrite)
+	--    Keep Camp/Kingdom single-shot (small), batch Player (largest) for predictability.
+    ----------------------------------------------------------------
+    DELETE FROM KVK.KVK_Camp_Windowed    WHERE KVK_NO = @KVK_NO;
+    DELETE FROM KVK.KVK_Kingdom_Windowed WHERE KVK_NO = @KVK_NO;
+
+    DECLARE @DeleteBatchSize INT = 20000;
+
+    DECLARE @RowsDeleted INT;
+
+    WHILE 1 = 1
+    BEGIN
+        DELETE TOP (@DeleteBatchSize) p
+        FROM KVK.KVK_Player_Windowed p WITH (INDEX(PK_KVK_Player_Windowed), PAGLOCK)
+        WHERE p.KVK_NO = @KVK_NO;
+
+        SET @RowsDeleted = @@ROWCOUNT;
+
+        IF @RowsDeleted = 0 BREAK;
+        IF @RowsDeleted < @DeleteBatchSize BREAK; -- typically avoids one extra terminal no-op pass
+    END;
+
+    ----------------------------------------------------------------
+    -- 2) Baseline rows (validation view): zeros + fixed starting_power
+    ----------------------------------------------------------------
+    ;WITH base AS (
+        SELECT b.KVK_NO,
+               b.governor_id,
+               b.starting_power,
+               b.baseline_scan_id,
+               r.name,
+               r.kingdom
+        FROM KVK.KVK_Player_Baseline b
+        LEFT JOIN KVK.KVK_AllPlayers_Raw r
+               ON r.KVK_NO = b.KVK_NO
+              AND r.ScanID = b.baseline_scan_id
+              AND r.governor_id = b.governor_id
+        WHERE b.KVK_NO = @KVK_NO
+    ),
+    cm AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT  @KVK_NO, N'Baseline', b.governor_id, b.name, b.kingdom,
+            ISNULL(cm.CampID, 0),
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, b.starting_power, 0.0,
+            b.baseline_scan_id, SYSUTCDATETIME()
+    FROM base b
+    LEFT JOIN cm
+      ON cm.KVK_NO = b.KVK_NO AND cm.Kingdom = b.kingdom;
+
+    ----------------------------------------------------------------
+    -- 3) Windowed deltas (Start→End, End defaults to MaxScanID)
+    --    Window delta = End cumulative - Start cumulative
+    ----------------------------------------------------------------
+	;WITH W AS (
+		SELECT
+			RTRIM(w.WindowName) AS WindowName,
+			w.StartScanID,
+			-- Auto-cap EndScanID to max available scan (prevents future scan references)
+			CASE
+				WHEN w.EndScanID IS NULL THEN @MaxScanID
+				WHEN w.EndScanID > @MaxScanID THEN @MaxScanID  -- ← NEW: Safety cap
+				ELSE w.EndScanID
+			END AS EndScanID
+		FROM KVK.KVK_Windows w WITH (READCOMMITTEDLOCK)
+		WHERE w.KVK_NO = @KVK_NO
+		  AND w.StartScanID IS NOT NULL
+		  AND w.WindowName <> N'Baseline'
+	),
+    S AS (
+        SELECT
+            W.WindowName, W.StartScanID, W.EndScanID,
+            r.governor_id, r.name, r.kingdom,
+            r.max_kill_points AS kp_endpoint_s,
+            r.max_kills_iv AS t4_endpoint_s,
+            r.max_kills_v AS t5_endpoint_s,
+            r.max_dead AS deads_endpoint_s,
+            r.max_units_healed AS heals_endpoint_s,
+            r.max_max_contribute AS max_contrib_endpoint_s,
+            r.max_cur_contribute AS cur_contrib_endpoint_s,
+            COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_s,
+            COALESCE(r.kills_iv_diff, 0) AS t4_legacy_s,
+            COALESCE(r.kills_v_diff, 0) AS t5_legacy_s,
+            COALESCE(r.dead_diff, 0) AS deads_legacy_s,
+            COALESCE(r.healed_troops, r.max_units_healed_diff, 0) AS heals_legacy_s,
+            COALESCE(r.max_contribute_diff, 0) AS max_contrib_legacy_s,
+            COALESCE(r.cur_contribute_diff, 0) AS cur_contrib_legacy_s
+        FROM W
+        JOIN KVK.KVK_AllPlayers_Raw r
+          ON r.KVK_NO = @KVK_NO
+         AND r.ScanID = W.StartScanID
+    ),
+    E AS (
+        SELECT
+            W.WindowName, W.StartScanID, W.EndScanID,
+            r.governor_id, r.name, r.kingdom,
+            r.max_kill_points AS kp_endpoint_e,
+            r.max_kills_iv AS t4_endpoint_e,
+            r.max_kills_v AS t5_endpoint_e,
+            r.max_dead AS deads_endpoint_e,
+            r.max_units_healed AS heals_endpoint_e,
+            r.max_max_contribute AS max_contrib_endpoint_e,
+            r.max_cur_contribute AS cur_contrib_endpoint_e,
+            COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_e,
+            COALESCE(r.kills_iv_diff, 0) AS t4_legacy_e,
+            COALESCE(r.kills_v_diff, 0) AS t5_legacy_e,
+            COALESCE(r.dead_diff, 0) AS deads_legacy_e,
+            COALESCE(r.healed_troops, r.max_units_healed_diff, 0) AS heals_legacy_e,
+            COALESCE(r.max_contribute_diff, 0) AS max_contrib_legacy_e,
+            COALESCE(r.cur_contribute_diff, 0) AS cur_contrib_legacy_e
+        FROM W
+        JOIN KVK.KVK_AllPlayers_Raw r
+          ON r.KVK_NO = @KVK_NO
+         AND r.ScanID = W.EndScanID
+    ),
+    U AS (
+        -- Full outer join: include govs that appear in Start or End (defensive)
+        SELECT
+            COALESCE(S.WindowName, E.WindowName) AS WindowName,
+            COALESCE(S.StartScanID, E.StartScanID) AS StartScanID,
+            COALESCE(S.EndScanID,   E.EndScanID)   AS EndScanID,
+            COALESCE(S.governor_id, E.governor_id) AS governor_id,
+            COALESCE(E.name, S.name)               AS name,
+            COALESCE(E.kingdom, S.kingdom)         AS kingdom,
+            -- Deltas
+            CASE WHEN E.kp_endpoint_e IS NOT NULL AND S.kp_endpoint_s IS NOT NULL
+                 THEN E.kp_endpoint_e - S.kp_endpoint_s
+                 ELSE ISNULL(E.kp_legacy_e,0) - ISNULL(S.kp_legacy_s,0) END AS kp_gain,
+            CASE WHEN E.t4_endpoint_e IS NOT NULL AND S.t4_endpoint_s IS NOT NULL
+                 THEN E.t4_endpoint_e - S.t4_endpoint_s
+                 ELSE ISNULL(E.t4_legacy_e,0) - ISNULL(S.t4_legacy_s,0) END
+          + CASE WHEN E.t5_endpoint_e IS NOT NULL AND S.t5_endpoint_s IS NOT NULL
+                 THEN E.t5_endpoint_e - S.t5_endpoint_s
+                 ELSE ISNULL(E.t5_legacy_e,0) - ISNULL(S.t5_legacy_s,0) END AS kills_gain,
+            CASE WHEN E.t4_endpoint_e IS NOT NULL AND S.t4_endpoint_s IS NOT NULL
+                 THEN E.t4_endpoint_e - S.t4_endpoint_s
+                 ELSE ISNULL(E.t4_legacy_e,0) - ISNULL(S.t4_legacy_s,0) END AS t4_kills,
+            CASE WHEN E.t5_endpoint_e IS NOT NULL AND S.t5_endpoint_s IS NOT NULL
+                 THEN E.t5_endpoint_e - S.t5_endpoint_s
+                 ELSE ISNULL(E.t5_legacy_e,0) - ISNULL(S.t5_legacy_s,0) END AS t5_kills,
+            CASE WHEN E.heals_endpoint_e IS NOT NULL AND S.heals_endpoint_s IS NOT NULL
+                 THEN E.heals_endpoint_e - S.heals_endpoint_s
+                 ELSE ISNULL(E.heals_legacy_e,0) - ISNULL(S.heals_legacy_s,0) END AS healed_troops,
+            CASE WHEN E.deads_endpoint_e IS NOT NULL AND S.deads_endpoint_s IS NOT NULL
+                 THEN E.deads_endpoint_e - S.deads_endpoint_s
+                 ELSE ISNULL(E.deads_legacy_e,0) - ISNULL(S.deads_legacy_s,0) END AS deads,
+            CASE WHEN E.max_contrib_endpoint_e IS NOT NULL AND S.max_contrib_endpoint_s IS NOT NULL
+                 THEN E.max_contrib_endpoint_e - S.max_contrib_endpoint_s
+                 ELSE ISNULL(E.max_contrib_legacy_e,0) - ISNULL(S.max_contrib_legacy_s,0) END AS max_contribute_gain,
+            CASE WHEN E.cur_contrib_endpoint_e IS NOT NULL AND S.cur_contrib_endpoint_s IS NOT NULL
+                 THEN E.cur_contrib_endpoint_e - S.cur_contrib_endpoint_s
+                 ELSE ISNULL(E.cur_contrib_legacy_e,0) - ISNULL(S.cur_contrib_legacy_s,0) END AS cur_contribute_gain
+        FROM S
+        FULL OUTER JOIN E
+          ON E.WindowName = S.WindowName
+         AND E.StartScanID = S.StartScanID
+         AND E.EndScanID   = S.EndScanID
+         AND E.governor_id = S.governor_id
+    ),
+    B AS (
+        SELECT b.governor_id, b.starting_power
+        FROM KVK.KVK_Player_Baseline b WITH (READCOMMITTEDLOCK)
+        WHERE b.KVK_NO = @KVK_NO
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        @KVK_NO,
+        RTRIM(U.WindowName),
+        U.governor_id,
+        U.name,
+        U.kingdom,
+        ISNULL(CM.CampID, 0) AS campid,
+        -- KP Gain (source-of-truth)
+        U.kp_gain,
+        -- KP Gain (recalc) = 10*T4 + 20*T5
+        (U.t4_kills * 10) + (U.t5_kills * 20) AS kp_gain_recalc,
+        U.kills_gain,
+        U.t4_kills,
+        U.t5_kills,
+        -- KP Loss = heals * 20
+        (U.healed_troops * 20) AS kp_loss,
+        U.healed_troops,
+        U.deads,
+        U.max_contribute_gain,
+        U.cur_contribute_gain,
+        ISNULL(B.starting_power, 0) AS starting_power,
+        CASE WHEN ISNULL(B.starting_power,0) > 0
+             THEN ((U.t4_kills * @X) + (U.t5_kills * @Y) + (U.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        U.EndScanID,
+        SYSUTCDATETIME()
+    FROM U
+    LEFT JOIN B  ON B.governor_id = U.governor_id
+    LEFT JOIN CM ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = U.kingdom;
+
+    ----------------------------------------------------------------
+    -- 4) Full KVK (Baseline→MaxScanID): endpoint-aware for Full Data v2
+    ----------------------------------------------------------------
+    ;WITH E AS (
+        SELECT r.governor_id, r.name, r.kingdom,
+               r.max_kill_points,
+               r.max_kills_iv,
+               r.max_kills_v,
+               r.max_dead,
+               r.max_units_healed,
+               r.max_max_contribute,
+               r.max_cur_contribute,
+               COALESCE(r.kill_points_diff, r.points_difference, 0) AS legacy_kp,
+               COALESCE(r.kills_iv_diff, 0) AS legacy_t4,
+               COALESCE(r.kills_v_diff, 0) AS legacy_t5,
+               COALESCE(r.dead_diff, 0) AS legacy_deads,
+               COALESCE(r.healed_troops, r.max_units_healed_diff, 0) AS legacy_heals,
+               COALESCE(r.max_contribute_diff, 0) AS legacy_max_contribute_gain,
+               COALESCE(r.cur_contribute_diff, 0) AS legacy_cur_contribute_gain
+        FROM KVK.KVK_AllPlayers_Raw r WITH (READCOMMITTEDLOCK)
+        WHERE r.KVK_NO = @KVK_NO
+          AND r.ScanID = @MaxScanID
+    ),
+    B AS (
+        SELECT governor_id, baseline_scan_id, starting_power
+        FROM KVK.KVK_Player_Baseline WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    S AS (
+        SELECT r.governor_id,
+               r.max_kill_points,
+               r.max_kills_iv,
+               r.max_kills_v,
+               r.max_dead,
+               r.max_units_healed,
+               r.max_max_contribute,
+               r.max_cur_contribute
+        FROM KVK.KVK_AllPlayers_Raw r WITH (READCOMMITTEDLOCK)
+        JOIN B
+          ON B.governor_id = r.governor_id
+         AND r.KVK_NO = @KVK_NO
+         AND r.ScanID = B.baseline_scan_id
+    ),
+    U AS (
+        SELECT E.governor_id, E.name, E.kingdom,
+               CASE WHEN E.max_kill_points IS NOT NULL AND S.max_kill_points IS NOT NULL
+                    THEN E.max_kill_points - S.max_kill_points
+                    ELSE E.legacy_kp END AS kp,
+               CASE WHEN E.max_kills_iv IS NOT NULL AND S.max_kills_iv IS NOT NULL
+                    THEN E.max_kills_iv - S.max_kills_iv
+                    ELSE E.legacy_t4 END AS t4,
+               CASE WHEN E.max_kills_v IS NOT NULL AND S.max_kills_v IS NOT NULL
+                    THEN E.max_kills_v - S.max_kills_v
+                    ELSE E.legacy_t5 END AS t5,
+               CASE WHEN E.max_dead IS NOT NULL AND S.max_dead IS NOT NULL
+                    THEN E.max_dead - S.max_dead
+                    ELSE E.legacy_deads END AS deads,
+               CASE WHEN E.max_units_healed IS NOT NULL AND S.max_units_healed IS NOT NULL
+                    THEN E.max_units_healed - S.max_units_healed
+                    ELSE E.legacy_heals END AS heals,
+               CASE WHEN E.max_max_contribute IS NOT NULL AND S.max_max_contribute IS NOT NULL
+                    THEN E.max_max_contribute - S.max_max_contribute
+                    ELSE E.legacy_max_contribute_gain END AS max_contribute_gain,
+               CASE WHEN E.max_cur_contribute IS NOT NULL AND S.max_cur_contribute IS NOT NULL
+                    THEN E.max_cur_contribute - S.max_cur_contribute
+                    ELSE E.legacy_cur_contribute_gain END AS cur_contribute_gain
+        FROM E
+        LEFT JOIN S
+          ON S.governor_id = E.governor_id
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    )
+    INSERT INTO KVK.KVK_Player_Windowed
+    (
+        KVK_NO, WindowName, governor_id, name, kingdom, campid,
+        kp_gain, kp_gain_recalc, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain,
+        starting_power, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        @KVK_NO,
+        N'Full',
+        E.governor_id,
+        E.name,
+        E.kingdom,
+        ISNULL(CM.CampID, 0),
+        -- Full uses baseline-to-latest endpoint deltas when Full Data v2 endpoints exist.
+        E.kp,
+        (E.t4 * 10) + (E.t5 * 20) AS kp_gain_recalc,
+        (E.t4 + E.t5)             AS kills_gain,
+        E.t4, E.t5,
+        (E.heals * 20)            AS kp_loss,
+        E.heals,
+        E.deads,
+        E.max_contribute_gain,
+        E.cur_contribute_gain,
+        ISNULL(B.starting_power, 0) AS starting_power,
+        CASE WHEN ISNULL(B.starting_power,0) > 0
+             THEN ((E.t4 * @X) + (E.t5 * @Y) + (E.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        @MaxScanID,
+        SYSUTCDATETIME()
+    FROM U AS E
+    LEFT JOIN B  ON B.governor_id = E.governor_id
+    LEFT JOIN CM ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = E.kingdom;
+
+    ----------------------------------------------------------------
+    -- 5) Rollups (Kingdom & Camp) from Player_Windowed just written
+    ----------------------------------------------------------------
+    -- Kingdom
+    ;WITH P AS (
+		SELECT *
+		FROM KVK.KVK_Player_Windowed WITH (READCOMMITTEDLOCK)
+		WHERE KVK_NO = @KVK_NO
+	),
+	CM AS (
+		SELECT KVK_NO, Kingdom, CampID, CampName
+		FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+		WHERE KVK_NO = @KVK_NO
+	),
+	K AS (
+		SELECT
+			@KVK_NO AS KVK_NO,
+			p.WindowName,
+			p.kingdom,
+			ISNULL(cm.CampID, 0)        AS campid,
+			ISNULL(cm.CampName, N'')    AS camp_name,
+			SUM(p.kp_gain)              AS kp_gain,
+			SUM(p.kp_gain_recalc)       AS kp_gain_recalc, -- only used for DKP calc here
+			SUM(p.kills_gain)           AS kills_gain,
+			SUM(p.t4_kills)             AS t4_kills,
+			SUM(p.t5_kills)             AS t5_kills,
+			SUM(p.kp_loss)              AS kp_loss,
+			SUM(p.healed_troops)        AS healed_troops,
+			SUM(p.deads)                AS deads,
+			SUM(p.max_contribute_gain)  AS max_contribute_gain,
+			SUM(p.cur_contribute_gain)  AS cur_contribute_gain,
+			SUM(p.starting_power)       AS starting_power_sum,
+			MAX(p.last_scan_id)         AS last_scan_id
+		FROM P p
+		LEFT JOIN CM
+		  ON CM.KVK_NO = @KVK_NO
+		 AND CM.Kingdom = p.kingdom
+		GROUP BY p.WindowName, p.kingdom, ISNULL(cm.CampID, 0), ISNULL(cm.CampName, N'')
+	)
+	INSERT INTO KVK.KVK_Kingdom_Windowed
+	(
+		KVK_NO, WindowName, kingdom, campid, camp_name,
+		kp_gain, kills_gain, t4_kills, t5_kills,
+		kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain, dkp,
+		last_scan_id, computed_at_utc
+	)
+	SELECT
+		K.KVK_NO, K.WindowName, K.kingdom, K.campid, K.camp_name,
+		K.kp_gain, K.kills_gain, K.t4_kills, K.t5_kills,
+		K.kp_loss, K.healed_troops, K.deads, K.max_contribute_gain, K.cur_contribute_gain,
+		CASE WHEN K.starting_power_sum > 0
+			 THEN ((K.t4_kills * @X) + (K.t5_kills * @Y) + (K.deads * @Z))
+			 ELSE 0.0 END AS dkp,
+		K.last_scan_id,
+		SYSUTCDATETIME()
+	FROM K;
+
+    -- Camp
+    ;WITH P AS (
+        SELECT *
+        FROM KVK.KVK_Player_Windowed WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    CM AS (
+        SELECT KVK_NO, Kingdom, CampID, CampName
+        FROM KVK.KVK_CampMap WITH (READCOMMITTEDLOCK)
+        WHERE KVK_NO = @KVK_NO
+    ),
+    C AS (
+        SELECT
+            @KVK_NO AS KVK_NO,
+            p.WindowName,
+            ISNULL(cm.CampID, 0)   AS campid,
+            ISNULL(cm.CampName, N'') AS camp_name,
+            SUM(p.kp_gain)         AS kp_gain,
+            SUM(p.kills_gain)      AS kills_gain,
+            SUM(p.t4_kills)        AS t4_kills,
+            SUM(p.t5_kills)        AS t5_kills,
+            SUM(p.kp_loss)         AS kp_loss,
+            SUM(p.healed_troops)   AS healed_troops,
+            SUM(p.deads)           AS deads,
+            SUM(p.max_contribute_gain) AS max_contribute_gain,
+            SUM(p.cur_contribute_gain) AS cur_contribute_gain,
+            SUM(p.starting_power)  AS starting_power_sum,
+            MAX(p.last_scan_id)    AS last_scan_id
+        FROM P p
+        LEFT JOIN CM
+          ON CM.KVK_NO = @KVK_NO AND CM.Kingdom = p.kingdom
+        GROUP BY p.WindowName, ISNULL(cm.CampID, 0), ISNULL(cm.CampName, N'')
+    )
+    INSERT INTO KVK.KVK_Camp_Windowed
+    (
+        KVK_NO, WindowName, campid, camp_name,
+        kp_gain, kills_gain, t4_kills, t5_kills,
+        kp_loss, healed_troops, deads, max_contribute_gain, cur_contribute_gain, dkp,
+        last_scan_id, computed_at_utc
+    )
+    SELECT
+        C.KVK_NO, C.WindowName, C.campid, C.camp_name,
+        C.kp_gain, C.kills_gain, C.t4_kills, C.t5_kills,
+        C.kp_loss, C.healed_troops, C.deads, C.max_contribute_gain, C.cur_contribute_gain,
+        CASE WHEN C.starting_power_sum > 0
+             THEN ((C.t4_kills * @X) + (C.t5_kills * @Y) + (C.deads * @Z))
+             ELSE 0.0 END AS dkp,
+        C.last_scan_id,
+        SYSUTCDATETIME()
+    FROM C;
+
+    RETURN 0;
+END
+
+
+
+
+
+GO
+
+

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -141,6 +141,7 @@ def test_phase10_prod_sql_script_contains_recompute_correctness_fix() -> None:
     required_tokens = [
         "KVK_ALL Schema Modernisation - Phase 10 Recompute Correctness",
         "ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]",
+        "AND w.StartScanID <= @MaxScanID",
         "r.max_kill_points AS kp_endpoint_s",
         "COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_s",
         "THEN E.kp_endpoint_e - S.kp_endpoint_s",

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -49,6 +49,15 @@ def _compact(sql: str) -> str:
     return sql.strip()
 
 
+def _phase10_recompute_sql_contract_source() -> str:
+    canonical = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+    if _compact("r.max_kill_points AS kp_endpoint_s") in canonical:
+        return canonical
+    return _compact(
+        Path("sql/kvk_all_phase10_recompute_correctness.sql").read_text(encoding="utf-8-sig")
+    )
+
+
 def test_phase4_metric_source_rules_are_documented() -> None:
     doc = Path("docs/KVK_ALL Schema Modernisation - Phase 4 Metric Source Rules.md")
     text = doc.read_text(encoding="utf-8")
@@ -98,7 +107,7 @@ def test_windowed_tables_add_contribution_columns_additively() -> None:
 
 
 def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
-    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+    sql = _phase10_recompute_sql_contract_source()
 
     expected_source_expressions = [
         "r.max_kill_points AS kp_endpoint_s",
@@ -118,7 +127,7 @@ def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
 
 
 def test_recompute_full_row_uses_baseline_to_latest_endpoint_delta() -> None:
-    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+    sql = _phase10_recompute_sql_contract_source()
 
     required_tokens = [
         "SELECT governor_id,baseline_scan_id,starting_power",
@@ -156,7 +165,7 @@ def test_phase10_prod_sql_script_contains_recompute_correctness_fix() -> None:
 
 
 def test_recompute_populates_contribution_outputs_and_rollups() -> None:
-    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+    sql = _phase10_recompute_sql_contract_source()
 
     required_tokens = [
         "max_contribute_gain, cur_contribute_gain",

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -9,6 +9,8 @@ import pytest
 K98_SQL_REPO_ENV = os.environ.get("K98_SQL_REPO")
 SQL_REPO = Path(K98_SQL_REPO_ENV) if K98_SQL_REPO_ENV else Path(r"C:\K98-bot-SQL-Server")
 SQL_SCHEMA = SQL_REPO / "sql_schema"
+# Phase 10 recompute switched configured-window KP gain to endpoint delta logic and
+# introduced this alias in both canonical and deployment-script definitions.
 PHASE10_RECOMPUTE_SENTINEL = "r.max_kill_points AS kp_endpoint_s"
 
 

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -58,9 +58,9 @@ def _phase10_recompute_sql_contract_source() -> str:
     # script when this Phase 10 endpoint-source token is absent.
     if PHASE_10_RECOMPUTE_SENTINEL in canonical:
         return canonical
-    phase10_sql_repo_script = SQL_SCHEMA / "kvk_all_phase10_recompute_correctness.sql"
-    if phase10_sql_repo_script.exists():
-        return _compact(phase10_sql_repo_script.read_text(encoding="utf-8-sig"))
+    sql_repo_script = SQL_SCHEMA / "kvk_all_phase10_recompute_correctness.sql"
+    if sql_repo_script.exists():
+        return _compact(sql_repo_script.read_text(encoding="utf-8-sig"))
     return _compact(
         Path("sql/kvk_all_phase10_recompute_correctness.sql").read_text(encoding="utf-8-sig")
     )

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -67,6 +67,23 @@ def test_phase4_metric_source_rules_are_documented() -> None:
         assert token in text
 
 
+def test_phase10_metric_source_correction_is_documented() -> None:
+    doc = Path("docs/KVK_ALL Schema Modernisation - Phase 10 Metric Source Correction.md")
+    text = doc.read_text(encoding="utf-8")
+
+    required_tokens = [
+        "configured windows such as Pass 4 use cumulative\nendpoint deltas",
+        "`End.max_kill_points - Start.max_kill_points`",
+        "Legacy diff fields remain fallback inputs",
+        "Zero diff fields are not authoritative for Full Data v2 configured windows",
+        "`Full` output rows represent baseline-to-latest values",
+        "Older 22-column Full Data workbooks do not contain raw endpoint families",
+    ]
+
+    for token in required_tokens:
+        assert token in text
+
+
 def test_windowed_tables_add_contribution_columns_additively() -> None:
     table_files = [
         "KVK.KVK_Player_Windowed.Table.sql",
@@ -84,14 +101,57 @@ def test_recompute_uses_documented_full_data_v2_source_precedence() -> None:
     sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
 
     expected_source_expressions = [
-        "COALESCE(r.kill_points_diff, r.points_difference, r.max_kill_points - r.min_kill_points, 0)",
-        "COALESCE(r.healed_troops, r.max_units_healed_diff, r.max_units_healed - r.min_units_healed, 0)",
-        "COALESCE(r.max_contribute_diff, r.max_max_contribute - r.min_max_contribute, 0)",
-        "COALESCE(r.cur_contribute_diff, r.max_cur_contribute - r.min_cur_contribute, 0)",
+        "r.max_kill_points AS kp_endpoint_s",
+        "r.max_kill_points AS kp_endpoint_e",
+        "COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_s",
+        "COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_e",
+        "r.max_units_healed AS heals_endpoint_s",
+        "r.max_units_healed AS heals_endpoint_e",
+        "COALESCE(r.healed_troops, r.max_units_healed_diff, 0) AS heals_legacy_s",
+        "COALESCE(r.healed_troops, r.max_units_healed_diff, 0) AS heals_legacy_e",
+        "CASE WHEN E.kp_endpoint_e IS NOT NULL AND S.kp_endpoint_s IS NOT NULL THEN E.kp_endpoint_e - S.kp_endpoint_s ELSE ISNULL(E.kp_legacy_e,0) - ISNULL(S.kp_legacy_s,0) END AS kp_gain",
+        "CASE WHEN E.max_contrib_endpoint_e IS NOT NULL AND S.max_contrib_endpoint_s IS NOT NULL THEN E.max_contrib_endpoint_e - S.max_contrib_endpoint_s ELSE ISNULL(E.max_contrib_legacy_e,0) - ISNULL(S.max_contrib_legacy_s,0) END AS max_contribute_gain",
     ]
 
     for expression in expected_source_expressions:
         assert _compact(expression) in sql
+
+
+def test_recompute_full_row_uses_baseline_to_latest_endpoint_delta() -> None:
+    sql = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
+
+    required_tokens = [
+        "SELECT governor_id,baseline_scan_id,starting_power",
+        "AND r.ScanID = B.baseline_scan_id",
+        "CASE WHEN E.max_kill_points IS NOT NULL AND S.max_kill_points IS NOT NULL THEN E.max_kill_points-S.max_kill_points ELSE E.legacy_kp END AS kp",
+        "CASE WHEN E.max_kills_iv IS NOT NULL AND S.max_kills_iv IS NOT NULL THEN E.max_kills_iv-S.max_kills_iv ELSE E.legacy_t4 END AS t4",
+        "CASE WHEN E.max_kills_v IS NOT NULL AND S.max_kills_v IS NOT NULL THEN E.max_kills_v-S.max_kills_v ELSE E.legacy_t5 END AS t5",
+        "CASE WHEN E.max_dead IS NOT NULL AND S.max_dead IS NOT NULL THEN E.max_dead-S.max_dead ELSE E.legacy_deads END AS deads",
+        "CASE WHEN E.max_units_healed IS NOT NULL AND S.max_units_healed IS NOT NULL THEN E.max_units_healed-S.max_units_healed ELSE E.legacy_heals END AS heals",
+    ]
+
+    for token in required_tokens:
+        assert _compact(token) in sql
+
+
+def test_phase10_prod_sql_script_contains_recompute_correctness_fix() -> None:
+    script = Path("sql/kvk_all_phase10_recompute_correctness.sql").read_text(encoding="utf-8-sig")
+    compact = _compact(script)
+
+    required_tokens = [
+        "KVK_ALL Schema Modernisation - Phase 10 Recompute Correctness",
+        "ALTER PROCEDURE [KVK].[sp_KVK_Recompute_Windows]",
+        "r.max_kill_points AS kp_endpoint_s",
+        "COALESCE(r.kill_points_diff, r.points_difference, 0) AS kp_legacy_s",
+        "THEN E.kp_endpoint_e - S.kp_endpoint_s",
+        "ELSE E.legacy_kp END AS kp",
+        "max_contribute_gain",
+        "cur_contribute_gain",
+        "GO",
+    ]
+
+    for token in required_tokens:
+        assert _compact(token) in compact
 
 
 def test_recompute_populates_contribution_outputs_and_rollups() -> None:
@@ -99,8 +159,10 @@ def test_recompute_populates_contribution_outputs_and_rollups() -> None:
 
     required_tokens = [
         "max_contribute_gain, cur_contribute_gain",
-        "ISNULL(E.max_contrib_e,0)- ISNULL(S.max_contrib_s,0) AS max_contribute_gain",
-        "ISNULL(E.cur_contrib_e,0)- ISNULL(S.cur_contrib_s,0) AS cur_contribute_gain",
+        "THEN E.max_contrib_endpoint_e-S.max_contrib_endpoint_s",
+        "ELSE ISNULL(E.max_contrib_legacy_e,0)-ISNULL(S.max_contrib_legacy_s,0) END AS max_contribute_gain",
+        "THEN E.cur_contrib_endpoint_e-S.cur_contrib_endpoint_s",
+        "ELSE ISNULL(E.cur_contrib_legacy_e,0)-ISNULL(S.cur_contrib_legacy_s,0) END AS cur_contribute_gain",
         "SUM(p.max_contribute_gain) AS max_contribute_gain",
         "SUM(p.cur_contribute_gain) AS cur_contribute_gain",
         "K.max_contribute_gain, K.cur_contribute_gain",

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -11,7 +11,7 @@ SQL_REPO = Path(K98_SQL_REPO_ENV) if K98_SQL_REPO_ENV else Path(r"C:\K98-bot-SQL
 SQL_SCHEMA = SQL_REPO / "sql_schema"
 # Phase 10 recompute switched configured-window KP gain to endpoint delta logic and
 # introduced this alias in both canonical and deployment-script definitions.
-PHASE10_RECOMPUTE_SENTINEL = "r.max_kill_points AS kp_endpoint_s"
+PHASE_10_RECOMPUTE_SENTINEL = "r.max_kill_points AS kp_endpoint_s"
 
 
 def _running_in_ci() -> bool:
@@ -56,8 +56,11 @@ def _phase10_recompute_sql_contract_source() -> str:
     canonical = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
     # Canonical SQL repo may lag deployment scripts; fall back to the PR deployment
     # script when this Phase 10 endpoint-source token is absent.
-    if PHASE10_RECOMPUTE_SENTINEL in canonical:
+    if PHASE_10_RECOMPUTE_SENTINEL in canonical:
         return canonical
+    phase10_sql_repo_script = SQL_SCHEMA / "kvk_all_phase10_recompute_correctness.sql"
+    if phase10_sql_repo_script.exists():
+        return _compact(phase10_sql_repo_script.read_text(encoding="utf-8-sig"))
     return _compact(
         Path("sql/kvk_all_phase10_recompute_correctness.sql").read_text(encoding="utf-8-sig")
     )

--- a/tests/test_kvk_all_recompute_sql_contract.py
+++ b/tests/test_kvk_all_recompute_sql_contract.py
@@ -9,6 +9,7 @@ import pytest
 K98_SQL_REPO_ENV = os.environ.get("K98_SQL_REPO")
 SQL_REPO = Path(K98_SQL_REPO_ENV) if K98_SQL_REPO_ENV else Path(r"C:\K98-bot-SQL-Server")
 SQL_SCHEMA = SQL_REPO / "sql_schema"
+PHASE10_RECOMPUTE_SENTINEL = "r.max_kill_points AS kp_endpoint_s"
 
 
 def _running_in_ci() -> bool:
@@ -51,7 +52,9 @@ def _compact(sql: str) -> str:
 
 def _phase10_recompute_sql_contract_source() -> str:
     canonical = _compact(_sql_file("KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql"))
-    if _compact("r.max_kill_points AS kp_endpoint_s") in canonical:
+    # Canonical SQL repo may lag deployment scripts; fall back to the PR deployment
+    # script when this Phase 10 endpoint-source token is absent.
+    if PHASE10_RECOMPUTE_SENTINEL in canonical:
         return canonical
     return _compact(
         Path("sql/kvk_all_phase10_recompute_correctness.sql").read_text(encoding="utf-8-sig")


### PR DESCRIPTION
## Summary

Phase 10 fixes the KVK_ALL Full Data v2 recompute correctness issue where zero diff fields masked moving cumulative endpoint values across scans.

The recompute deployment script now treats configured windows as endpoint deltas when Full Data v2 endpoint columns are present, while preserving legacy diff-field fallback for older 22-column Full Data rows. It also documents and tests the corrected source-of-truth rule.

## Changes

- Add `sql/kvk_all_phase10_recompute_correctness.sql` for production deployment of `KVK.sp_KVK_Recompute_Windows`.
- Add `scripts/diagnose_kvk_all_phase10.py` to derive expected scan-to-scan endpoint deltas from the four KVK 15 sample workbooks without mutating SQL or posting Sheets output.
- Update SQL contract tests for endpoint-aware configured windows, baseline-to-latest Full semantics, and the Phase 10 deployment script.
- Add Phase 10 source-rule documentation.
- Include the local Phase 9 task-pack completion update and Phase 10 initiation statement as requested.

## Root Cause

The current recompute procedure uses diff fields before endpoint fields. In Full Data v2 samples, diff fields such as `kill_points_diff` can be present but zero while cumulative endpoint values like `max_kill_points` move between scans. Because zero is non-null, the previous precedence produced zero gains.

## Validation

Passed locally:

- `python scripts/diagnose_kvk_all_phase10.py`
- `python -m pytest -q tests/test_kvk_all_recompute_sql_contract.py`
- `python -m pytest -q tests/test_kvk_all_import_service.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_importer.py tests/test_kvk_all_schema.py tests/test_kvk_all_recompute_sql_contract.py tests/test_kvk_export_service.py tests/test_gsheet_module.py tests/test_kvk_admin_service.py tests/test_kvk_reporting_service.py`
- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `python -m ruff check scripts/diagnose_kvk_all_phase10.py tests/test_kvk_all_recompute_sql_contract.py`
- `python -m black --check scripts/diagnose_kvk_all_phase10.py tests/test_kvk_all_recompute_sql_contract.py`
- `git diff --check`

Pyright reported 0 errors with local import-resolution warnings for `pandas` and `pytest`.

## Deployment Notes

`sql/kvk_all_phase10_recompute_correctness.sql` is intended for production SQL deployment. It uses the same safer batch style as prior production scripts: `SET ANSI_NULLS`, `GO`, `SET QUOTED_IDENTIFIER`, `GO`, object bootstrap, `GO`, then `ALTER PROCEDURE`.

After SQL deployment, run an explicit KVK recompute for the affected KVK before validating exports or Sheets output. No live SQL recompute/export or Google Sheets posting was run from this PR.

## Deferred Optimisations

None.