### PR TITLE
[codex] Fix MGE open switch award audit insert

### DIFF
--- a/mge/dal/mge_event_dal.py
+++ b/mge/dal/mge_event_dal.py
@@ -410,7 +410,8 @@ def apply_open_mode_switch_atomic(
 ) -> int:
     """
     Atomically:
-      - hard delete awards for this event (written to MGE_AwardAudit first)
+      - write MGE_AwardAudit rows for awards in this event
+      - hard delete awards for this event
       - hard delete signups for this event (written to MGE_SignupAudit)
       - switch event mode/rule mode/rules text
       - write MGE_RuleAudit
@@ -439,30 +440,57 @@ def apply_open_mode_switch_atomic(
 
         cur.execute(
             """
+            SET NOCOUNT ON;
+
+            DECLARE @DeletedAwards TABLE
+            (
+                AwardId BIGINT NOT NULL,
+                EventId BIGINT NOT NULL,
+                GovernorId BIGINT NOT NULL,
+                AwardedRank INT NULL,
+                AwardStatus VARCHAR(20) NULL,
+                TargetScore BIGINT NULL
+            );
+
             DELETE FROM dbo.MGE_Awards
             OUTPUT
                 DELETED.AwardId,
                 DELETED.EventId,
                 DELETED.GovernorId,
-                'bulk_delete_open_switch',
-                ?,
                 DELETED.AwardedRank,
-                NULL,
                 DELETED.AwardStatus,
-                'removed',
-                DELETED.TargetScore,
-                DELETED.TargetScore,
-                ?,
-                SYSUTCDATETIME()
-            INTO dbo.MGE_AwardAudit
+                DELETED.TargetScore
+            INTO @DeletedAwards
+                (AwardId, EventId, GovernorId, AwardedRank, AwardStatus, TargetScore)
+            WHERE EventId = ?;
+
+            INSERT INTO dbo.MGE_AwardAudit
                 (AwardId, EventId, GovernorId, ActionType, ActorDiscordId,
                  OldRank, NewRank, OldStatus, NewStatus, OldTargetScore, NewTargetScore,
                  DetailsJson, CreatedUtc)
-            WHERE EventId = ?;
+            SELECT
+                AwardId,
+                EventId,
+                GovernorId,
+                'bulk_delete_open_switch',
+                ?,
+                AwardedRank,
+                NULL,
+                AwardStatus,
+                'removed',
+                TargetScore,
+                TargetScore,
+                ?,
+                SYSUTCDATETIME()
+            FROM @DeletedAwards;
+
+            SELECT COUNT_BIG(1) AS DeletedAwardCount
+            FROM @DeletedAwards;
             """,
-            (actor_discord_id, award_details_json, event_id),
+            (event_id, actor_discord_id, award_details_json),
         )
-        deleted_award_count = int(cur.rowcount or 0)
+        row = cur.fetchone()
+        deleted_award_count = int(row[0]) if row else 0
 
         cur.execute(
             """

--- a/mge/dal/mge_event_dal.py
+++ b/mge/dal/mge_event_dal.py
@@ -410,8 +410,8 @@ def apply_open_mode_switch_atomic(
 ) -> int:
     """
     Atomically:
-      - write MGE_AwardAudit rows for awards in this event
-      - hard delete awards for this event
+      - hard delete awards for this event while capturing rows for MGE_AwardAudit
+      - write captured award rows to MGE_AwardAudit
       - hard delete signups for this event (written to MGE_SignupAudit)
       - switch event mode/rule mode/rules text
       - write MGE_RuleAudit
@@ -486,6 +486,8 @@ def apply_open_mode_switch_atomic(
 
             SELECT COUNT_BIG(1) AS DeletedAwardCount
             FROM @DeletedAwards;
+
+            SET NOCOUNT OFF;
             """,
             (event_id, actor_discord_id, award_details_json),
         )

