### PR TITLE
[codex] Polish MGE admin operations

### DIFF
--- a/commands/mge_cmds.py
+++ b/commands/mge_cmds.py
@@ -10,12 +10,15 @@ from bot_config import GUILD_ID, MGE_LEADERSHIP_CHANNEL_ID, MGE_SIMPLIFIED_FLOW_
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import (
     channel_only,
+    is_admin_and_notify_channel,
     is_admin_or_leadership_only,
     track_usage,
 )
+from mge import mge_commander_service, mge_publish_service
 from mge.mge_embed_manager import sync_event_leadership_embed
 from mge.mge_results_import import OverwriteConfirmationRequired, import_results_manual
 from mge.mge_review_service import get_review_pool_with_summary
+from ui.views.mge_commander_admin_view import MgeCommanderAdminView
 from ui.views.mge_leadership_board_view import MgeLeadershipBoardView
 from ui.views.mge_results_overwrite_confirm_view import MgeResultsOverwriteConfirmView
 from versioning import versioned
@@ -292,3 +295,64 @@ def register_mge(bot: ext_commands.Bot) -> None:
                 "❌ Cache refresh failed. Check logs for details.",
                 ephemeral=True,
             )
+
+    @bot.slash_command(
+        name="mge_refresh_award_reminders",
+        description="Refresh or repost MGE award reminders for a published event",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.0")
+    @safe_command
+    @is_admin_and_notify_channel(allow_leadership=True)
+    @track_usage()
+    async def mge_refresh_award_reminders(
+        ctx: discord.ApplicationContext,
+        event_id: int | None = discord.Option(
+            int,
+            "Published MGE event id; omit to use the active/upcoming event",
+            min_value=1,
+            required=False,
+            default=None,
+        ),
+    ) -> None:
+        logger.info(
+            "mge_refresh_award_reminders_command_used actor_discord_id=%s event_id=%s",
+            ctx.user.id,
+            event_id,
+        )
+        await safe_defer(ctx, ephemeral=True)
+        result = await mge_publish_service.refresh_award_reminders(
+            bot=ctx.bot,
+            event_id=event_id,
+            actor_discord_id=int(ctx.user.id),
+            allow_completed=event_id is not None,
+        )
+        text = ("OK: " if result.success else "Error: ") + result.message
+        if result.event_id is not None:
+            text += f"\nEventId: `{result.event_id}`"
+        if result.status:
+            text += f"\nStatus: `{result.status}`"
+        await ctx.followup.send(text, ephemeral=True)
+
+    @bot.slash_command(
+        name="mge_commanders",
+        description="Manage MGE commanders and variant assignment (admin only)",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.0")
+    @safe_command
+    @is_admin_and_notify_channel(allow_leadership=True)
+    @track_usage()
+    async def mge_commanders(ctx: discord.ApplicationContext) -> None:
+        logger.info(
+            "mge_commanders_command_used actor_discord_id=%s",
+            ctx.user.id,
+        )
+        await safe_defer(ctx, ephemeral=True)
+        variants = await asyncio.to_thread(mge_commander_service.list_variants)
+        await ctx.followup.send(
+            # architecture-check: allow - user-facing copy, not SQL.
+            "Select a variant to add, edit, activate, deactivate, or reassign commanders.",
+            view=MgeCommanderAdminView(variants=variants),
+            ephemeral=True,
+        )

--- a/docs/Codex Task Pack — MGE Process Audit + Polish.md
+++ b/docs/Codex Task Pack — MGE Process Audit + Polish.md
@@ -1,0 +1,347 @@
+# Codex Task Pack — MGE Process Audit + Polish
+
+## Delivery Status
+
+Phase 1 has been delivered in branch `codex/mge-process-polish`.
+
+### Phase 1 Delivered
+
+* Completed the Step 1 MGE lifecycle audit before implementation.
+* Added admin-only `/mge_refresh_award_reminders`.
+* Added idempotent award reminder refresh behaviour:
+
+  * updates existing reminder messages when message metadata is present
+  * reposts reminders when message metadata is missing or the message was deleted
+  * refuses refresh when awards have not been published
+  * rebuilds reminder content from the current active default reminder text for the event rule mode, falling back to the stored event reminder text
+  * persists reminder message/channel IDs for future refreshes
+
+* Added admin-only `/mge_commanders`.
+* Added MGE commander DAL/service/view support for:
+
+  * listing commanders by variant
+  * adding commanders
+  * updating commander names
+  * activating/deactivating commanders
+  * reassigning commanders to variants
+  * duplicate-name protection
+  * cache refresh after commander changes
+
+* Preserved historical stability by continuing to rely on `GovernorNameSnapshot` and `RequestedCommanderName` on signup/award rows for historical display.
+* Added focused tests for reminder refresh and commander management.
+* Rechecked the MGE validation blocker noted for `tests/test_dl_bot_mge_auto_import.py`; it now passes in the focused MGE validation run.
+* Added bot-repo SQL migration mirror:
+
+  * `sql/mge_award_reminder_message_ids_schema.sql`
+
+### SQL Promotion Required
+
+Before production use of award reminder refresh, promote the matching SQL change to the authoritative SQL Server repo:
+
+* `dbo.MGE_Events.AwardRemindersMessageId BIGINT NULL`
+* `dbo.MGE_Events.AwardRemindersChannelId BIGINT NULL`
+
+### Deferred To Phase 2
+
+The following items were explicitly deferred because they are broader architecture work, not required for the two operational features delivered in Phase 1:
+
+* MGE signup registry-service alignment:
+
+  * GitHub issue #29: `service misalignment (MGE / stats)`
+  * GitHub issue #32: `Service Layer Consolidation Pack`
+  * Deferred because it touches shared registry/account lookup behaviour across MGE and stats.
+
+* MGE publish-service Discord IO extraction:
+
+  * `mge_publish_service.py` already mixes publish state orchestration with Discord send/edit/delete operations.
+  * Phase 1 reused that existing boundary to avoid broad refactoring of publish, republish, reminders, award DMs, unpublish, and board refresh in the same PR.
+  * Captured as a structured deferred optimisation in `docs/deferred_optimisations.md`.
+
+### Phase 1 Validation
+
+Completed validation:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName tests\test_dl_bot_mge_auto_import.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m ruff check mge commands ui tests
+.\.venv\Scripts\python.exe -m black --check mge commands ui tests
+git diff --check
+.\.venv\Scripts\python.exe -m pytest -q tests
+```
+
+Results:
+
+* Focused MGE validation: `278 passed`
+* Full suite: `1291 passed, 8 skipped`
+* `git diff --check` passed with only a CRLF warning for `commands/mge_cmds.py`
+
+## Goal
+
+Fully audit and polish the MGE process, resolving hidden issues, improving admin control, and adding two missing operational features:
+
+1. Allow admins to update/re-publish MGE award reminders after rules or award text changes.
+2. Add an admin-only command to add, update, activate/deactivate, or reassign MGE commanders.
+
+Also review GitHub issues, recent MGE PR history, and `docs/deferred_optimisations.md` for any MGE-related cleanup.
+
+---
+
+# Required Reading
+
+Before changing code, review:
+
+* `AGENTS.md`
+* `docs/codex_execution_guidelines.md`
+* `docs/K98 Bot — Project Engineering Standards.md`
+* `docs/deferred_optimisations.md`
+* MGE modules under:
+
+  * `mge/`
+  * `commands/`
+  * `ui/views/`
+  * `tests/test_mge_*.py`
+
+Recent MGE PR context:
+
+* PR #71: fixed MGE open-mode award cleanup ordering
+* PR #72: fixed MGE open-mode award audit insert and signup race
+
+STOP after Step 1 with findings before implementing.
+
+---
+
+# Step 1 — Audit Current MGE Process
+
+Map the full MGE lifecycle:
+
+* Event creation
+* Signup open/close
+* Controlled/fixed mode vs open mode
+* Commander selection
+* Award allocation
+* Award list publish/re-publish
+* Award reminder generation/posting
+* Rules text storage and editing
+* Open-mode switch cleanup/audit behaviour
+* Signup/public embed refresh behaviour
+* Any scheduled reminder behaviour
+
+Produce a short audit report covering:
+
+* Current command list
+* Current DAL/service/view boundaries
+* Where rules are read from
+* Where award reminder content is generated
+* Whether reminders store enough metadata to be safely updated
+* Whether current event history relies on commander name snapshots or live commander rows
+* Any direct SQL in command handlers
+* Any missing tests or weak regression coverage
+
+Do not implement until this audit is complete.
+
+---
+
+# Step 2 — Add Award Reminder Re-Publish / Refresh Support
+
+## Problem
+
+Currently, if admins publish the award list before correcting rules text, they can re-publish the award list but not the related award reminders. This leaves stale reminder messages unless they are manually posted.
+
+## Required Behaviour
+
+Add an admin-only flow to refresh award reminders for an existing MGE event.
+
+Preferred command name:
+
+* `/mge_refresh_award_reminders`
+
+Alternative acceptable if current naming conventions suggest better:
+
+* `/mge_republish_award_reminders`
+
+The command must:
+
+* Be admin-only using the existing admin decorator pattern.
+* Select or infer the relevant active/upcoming MGE event.
+* Rebuild reminder content from the current stored event rules/award data.
+* Update existing reminder messages where possible.
+* If message IDs are missing or messages were deleted, repost cleanly.
+* Avoid duplicate reminders.
+* Log what happened:
+
+  * updated existing reminders
+  * reposted missing reminders
+  * skipped because no awards published
+  * failed due to missing channel/message permissions
+
+## Important Rules
+
+* Do not require manually editing Discord messages.
+* Do not reallocate awards.
+* Do not alter signups.
+* Do not change open/fixed mode.
+* Do not touch historical completed MGE events unless explicitly selected by admin.
+* Keep idempotent behaviour: running twice should not create duplicates.
+
+## Tests
+
+Add/extend tests for:
+
+* Refresh updates existing reminder messages.
+* Refresh reposts missing/deleted reminder messages.
+* Refresh does not duplicate reminders.
+* Refresh uses latest rules text.
+* Refresh refuses when awards are not published.
+* Permission/admin guard remains intact.
+
+---
+
+# Step 3 — Add Admin Commander Management Command
+
+## Goal
+
+Add an admin-only Discord command to manage `MGE_Commanders`.
+
+Suggested command:
+
+* `/mge_commanders`
+
+The UI should use Discord components:
+
+1. Dropdown: select variant.
+2. Dropdown: `Add New Commander` or select existing commander.
+3. Modal for fields:
+
+   * Commander name
+   * Active status
+   * Linked variant
+   * Optional display/order field if the table already supports it
+
+## Required Operations
+
+Support:
+
+* Add commander
+* Update commander name
+* Activate/deactivate commander
+* Move commander to a different variant
+* View current commanders by variant
+* Prevent accidental duplicate active commander names for the same variant
+
+## History / Current Event Rules
+
+Codex must inspect the schema and current code, then enforce this policy unless the existing model requires a safer alternative:
+
+* Historical MGE signups/awards should remain stable by using existing snapshot fields where available.
+* Updating `MGE_Commanders` should affect future event setup and future commander dropdowns.
+* Existing MGE events already created should not silently mutate their published award history.
+* If a commander is inactive, it should not appear for new signup/award flows, but existing historical records should still display correctly.
+* Deleting commanders should be avoided unless no references exist. Prefer inactive status over physical delete.
+
+## If Delete Is Requested
+
+The command may include “Deactivate” rather than hard delete.
+
+Only add hard delete if:
+
+* No signup/award/event history references the commander.
+* The DAL performs a safe reference check.
+* The UI labels it clearly as dangerous.
+
+## Tests
+
+Add tests for:
+
+* Admin-only access.
+* Listing by variant.
+* Add new commander.
+* Update name.
+* Update active flag.
+* Move variant.
+* Duplicate prevention.
+* Inactive commanders excluded from new event/signup dropdowns.
+* Historical snapshots remain unchanged.
+
+---
+
+# Step 4 — Resolve MGE-Related Deferred Items / GitHub Issues
+
+Review:
+
+* `docs/deferred_optimisations.md`
+* Open GitHub issues
+* Recent closed MGE PRs
+* Current `tests/test_mge_*.py`
+
+Known relevant point from deferred docs:
+
+* `tests/test_dl_bot_mge_auto_import.py` is listed among tests affected by local validation/environment blockers.
+* If this still affects reliable MGE validation, either fix it or clearly isolate it with an environment capability gate.
+
+Do not resolve unrelated deferred items unless they directly block MGE.
+
+---
+
+# Step 5 — MGE Optimisation / Underlying Issue Review
+
+Look for and fix low-risk issues in:
+
+* Race conditions around signup close/open-mode switch.
+* Duplicate reminder/message creation.
+* Missing message ID persistence.
+* Stale component views after event mode changes.
+* Direct SQL in command/view layers.
+* Missing transaction boundaries in DAL writes.
+* Weak error handling around Discord message edits/deletes.
+* Inconsistent UTC handling.
+* Embed fields near Discord limits.
+* Rules text escaping/formatting issues.
+* Permission checks.
+
+Any large architectural refactor should be captured as a new deferred optimisation unless it is directly required for this task.
+
+---
+
+# Step 6 — Validation
+
+Run focused MGE validation:
+
+```powershell
+python -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName
+python scripts\validate_architecture_boundaries.py
+python scripts\validate_deferred_items.py
+python scripts\select_tests.py
+python scripts\smoke_imports.py
+python scripts\validate_command_registration.py
+python -m ruff check mge commands ui tests
+python -m black --check mge commands ui tests
+git diff --check
+```
+
+If full suite is practical:
+
+```powershell
+python -m pytest -q tests
+```
+
+If any test is gated due to environment constraints, document clearly why and ensure it is not silently skipped without explanation.
+
+---
+
+# Acceptance Criteria
+
+* MGE audit report produced before implementation.
+* Admin can refresh/re-publish award reminders after correcting rules.
+* Reminder refresh is idempotent and avoids duplicate posts.
+* Admin can manage MGE commanders from Discord.
+* Commander changes affect future events only unless current-event behaviour is explicitly and safely handled.
+* Historical MGE display remains stable.
+* Existing open/fixed mode behaviour remains protected.
+* No new direct SQL is added to Discord command handlers.
+* Tests cover the new reminder and commander workflows.
+* MGE-related deferred/GitHub items are resolved or explicitly re-deferred with reason.

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -51,3 +51,21 @@
 - Impact: medium
 - Risk: medium
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to Phase 9.
+
+### Deferred Optimisation
+- Area: `mge/mge_signup_service.py`
+- Type: consistency
+- Description: MGE signup governor lookup still reads the registry through the legacy registry shape instead of the newer `registry_service.get_user_accounts()` service boundary. This remains aligned with GitHub issues #29 and #32 and is not required for MGE reminder refresh or commander administration.
+- Suggested Fix: Move MGE signup account resolution onto `registry_service.get_user_accounts()` in a focused service-consolidation pass, preserving existing self-service/admin-add behaviour and tests.
+- Impact: medium
+- Risk: medium
+- Dependencies: Coordinate with the broader Service Layer Consolidation Pack so stats and MGE registry-service alignment are handled together.
+
+### Deferred Optimisation
+- Area: `mge/mge_publish_service.py`
+- Type: architecture
+- Description: MGE publish orchestration still mixes domain publish state transitions with Discord message IO. The current task reused that existing boundary for award reminder refresh to avoid splitting publish/repost behaviour mid-feature, with explicit architecture-check allowances on the pre-existing Discord-aware service surface.
+- Suggested Fix: Extract Discord message fetch/edit/send operations into a dedicated interaction adapter or UI orchestration module, leaving `mge_publish_service.py` to produce publish/reminder intents and persist outcomes through DAL calls.
+- Impact: high
+- Risk: medium
+- Dependencies: Requires careful regression coverage for publish, republish, reminder refresh, unpublish, award DM, and board refresh behaviours.

--- a/mge/dal/mge_commander_dal.py
+++ b/mge/dal/mge_commander_dal.py
@@ -1,0 +1,240 @@
+"""DAL for MGE commander administration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import logging
+from typing import Any
+
+from stats_alerts.db import exec_with_cursor, run_query
+
+logger = logging.getLogger(__name__)
+
+
+def _naive_utc(dt: datetime) -> datetime:
+    aware = dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+    return aware.replace(tzinfo=None)
+
+
+def fetch_active_variants() -> list[dict[str, Any]]:
+    try:
+        return run_query("""
+            SELECT VariantId, VariantName
+            FROM dbo.MGE_Variants
+            WHERE IsActive = 1
+            ORDER BY VariantName;
+            """)
+    except Exception:
+        logger.exception("mge_commander_dal_fetch_active_variants_failed")
+        return []
+
+
+def fetch_commanders_for_variant(
+    variant_id: int, *, include_inactive: bool = True
+) -> list[dict[str, Any]]:
+    try:
+        active_filter = "" if include_inactive else "AND c.IsActive = 1 AND vc.IsActive = 1"
+        return run_query(
+            f"""
+            SELECT
+                c.CommanderId,
+                c.CommanderName,
+                c.IsActive AS CommanderIsActive,
+                c.ReleaseStartUtc,
+                c.ReleaseEndUtc,
+                c.ImageUrl,
+                vc.VariantCommanderId,
+                vc.VariantId,
+                vc.IsActive AS VariantCommanderIsActive,
+                v.VariantName
+            FROM dbo.MGE_VariantCommanders vc
+            JOIN dbo.MGE_Commanders c ON c.CommanderId = vc.CommanderId
+            JOIN dbo.MGE_Variants v ON v.VariantId = vc.VariantId
+            WHERE vc.VariantId = ?
+              {active_filter}
+            ORDER BY c.CommanderName;
+            """,
+            (int(variant_id),),
+        )
+    except Exception:
+        logger.exception(
+            "mge_commander_dal_fetch_commanders_for_variant_failed variant_id=%s",
+            variant_id,
+        )
+        return []
+
+
+def fetch_commander_by_id(commander_id: int) -> dict[str, Any] | None:
+    try:
+        rows = run_query(
+            """
+            SELECT CommanderId, CommanderName, IsActive, ReleaseStartUtc, ReleaseEndUtc, ImageUrl
+            FROM dbo.MGE_Commanders
+            WHERE CommanderId = ?;
+            """,
+            (int(commander_id),),
+        )
+        return rows[0] if rows else None
+    except Exception:
+        logger.exception(
+            "mge_commander_dal_fetch_commander_by_id_failed commander_id=%s", commander_id
+        )
+        return None
+
+
+def fetch_commander_by_name(commander_name: str) -> dict[str, Any] | None:
+    try:
+        rows = run_query(
+            """
+            SELECT CommanderId, CommanderName, IsActive, ReleaseStartUtc, ReleaseEndUtc, ImageUrl
+            FROM dbo.MGE_Commanders
+            WHERE CommanderName = ?;
+            """,
+            (str(commander_name).strip(),),
+        )
+        return rows[0] if rows else None
+    except Exception:
+        logger.exception("mge_commander_dal_fetch_commander_by_name_failed")
+        return None
+
+
+def commander_has_history(commander_id: int) -> bool:
+    try:
+        rows = run_query(
+            """
+            SELECT TOP (1) 1 AS HasHistory
+            WHERE EXISTS (SELECT 1 FROM dbo.MGE_Signups WHERE RequestedCommanderId = ?)
+               OR EXISTS (SELECT 1 FROM dbo.MGE_Awards WHERE RequestedCommanderId = ?)
+               OR EXISTS (SELECT 1 FROM dbo.MGE_EventCommanderOverrides WHERE CommanderId = ?);
+            """,
+            (int(commander_id), int(commander_id), int(commander_id)),
+        )
+        return bool(rows)
+    except Exception:
+        logger.exception(
+            "mge_commander_dal_commander_has_history_failed commander_id=%s",
+            commander_id,
+        )
+        return True
+
+
+def upsert_commander_assignment(
+    *,
+    commander_id: int | None,
+    commander_name: str,
+    variant_id: int,
+    is_active: bool,
+    now_utc: datetime,
+) -> dict[str, Any] | None:
+    """Create/update a commander and make exactly one active variant mapping."""
+
+    def _op(cur: Any) -> dict[str, Any] | None:
+        effective_commander_id = int(commander_id or 0)
+        if effective_commander_id <= 0:
+            cur.execute(
+                """
+                SELECT TOP (1) CommanderId
+                FROM dbo.MGE_Commanders WITH (UPDLOCK, HOLDLOCK)
+                WHERE CommanderName = ?;
+                """,
+                (commander_name,),
+            )
+            row = cur.fetchone()
+            if row:
+                effective_commander_id = int(row[0])
+            else:
+                cur.execute(
+                    """
+                    INSERT INTO dbo.MGE_Commanders
+                        (CommanderName, IsActive, ReleaseStartUtc, ReleaseEndUtc, ImageUrl, CreatedUtc, UpdatedUtc)
+                    OUTPUT INSERTED.CommanderId
+                    VALUES (?, ?, NULL, NULL, NULL, ?, ?);
+                    """,
+                    (
+                        commander_name,
+                        1 if is_active else 0,
+                        _naive_utc(now_utc),
+                        _naive_utc(now_utc),
+                    ),
+                )
+                inserted = cur.fetchone()
+                if not inserted:
+                    return None
+                effective_commander_id = int(inserted[0])
+
+        cur.execute(
+            """
+            UPDATE dbo.MGE_Commanders
+            SET CommanderName = ?,
+                IsActive = ?,
+                UpdatedUtc = ?
+            WHERE CommanderId = ?;
+            """,
+            (
+                commander_name,
+                1 if is_active else 0,
+                _naive_utc(now_utc),
+                effective_commander_id,
+            ),
+        )
+
+        cur.execute(
+            """
+            UPDATE dbo.MGE_VariantCommanders
+            SET IsActive = 0
+            WHERE CommanderId = ?
+              AND VariantId <> ?;
+            """,
+            (effective_commander_id, int(variant_id)),
+        )
+
+        cur.execute(
+            """
+            SELECT TOP (1) VariantCommanderId
+            FROM dbo.MGE_VariantCommanders WITH (UPDLOCK, HOLDLOCK)
+            WHERE CommanderId = ?
+              AND VariantId = ?;
+            """,
+            (effective_commander_id, int(variant_id)),
+        )
+        mapping = cur.fetchone()
+        if mapping:
+            cur.execute(
+                """
+                UPDATE dbo.MGE_VariantCommanders
+                SET IsActive = ?
+                WHERE VariantCommanderId = ?;
+                """,
+                (1 if is_active else 0, int(mapping[0])),
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO dbo.MGE_VariantCommanders
+                    (VariantId, CommanderId, IsActive, CreatedUtc)
+                VALUES (?, ?, ?, ?);
+                """,
+                (
+                    int(variant_id),
+                    effective_commander_id,
+                    1 if is_active else 0,
+                    _naive_utc(now_utc),
+                ),
+            )
+
+        return {
+            "CommanderId": effective_commander_id,
+            "CommanderName": commander_name,
+            "VariantId": int(variant_id),
+            "IsActive": bool(is_active),
+        }
+
+    try:
+        return exec_with_cursor(_op)
+    except Exception:
+        logger.exception(
+            "mge_commander_dal_upsert_assignment_failed commander_id=%s variant_id=%s",
+            commander_id,
+            variant_id,
+        )
+        return None

--- a/mge/dal/mge_commander_dal.py
+++ b/mge/dal/mge_commander_dal.py
@@ -126,7 +126,7 @@ def upsert_commander_assignment(
     is_active: bool,
     now_utc: datetime,
 ) -> dict[str, Any] | None:
-    """Create/update a commander and make exactly one active variant mapping."""
+    """Create/update a commander and upsert the requested variant mapping."""
 
     def _op(cur: Any) -> dict[str, Any] | None:
         effective_commander_id = int(commander_id or 0)
@@ -176,16 +176,6 @@ def upsert_commander_assignment(
                 _naive_utc(now_utc),
                 effective_commander_id,
             ),
-        )
-
-        cur.execute(
-            """
-            UPDATE dbo.MGE_VariantCommanders
-            SET IsActive = 0
-            WHERE CommanderId = ?
-              AND VariantId <> ?;
-            """,
-            (effective_commander_id, int(variant_id)),
         )
 
         cur.execute(

--- a/mge/dal/mge_publish_dal.py
+++ b/mge/dal/mge_publish_dal.py
@@ -30,10 +30,22 @@ SELECT
     e.AwardRemindersText,
     e.AwardRemindersSentUtc,
     e.AwardRemindersSentByDiscordId,
+    e.AwardRemindersMessageId,
+    e.AwardRemindersChannelId,
     v.VariantName
 FROM dbo.MGE_Events e
 JOIN dbo.MGE_Variants v ON e.VariantId = v.VariantId
 WHERE e.EventId = ?;
+"""
+
+SQL_SELECT_REFRESHABLE_EVENT_ID = """
+SELECT TOP (1) EventId
+FROM dbo.MGE_Events
+WHERE Status IN ('published', 'signup_closed', 'signup_open', 'reopened')
+ORDER BY
+    CASE WHEN Status = 'published' THEN 0 ELSE 1 END,
+    StartUtc ASC,
+    EventId ASC;
 """
 
 SQL_SELECT_AWARDS_WITH_SIGNUP_USER = """
@@ -112,6 +124,18 @@ def fetch_event_publish_context(event_id: int) -> dict[str, Any] | None:
         return rows[0] if rows else None
     except Exception:
         logger.exception("mge_publish_dal_fetch_event_publish_context_failed event_id=%s", event_id)
+        return None
+
+
+def fetch_refreshable_award_reminder_event_id() -> int | None:
+    """Return the preferred non-completed MGE event for reminder refresh."""
+    try:
+        rows = run_query(SQL_SELECT_REFRESHABLE_EVENT_ID)
+        if not rows:
+            return None
+        return int(rows[0]["EventId"])
+    except Exception:
+        logger.exception("mge_publish_dal_fetch_refreshable_event_id_failed")
         return None
 
 
@@ -804,6 +828,33 @@ def update_event_award_reminders_text(
     except Exception:
         logger.exception(
             "mge_publish_dal_update_event_award_reminders_text_failed event_id=%s",
+            event_id,
+        )
+        return False
+
+
+def update_award_reminder_message_ids(
+    *,
+    event_id: int,
+    message_id: int,
+    channel_id: int,
+    now_utc: datetime,
+) -> bool:
+    try:
+        updated = execute(
+            """
+            UPDATE dbo.MGE_Events
+            SET AwardRemindersMessageId = ?,
+                AwardRemindersChannelId = ?,
+                UpdatedUtc = ?
+            WHERE EventId = ?;
+            """,
+            (int(message_id), int(channel_id), _naive_utc(now_utc), int(event_id)),
+        )
+        return int(updated or 0) > 0
+    except Exception:
+        logger.exception(
+            "mge_publish_dal_update_award_reminder_message_ids_failed event_id=%s",
             event_id,
         )
         return False

--- a/mge/mge_commander_service.py
+++ b/mge/mge_commander_service.py
@@ -66,7 +66,14 @@ def save_commander_assignment(
     existing_by_name = mge_commander_dal.fetch_commander_by_name(name)
     if existing_by_name:
         existing_id = int(existing_by_name["CommanderId"])
-        if resolved_commander_id <= 0 or resolved_commander_id != existing_id:
+        if resolved_commander_id != existing_id:
+            logger.info(
+                "mge_commander_save_reusing_existing_name requested_commander_id=%s existing_commander_id=%s commander_name=%s variant_id=%s",
+                commander_id,
+                existing_id,
+                name,
+                variant_id,
+            )
             resolved_commander_id = existing_id
 
     row = mge_commander_dal.upsert_commander_assignment(

--- a/mge/mge_commander_service.py
+++ b/mge/mge_commander_service.py
@@ -62,15 +62,15 @@ def save_commander_assignment(
     if int(variant_id or 0) <= 0:
         return CommanderServiceResult(False, "A linked variant is required.")
 
+    resolved_commander_id = int(commander_id or 0)
     existing_by_name = mge_commander_dal.fetch_commander_by_name(name)
-    if existing_by_name and int(existing_by_name["CommanderId"]) != int(commander_id or 0):
-        return CommanderServiceResult(
-            False,
-            "A commander with that name already exists.",
-        )
+    if existing_by_name:
+        existing_id = int(existing_by_name["CommanderId"])
+        if resolved_commander_id <= 0 or resolved_commander_id != existing_id:
+            resolved_commander_id = existing_id
 
     row = mge_commander_dal.upsert_commander_assignment(
-        commander_id=commander_id,
+        commander_id=resolved_commander_id if resolved_commander_id > 0 else None,
         commander_name=name,
         variant_id=int(variant_id),
         is_active=bool(is_active),
@@ -79,7 +79,19 @@ def save_commander_assignment(
     if not row:
         return CommanderServiceResult(False, "Failed to save commander.")
 
-    refresh = mge_cache.refresh_mge_caches()
+    try:
+        refresh = mge_cache.refresh_mge_caches()
+    except Exception:
+        logger.exception(
+            "mge_commander_save_cache_refresh_failed commander_id=%s",
+            row.get("CommanderId"),
+        )
+        return CommanderServiceResult(
+            False,
+            "Commander saved, but cache refresh failed.",
+            commander_id=int(row["CommanderId"]),
+            variant_id=int(row["VariantId"]),
+        )
     if not all(refresh.values()):
         logger.warning(
             "mge_commander_save_cache_refresh_partial commander_id=%s results=%s",

--- a/mge/mge_commander_service.py
+++ b/mge/mge_commander_service.py
@@ -1,0 +1,101 @@
+"""Service layer for MGE commander administration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import logging
+from typing import Any
+
+from mge import mge_cache
+from mge.dal import mge_commander_dal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CommanderServiceResult:
+    success: bool
+    message: str
+    commander_id: int | None = None
+    variant_id: int | None = None
+
+
+def _now_utc(now_utc: datetime | None = None) -> datetime:
+    if now_utc is None:
+        return datetime.now(UTC)
+    if now_utc.tzinfo is None:
+        return now_utc.replace(tzinfo=UTC)
+    return now_utc.astimezone(UTC)
+
+
+def _normalize_name(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def list_variants() -> list[dict[str, Any]]:
+    return mge_commander_dal.fetch_active_variants()
+
+
+def list_commanders_by_variant(
+    variant_id: int, *, include_inactive: bool = True
+) -> list[dict[str, Any]]:
+    return mge_commander_dal.fetch_commanders_for_variant(
+        int(variant_id),
+        include_inactive=include_inactive,
+    )
+
+
+def save_commander_assignment(
+    *,
+    commander_id: int | None,
+    commander_name: str,
+    variant_id: int,
+    is_active: bool,
+    now_utc: datetime | None = None,
+) -> CommanderServiceResult:
+    name = _normalize_name(commander_name)
+    if not name:
+        return CommanderServiceResult(False, "Commander name cannot be empty.")
+    if len(name) > 100:
+        return CommanderServiceResult(False, "Commander name is too long (max 100 characters).")
+    if int(variant_id or 0) <= 0:
+        return CommanderServiceResult(False, "A linked variant is required.")
+
+    existing_by_name = mge_commander_dal.fetch_commander_by_name(name)
+    if existing_by_name and int(existing_by_name["CommanderId"]) != int(commander_id or 0):
+        return CommanderServiceResult(
+            False,
+            "A commander with that name already exists.",
+        )
+
+    row = mge_commander_dal.upsert_commander_assignment(
+        commander_id=commander_id,
+        commander_name=name,
+        variant_id=int(variant_id),
+        is_active=bool(is_active),
+        now_utc=_now_utc(now_utc),
+    )
+    if not row:
+        return CommanderServiceResult(False, "Failed to save commander.")
+
+    refresh = mge_cache.refresh_mge_caches()
+    if not all(refresh.values()):
+        logger.warning(
+            "mge_commander_save_cache_refresh_partial commander_id=%s results=%s",
+            row.get("CommanderId"),
+            refresh,
+        )
+
+    logger.info(
+        "mge_commander_saved commander_id=%s variant_id=%s is_active=%s",
+        row.get("CommanderId"),
+        row.get("VariantId"),
+        row.get("IsActive"),
+    )
+    return CommanderServiceResult(
+        True,
+        "Commander saved.",
+        commander_id=int(row["CommanderId"]),
+        variant_id=int(row["VariantId"]),
+    )

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -752,12 +752,19 @@ async def refresh_award_reminders(
         )
 
     if reminders_text != str(ctx.get("AwardRemindersText") or "").strip():
-        await asyncio.to_thread(
+        updated = await asyncio.to_thread(
             mge_publish_dal.update_event_award_reminders_text,
             event_id=resolved_event_id,
             reminders_text=reminders_text,
             now_utc=now,
         )
+        if not updated:
+            return RefreshAwardRemindersResult(
+                False,
+                "Failed to persist award reminders text before refreshing the reminder message.",
+                event_id=resolved_event_id,
+                status="db_update_failed",
+            )
 
     channel = await _resolve_messageable_channel(bot, channel_id)
     if channel is None:

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -537,7 +537,7 @@ async def publish_event_awards(
                         now_utc=now,
                     )
                     if not reminder_ids_updated and not reminders_marked_sent:
-                        reminders_embed_status = "ids_and_mark_failed"
+                        reminders_embed_status = "ids_persist_and_mark_failed"
                         logger.warning(
                             "mge_publish_reminders_id_and_mark_failed event_id=%s actor_discord_id=%s channel_id=%s version=%s",
                             event_id,

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -864,19 +864,64 @@ async def refresh_award_reminders(
             status="post_failed",
         )
 
-    await asyncio.to_thread(
+    message_ids_updated = await asyncio.to_thread(
         mge_publish_dal.update_award_reminder_message_ids,
         event_id=resolved_event_id,
         message_id=int(message.id),
         channel_id=int(channel.id),
         now_utc=now,
     )
-    await asyncio.to_thread(
+    reminders_marked_sent = await asyncio.to_thread(
         mge_publish_dal.mark_award_reminders_sent,
         event_id=resolved_event_id,
         actor_discord_id=actor_discord_id,
         now_utc=now,
     )
+    if not message_ids_updated and not reminders_marked_sent:
+        logger.warning(
+            "mge_refresh_award_reminders_reposted_persist_and_mark_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
+            resolved_event_id,
+            actor_discord_id,
+            int(message.id),
+            int(channel.id),
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders reposted, but failed to save reminder message details and mark reminders sent.",
+            event_id=resolved_event_id,
+            status="reposted_persist_and_mark_failed",
+            reposted_missing=True,
+        )
+    if not message_ids_updated:
+        logger.warning(
+            "mge_refresh_award_reminders_reposted_persist_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
+            resolved_event_id,
+            actor_discord_id,
+            int(message.id),
+            int(channel.id),
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders reposted, but failed to save reminder message details.",
+            event_id=resolved_event_id,
+            status="reposted_persist_failed",
+            reposted_missing=True,
+        )
+    if not reminders_marked_sent:
+        logger.warning(
+            "mge_refresh_award_reminders_reposted_mark_sent_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
+            resolved_event_id,
+            actor_discord_id,
+            int(message.id),
+            int(channel.id),
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders reposted, but failed to mark reminders sent.",
+            event_id=resolved_event_id,
+            status="reposted_mark_sent_failed",
+            reposted_missing=True,
+        )
     logger.info(
         "mge_refresh_award_reminders_reposted event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
         resolved_event_id,

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -523,7 +523,7 @@ async def publish_event_awards(
                         embed=reminders_embed,
                     )
                     reminders_embed_sent = True
-                    await asyncio.to_thread(
+                    reminder_ids_updated = await asyncio.to_thread(
                         mge_publish_dal.update_award_reminder_message_ids,
                         event_id=event_id,
                         message_id=int(reminders_message.id),
@@ -536,7 +536,25 @@ async def publish_event_awards(
                         actor_discord_id=actor_discord_id,
                         now_utc=now,
                     )
-                    if reminders_marked_sent:
+                    if not reminder_ids_updated and not reminders_marked_sent:
+                        reminders_embed_status = "ids_and_mark_failed"
+                        logger.warning(
+                            "mge_publish_reminders_id_and_mark_failed event_id=%s actor_discord_id=%s channel_id=%s version=%s",
+                            event_id,
+                            actor_discord_id,
+                            channel_id,
+                            new_version,
+                        )
+                    elif not reminder_ids_updated:
+                        reminders_embed_status = "ids_persist_failed"
+                        logger.warning(
+                            "mge_publish_reminders_id_persist_failed event_id=%s actor_discord_id=%s channel_id=%s version=%s",
+                            event_id,
+                            actor_discord_id,
+                            channel_id,
+                            new_version,
+                        )
+                    elif reminders_marked_sent:
                         reminders_embed_status = "sent"
                     else:
                         reminders_embed_status = "mark_failed"

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 from typing import Any
 
+# architecture-check: allow - existing publish orchestration owns Discord message IO.
 import discord
 
 from bot_config import MGE_AWARD_CHANNEL_ID, MGE_MAIL_DM_USER_IDS
@@ -46,6 +47,17 @@ class UnpublishResult:
     old_status: str | None = None
     restored_status: str | None = None
     old_publish_version: int | None = None
+
+
+@dataclass(slots=True)
+class RefreshAwardRemindersResult:
+    success: bool
+    message: str
+    event_id: int | None = None
+    status: str | None = None
+    updated_existing: bool = False
+    reposted_missing: bool = False
+    skipped_no_awards: bool = False
 
 
 def _now_utc(now_utc: datetime | None = None) -> datetime:
@@ -140,6 +152,39 @@ def _build_award_mail_text(
 
 def _current_award_dataset(event_id: int) -> dict[str, Any]:
     return get_ordered_leadership_rows(event_id)
+
+
+async def _resolve_messageable_channel(
+    bot: discord.Client,  # architecture-check: allow
+    channel_id: int,
+) -> discord.abc.Messageable | None:  # architecture-check: allow
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(channel_id)
+        except Exception:
+            logger.exception("mge_channel_fetch_failed channel_id=%s", channel_id)
+            return None
+    if not hasattr(channel, "send"):
+        logger.error("mge_channel_not_messageable channel_id=%s", channel_id)
+        return None
+    return channel
+
+
+async def _send_award_reminders_embed(
+    *,
+    channel: discord.abc.Messageable,  # architecture-check: allow
+    embed: discord.Embed,  # architecture-check: allow
+) -> discord.Message:  # architecture-check: allow
+    return await channel.send(
+        content="@everyone",
+        embed=embed,
+        allowed_mentions=discord.AllowedMentions(  # architecture-check: allow
+            everyone=True,
+            roles=False,
+            users=False,
+        ),
+    )
 
 
 def _current_roster_rows_from_dataset(dataset: dict[str, Any]) -> list[dict[str, Any]]:
@@ -306,7 +351,7 @@ def override_target_score(
 
 async def publish_event_awards(
     *,
-    bot: discord.Client,
+    bot: discord.Client,  # architecture-check: allow
     event_id: int,
     actor_discord_id: int,
     reminders_text_override: str | None = None,
@@ -387,7 +432,9 @@ async def publish_event_awards(
         published_utc=now,
     )
 
-    allowed_mentions = discord.AllowedMentions(everyone=False, roles=False, users=True)
+    allowed_mentions = discord.AllowedMentions(  # architecture-check: allow
+        everyone=False, roles=False, users=True
+    )
 
     try:
         mention_content = build_award_notifications_content(awarded + waitlist)
@@ -426,7 +473,7 @@ async def publish_event_awards(
     if new_version > 1 and changes:
         await channel.send(
             "📌 **MGE Republish Change Log**\n" + "\n".join(f"- {line}" for line in changes[:50]),
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
         )
 
     reminders_embed_sent = False
@@ -471,16 +518,18 @@ async def publish_event_awards(
                     published_utc=now,
                 )
                 try:
-                    await channel.send(
-                        content="@everyone",
+                    reminders_message = await _send_award_reminders_embed(
+                        channel=channel,
                         embed=reminders_embed,
-                        allowed_mentions=discord.AllowedMentions(
-                            everyone=True,
-                            roles=False,
-                            users=False,
-                        ),
                     )
                     reminders_embed_sent = True
+                    await asyncio.to_thread(
+                        mge_publish_dal.update_award_reminder_message_ids,
+                        event_id=event_id,
+                        message_id=int(reminders_message.id),
+                        channel_id=int(channel.id),
+                        now_utc=now,
+                    )
                     reminders_marked_sent = await asyncio.to_thread(
                         mge_publish_dal.mark_award_reminders_sent,
                         event_id=event_id,
@@ -539,7 +588,7 @@ async def publish_event_awards(
                     mail_user = await bot.fetch_user(mail_user_id)
                     await mail_user.send(
                         dm_text,
-                        allowed_mentions=discord.AllowedMentions.none(),
+                        allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
                     )
                     sent_count += 1
                     logger.info(
@@ -614,9 +663,232 @@ async def publish_event_awards(
     )
 
 
+async def refresh_award_reminders(
+    *,
+    bot: discord.Client,  # architecture-check: allow
+    event_id: int | None,
+    actor_discord_id: int,
+    allow_completed: bool = False,
+    now_utc: datetime | None = None,
+) -> RefreshAwardRemindersResult:
+    """Refresh the persisted award-reminders post without reallocating awards."""
+    now = _now_utc(now_utc)
+    resolved_event_id = int(event_id or 0)
+    if resolved_event_id <= 0:
+        resolved = await asyncio.to_thread(
+            mge_publish_dal.fetch_refreshable_award_reminder_event_id
+        )
+        if not resolved:
+            return RefreshAwardRemindersResult(
+                False,
+                "No active or upcoming MGE event was found.",
+                status="no_event",
+            )
+        resolved_event_id = int(resolved)
+
+    ctx = await asyncio.to_thread(mge_publish_dal.fetch_event_publish_context, resolved_event_id)
+    if not ctx:
+        return RefreshAwardRemindersResult(
+            False,
+            "Event not found.",
+            event_id=resolved_event_id,
+            status="event_not_found",
+        )
+
+    status = str(ctx.get("Status") or "").strip().lower()
+    if status == "completed" and not allow_completed:
+        return RefreshAwardRemindersResult(
+            False,
+            "Completed MGE events require an explicit admin-selected event id.",
+            event_id=resolved_event_id,
+            status="completed_not_allowed",
+        )
+
+    if _to_int(ctx.get("PublishVersion"), 0) <= 0:
+        logger.info(
+            "mge_refresh_award_reminders_skipped_no_awards event_id=%s actor_discord_id=%s",
+            resolved_event_id,
+            actor_discord_id,
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Awards have not been published for this event.",
+            event_id=resolved_event_id,
+            status="no_awards_published",
+            skipped_no_awards=True,
+        )
+
+    channel_id = _to_int(ctx.get("AwardRemindersChannelId"), 0)
+    if channel_id <= 0:
+        channel_id = _to_int(ctx.get("AwardEmbedChannelId"), 0)
+    if channel_id <= 0:
+        channel_id = int(MGE_AWARD_CHANNEL_ID)
+    if channel_id <= 0:
+        return RefreshAwardRemindersResult(
+            False,
+            "MGE award channel is not configured.",
+            event_id=resolved_event_id,
+            status="missing_channel",
+        )
+
+    rule_mode = str(ctx.get("RuleMode") or "").strip().lower()
+    latest_default = await asyncio.to_thread(
+        mge_publish_dal.fetch_default_award_reminders_text, rule_mode
+    )
+    reminders_text = str(latest_default or ctx.get("AwardRemindersText") or "").strip()
+    if not reminders_text:
+        return RefreshAwardRemindersResult(
+            False,
+            "No award reminder text is configured for this event/rule mode.",
+            event_id=resolved_event_id,
+            status="missing_text",
+        )
+    if len(reminders_text) > 4000:
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders text is too long (max 4000 characters).",
+            event_id=resolved_event_id,
+            status="text_too_long",
+        )
+
+    if reminders_text != str(ctx.get("AwardRemindersText") or "").strip():
+        await asyncio.to_thread(
+            mge_publish_dal.update_event_award_reminders_text,
+            event_id=resolved_event_id,
+            reminders_text=reminders_text,
+            now_utc=now,
+        )
+
+    channel = await _resolve_messageable_channel(bot, channel_id)
+    if channel is None:
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders channel is unavailable or not messageable.",
+            event_id=resolved_event_id,
+            status="channel_unavailable",
+        )
+
+    embed = build_mge_award_reminders_embed(
+        event_row=ctx,
+        reminders_text=reminders_text,
+        published_utc=now,
+    )
+    old_message_id = _to_int(ctx.get("AwardRemindersMessageId"), 0)
+
+    if old_message_id > 0 and hasattr(channel, "fetch_message"):
+        try:
+            message = await channel.fetch_message(old_message_id)
+            await message.edit(
+                content="@everyone",
+                embed=embed,
+                allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
+            )
+            logger.info(
+                "mge_refresh_award_reminders_updated event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
+                resolved_event_id,
+                actor_discord_id,
+                old_message_id,
+                channel_id,
+            )
+            return RefreshAwardRemindersResult(
+                True,
+                "Award reminders updated.",
+                event_id=resolved_event_id,
+                status="updated",
+                updated_existing=True,
+            )
+        except discord.NotFound:  # architecture-check: allow
+            logger.info(
+                "mge_refresh_award_reminders_missing_message event_id=%s message_id=%s",
+                resolved_event_id,
+                old_message_id,
+            )
+        except discord.Forbidden:  # architecture-check: allow
+            logger.exception(
+                "mge_refresh_award_reminders_forbidden event_id=%s message_id=%s channel_id=%s",
+                resolved_event_id,
+                old_message_id,
+                channel_id,
+            )
+            return RefreshAwardRemindersResult(
+                False,
+                "Missing permission to update the existing award reminders message.",
+                event_id=resolved_event_id,
+                status="permission_failed",
+            )
+        except Exception:
+            logger.exception(
+                "mge_refresh_award_reminders_edit_failed event_id=%s message_id=%s channel_id=%s",
+                resolved_event_id,
+                old_message_id,
+                channel_id,
+            )
+            return RefreshAwardRemindersResult(
+                False,
+                "Failed to update the existing award reminders message.",
+                event_id=resolved_event_id,
+                status="edit_failed",
+            )
+
+    try:
+        message = await _send_award_reminders_embed(channel=channel, embed=embed)
+    except discord.Forbidden:  # architecture-check: allow
+        logger.exception(
+            "mge_refresh_award_reminders_post_forbidden event_id=%s channel_id=%s",
+            resolved_event_id,
+            channel_id,
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Missing permission to post award reminders.",
+            event_id=resolved_event_id,
+            status="permission_failed",
+        )
+    except Exception:
+        logger.exception(
+            "mge_refresh_award_reminders_post_failed event_id=%s channel_id=%s",
+            resolved_event_id,
+            channel_id,
+        )
+        return RefreshAwardRemindersResult(
+            False,
+            "Failed to post award reminders.",
+            event_id=resolved_event_id,
+            status="post_failed",
+        )
+
+    await asyncio.to_thread(
+        mge_publish_dal.update_award_reminder_message_ids,
+        event_id=resolved_event_id,
+        message_id=int(message.id),
+        channel_id=int(channel.id),
+        now_utc=now,
+    )
+    await asyncio.to_thread(
+        mge_publish_dal.mark_award_reminders_sent,
+        event_id=resolved_event_id,
+        actor_discord_id=actor_discord_id,
+        now_utc=now,
+    )
+    logger.info(
+        "mge_refresh_award_reminders_reposted event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
+        resolved_event_id,
+        actor_discord_id,
+        int(message.id),
+        int(channel.id),
+    )
+    return RefreshAwardRemindersResult(
+        True,
+        "Award reminders reposted.",
+        event_id=resolved_event_id,
+        status="reposted",
+        reposted_missing=True,
+    )
+
+
 async def unpublish_event_awards(
     *,
-    bot: discord.Client,
+    bot: discord.Client,  # architecture-check: allow
     event_id: int,
     actor_discord_id: int,
     now_utc: datetime | None = None,
@@ -656,9 +928,9 @@ async def unpublish_event_awards(
                 message = await channel.fetch_message(message_id)
                 await message.delete()
                 embed_deleted = True
-        except discord.NotFound:
+        except discord.NotFound:  # architecture-check: allow
             embed_deleted = False
-        except discord.Forbidden:
+        except discord.Forbidden:  # architecture-check: allow
             embed_deleted = False
         except Exception:
             logger.exception(

--- a/sql/mge_award_reminder_message_ids_schema.sql
+++ b/sql/mge_award_reminder_message_ids_schema.sql
@@ -9,11 +9,9 @@ BEGIN
         ADD AwardRemindersMessageId BIGINT NULL;
 END
 GO
-
 IF COL_LENGTH('dbo.MGE_Events', 'AwardRemindersChannelId') IS NULL
 BEGIN
     ALTER TABLE dbo.MGE_Events
         ADD AwardRemindersChannelId BIGINT NULL;
 END
 GO
-

--- a/sql/mge_award_reminder_message_ids_schema.sql
+++ b/sql/mge_award_reminder_message_ids_schema.sql
@@ -1,0 +1,19 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+IF COL_LENGTH('dbo.MGE_Events', 'AwardRemindersMessageId') IS NULL
+BEGIN
+    ALTER TABLE dbo.MGE_Events
+        ADD AwardRemindersMessageId BIGINT NULL;
+END
+GO
+
+IF COL_LENGTH('dbo.MGE_Events', 'AwardRemindersChannelId') IS NULL
+BEGIN
+    ALTER TABLE dbo.MGE_Events
+        ADD AwardRemindersChannelId BIGINT NULL;
+END
+GO
+

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -194,9 +194,8 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
     class _RecordedRegistrar:
         def __init__(self):
             self.commands = []
-            self.added_commands = []
 
-        def command(self, *args, **kwargs):
+        def slash_command(self, *args, **kwargs):
             def decorator(func):
                 self.commands.append(
                     _RecordedCommand(
@@ -209,21 +208,12 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
 
             return decorator
 
-        def add_command(self, command):
-            self.added_commands.append(command)
-
-    class _RecordedGroup(_RecordedRegistrar):
-        def __init__(self, *args, **kwargs):
-            super().__init__()
-            self.args = args
-            self.kwargs = kwargs
-
     class _RecordedBot:
         def __init__(self):
             self.tree = _RecordedRegistrar()
 
-        def command(self, *args, **kwargs):
-            return self.tree.command(*args, **kwargs)
+        def slash_command(self, *args, **kwargs):
+            return self.tree.slash_command(*args, **kwargs)
 
     def _fake_is_admin_and_notify_channel(*, allow_leadership=False):
         captured["allow_leadership"] = allow_leadership
@@ -239,18 +229,13 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
         "is_admin_and_notify_channel",
         _fake_is_admin_and_notify_channel,
     )
-    monkeypatch.setattr(mge_cmds.app_commands, "Group", _RecordedGroup)
 
     bot = _RecordedBot()
     mge_cmds.register_mge(bot)
 
-    registered_commands = list(bot.tree.commands)
-    for command_group in bot.tree.added_commands:
-        registered_commands.extend(getattr(command_group, "commands", []))
-
     refresh_commands = [
         command
-        for command in registered_commands
+        for command in bot.tree.commands
         if command.name == "mge_refresh_award_reminders"
     ]
 

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -180,11 +180,83 @@ async def test_refresh_refuses_when_awards_not_published(monkeypatch):
     assert result.status == "no_awards_published"
 
 
-def test_refresh_award_reminders_command_uses_admin_decorator():
-    import inspect
-
+def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
     from commands import mge_cmds
 
-    source = inspect.getsource(mge_cmds.register_mge)
-    assert 'name="mge_refresh_award_reminders"' in source
-    assert "@is_admin_and_notify_channel(allow_leadership=True)" in source
+    captured = {"allow_leadership": None}
+
+    class _RecordedCommand:
+        def __init__(self, callback, *, name=None, **kwargs):
+            self.callback = callback
+            self.name = name
+            self.kwargs = kwargs
+
+    class _RecordedRegistrar:
+        def __init__(self):
+            self.commands = []
+            self.added_commands = []
+
+        def command(self, *args, **kwargs):
+            def decorator(func):
+                self.commands.append(
+                    _RecordedCommand(
+                        func,
+                        name=kwargs.get("name"),
+                        **{k: v for k, v in kwargs.items() if k != "name"},
+                    )
+                )
+                return func
+
+            return decorator
+
+        def add_command(self, command):
+            self.added_commands.append(command)
+
+    class _RecordedGroup(_RecordedRegistrar):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.args = args
+            self.kwargs = kwargs
+
+    class _RecordedBot:
+        def __init__(self):
+            self.tree = _RecordedRegistrar()
+
+        def command(self, *args, **kwargs):
+            return self.tree.command(*args, **kwargs)
+
+    def _fake_is_admin_and_notify_channel(*, allow_leadership=False):
+        captured["allow_leadership"] = allow_leadership
+
+        def decorator(func):
+            func._admin_check_applied = True
+            return func
+
+        return decorator
+
+    monkeypatch.setattr(
+        mge_cmds,
+        "is_admin_and_notify_channel",
+        _fake_is_admin_and_notify_channel,
+    )
+    monkeypatch.setattr(mge_cmds.app_commands, "Group", _RecordedGroup)
+
+    bot = _RecordedBot()
+    mge_cmds.register_mge(bot)
+
+    registered_commands = list(bot.tree.commands)
+    for command_group in bot.tree.added_commands:
+        registered_commands.extend(getattr(command_group, "commands", []))
+
+    refresh_commands = [
+        command
+        for command in registered_commands
+        if command.name == "mge_refresh_award_reminders"
+    ]
+
+    assert captured["allow_leadership"] is True
+    assert refresh_commands
+    assert any(
+        getattr(command.callback, "_admin_check_applied", False)
+        for command in refresh_commands
+    )

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mge import mge_publish_service
+
+
+def _ctx(**overrides):
+    base = {
+        "EventId": 10,
+        "EventName": "MGE Test",
+        "VariantName": "Infantry",
+        "RuleMode": "fixed",
+        "Status": "published",
+        "PublishVersion": 1,
+        "AwardRemindersText": "old reminders",
+        "AwardRemindersSentUtc": "2026-05-01T00:00:00",
+        "AwardRemindersMessageId": 111,
+        "AwardRemindersChannelId": 999,
+        "AwardEmbedChannelId": 999,
+    }
+    base.update(overrides)
+    return base
+
+
+class _Message:
+    def __init__(self, message_id: int = 111) -> None:
+        self.id = message_id
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+class _Channel:
+    id = 999
+
+    def __init__(self, *, message: _Message | None = None, missing: bool = False) -> None:
+        self.message = message or _Message()
+        self.missing = missing
+        self.sent = []
+
+    async def fetch_message(self, message_id: int):
+        if self.missing:
+            raise mge_publish_service.discord.NotFound()
+        return self.message
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        return _Message(222)
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_existing_reminder_message(monkeypatch):
+    channel = _Channel()
+    updates = []
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: _ctx(),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_default_award_reminders_text",
+        lambda mode: "latest reminders",
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_event_award_reminders_text",
+        lambda **kwargs: updates.append(kwargs) or True,
+    )
+    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
+
+    result = await mge_publish_service.refresh_award_reminders(
+        bot=bot,
+        event_id=10,
+        actor_discord_id=1,
+    )
+
+    assert result.success is True
+    assert result.updated_existing is True
+    assert channel.sent == []
+    assert channel.message.edits
+    assert updates[0]["reminders_text"] == "latest reminders"
+
+
+@pytest.mark.asyncio
+async def test_refresh_reposts_missing_message_and_persists_ids(monkeypatch):
+    class _NotFound(Exception):
+        pass
+
+    channel = _Channel(missing=True)
+    ids = {}
+    monkeypatch.setattr(mge_publish_service.discord, "NotFound", _NotFound)
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: _ctx(),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_default_award_reminders_text",
+        lambda mode: "latest reminders",
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_event_award_reminders_text",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_award_reminder_message_ids",
+        lambda **kwargs: ids.update(kwargs) or True,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "mark_award_reminders_sent",
+        lambda **kwargs: True,
+    )
+    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
+
+    result = await mge_publish_service.refresh_award_reminders(
+        bot=bot,
+        event_id=10,
+        actor_discord_id=1,
+    )
+
+    assert result.success is True
+    assert result.reposted_missing is True
+    assert len(channel.sent) == 1
+    assert ids["message_id"] == 222
+    assert ids["channel_id"] == 999
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_duplicate_when_message_exists(monkeypatch):
+    channel = _Channel()
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: _ctx(AwardRemindersText="latest reminders"),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_default_award_reminders_text",
+        lambda mode: "latest reminders",
+    )
+    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
+
+    result = await mge_publish_service.refresh_award_reminders(
+        bot=bot,
+        event_id=10,
+        actor_discord_id=1,
+    )
+
+    assert result.success is True
+    assert result.status == "updated"
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_refuses_when_awards_not_published(monkeypatch):
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: _ctx(PublishVersion=0),
+    )
+    bot = SimpleNamespace(get_channel=lambda _cid: None, fetch_channel=lambda _cid: None)
+
+    result = await mge_publish_service.refresh_award_reminders(
+        bot=bot,
+        event_id=10,
+        actor_discord_id=1,
+    )
+
+    assert result.success is False
+    assert result.skipped_no_awards is True
+    assert result.status == "no_awards_published"
+
+
+def test_refresh_award_reminders_command_uses_admin_decorator():
+    import inspect
+
+    from commands import mge_cmds
+
+    source = inspect.getsource(mge_cmds.register_mge)
+    assert 'name="mge_refresh_award_reminders"' in source
+    assert "@is_admin_and_notify_channel(allow_leadership=True)" in source

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -234,14 +234,11 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
     mge_cmds.register_mge(bot)
 
     refresh_commands = [
-        command
-        for command in bot.tree.commands
-        if command.name == "mge_refresh_award_reminders"
+        command for command in bot.tree.commands if command.name == "mge_refresh_award_reminders"
     ]
 
     assert captured["allow_leadership"] is True
     assert refresh_commands
     assert any(
-        getattr(command.callback, "_admin_check_applied", False)
-        for command in refresh_commands
+        getattr(command.callback, "_admin_check_applied", False) for command in refresh_commands
     )

--- a/tests/test_mge_commander_service.py
+++ b/tests/test_mge_commander_service.py
@@ -123,7 +123,8 @@ def test_move_variant_is_service_level_assignment(monkeypatch):
     assert captured["variant_id"] == 8
 
 
-def test_duplicate_active_commander_name_rejected(monkeypatch):
+def test_duplicate_commander_name_reuses_existing_commander_id(monkeypatch):
+    captured = {}
     monkeypatch.setattr(
         mge_commander_service.mge_commander_dal,
         "fetch_commander_by_name",
@@ -131,8 +132,19 @@ def test_duplicate_active_commander_name_rejected(monkeypatch):
     )
     monkeypatch.setattr(
         mge_commander_service.mge_commander_dal,
-        "fetch_commanders_for_variant",
-        lambda variant_id, include_inactive=False: [{"CommanderId": 5}],
+        "upsert_commander_assignment",
+        lambda **kwargs: captured.update(kwargs)
+        or {
+            "CommanderId": kwargs["commander_id"],
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        },
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_cache,
+        "refresh_mge_caches",
+        lambda: {"commanders": True, "variant_commanders": True},
     )
 
     result = mge_commander_service.save_commander_assignment(
@@ -142,8 +154,41 @@ def test_duplicate_active_commander_name_rejected(monkeypatch):
         is_active=True,
     )
 
+    assert result.success is True
+    assert captured["commander_id"] == 5
+
+
+def test_cache_refresh_exception_returns_failure(monkeypatch):
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: None,
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "upsert_commander_assignment",
+        lambda **kwargs: {
+            "CommanderId": 9,
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        },
+    )
+
+    def _raise_refresh():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(mge_commander_service.mge_cache, "refresh_mge_caches", _raise_refresh)
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=None,
+        commander_name="Commander",
+        variant_id=2,
+        is_active=True,
+    )
+
     assert result.success is False
-    assert "already exists" in result.message
+    assert "cache refresh failed" in result.message.lower()
 
 
 def test_inactive_commanders_excluded_from_signup_cache(monkeypatch):

--- a/tests/test_mge_commander_service.py
+++ b/tests/test_mge_commander_service.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from mge import mge_commander_service
+
+
+def test_list_commanders_by_variant_uses_dal(monkeypatch):
+    rows = [{"CommanderId": 1, "CommanderName": "Attila"}]
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commanders_for_variant",
+        lambda variant_id, include_inactive=True: rows,
+    )
+
+    assert mge_commander_service.list_commanders_by_variant(5) == rows
+
+
+def test_add_new_commander_refreshes_cache(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: None,
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "upsert_commander_assignment",
+        lambda **kwargs: captured.update(kwargs)
+        or {
+            "CommanderId": 9,
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        },
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_cache,
+        "refresh_mge_caches",
+        lambda: {"commanders": True, "variant_commanders": True},
+    )
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=None,
+        commander_name="  New   Commander ",
+        variant_id=2,
+        is_active=True,
+    )
+
+    assert result.success is True
+    assert result.commander_id == 9
+    assert captured["commander_name"] == "New Commander"
+    assert captured["variant_id"] == 2
+
+
+def test_update_name_and_active_flag(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: None,
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "upsert_commander_assignment",
+        lambda **kwargs: captured.update(kwargs)
+        or {
+            "CommanderId": kwargs["commander_id"],
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        },
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_cache,
+        "refresh_mge_caches",
+        lambda: {"commanders": True, "variant_commanders": True},
+    )
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=3,
+        commander_name="Renamed",
+        variant_id=4,
+        is_active=False,
+    )
+
+    assert result.success is True
+    assert captured["commander_id"] == 3
+    assert captured["commander_name"] == "Renamed"
+    assert captured["is_active"] is False
+
+
+def test_move_variant_is_service_level_assignment(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: None,
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "upsert_commander_assignment",
+        lambda **kwargs: captured.update(kwargs)
+        or {
+            "CommanderId": kwargs["commander_id"],
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        },
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_cache,
+        "refresh_mge_caches",
+        lambda: {"commanders": True, "variant_commanders": True},
+    )
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=7,
+        commander_name="Mover",
+        variant_id=8,
+        is_active=True,
+    )
+
+    assert result.success is True
+    assert captured["variant_id"] == 8
+
+
+def test_duplicate_active_commander_name_rejected(monkeypatch):
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: {"CommanderId": 5, "CommanderName": name, "IsActive": True},
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commanders_for_variant",
+        lambda variant_id, include_inactive=False: [{"CommanderId": 5}],
+    )
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=6,
+        commander_name="Duplicate",
+        variant_id=1,
+        is_active=True,
+    )
+
+    assert result.success is False
+    assert "already exists" in result.message
+
+
+def test_inactive_commanders_excluded_from_signup_cache(monkeypatch):
+    from mge import mge_cache
+
+    monkeypatch.setattr(
+        mge_cache,
+        "read_variant_commanders_cache",
+        lambda: [
+            {"VariantName": "Infantry", "CommanderName": "Active", "IsActive": True},
+        ],
+    )
+
+    result = mge_cache.get_commanders_for_variant("Infantry")
+
+    assert [row["CommanderName"] for row in result] == ["Active"]
+
+
+def test_historical_snapshots_are_not_rewritten_by_commander_service(monkeypatch):
+    called = {"upsert": False}
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal,
+        "fetch_commander_by_name",
+        lambda name: None,
+    )
+
+    def _upsert(**kwargs):
+        called["upsert"] = True
+        return {
+            "CommanderId": kwargs["commander_id"],
+            "CommanderName": kwargs["commander_name"],
+            "VariantId": kwargs["variant_id"],
+            "IsActive": kwargs["is_active"],
+        }
+
+    monkeypatch.setattr(
+        mge_commander_service.mge_commander_dal, "upsert_commander_assignment", _upsert
+    )
+    monkeypatch.setattr(
+        mge_commander_service.mge_cache,
+        "refresh_mge_caches",
+        lambda: {"commanders": True, "variant_commanders": True},
+    )
+
+    result = mge_commander_service.save_commander_assignment(
+        commander_id=12,
+        commander_name="Future Name",
+        variant_id=1,
+        is_active=True,
+    )
+
+    assert result.success is True
+    assert called["upsert"] is True

--- a/tests/test_mge_publish_service.py
+++ b/tests/test_mge_publish_service.py
@@ -419,6 +419,11 @@ async def test_publish_sends_reminders_once_and_marks_sent(monkeypatch: pytest.M
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
     )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_award_reminder_message_ids",
+        lambda **kwargs: True,
+    )
     monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
@@ -677,6 +682,11 @@ async def test_publish_reminders_mark_sent_failure_reports_status(
     )
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
+        "update_award_reminder_message_ids",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
         "update_event_award_reminders_text",
         lambda **kwargs: True,
     )
@@ -707,6 +717,101 @@ async def test_publish_reminders_mark_sent_failure_reports_status(
 
     assert res.success is True
     assert res.reminders_embed_status == "mark_failed"
+    assert res.reminders_embed_sent is True
+    assert len(sent_payloads) == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_reminders_message_id_persist_failure_reports_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_payloads = []
+    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
+    monkeypatch.setattr(
+        mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: {
+            "EventId": event_id,
+            "EventName": "E6",
+            "VariantName": "Infantry",
+            "RuleMode": "fixed",
+            "PublishVersion": 0,
+            "AwardRemindersText": None,
+            "AwardRemindersSentUtc": None,
+        },
+    )
+    monkeypatch.setattr(
+        mge_publish_service,
+        "_build_publish_sets",
+        lambda event_id: (
+            [{"AwardId": 1, "FinalAwardedRank": 1, "TargetScore": 8_000_000}],
+            [],
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "apply_publish_atomic", lambda **kwargs: 1
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "fetch_published_snapshot", lambda *args, **kwargs: []
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_awards_with_signup_user",
+        lambda event_id: [
+            {
+                "AwardId": 1,
+                "AwardStatus": "awarded",
+                "AwardedRank": 1,
+                "GovernorNameSnapshot": "Gov1",
+                "RequestedCommanderName": "Cmd1",
+                "TargetScore": 8_000_000,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_event_award_reminders_text",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_award_reminder_message_ids",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "mark_award_reminders_sent",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
+
+    class _Msg:
+        id = 1003
+
+    class _Channel:
+        id = 999
+
+        async def send(self, **kwargs):
+            sent_payloads.append(kwargs)
+            return _Msg()
+
+    bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
+    res = await mge_publish_service.publish_event_awards(
+        bot=bot,
+        event_id=6,
+        actor_discord_id=9,
+        reminders_text_override="custom text",
+    )
+
+    assert res.success is True
+    assert res.reminders_embed_status == "ids_persist_failed"
     assert res.reminders_embed_sent is True
     assert len(sent_payloads) == 2
 

--- a/tests/test_mge_publish_service.py
+++ b/tests/test_mge_publish_service.py
@@ -817,6 +817,101 @@ async def test_publish_reminders_message_id_persist_failure_reports_status(
 
 
 @pytest.mark.asyncio
+async def test_publish_reminders_id_and_mark_failure_reports_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent_payloads = []
+    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
+    monkeypatch.setattr(
+        mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: {
+            "EventId": event_id,
+            "EventName": "E7",
+            "VariantName": "Infantry",
+            "RuleMode": "fixed",
+            "PublishVersion": 0,
+            "AwardRemindersText": None,
+            "AwardRemindersSentUtc": None,
+        },
+    )
+    monkeypatch.setattr(
+        mge_publish_service,
+        "_build_publish_sets",
+        lambda event_id: (
+            [{"AwardId": 1, "FinalAwardedRank": 1, "TargetScore": 8_000_000}],
+            [],
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "apply_publish_atomic", lambda **kwargs: 1
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "fetch_published_snapshot", lambda *args, **kwargs: []
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_awards_with_signup_user",
+        lambda event_id: [
+            {
+                "AwardId": 1,
+                "AwardStatus": "awarded",
+                "AwardedRank": 1,
+                "GovernorNameSnapshot": "Gov1",
+                "RequestedCommanderName": "Cmd1",
+                "TargetScore": 8_000_000,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_event_award_reminders_text",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "update_award_reminder_message_ids",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "mark_award_reminders_sent",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
+
+    class _Msg:
+        id = 1004
+
+    class _Channel:
+        id = 999
+
+        async def send(self, **kwargs):
+            sent_payloads.append(kwargs)
+            return _Msg()
+
+    bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
+    res = await mge_publish_service.publish_event_awards(
+        bot=bot,
+        event_id=7,
+        actor_discord_id=9,
+        reminders_text_override="custom text",
+    )
+
+    assert res.success is True
+    assert res.reminders_embed_status == "ids_persist_and_mark_failed"
+    assert res.reminders_embed_sent is True
+    assert len(sent_payloads) == 2
+
+
+@pytest.mark.asyncio
 async def test_unpublish_preserves_state_and_refreshes(monkeypatch: pytest.MonkeyPatch) -> None:
     refresh_calls = []
     monkeypatch.setattr(

--- a/ui/views/mge_commander_admin_view.py
+++ b/ui/views/mge_commander_admin_view.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import discord
+
+from core.interaction_safety import send_ephemeral
+from core.mge_permissions import is_admin_interaction
+from mge import mge_commander_service
+
+
+def _to_bool(value: str) -> bool | None:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"true", "yes", "y", "1", "active"}:
+        return True
+    if normalized in {"false", "no", "n", "0", "inactive"}:
+        return False
+    return None
+
+
+def _row_active(row: dict[str, Any]) -> bool:
+    return bool(row.get("CommanderIsActive")) and bool(row.get("VariantCommanderIsActive"))
+
+
+class _CommanderEditModal(discord.ui.Modal):
+    def __init__(
+        self,
+        *,
+        parent: MgeCommanderAdminView,
+        commander_id: int | None,
+        current_name: str,
+        current_active: bool,
+    ) -> None:
+        super().__init__(title="MGE Commander", timeout=300)
+        self.parent_view = parent
+        self.commander_id = commander_id
+        self.name = discord.ui.InputText(
+            label="Commander name",
+            value=current_name,
+            required=True,
+            max_length=100,
+        )
+        self.active = discord.ui.InputText(
+            label="Active? yes/no",
+            value="yes" if current_active else "no",
+            required=True,
+            max_length=8,
+        )
+        self.variant = discord.ui.InputText(
+            label="Linked variant id",
+            value=str(parent.variant_id or ""),
+            required=True,
+            max_length=8,
+        )
+        self.add_item(self.name)
+        self.add_item(self.active)
+        self.add_item(self.variant)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await self.parent_view._guard(interaction):
+            return
+        active = _to_bool(str(self.active.value))
+        if active is None:
+            await send_ephemeral(interaction, "Active must be yes or no.")
+            return
+        try:
+            variant_id = int(str(self.variant.value).strip())
+        except Exception:
+            await send_ephemeral(interaction, "Variant id must be numeric.")
+            return
+
+        result = await asyncio.to_thread(
+            mge_commander_service.save_commander_assignment,
+            commander_id=self.commander_id,
+            commander_name=str(self.name.value or ""),
+            variant_id=variant_id,
+            is_active=active,
+        )
+        prefix = "OK: " if result.success else "Error: "
+        await send_ephemeral(interaction, prefix + result.message)
+
+
+class _VariantSelect(discord.ui.Select):
+    def __init__(self, *, variants: list[dict[str, Any]], parent: MgeCommanderAdminView) -> None:
+        options = [
+            discord.SelectOption(
+                label=str(row.get("VariantName") or f"Variant {row.get('VariantId')}")[:100],
+                value=str(int(row["VariantId"])),
+            )
+            for row in variants[:25]
+        ]
+        super().__init__(
+            placeholder="Select variant",
+            min_values=1,
+            max_values=1,
+            options=options or [discord.SelectOption(label="No variants", value="0")],
+        )
+        self.parent_view = parent
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await self.parent_view._guard(interaction):
+            return
+        variant_id = int(self.values[0])
+        if variant_id <= 0:
+            await send_ephemeral(interaction, "No active MGE variants are configured.")
+            return
+        self.parent_view.variant_id = variant_id
+        rows = await asyncio.to_thread(
+            mge_commander_service.list_commanders_by_variant,
+            variant_id,
+            include_inactive=True,
+        )
+        await send_ephemeral(
+            interaction,
+            self.parent_view._format_variant_rows(rows),
+            view=_CommanderPickerView(parent=self.parent_view, rows=rows),
+        )
+
+
+class _CommanderSelect(discord.ui.Select):
+    def __init__(self, *, parent: MgeCommanderAdminView, rows: list[dict[str, Any]]) -> None:
+        options = [discord.SelectOption(label="Add New Commander", value="new")]
+        for row in rows[:24]:
+            name = str(row.get("CommanderName") or "Unknown")
+            state = "active" if _row_active(row) else "inactive"
+            options.append(
+                discord.SelectOption(
+                    label=name[:100],
+                    value=str(int(row["CommanderId"])),
+                    description=state,
+                )
+            )
+        super().__init__(
+            placeholder="Add or edit commander",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+        self.parent_view = parent
+        self.rows = rows
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await self.parent_view._guard(interaction):
+            return
+        value = str(self.values[0])
+        if value == "new":
+            await interaction.response.send_modal(
+                _CommanderEditModal(
+                    parent=self.parent_view,
+                    commander_id=None,
+                    current_name="",
+                    current_active=True,
+                )
+            )
+            return
+
+        commander_id = int(value)
+        row = next((r for r in self.rows if int(r.get("CommanderId") or 0) == commander_id), None)
+        if row is None:
+            await send_ephemeral(interaction, "Commander selection is no longer available.")
+            return
+        await interaction.response.send_modal(
+            _CommanderEditModal(
+                parent=self.parent_view,
+                commander_id=commander_id,
+                current_name=str(row.get("CommanderName") or ""),
+                current_active=_row_active(row),
+            )
+        )
+
+
+class _CommanderPickerView(discord.ui.View):
+    def __init__(self, *, parent: MgeCommanderAdminView, rows: list[dict[str, Any]]) -> None:
+        super().__init__(timeout=300)
+        self.add_item(_CommanderSelect(parent=parent, rows=rows))
+
+
+class MgeCommanderAdminView(discord.ui.View):
+    def __init__(self, *, variants: list[dict[str, Any]], timeout: float | None = 300) -> None:
+        super().__init__(timeout=timeout)
+        self.variant_id: int | None = None
+        self.add_item(_VariantSelect(variants=variants, parent=self))
+
+    async def _guard(self, interaction: discord.Interaction) -> bool:
+        if not is_admin_interaction(interaction):
+            await send_ephemeral(interaction, "Admin only.")
+            return False
+        return True
+
+    def _format_variant_rows(self, rows: list[dict[str, Any]]) -> str:
+        if not rows:
+            return "No commanders are mapped to this variant yet."
+        lines = ["Current commanders:"]
+        for row in rows[:20]:
+            state = "active" if _row_active(row) else "inactive"
+            lines.append(f"- {row.get('CommanderName') or 'Unknown'} ({state})")
+        if len(rows) > 20:
+            lines.append(f"- ...and {len(rows) - 20} more")
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

Phase 1 of the MGE Process Audit + Polish task pack.

This PR adds two operational admin features and documents the remaining Phase 2 architecture work:

- `/mge_refresh_award_reminders` to refresh or repost MGE award reminders after rules/default reminder text changes.
- `/mge_commanders` to add, update, activate/deactivate, and reassign MGE commanders by variant.
- A task-pack delivery status section describing Phase 1 delivered work, SQL promotion requirements, validation, and Phase 2 deferrals.

## Changes

### Award reminder refresh

- Adds idempotent refresh logic in `mge_publish_service.refresh_award_reminders()`.
- Updates an existing reminder message when persisted message metadata is available.
- Reposts cleanly if the message ID is missing or the Discord message was deleted.
- Refuses refresh when awards have not been published.
- Rebuilds reminder content from the current active default reminder text for the event rule mode, falling back to stored event reminder text.
- Persists `AwardRemindersMessageId` and `AwardRemindersChannelId` after first publish/refresh.

### Commander admin management

- Adds `mge/dal/mge_commander_dal.py` and `mge/mge_commander_service.py`.
- Adds `ui/views/mge_commander_admin_view.py` with variant select, commander select, and modal edit flow.
- Supports listing by variant, adding commanders, updating names, active/inactive state, variant reassignment, duplicate-name protection, and cache refresh after changes.
- Preserves historical display by leaving signup/award snapshot fields untouched.

### SQL

- Adds bot-repo migration mirror: `sql/mge_award_reminder_message_ids_schema.sql`.
- Production requires matching authoritative SQL repo promotion before reminder refresh can persist message IDs:
  - `dbo.MGE_Events.AwardRemindersMessageId BIGINT NULL`
  - `dbo.MGE_Events.AwardRemindersChannelId BIGINT NULL`

### Deferred to Phase 2

Documented in `docs/deferred_optimisations.md` and the task pack:

- MGE signup registry-service alignment, matching GitHub issues #29 and #32.
- Extracting Discord message IO out of `mge_publish_service.py` into a cleaner adapter/orchestration boundary.

These were deferred because they are broader architecture consolidation items and not required for Phase 1 operational behavior.

## Validation

Completed locally:

```powershell
.\.venv\Scripts\python.exe -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName tests\test_dl_bot_mge_auto_import.py
.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
.\.venv\Scripts\python.exe scripts\select_tests.py
.\.venv\Scripts\python.exe scripts\smoke_imports.py
.\.venv\Scripts\python.exe scripts\validate_command_registration.py
.\.venv\Scripts\python.exe -m ruff check mge commands ui tests
.\.venv\Scripts\python.exe -m black --check mge commands ui tests
git diff --check
.\.venv\Scripts\python.exe -m pytest -q tests
```

Results:

- Focused MGE validation: `278 passed`
- Full suite: `1291 passed, 8 skipped`
- `git diff --check` passed with only the existing CRLF warning for `commands/mge_cmds.py`

## Risk / Rollback

Risk is concentrated in MGE publish/reminder operations and commander cache administration. Rollback is PR revert plus not applying/removing the SQL mirror columns if they have not been promoted. If SQL is promoted, the added nullable columns are backward-compatible.