### PR TITLE
[codex] Fix MGE open switch award cleanup

### DIFF
--- a/mge/dal/mge_event_dal.py
+++ b/mge/dal/mge_event_dal.py
@@ -410,13 +410,14 @@ def apply_open_mode_switch_atomic(
 ) -> int:
     """
     Atomically:
-      - hard delete awards for this event
-      - hard delete signups
+      - hard delete awards for this event (written to MGE_AwardAudit first)
+      - hard delete signups for this event (written to MGE_SignupAudit)
       - switch event mode/rule mode/rules text
-      - write MGE_AwardAudit for deleted awards
       - write MGE_RuleAudit
-      - write MGE_SignupAudit (bulk_delete_open_switch)
-    Returns deleted row count.
+
+    Returns the number of signup rows deleted (not total rows deleted across
+    all tables).  Award deletions are captured in MGE_AwardAudit and their
+    count is embedded in the MGE_SignupAudit DetailsJson payload.
     """
 
     def _callback(cur):
@@ -478,7 +479,7 @@ def apply_open_mode_switch_atomic(
             """,
             (event_id,),
         )
-        deleted_count = int(cur.rowcount or 0)
+        deleted_signup_count = int(cur.rowcount or 0)
 
         cur.execute(
             """
@@ -505,7 +506,7 @@ def apply_open_mode_switch_atomic(
         details_json = json.dumps(
             {
                 "action": "bulk_delete_open_switch",
-                "deleted_signup_count": deleted_count,
+                "deleted_signup_count": deleted_signup_count,
                 "deleted_award_count": deleted_award_count,
             },
             ensure_ascii=False,
@@ -520,7 +521,7 @@ def apply_open_mode_switch_atomic(
             """,
             (event_id, actor_discord_id, details_json),
         )
-        return deleted_count
+        return deleted_signup_count
 
     result = exec_with_cursor(_callback)
     if result is None:

--- a/mge/dal/mge_event_dal.py
+++ b/mge/dal/mge_event_dal.py
@@ -132,7 +132,7 @@ WHERE EventId = ?;
 """
 
 SQL_SELECT_EVENT_SWITCH_CONTEXT = """
-SELECT EventId, Status, RuleMode, RulesText
+SELECT EventId, EventMode, Status, RuleMode, RulesText
 FROM dbo.MGE_Events
 WHERE EventId = ?;
 """
@@ -410,14 +410,67 @@ def apply_open_mode_switch_atomic(
 ) -> int:
     """
     Atomically:
+      - hard delete awards for this event
       - hard delete signups
       - switch event mode/rule mode/rules text
+      - write MGE_AwardAudit for deleted awards
       - write MGE_RuleAudit
       - write MGE_SignupAudit (bulk_delete_open_switch)
     Returns deleted row count.
     """
 
     def _callback(cur):
+        cur.execute(
+            """
+            SELECT EventId
+            FROM dbo.MGE_Events WITH (UPDLOCK, HOLDLOCK)
+            WHERE EventId = ?;
+            """,
+            (event_id,),
+        )
+        if cur.fetchone() is None:
+            return None
+
+        award_details_json = json.dumps(
+            {"action": "bulk_delete_open_switch"},
+            ensure_ascii=False,
+        )
+
+        cur.execute(
+            """
+            INSERT INTO dbo.MGE_AwardAudit
+                (AwardId, EventId, GovernorId, ActionType, ActorDiscordId,
+                 OldRank, NewRank, OldStatus, NewStatus, OldTargetScore, NewTargetScore,
+                 DetailsJson, CreatedUtc)
+            SELECT
+                AwardId,
+                EventId,
+                GovernorId,
+                'bulk_delete_open_switch',
+                ?,
+                AwardedRank,
+                NULL,
+                AwardStatus,
+                'removed',
+                TargetScore,
+                TargetScore,
+                ?,
+                SYSUTCDATETIME()
+            FROM dbo.MGE_Awards
+            WHERE EventId = ?;
+            """,
+            (actor_discord_id, award_details_json, event_id),
+        )
+        deleted_award_count = int(cur.rowcount or 0)
+
+        cur.execute(
+            """
+            DELETE FROM dbo.MGE_Awards
+            WHERE EventId = ?;
+            """,
+            (event_id,),
+        )
+
         cur.execute(
             """
             DELETE FROM dbo.MGE_Signups
@@ -453,6 +506,7 @@ def apply_open_mode_switch_atomic(
             {
                 "action": "bulk_delete_open_switch",
                 "deleted_signup_count": deleted_count,
+                "deleted_award_count": deleted_award_count,
             },
             ensure_ascii=False,
         )

--- a/tests/test_mge_open_mode_switch.py
+++ b/tests/test_mge_open_mode_switch.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
+import json
+
+from mge.dal import mge_event_dal
 from mge.mge_event_service import switch_event_to_fixed, switch_event_to_open
 
 
 class _DalStub:
-    def __init__(self, status: str = "signup_open", rule_mode: str = "fixed"):
+    def __init__(
+        self,
+        status: str = "signup_open",
+        rule_mode: str = "fixed",
+        event_mode: str = "controlled",
+    ):
         self.status = status
         self.rule_mode = rule_mode
+        self.event_mode = event_mode
         self.called_open = False
         self.called_fixed = False
 
     def fetch_event_switch_context(self, event_id: int):
         return {
             "EventId": event_id,
+            "EventMode": self.event_mode,
             "Status": self.status,
             "RuleMode": self.rule_mode,
             "RulesText": "current rules",
@@ -69,7 +79,7 @@ def test_switch_to_open_blocked_completed(monkeypatch):
 
 
 def test_switch_to_fixed_ok(monkeypatch):
-    stub = _DalStub("signup_open", "open")
+    stub = _DalStub("signup_open", "open", "open")
     from mge import mge_event_service as svc
 
     monkeypatch.setattr(svc, "mge_event_dal", stub)
@@ -82,7 +92,7 @@ def test_switch_to_fixed_ok(monkeypatch):
 
 
 def test_switch_to_fixed_uses_fixed_rules(monkeypatch):
-    stub = _DalStub("signup_open", "open")
+    stub = _DalStub("signup_open", "open", "open")
     from mge import mge_event_service as svc
 
     monkeypatch.setattr(svc, "mge_event_dal", stub)
@@ -103,7 +113,7 @@ def test_switch_to_fixed_uses_fixed_rules(monkeypatch):
 
 
 def test_switch_to_fixed_blocked_published(monkeypatch):
-    stub = _DalStub("published", "open")
+    stub = _DalStub("published", "open", "open")
     from mge import mge_event_service as svc
 
     monkeypatch.setattr(svc, "mge_event_dal", stub)
@@ -114,7 +124,7 @@ def test_switch_to_fixed_blocked_published(monkeypatch):
 
 
 def test_switch_to_fixed_blocked_completed(monkeypatch):
-    stub = _DalStub("completed", "open")
+    stub = _DalStub("completed", "open", "open")
     from mge import mge_event_service as svc
 
     monkeypatch.setattr(svc, "mge_event_dal", stub)
@@ -122,3 +132,110 @@ def test_switch_to_fixed_blocked_completed(monkeypatch):
     result = switch_event_to_fixed(event_id=5, actor_discord_id=123)
 
     assert result.success is False
+
+
+def test_switch_to_open_skips_when_already_open(monkeypatch):
+    stub = _DalStub("signup_open", "open", "open")
+    from mge import mge_event_service as svc
+
+    monkeypatch.setattr(svc, "mge_event_dal", stub)
+
+    result = switch_event_to_open(event_id=6, actor_discord_id=123)
+
+    assert result.success is True
+    assert result.changed is False
+    assert stub.called_open is False
+
+
+def test_switch_to_fixed_skips_when_already_controlled(monkeypatch):
+    stub = _DalStub("signup_open", "fixed", "controlled")
+    from mge import mge_event_service as svc
+
+    monkeypatch.setattr(svc, "mge_event_dal", stub)
+
+    result = switch_event_to_fixed(event_id=7, actor_discord_id=123)
+
+    assert result.success is True
+    assert result.changed is False
+    assert stub.called_fixed is False
+
+
+def test_switch_context_query_includes_event_mode():
+    assert "EventMode" in mge_event_dal.SQL_SELECT_EVENT_SWITCH_CONTEXT
+
+
+class _OpenSwitchCursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.rowcount = 0
+        self._last_sql = ""
+
+    def execute(self, sql: str, params: tuple[object, ...] = ()) -> None:
+        self._last_sql = " ".join(sql.split())
+        self.calls.append((self._last_sql, params))
+        if "INSERT INTO dbo.MGE_AwardAudit" in self._last_sql:
+            self.rowcount = 2
+        elif "DELETE FROM dbo.MGE_Awards" in self._last_sql:
+            self.rowcount = 2
+        elif "DELETE FROM dbo.MGE_Signups" in self._last_sql:
+            self.rowcount = 3
+        elif self._last_sql.startswith("UPDATE dbo.MGE_Events"):
+            self.rowcount = 1
+        else:
+            self.rowcount = 0
+
+    def fetchone(self) -> tuple[int] | None:
+        if self._last_sql.startswith("SELECT EventId FROM dbo.MGE_Events"):
+            return (563,)
+        return None
+
+
+def test_apply_open_switch_deletes_only_target_event_awards_before_signups(monkeypatch):
+    cursor = _OpenSwitchCursor()
+
+    def _fake_exec_with_cursor(callback):
+        return callback(cursor)
+
+    monkeypatch.setattr(mge_event_dal, "exec_with_cursor", _fake_exec_with_cursor)
+
+    deleted = mge_event_dal.apply_open_mode_switch_atomic(
+        event_id=563,
+        actor_discord_id=559076207627468807,
+        old_rule_mode="fixed",
+        old_rules_text="old rules",
+        new_rules_text="open rules",
+    )
+
+    assert deleted == 3
+
+    sql_calls = [sql for sql, _ in cursor.calls]
+    award_audit_idx = next(
+        i for i, sql in enumerate(sql_calls) if "INSERT INTO dbo.MGE_AwardAudit" in sql
+    )
+    award_delete_idx = next(
+        i for i, sql in enumerate(sql_calls) if "DELETE FROM dbo.MGE_Awards" in sql
+    )
+    signup_delete_idx = next(
+        i for i, sql in enumerate(sql_calls) if "DELETE FROM dbo.MGE_Signups" in sql
+    )
+
+    assert award_audit_idx < award_delete_idx < signup_delete_idx
+
+    award_audit_sql, award_audit_params = cursor.calls[award_audit_idx]
+    award_delete_sql, award_delete_params = cursor.calls[award_delete_idx]
+    signup_delete_sql, signup_delete_params = cursor.calls[signup_delete_idx]
+
+    assert "WHERE EventId = ?" in award_audit_sql
+    assert "WHERE EventId = ?" in award_delete_sql
+    assert "WHERE EventId = ?" in signup_delete_sql
+    assert award_audit_params[-1] == 563
+    assert award_delete_params == (563,)
+    assert signup_delete_params == (563,)
+
+    signup_audit_sql, signup_audit_params = next(
+        (sql, params) for sql, params in cursor.calls if "INSERT INTO dbo.MGE_SignupAudit" in sql
+    )
+    assert "bulk_delete_open_switch" in signup_audit_sql
+    details = json.loads(str(signup_audit_params[2]))
+    assert details["deleted_signup_count"] == 3
+    assert details["deleted_award_count"] == 2


### PR DESCRIPTION
## Summary

Fixes the MGE fixed-to-open switch failure caused by deleting `dbo.MGE_Signups` while related `dbo.MGE_Awards` rows still reference those signup IDs.

## Root Cause

`apply_open_mode_switch_atomic()` deleted signups first. SQL Server correctly rejected that delete when `MGE_Awards.SignupId` still referenced one of the signup rows through `FK_MGE_Awards_SignupId`.

## Changes

- Deletes and audits `dbo.MGE_Awards` rows for the target event before deleting signups.
- Keeps all destructive SQL scoped by `WHERE EventId = ?` so other MGE events are unaffected.
- Adds `EventMode` to the event switch context query so already-open/already-fixed checks work correctly.
- Adds regression coverage for event-scoped delete ordering and idempotent mode switching.

## Validation

- `python -m pytest tests\test_mge_open_mode_switch.py -vv`
- `python -m pytest tests\test_mge_event_service_rules_regression.py -vv`
- `python -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName`
- `python scripts\validate_architecture_boundaries.py`
- `python scripts\validate_deferred_items.py`
- `python scripts\select_tests.py`
- `python -m py_compile mge\dal\mge_event_dal.py mge\mge_event_service.py tests\test_mge_open_mode_switch.py`
- `git diff --check -- mge\dal\mge_event_dal.py tests\test_mge_open_mode_switch.py`

## Risk / Rollback

Risk is limited to the MGE fixed-to-open switch path. Rollback is the PR revert; no SQL schema migration is required.