--- a/mge/dal/mge_signup_dal.py
+++ b/mge/dal/mge_signup_dal.py
@@ -219,6 +219,18 @@ def insert_signup(
     def _callback(cur):
         cur.execute(
             """
+            SELECT EventMode
+            FROM dbo.MGE_Events WITH (UPDLOCK, HOLDLOCK)
+            WHERE EventId = ?;
+            """,
+            (event_id,),
+        )
+        row = cur.fetchone()
+        if row is None or str(row[0] or "").strip().lower() != "controlled":
+            return None
+
+        cur.execute(
+            """
             INSERT INTO dbo.MGE_Signups
             (
                 EventId,

--- a/mge/mge_embed_manager.py
+++ b/mge/mge_embed_manager.py
@@ -166,6 +166,13 @@ def _build_signup_view(
         return None
 
 
+def _should_attach_signup_view(event_row: dict[str, Any], lifecycle_state: str) -> bool:
+    event_mode = str(event_row.get("EventMode") or "").strip().lower()
+    if event_mode == "open":
+        return False
+    return lifecycle_state == "open"
+
+
 def _render_public_signup_list(names: list[str], limit: int = 1024) -> str:
     if not names:
         return "No signups yet."
@@ -592,12 +599,21 @@ async def sync_event_signup_embed(
     msg_id = row.get("SignupEmbedMessageId")
     message = None
 
-    view = _build_signup_view(
-        bot=bot,
-        event_id=event_id,
-        signup_channel_id=signup_channel_id,
-        lifecycle_state=lifecycle_state,
-    )
+    view = None
+    if _should_attach_signup_view(row, lifecycle_state):
+        view = _build_signup_view(
+            bot=bot,
+            event_id=event_id,
+            signup_channel_id=signup_channel_id,
+            lifecycle_state=lifecycle_state,
+        )
+    else:
+        logger.info(
+            "mge_embed_signup_view_suppressed event_id=%s lifecycle_state=%s event_mode=%s reason=mode_or_lifecycle",
+            event_id,
+            lifecycle_state,
+            row.get("EventMode"),
+        )
 
     # Determine if @everyone mention should be sent on first post
     should_mention = False

--- a/tests/test_mge_embed_manager.py
+++ b/tests/test_mge_embed_manager.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mge.mge_embed_manager import (
+    _should_attach_signup_view,
     build_mge_awards_embed,
     build_mge_leadership_embed,
     build_mge_main_embed,
@@ -92,6 +93,24 @@ def test_signup_embed_finished_state():
     # finished lifecycle sets colour to grey: 0x95A5A6
     assert embed.color.value == 0x95A5A6
     assert any(f.name == "Status" for f in embed.fields)
+
+
+def test_signup_view_hidden_when_event_mode_open():
+    event = _event("open")
+
+    assert _should_attach_signup_view(event, lifecycle_state="open") is False
+
+
+def test_signup_view_returns_when_switched_back_to_controlled():
+    event = _event("controlled")
+
+    assert _should_attach_signup_view(event, lifecycle_state="open") is True
+
+
+def test_signup_view_hidden_when_controlled_but_lifecycle_closed():
+    event = _event("controlled")
+
+    assert _should_attach_signup_view(event, lifecycle_state="closed") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mge_open_mode_switch.py
+++ b/tests/test_mge_open_mode_switch.py
@@ -185,6 +185,8 @@ class _OpenSwitchCursor:
     def fetchone(self) -> tuple[int] | None:
         if self._last_sql.startswith("SELECT EventId FROM dbo.MGE_Events"):
             return (563,)
+        if "SELECT COUNT_BIG(1) AS DeletedAwardCount" in self._last_sql:
+            return (2,)
         return None
 
 
@@ -220,13 +222,16 @@ def test_apply_open_switch_deletes_only_target_event_awards_before_signups(monke
     award_delete_sql, award_delete_params = cursor.calls[award_delete_idx]
     signup_delete_sql, signup_delete_params = cursor.calls[signup_delete_idx]
 
-    assert "INTO dbo.MGE_AwardAudit" in award_delete_sql
+    assert "OUTPUT" in award_delete_sql
+    assert "INTO @DeletedAwards" in award_delete_sql
+    assert "INSERT INTO dbo.MGE_AwardAudit" in award_delete_sql
+    assert "SELECT COUNT_BIG(1) AS DeletedAwardCount" in award_delete_sql
     assert "WHERE EventId = ?" in award_delete_sql
     assert "WHERE EventId = ?" in signup_delete_sql
-    assert award_delete_params[0] == actor_discord_id
-    award_details = json.loads(award_delete_params[1])
+    assert award_delete_params[0] == 563
+    assert award_delete_params[1] == actor_discord_id
+    award_details = json.loads(award_delete_params[2])
     assert award_details == {"action": "bulk_delete_open_switch"}
-    assert award_delete_params[-1] == 563
     assert signup_delete_params == (563,)
 
     signup_audit_sql, signup_audit_params = next(

--- a/tests/test_mge_signup_dal.py
+++ b/tests/test_mge_signup_dal.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from mge.dal import mge_signup_dal
+
+
+class _InsertSignupCursor:
+    def __init__(self, event_mode: str):
+        self.event_mode = event_mode
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self._last_sql = ""
+
+    def execute(self, sql: str, params: tuple[object, ...] = ()) -> None:
+        self._last_sql = " ".join(sql.split())
+        self.calls.append((self._last_sql, params))
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        if self._last_sql.startswith("SELECT EventMode FROM dbo.MGE_Events"):
+            return (self.event_mode,)
+        if self._last_sql.startswith("INSERT INTO dbo.MGE_Signups"):
+            return (42,)
+        return None
+
+
+def _insert_signup_kwargs() -> dict[str, object]:
+    return {
+        "event_id": 563,
+        "governor_id": 100,
+        "governor_name_snapshot": "Gov",
+        "discord_user_id": 123,
+        "request_priority": "High",
+        "preferred_rank_band": "1-5",
+        "requested_commander_id": 1,
+        "requested_commander_name": "Cmdr",
+        "current_heads": 100,
+        "kingdom_role": None,
+        "gear_text": None,
+        "armament_text": None,
+        "source": "discord",
+        "now_utc": datetime(2026, 5, 11, tzinfo=UTC),
+    }
+
+
+def test_insert_signup_locks_event_and_inserts_only_when_controlled(monkeypatch):
+    cursor = _InsertSignupCursor("controlled")
+
+    def _fake_exec_with_cursor(callback):
+        return callback(cursor)
+
+    monkeypatch.setattr(mge_signup_dal, "exec_with_cursor", _fake_exec_with_cursor)
+
+    signup_id = mge_signup_dal.insert_signup(**_insert_signup_kwargs())
+
+    assert signup_id == 42
+    lock_sql, lock_params = cursor.calls[0]
+    insert_sql, insert_params = cursor.calls[1]
+    assert "FROM dbo.MGE_Events WITH (UPDLOCK, HOLDLOCK)" in lock_sql
+    assert "WHERE EventId = ?" in lock_sql
+    assert lock_params == (563,)
+    assert "INSERT INTO dbo.MGE_Signups" in insert_sql
+    assert insert_params[0] == 563
+
+
+def test_insert_signup_skips_insert_if_switch_changed_event_to_open(monkeypatch):
+    cursor = _InsertSignupCursor("open")
+
+    def _fake_exec_with_cursor(callback):
+        return callback(cursor)
+
+    monkeypatch.setattr(mge_signup_dal, "exec_with_cursor", _fake_exec_with_cursor)
+
+    signup_id = mge_signup_dal.insert_signup(**_insert_signup_kwargs())
+
+    assert signup_id is None
+    assert len(cursor.calls) == 1
+    assert cursor.calls[0][1] == (563,)


### PR DESCRIPTION
## Summary

Follow-up fix for the MGE fixed-to-open switch path after SQL Server rejected `DELETE ... OUTPUT ... INTO dbo.MGE_AwardAudit` because `MGE_AwardAudit` has the enabled `CK_MGE_AwardAudit_DetailsJson` check constraint.

This also hardens the signup create race during a mode switch by locking the target event row in the signup insert transaction and only inserting if the event is still `controlled`.

Finally, public signup embeds now remove signup/edit/withdraw controls when the event is switched to open mode, and reattach them if the event is switched back to controlled/fixed mode.

## Root Cause

SQL Server does not allow an `OUTPUT INTO` target table to have enabled check constraints/rules. The prior fix used `DELETE FROM dbo.MGE_Awards OUTPUT ... INTO dbo.MGE_AwardAudit`, which fails before deleting awards/signups.

A plain `INSERT ... SELECT` followed by a separate `DELETE` also has a small race window where a concurrent award insert could be deleted without being captured by audit. The updated implementation captures the exact deleted rows into a local table variable, then inserts audit rows from that captured set.

Separately, the service checked event mode before signup insert, but the actual insert transaction did not lock/re-check the event row. A signup submitted during the switch could otherwise race with the switch transaction.

The public embed refresh path derived lifecycle from status/close time only, so an open-mode event could still edit the Discord message with the fixed-mode signup view attached.

## Changes

- Replaces direct `OUTPUT ... INTO dbo.MGE_AwardAudit` with `DELETE ... OUTPUT ... INTO @DeletedAwards`, where `@DeletedAwards` is a local table variable without check constraints.
- Inserts `dbo.MGE_AwardAudit` rows from `@DeletedAwards`, so audit rows correspond to the exact rows deleted.
- Keeps the signup delete and all destructive statements scoped by `WHERE EventId = ?`.
- Adds an `UPDLOCK, HOLDLOCK` event-mode guard inside `mge_signup_dal.insert_signup()` so signups only insert while the event is still `controlled`.
- Suppresses the public signup view when `EventMode = 'open'`, while allowing it to reattach when mode returns to `controlled` and lifecycle is open.
- Extends regression coverage to assert the switch path captures deleted awards into a table variable, audits from that captured set, remains event-scoped, signup insert waits on/re-checks the event mode, and open-mode embeds hide signup controls.

## Validation

- `python -m black mge\dal\mge_event_dal.py tests\test_mge_open_mode_switch.py mge\dal\mge_signup_dal.py tests\test_mge_signup_dal.py mge\mge_embed_manager.py tests\test_mge_embed_manager.py`
- `python -m py_compile mge\dal\mge_event_dal.py tests\test_mge_open_mode_switch.py mge\dal\mge_signup_dal.py tests\test_mge_signup_dal.py mge\mge_embed_manager.py tests\test_mge_embed_manager.py`
- `python -m pytest tests\test_mge_open_mode_switch.py tests\test_mge_signup_dal.py tests\test_mge_signup_service.py tests\test_mge_event_service_rules_regression.py -vv`
- `python -m pytest tests\test_mge_embed_manager.py -vv`
- `python scripts\validate_architecture_boundaries.py`
- `python scripts\validate_deferred_items.py`
- `python scripts\select_tests.py`
- `python -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName` (`263 passed`)
- `git diff --check -- mge\dal\mge_event_dal.py tests\test_mge_open_mode_switch.py mge\dal\mge_signup_dal.py tests\test_mge_signup_dal.py mge\mge_embed_manager.py tests\test_mge_embed_manager.py`

## Risk / Rollback

Risk remains limited to the MGE fixed-to-open switch transaction, signup creation path, and public signup embed view attachment. No SQL schema changes are required. Rollback is PR revert.