### PR TITLE
[codex] Polish MGE service boundaries

### DIFF
--- a/commands/mge_cmds.py
+++ b/commands/mge_cmds.py
@@ -16,6 +16,7 @@ from decoraters import (
 )
 from mge import mge_commander_service, mge_publish_service
 from mge.mge_embed_manager import sync_event_leadership_embed
+from mge.mge_publish_discord_adapter import MgePublishDiscordAdapter
 from mge.mge_results_import import OverwriteConfirmationRequired, import_results_manual
 from mge.mge_review_service import get_review_pool_with_summary
 from ui.views.mge_commander_admin_view import MgeCommanderAdminView
@@ -322,7 +323,7 @@ def register_mge(bot: ext_commands.Bot) -> None:
         )
         await safe_defer(ctx, ephemeral=True)
         result = await mge_publish_service.refresh_award_reminders(
-            bot=ctx.bot,
+            adapter=MgePublishDiscordAdapter(ctx.bot),
             event_id=event_id,
             actor_discord_id=int(ctx.user.id),
             allow_completed=event_id is not None,

--- a/docs/Codex Task Pack — MGE Process Audit + Polish.md
+++ b/docs/Codex Task Pack — MGE Process Audit + Polish.md
@@ -2,7 +2,7 @@
 
 ## Delivery Status
 
-Phase 1 has been delivered in branch `codex/mge-process-polish`.
+Phase 1 has been delivered in branch `codex/mge-process-polish` and promoted to production after local validation and production smoke testing.
 
 ### Phase 1 Delivered
 
@@ -34,12 +34,14 @@ Phase 1 has been delivered in branch `codex/mge-process-polish`.
 
   * `sql/mge_award_reminder_message_ids_schema.sql`
 
-### SQL Promotion Required
+### SQL Promotion Status
 
-Before production use of award reminder refresh, promote the matching SQL change to the authoritative SQL Server repo:
+Award reminder refresh depends on the following nullable metadata columns on `dbo.MGE_Events`:
 
 * `dbo.MGE_Events.AwardRemindersMessageId BIGINT NULL`
 * `dbo.MGE_Events.AwardRemindersChannelId BIGINT NULL`
+
+The production promotion was smoke-tested successfully after this requirement was satisfied. Future environment rebuilds or database restores must retain these columns before using `/mge_refresh_award_reminders`.
 
 ### Deferred To Phase 2
 
@@ -56,6 +58,8 @@ The following items were explicitly deferred because they are broader architectu
   * `mge_publish_service.py` already mixes publish state orchestration with Discord send/edit/delete operations.
   * Phase 1 reused that existing boundary to avoid broad refactoring of publish, republish, reminders, award DMs, unpublish, and board refresh in the same PR.
   * Captured as a structured deferred optimisation in `docs/deferred_optimisations.md`.
+
+Phase 2 initiation is captured in `docs/MGE Process Polish — Phase 2 Initiation Statement.md`.
 
 ### Phase 1 Validation
 

--- a/docs/MGE Process Polish — Phase 2 Initiation Statement.md
+++ b/docs/MGE Process Polish — Phase 2 Initiation Statement.md
@@ -1,0 +1,122 @@
+# MGE Process Polish — Phase 2 Initiation Statement
+
+## Purpose
+
+Continue the MGE process polish after Phase 1 production promotion and smoke testing.
+
+Phase 1 delivered the operational admin controls:
+
+* `/mge_refresh_award_reminders`
+* `/mge_commanders`
+* reminder message/channel ID persistence
+* focused reminder refresh and commander management tests
+
+Phase 2 should address the MGE architecture debt that was intentionally deferred from Phase 1 because it was broader than the two production-facing admin features.
+
+## Required Reading
+
+Before changing code, review:
+
+* `AGENTS.md`
+* `README-DEV.md`
+* `docs/K98 Bot — Coding Execution Guidelines.md`
+* `docs/K98 Bot — Project Engineering Standards.md`
+* `docs/K98 Bot — Testing Standards.md`
+* `docs/k98 Bot — Deferred Optimisation Framework.md`
+* `docs/deferred_optimisations.md`
+* `docs/Codex Task Pack — MGE Process Audit + Polish.md`
+* Recent MGE PRs, especially PR #74 and the earlier PRs #71 and #72
+* GitHub issues #29 and #32
+
+Also inspect the current MGE modules under:
+
+* `mge/`
+* `commands/mge_cmds.py`
+* `ui/views/`
+* `tests/test_mge_*.py`
+
+## Current Baseline
+
+Phase 1 is production-promoted and smoke-tested. Do not rework the delivered admin behavior unless the Phase 2 audit finds a direct regression or an implementation detail that blocks the service-boundary cleanup.
+
+The important Phase 1 invariants to preserve are:
+
+* award reminder refresh remains idempotent
+* commander administration affects future selection flows without mutating historical snapshots
+* open/fixed mode cleanup behavior remains protected
+* no direct SQL is added to Discord command handlers
+
+## Phase 2 Goals
+
+Address the two MGE deferred optimisation items now marked for this phase:
+
+1. Move `mge/mge_signup_service.py` governor/account lookup away from the legacy registry shape and onto the current registry service boundary, expected to be `registry_service.get_user_accounts()` unless the audit finds a newer preferred API.
+2. Extract Discord message fetch/edit/send/delete operations out of `mge/mge_publish_service.py` so the service layer owns publish state decisions and persistence, while Discord IO is handled by an interaction adapter or UI orchestration layer.
+
+Keep the PR focused on these service-boundary improvements. Do not add new MGE product features in this phase.
+
+## Step 1 — Audit Only
+
+Stop after Step 1 with findings before implementing.
+
+The audit should cover:
+
+* current signup account-resolution flow, including self-signup and admin-add paths
+* registry APIs available today and which one should become the MGE boundary
+* current publish, republish, unpublish, award reminder refresh, award DM, and board refresh flows
+* exactly which Discord objects `mge_publish_service.py` currently receives or mutates
+* existing architecture-check allowances related to MGE publish behavior
+* current regression tests that must remain green
+* any migration risk for production events already carrying reminder message metadata
+
+## Implementation Guidance
+
+Prefer small, staged changes that preserve public behavior:
+
+* Keep command/view code responsible for Discord interactions.
+* Keep service code responsible for validation, state decisions, and domain outcomes.
+* Keep DAL code responsible for SQL and persistence.
+* Use fake Discord objects in tests where needed rather than live Discord clients.
+* Do not change award allocation, signup semantics, event mode switching, or commander management unless directly required by the boundary cleanup.
+* If extracting all Discord IO from `mge_publish_service.py` is too large for one safe PR, split the work and update `docs/deferred_optimisations.md` with a precise remaining item.
+
+## Expected Tests
+
+Add or update focused coverage for:
+
+* MGE signup account lookup through the selected registry service boundary
+* self-signup behavior after registry-boundary migration
+* admin-add signup behavior after registry-boundary migration
+* publish and republish behavior after Discord IO extraction
+* reminder refresh behavior after Discord IO extraction
+* unpublish, award DM, and board refresh behavior if touched
+
+Run at minimum:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q (Get-ChildItem tests\test_mge_*.py).FullName tests\test_dl_bot_mge_auto_import.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m ruff check mge commands ui tests
+.\.venv\Scripts\python.exe -m black --check mge commands ui tests
+git diff --check
+```
+
+Run the full suite if practical:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests
+```
+
+## Acceptance Criteria
+
+* Step 1 audit report is produced before implementation.
+* MGE signup uses the selected registry service boundary without changing user-visible signup behavior.
+* `mge_publish_service.py` no longer owns Discord message IO, or any remaining Discord-aware surface is explicitly documented and re-deferred with a narrow reason.
+* Reminder refresh, republish, unpublish, award DM, and board refresh behavior remain protected by focused tests.
+* Existing Phase 1 commands remain registered and admin-only.
+* No new direct SQL is added to command or view modules.
+* `docs/deferred_optimisations.md` is updated to close, narrow, or re-defer the two Phase 2 MGE items.

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -55,17 +55,17 @@
 ### Deferred Optimisation
 - Area: `mge/mge_signup_service.py`
 - Type: consistency
-- Description: MGE signup governor lookup still reads the registry through the legacy registry shape instead of the newer `registry_service.get_user_accounts()` service boundary. This remains aligned with GitHub issues #29 and #32 and is not required for MGE reminder refresh or commander administration.
-- Suggested Fix: Move MGE signup account resolution onto `registry_service.get_user_accounts()` in a focused service-consolidation pass, preserving existing self-service/admin-add behaviour and tests.
+- Description: Resolved in MGE Process Polish Phase 2. MGE self-signup account resolution now uses `registry_service.get_user_accounts()` instead of the legacy registry dict shape, while admin-add reverse owner lookup remains on `get_discord_user_for_governor()`.
+- Suggested Fix: Closed for MGE. Remaining registry-service consolidation work belongs to the broader stats/service alignment tracked by GitHub issues #29 and #32.
 - Impact: medium
 - Risk: medium
-- Dependencies: Coordinate with the broader Service Layer Consolidation Pack so stats and MGE registry-service alignment are handled together.
+- Dependencies: Coordinate with the broader Service Layer Consolidation Pack so stats and MGE registry-service alignment are handled together. Selected for MGE Process Polish Phase 2; see `docs/MGE Process Polish — Phase 2 Initiation Statement.md`.
 
 ### Deferred Optimisation
 - Area: `mge/mge_publish_service.py`
 - Type: architecture
-- Description: MGE publish orchestration still mixes domain publish state transitions with Discord message IO. The current task reused that existing boundary for award reminder refresh to avoid splitting publish/repost behaviour mid-feature, with explicit architecture-check allowances on the pre-existing Discord-aware service surface.
-- Suggested Fix: Extract Discord message fetch/edit/send operations into a dedicated interaction adapter or UI orchestration module, leaving `mge_publish_service.py` to produce publish/reminder intents and persist outcomes through DAL calls.
+- Description: Narrowed in MGE Process Polish Phase 2. Publish, republish, reminder refresh, unpublish, award DM, and board refresh calls now go through a Discord IO adapter instead of direct Discord message operations in `mge_publish_service.py`.
+- Suggested Fix: Remaining follow-up, if desired, is to move Discord embed construction out of service-adjacent renderer calls and into a fully UI-owned publish orchestration model. This is lower priority because direct fetch/edit/send/delete/DM IO has been extracted from the service boundary.
 - Impact: high
 - Risk: medium
-- Dependencies: Requires careful regression coverage for publish, republish, reminder refresh, unpublish, award DM, and board refresh behaviours.
+- Dependencies: Requires careful regression coverage for publish, republish, reminder refresh, unpublish, award DM, and board refresh behaviours. Selected for MGE Process Polish Phase 2; see `docs/MGE Process Polish — Phase 2 Initiation Statement.md`.

--- a/mge/mge_publish_discord_adapter.py
+++ b/mge/mge_publish_discord_adapter.py
@@ -1,0 +1,295 @@
+"""Discord IO adapter for MGE publish workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+from typing import Any
+
+import discord
+
+from bot_config import MGE_AWARD_CHANNEL_ID, MGE_MAIL_DM_USER_IDS
+from mge.mge_embed_manager import (
+    build_award_notifications_content,
+    build_mge_award_reminders_embed,
+    build_mge_awards_embed,
+    refresh_mge_boards,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MessageRef:
+    message_id: int
+    channel_id: int
+
+
+@dataclass(slots=True)
+class MessageIoResult:
+    status: str
+    message_ref: MessageRef | None = None
+
+
+@dataclass(slots=True)
+class AwardMailResult:
+    sent: bool
+    status: str
+
+
+class MgePublishDiscordAdapter:
+    """Boundary object for Discord message operations used by MGE publish flows."""
+
+    def __init__(self, bot: discord.Client) -> None:
+        self.bot = bot
+
+    @property
+    def default_award_channel_id(self) -> int:
+        try:
+            return int(MGE_AWARD_CHANNEL_ID)
+        except Exception:
+            return 0
+
+    async def _resolve_messageable_channel(self, channel_id: int) -> discord.abc.Messageable | None:
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except Exception:
+                logger.exception("mge_channel_fetch_failed channel_id=%s", channel_id)
+                return None
+        if not hasattr(channel, "send"):
+            logger.error("mge_channel_not_messageable channel_id=%s", channel_id)
+            return None
+        return channel
+
+    async def send_awards_embed(
+        self,
+        *,
+        channel_id: int,
+        event_row: dict[str, Any],
+        awarded_rows: list[dict[str, Any]],
+        waitlist_rows: list[dict[str, Any]],
+        publish_version: int,
+        published_utc: datetime,
+    ) -> MessageIoResult:
+        channel = await self._resolve_messageable_channel(channel_id)
+        if channel is None:
+            return MessageIoResult("channel_unavailable")
+
+        embed = build_mge_awards_embed(
+            event_row=event_row,
+            awarded_rows=awarded_rows,
+            waitlist_rows=waitlist_rows,
+            publish_version=publish_version,
+            published_utc=published_utc,
+        )
+        try:
+            mention_content = build_award_notifications_content(awarded_rows + waitlist_rows)
+            message = await channel.send(
+                content=mention_content if mention_content else None,
+                embed=embed,
+                allowed_mentions=discord.AllowedMentions(everyone=False, roles=False, users=True),
+            )
+        except Exception:
+            logger.exception(
+                "mge_publish_embed_send_failed channel_id=%s version=%s",
+                channel_id,
+                publish_version,
+            )
+            return MessageIoResult("send_failed")
+
+        return MessageIoResult(
+            "sent",
+            MessageRef(message_id=int(message.id), channel_id=int(channel.id)),
+        )
+
+    async def send_republish_change_log(
+        self,
+        *,
+        channel_id: int,
+        change_lines: list[str],
+    ) -> MessageIoResult:
+        channel = await self._resolve_messageable_channel(channel_id)
+        if channel is None:
+            return MessageIoResult("channel_unavailable")
+        try:
+            await channel.send(
+                "📌 **MGE Republish Change Log**\n"
+                + "\n".join(f"- {line}" for line in change_lines[:50]),
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except Exception:
+            logger.exception("mge_publish_change_log_send_failed channel_id=%s", channel_id)
+            return MessageIoResult("send_failed")
+        return MessageIoResult("sent")
+
+    async def send_award_reminders_embed(
+        self,
+        *,
+        channel_id: int,
+        event_row: dict[str, Any],
+        reminders_text: str,
+        published_utc: datetime,
+    ) -> MessageIoResult:
+        channel = await self._resolve_messageable_channel(channel_id)
+        if channel is None:
+            return MessageIoResult("channel_unavailable")
+        embed = build_mge_award_reminders_embed(
+            event_row=event_row,
+            reminders_text=reminders_text,
+            published_utc=published_utc,
+        )
+        try:
+            message = await channel.send(
+                content="@everyone",
+                embed=embed,
+                allowed_mentions=discord.AllowedMentions(
+                    everyone=True,
+                    roles=False,
+                    users=False,
+                ),
+            )
+        except discord.Forbidden:
+            logger.exception("mge_award_reminders_post_forbidden channel_id=%s", channel_id)
+            return MessageIoResult("permission_failed")
+        except Exception:
+            logger.exception("mge_award_reminders_post_failed channel_id=%s", channel_id)
+            return MessageIoResult("post_failed")
+        return MessageIoResult(
+            "sent",
+            MessageRef(message_id=int(message.id), channel_id=int(channel.id)),
+        )
+
+    async def update_award_reminders_embed(
+        self,
+        *,
+        channel_id: int,
+        message_id: int,
+        event_row: dict[str, Any],
+        reminders_text: str,
+        published_utc: datetime,
+    ) -> MessageIoResult:
+        channel = await self._resolve_messageable_channel(channel_id)
+        if channel is None:
+            return MessageIoResult("channel_unavailable")
+        if not hasattr(channel, "fetch_message"):
+            return MessageIoResult("message_fetch_unavailable")
+
+        embed = build_mge_award_reminders_embed(
+            event_row=event_row,
+            reminders_text=reminders_text,
+            published_utc=published_utc,
+        )
+        try:
+            message = await channel.fetch_message(message_id)
+            await message.edit(
+                content="@everyone",
+                embed=embed,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.NotFound:
+            return MessageIoResult("not_found")
+        except discord.Forbidden:
+            logger.exception(
+                "mge_award_reminders_update_forbidden channel_id=%s message_id=%s",
+                channel_id,
+                message_id,
+            )
+            return MessageIoResult("permission_failed")
+        except Exception:
+            logger.exception(
+                "mge_award_reminders_update_failed channel_id=%s message_id=%s",
+                channel_id,
+                message_id,
+            )
+            return MessageIoResult("edit_failed")
+        return MessageIoResult(
+            "updated",
+            MessageRef(message_id=int(message_id), channel_id=int(channel_id)),
+        )
+
+    async def delete_message(self, *, channel_id: int, message_id: int) -> MessageIoResult:
+        channel = await self._resolve_messageable_channel(channel_id)
+        if channel is None:
+            return MessageIoResult("channel_unavailable")
+        if not hasattr(channel, "fetch_message"):
+            return MessageIoResult("message_fetch_unavailable")
+        try:
+            message = await channel.fetch_message(message_id)
+            await message.delete()
+        except discord.NotFound:
+            return MessageIoResult("not_found")
+        except discord.Forbidden:
+            return MessageIoResult("permission_failed")
+        except Exception:
+            logger.exception(
+                "mge_message_delete_failed channel_id=%s message_id=%s",
+                channel_id,
+                message_id,
+            )
+            return MessageIoResult("delete_failed")
+        return MessageIoResult("deleted")
+
+    async def refresh_boards(
+        self,
+        *,
+        event_id: int,
+        refresh_public: bool = True,
+        refresh_leadership: bool = True,
+        refresh_awards: bool = False,
+    ) -> dict[str, bool]:
+        return await refresh_mge_boards(
+            bot=self.bot,
+            event_id=event_id,
+            refresh_public=refresh_public,
+            refresh_leadership=refresh_leadership,
+            refresh_awards=refresh_awards,
+        )
+
+    async def send_award_mail(
+        self,
+        *,
+        event_id: int,
+        dm_text: str,
+    ) -> AwardMailResult:
+        mail_user_ids = [uid for uid in MGE_MAIL_DM_USER_IDS if uid > 0]
+        if not mail_user_ids:
+            logger.info(
+                "mge_publish_award_dm_skipped reason=MGE_MAIL_DM_USER_ID_not_set event_id=%s",
+                event_id,
+            )
+            return AwardMailResult(sent=False, status="skipped_no_recipient")
+
+        sent_count = 0
+        fail_count = 0
+        for mail_user_id in mail_user_ids:
+            try:
+                mail_user = await self.bot.fetch_user(mail_user_id)
+                await mail_user.send(
+                    dm_text,
+                    allowed_mentions=discord.AllowedMentions.none(),
+                )
+                sent_count += 1
+                logger.info(
+                    "mge_publish_award_dm_sent event_id=%s recipient_discord_id=%s",
+                    event_id,
+                    mail_user_id,
+                )
+            except Exception:
+                fail_count += 1
+                logger.exception(
+                    "mge_publish_award_dm_failed event_id=%s recipient_discord_id=%s",
+                    event_id,
+                    mail_user_id,
+                )
+
+        if fail_count == 0:
+            return AwardMailResult(sent=True, status=f"sent:{sent_count}")
+        if sent_count > 0:
+            return AwardMailResult(
+                sent=True,
+                status=f"partial:{sent_count}_ok_{fail_count}_failed",
+            )
+        return AwardMailResult(sent=False, status=f"all_failed:{fail_count}")

--- a/mge/mge_publish_discord_adapter.py
+++ b/mge/mge_publish_discord_adapter.py
@@ -105,6 +105,10 @@ class MgePublishDiscordAdapter:
             MessageRef(message_id=int(message.id), channel_id=int(channel.id)),
         )
 
+    async def check_award_channel_available(self, channel_id: int) -> bool:
+        channel = await self._resolve_messageable_channel(channel_id)
+        return channel is not None
+
     async def send_republish_change_log(
         self,
         *,

--- a/mge/mge_publish_discord_adapter.py
+++ b/mge/mge_publish_discord_adapter.py
@@ -257,7 +257,7 @@ class MgePublishDiscordAdapter:
         mail_user_ids = [uid for uid in MGE_MAIL_DM_USER_IDS if uid > 0]
         if not mail_user_ids:
             logger.info(
-                "mge_publish_award_dm_skipped reason=MGE_MAIL_DM_USER_ID_not_set event_id=%s",
+                "mge_publish_award_dm_skipped reason=MGE_MAIL_DM_USER_IDS_not_set event_id=%s",
                 event_id,
             )
             return AwardMailResult(sent=False, status="skipped_no_recipient")

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -113,6 +113,8 @@ class MgePublishIoAdapter(Protocol):
 
     async def delete_message(self, *, channel_id: int, message_id: int) -> _MessageIoResult: ...
 
+    async def check_award_channel_available(self, channel_id: int) -> bool: ...
+
     async def refresh_boards(
         self,
         *,
@@ -433,6 +435,9 @@ async def publish_event_awards(
         if old_version > 0
         else []
     )
+
+    if not await adapter.check_award_channel_available(channel_id):
+        return PublishResult(False, "Award channel unavailable.")
 
     new_version = await asyncio.to_thread(
         mge_publish_dal.apply_publish_atomic,

--- a/mge/mge_publish_service.py
+++ b/mge/mge_publish_service.py
@@ -7,24 +7,19 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import inspect
 import logging
-from typing import Any
+from typing import Any, Protocol
 
-# architecture-check: allow - existing publish orchestration owns Discord message IO.
-import discord
-
-from bot_config import MGE_AWARD_CHANNEL_ID, MGE_MAIL_DM_USER_IDS
 from mge.dal import mge_publish_dal
 from mge.mge_constants import DEFAULT_TARGET_DECREMENT_SCORE
-from mge.mge_embed_manager import (
-    build_award_notifications_content,
-    build_mge_award_reminders_embed,
-    build_mge_awards_embed,
-    build_publish_change_summary_lines,
-    refresh_mge_boards,
-)
+from mge.mge_embed_manager import build_publish_change_summary_lines
 from mge.mge_simplified_flow_service import evaluate_publish_readiness, get_ordered_leadership_rows
 
 logger = logging.getLogger(__name__)
+
+# Retained only so older tests or downstream monkeypatches fail softly after
+# Discord IO moved behind MgePublishIoAdapter.
+MGE_AWARD_CHANNEL_ID: str | int = 0
+MGE_MAIL_DM_USER_IDS: list[int] = []
 
 
 @dataclass(slots=True)
@@ -58,6 +53,81 @@ class RefreshAwardRemindersResult:
     updated_existing: bool = False
     reposted_missing: bool = False
     skipped_no_awards: bool = False
+
+
+class _MessageRef(Protocol):
+    message_id: int
+    channel_id: int
+
+
+class _MessageIoResult(Protocol):
+    status: str
+    message_ref: _MessageRef | None
+
+
+class _AwardMailResult(Protocol):
+    sent: bool
+    status: str
+
+
+class MgePublishIoAdapter(Protocol):
+    @property
+    def default_award_channel_id(self) -> int: ...
+
+    async def send_awards_embed(
+        self,
+        *,
+        channel_id: int,
+        event_row: dict[str, Any],
+        awarded_rows: list[dict[str, Any]],
+        waitlist_rows: list[dict[str, Any]],
+        publish_version: int,
+        published_utc: datetime,
+    ) -> _MessageIoResult: ...
+
+    async def send_republish_change_log(
+        self,
+        *,
+        channel_id: int,
+        change_lines: list[str],
+    ) -> _MessageIoResult: ...
+
+    async def send_award_reminders_embed(
+        self,
+        *,
+        channel_id: int,
+        event_row: dict[str, Any],
+        reminders_text: str,
+        published_utc: datetime,
+    ) -> _MessageIoResult: ...
+
+    async def update_award_reminders_embed(
+        self,
+        *,
+        channel_id: int,
+        message_id: int,
+        event_row: dict[str, Any],
+        reminders_text: str,
+        published_utc: datetime,
+    ) -> _MessageIoResult: ...
+
+    async def delete_message(self, *, channel_id: int, message_id: int) -> _MessageIoResult: ...
+
+    async def refresh_boards(
+        self,
+        *,
+        event_id: int,
+        refresh_public: bool = True,
+        refresh_leadership: bool = True,
+        refresh_awards: bool = False,
+    ) -> dict[str, bool]: ...
+
+    async def send_award_mail(
+        self,
+        *,
+        event_id: int,
+        dm_text: str,
+    ) -> _AwardMailResult: ...
 
 
 def _now_utc(now_utc: datetime | None = None) -> datetime:
@@ -152,39 +222,6 @@ def _build_award_mail_text(
 
 def _current_award_dataset(event_id: int) -> dict[str, Any]:
     return get_ordered_leadership_rows(event_id)
-
-
-async def _resolve_messageable_channel(
-    bot: discord.Client,  # architecture-check: allow
-    channel_id: int,
-) -> discord.abc.Messageable | None:  # architecture-check: allow
-    channel = bot.get_channel(channel_id)
-    if channel is None:
-        try:
-            channel = await bot.fetch_channel(channel_id)
-        except Exception:
-            logger.exception("mge_channel_fetch_failed channel_id=%s", channel_id)
-            return None
-    if not hasattr(channel, "send"):
-        logger.error("mge_channel_not_messageable channel_id=%s", channel_id)
-        return None
-    return channel
-
-
-async def _send_award_reminders_embed(
-    *,
-    channel: discord.abc.Messageable,  # architecture-check: allow
-    embed: discord.Embed,  # architecture-check: allow
-) -> discord.Message:  # architecture-check: allow
-    return await channel.send(
-        content="@everyone",
-        embed=embed,
-        allowed_mentions=discord.AllowedMentions(  # architecture-check: allow
-            everyone=True,
-            roles=False,
-            users=False,
-        ),
-    )
 
 
 def _current_roster_rows_from_dataset(dataset: dict[str, Any]) -> list[dict[str, Any]]:
@@ -351,7 +388,7 @@ def override_target_score(
 
 async def publish_event_awards(
     *,
-    bot: discord.Client,  # architecture-check: allow
+    adapter: MgePublishIoAdapter,
     event_id: int,
     actor_discord_id: int,
     reminders_text_override: str | None = None,
@@ -378,7 +415,7 @@ async def publish_event_awards(
     if not publish_rows and not waitlist_rows:
         return PublishResult(False, "No awarded or waitlist rows available to publish.")
 
-    channel_id = int(MGE_AWARD_CHANNEL_ID)
+    channel_id = int(adapter.default_award_channel_id)
     if channel_id <= 0:
         return PublishResult(False, "MGE_AWARD_CHANNEL_ID is not configured.")
 
@@ -397,17 +434,6 @@ async def publish_event_awards(
         else []
     )
 
-    channel = bot.get_channel(channel_id)
-    if channel is None:
-        try:
-            channel = await bot.fetch_channel(channel_id)
-        except Exception:
-            logger.exception("mge_publish_channel_fetch_failed channel_id=%s", channel_id)
-            return PublishResult(False, "Award channel unavailable.")
-
-    if not hasattr(channel, "send"):
-        return PublishResult(False, "Award channel is not messageable.")
-
     new_version = await asyncio.to_thread(
         mge_publish_dal.apply_publish_atomic,
         event_id=event_id,
@@ -424,32 +450,17 @@ async def publish_event_awards(
     awarded = [r for r in posted_rows if _status(r.get("AwardStatus")) == "awarded"]
     waitlist = [r for r in posted_rows if _status(r.get("AwardStatus")) == "waitlist"]
 
-    embed = build_mge_awards_embed(
+    awards_send = await adapter.send_awards_embed(
+        channel_id=channel_id,
         event_row=ctx,
         awarded_rows=awarded,
         waitlist_rows=waitlist,
         publish_version=new_version,
         published_utc=now,
     )
-
-    allowed_mentions = discord.AllowedMentions(  # architecture-check: allow
-        everyone=False, roles=False, users=True
-    )
-
-    try:
-        mention_content = build_award_notifications_content(awarded + waitlist)
-        message = await channel.send(
-            content=mention_content if mention_content else None,
-            embed=embed,
-            allowed_mentions=allowed_mentions,
-        )
-    except Exception:
-        logger.exception(
-            "mge_publish_embed_send_failed event_id=%s channel_id=%s version=%s",
-            event_id,
-            channel_id,
-            new_version,
-        )
+    if awards_send.status == "channel_unavailable":
+        return PublishResult(False, "Award channel unavailable.", publish_version=new_version)
+    if awards_send.status != "sent" or awards_send.message_ref is None:
         return PublishResult(
             False,
             "Publish persisted in DB, but posting the Discord embed failed. "
@@ -460,8 +471,8 @@ async def publish_event_awards(
     await asyncio.to_thread(
         mge_publish_dal.update_award_embed_ids,
         event_id=event_id,
-        message_id=int(message.id),
-        channel_id=int(channel.id),
+        message_id=int(awards_send.message_ref.message_id),
+        channel_id=int(awards_send.message_ref.channel_id),
         now_utc=now,
     )
 
@@ -471,9 +482,9 @@ async def publish_event_awards(
     changes = build_publish_change_summary_lines(previous_rows, latest_rows)
 
     if new_version > 1 and changes:
-        await channel.send(
-            "📌 **MGE Republish Change Log**\n" + "\n".join(f"- {line}" for line in changes[:50]),
-            allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
+        await adapter.send_republish_change_log(
+            channel_id=channel_id,
+            change_lines=changes,
         )
 
     reminders_embed_sent = False
@@ -512,22 +523,19 @@ async def publish_event_awards(
                     new_version,
                 )
             else:
-                reminders_embed = build_mge_award_reminders_embed(
+                reminder_send = await adapter.send_award_reminders_embed(
+                    channel_id=channel_id,
                     event_row=ctx,
                     reminders_text=final_reminders_text,
                     published_utc=now,
                 )
-                try:
-                    reminders_message = await _send_award_reminders_embed(
-                        channel=channel,
-                        embed=reminders_embed,
-                    )
+                if reminder_send.status == "sent" and reminder_send.message_ref is not None:
                     reminders_embed_sent = True
                     reminder_ids_updated = await asyncio.to_thread(
                         mge_publish_dal.update_award_reminder_message_ids,
                         event_id=event_id,
-                        message_id=int(reminders_message.id),
-                        channel_id=int(channel.id),
+                        message_id=int(reminder_send.message_ref.message_id),
+                        channel_id=int(reminder_send.message_ref.channel_id),
                         now_utc=now,
                     )
                     reminders_marked_sent = await asyncio.to_thread(
@@ -565,9 +573,9 @@ async def publish_event_awards(
                             channel_id,
                             new_version,
                         )
-                except Exception:
-                    reminders_embed_status = "send_failed"
-                    logger.exception(
+                else:
+                    reminders_embed_status = reminder_send.status or "send_failed"
+                    logger.warning(
                         "mge_publish_reminders_send_failed event_id=%s actor_discord_id=%s channel_id=%s version=%s",
                         event_id,
                         actor_discord_id,
@@ -575,8 +583,7 @@ async def publish_event_awards(
                         new_version,
                     )
 
-    refresh_result = refresh_mge_boards(
-        bot=bot,
+    refresh_result = adapter.refresh_boards(
         event_id=event_id,
         refresh_public=True,
         refresh_leadership=True,
@@ -586,50 +593,13 @@ async def publish_event_awards(
     if maybe_refresh is not None:
         await maybe_refresh
 
-    # --- Award mail DM: send a copy-friendly in-game mail to all MGE_MAIL_DM_USER_IDS recipients ---
     award_mail_dm_sent = False
     award_mail_dm_status: str | None = None
     try:
-        mail_user_ids = [uid for uid in MGE_MAIL_DM_USER_IDS if uid > 0]
-        if not mail_user_ids:
-            award_mail_dm_status = "skipped_no_recipient"
-            logger.info(
-                "mge_publish_award_dm_skipped reason=MGE_MAIL_DM_USER_ID_not_set event_id=%s",
-                event_id,
-            )
-        else:
-            dm_text = _build_award_mail_text(ctx, awarded)
-            sent_count = 0
-            fail_count = 0
-            for mail_user_id in mail_user_ids:
-                try:
-                    mail_user = await bot.fetch_user(mail_user_id)
-                    await mail_user.send(
-                        dm_text,
-                        allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
-                    )
-                    sent_count += 1
-                    logger.info(
-                        "mge_publish_award_dm_sent event_id=%s recipient_discord_id=%s",
-                        event_id,
-                        mail_user_id,
-                    )
-                except Exception:
-                    fail_count += 1
-                    logger.exception(
-                        "mge_publish_award_dm_failed event_id=%s recipient_discord_id=%s",
-                        event_id,
-                        mail_user_id,
-                    )
-            if fail_count == 0:
-                award_mail_dm_sent = True
-                award_mail_dm_status = f"sent:{sent_count}"
-            elif sent_count > 0:
-                award_mail_dm_sent = True
-                award_mail_dm_status = f"partial:{sent_count}_ok_{fail_count}_failed"
-            else:
-                award_mail_dm_sent = False
-                award_mail_dm_status = f"all_failed:{fail_count}"
+        dm_text = _build_award_mail_text(ctx, awarded)
+        dm_result = await adapter.send_award_mail(event_id=event_id, dm_text=dm_text)
+        award_mail_dm_sent = bool(dm_result.sent)
+        award_mail_dm_status = str(dm_result.status)
     except Exception:
         award_mail_dm_sent = False
         award_mail_dm_status = "dm_error"
@@ -683,7 +653,7 @@ async def publish_event_awards(
 
 async def refresh_award_reminders(
     *,
-    bot: discord.Client,  # architecture-check: allow
+    adapter: MgePublishIoAdapter,
     event_id: int | None,
     actor_discord_id: int,
     allow_completed: bool = False,
@@ -740,7 +710,7 @@ async def refresh_award_reminders(
     if channel_id <= 0:
         channel_id = _to_int(ctx.get("AwardEmbedChannelId"), 0)
     if channel_id <= 0:
-        channel_id = int(MGE_AWARD_CHANNEL_ID)
+        channel_id = int(adapter.default_award_channel_id)
     if channel_id <= 0:
         return RefreshAwardRemindersResult(
             False,
@@ -797,30 +767,17 @@ async def refresh_award_reminders(
             reposted_missing=reposted_missing,
         )
 
-    channel = await _resolve_messageable_channel(bot, channel_id)
-    if channel is None:
-        return RefreshAwardRemindersResult(
-            False,
-            "Award reminders channel is unavailable or not messageable.",
-            event_id=resolved_event_id,
-            status="channel_unavailable",
-        )
-
-    embed = build_mge_award_reminders_embed(
-        event_row=ctx,
-        reminders_text=reminders_text,
-        published_utc=now,
-    )
     old_message_id = _to_int(ctx.get("AwardRemindersMessageId"), 0)
 
-    if old_message_id > 0 and hasattr(channel, "fetch_message"):
-        try:
-            message = await channel.fetch_message(old_message_id)
-            await message.edit(
-                content="@everyone",
-                embed=embed,
-                allowed_mentions=discord.AllowedMentions.none(),  # architecture-check: allow
-            )
+    if old_message_id > 0:
+        update_result = await adapter.update_award_reminders_embed(
+            channel_id=channel_id,
+            message_id=old_message_id,
+            event_row=ctx,
+            reminders_text=reminders_text,
+            published_utc=now,
+        )
+        if update_result.status == "updated":
             logger.info(
                 "mge_refresh_award_reminders_updated event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
                 resolved_event_id,
@@ -842,32 +799,27 @@ async def refresh_award_reminders(
                 status="updated",
                 updated_existing=True,
             )
-        except discord.NotFound:  # architecture-check: allow
+        if update_result.status in {"not_found", "message_fetch_unavailable"}:
             logger.info(
                 "mge_refresh_award_reminders_missing_message event_id=%s message_id=%s",
                 resolved_event_id,
                 old_message_id,
             )
-        except discord.Forbidden:  # architecture-check: allow
-            logger.exception(
-                "mge_refresh_award_reminders_forbidden event_id=%s message_id=%s channel_id=%s",
-                resolved_event_id,
-                old_message_id,
-                channel_id,
-            )
+        elif update_result.status == "permission_failed":
             return RefreshAwardRemindersResult(
                 False,
                 "Missing permission to update the existing award reminders message.",
                 event_id=resolved_event_id,
                 status="permission_failed",
             )
-        except Exception:
-            logger.exception(
-                "mge_refresh_award_reminders_edit_failed event_id=%s message_id=%s channel_id=%s",
-                resolved_event_id,
-                old_message_id,
-                channel_id,
+        elif update_result.status == "channel_unavailable":
+            return RefreshAwardRemindersResult(
+                False,
+                "Award reminders channel is unavailable or not messageable.",
+                event_id=resolved_event_id,
+                status="channel_unavailable",
             )
+        elif update_result.status == "edit_failed":
             return RefreshAwardRemindersResult(
                 False,
                 "Failed to update the existing award reminders message.",
@@ -875,26 +827,27 @@ async def refresh_award_reminders(
                 status="edit_failed",
             )
 
-    try:
-        message = await _send_award_reminders_embed(channel=channel, embed=embed)
-    except discord.Forbidden:  # architecture-check: allow
-        logger.exception(
-            "mge_refresh_award_reminders_post_forbidden event_id=%s channel_id=%s",
-            resolved_event_id,
-            channel_id,
-        )
+    post_result = await adapter.send_award_reminders_embed(
+        channel_id=channel_id,
+        event_row=ctx,
+        reminders_text=reminders_text,
+        published_utc=now,
+    )
+    if post_result.status == "permission_failed":
         return RefreshAwardRemindersResult(
             False,
             "Missing permission to post award reminders.",
             event_id=resolved_event_id,
             status="permission_failed",
         )
-    except Exception:
-        logger.exception(
-            "mge_refresh_award_reminders_post_failed event_id=%s channel_id=%s",
-            resolved_event_id,
-            channel_id,
+    if post_result.status == "channel_unavailable":
+        return RefreshAwardRemindersResult(
+            False,
+            "Award reminders channel is unavailable or not messageable.",
+            event_id=resolved_event_id,
+            status="channel_unavailable",
         )
+    if post_result.status != "sent" or post_result.message_ref is None:
         return RefreshAwardRemindersResult(
             False,
             "Failed to post award reminders.",
@@ -913,8 +866,8 @@ async def refresh_award_reminders(
     message_ids_updated = await asyncio.to_thread(
         mge_publish_dal.update_award_reminder_message_ids,
         event_id=resolved_event_id,
-        message_id=int(message.id),
-        channel_id=int(channel.id),
+        message_id=int(post_result.message_ref.message_id),
+        channel_id=int(post_result.message_ref.channel_id),
         now_utc=now,
     )
     reminders_marked_sent = await asyncio.to_thread(
@@ -928,8 +881,8 @@ async def refresh_award_reminders(
             "mge_refresh_award_reminders_reposted_persist_and_mark_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
             resolved_event_id,
             actor_discord_id,
-            int(message.id),
-            int(channel.id),
+            int(post_result.message_ref.message_id),
+            int(post_result.message_ref.channel_id),
         )
         return RefreshAwardRemindersResult(
             False,
@@ -943,8 +896,8 @@ async def refresh_award_reminders(
             "mge_refresh_award_reminders_reposted_persist_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
             resolved_event_id,
             actor_discord_id,
-            int(message.id),
-            int(channel.id),
+            int(post_result.message_ref.message_id),
+            int(post_result.message_ref.channel_id),
         )
         return RefreshAwardRemindersResult(
             False,
@@ -958,8 +911,8 @@ async def refresh_award_reminders(
             "mge_refresh_award_reminders_reposted_mark_sent_failed event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
             resolved_event_id,
             actor_discord_id,
-            int(message.id),
-            int(channel.id),
+            int(post_result.message_ref.message_id),
+            int(post_result.message_ref.channel_id),
         )
         return RefreshAwardRemindersResult(
             False,
@@ -972,8 +925,8 @@ async def refresh_award_reminders(
         "mge_refresh_award_reminders_reposted event_id=%s actor_discord_id=%s message_id=%s channel_id=%s",
         resolved_event_id,
         actor_discord_id,
-        int(message.id),
-        int(channel.id),
+        int(post_result.message_ref.message_id),
+        int(post_result.message_ref.channel_id),
     )
     return RefreshAwardRemindersResult(
         True,
@@ -986,7 +939,7 @@ async def refresh_award_reminders(
 
 async def unpublish_event_awards(
     *,
-    bot: discord.Client,  # architecture-check: allow
+    adapter: MgePublishIoAdapter,
     event_id: int,
     actor_discord_id: int,
     now_utc: datetime | None = None,
@@ -1018,28 +971,10 @@ async def unpublish_event_awards(
     message_id = _to_int(result.get("embed_message_id"), 0)
 
     if channel_id > 0 and message_id > 0:
-        try:
-            channel = bot.get_channel(channel_id)
-            if channel is None:
-                channel = await bot.fetch_channel(channel_id)
-            if hasattr(channel, "fetch_message"):
-                message = await channel.fetch_message(message_id)
-                await message.delete()
-                embed_deleted = True
-        except discord.NotFound:  # architecture-check: allow
-            embed_deleted = False
-        except discord.Forbidden:  # architecture-check: allow
-            embed_deleted = False
-        except Exception:
-            logger.exception(
-                "mge_publish_unpublish_embed_delete_failed event_id=%s channel_id=%s message_id=%s",
-                event_id,
-                channel_id,
-                message_id,
-            )
+        delete_result = await adapter.delete_message(channel_id=channel_id, message_id=message_id)
+        embed_deleted = delete_result.status == "deleted"
 
-    refresh_result = refresh_mge_boards(
-        bot=bot,
+    refresh_result = adapter.refresh_boards(
         event_id=event_id,
         refresh_public=True,
         refresh_leadership=True,

--- a/mge/mge_signup_service.py
+++ b/mge/mge_signup_service.py
@@ -19,8 +19,7 @@ from mge.mge_validation import (
     validate_rank_band,
     validate_self_service_window,
 )
-from registry.governor_registry import load_registry
-from registry.registry_service import get_discord_user_for_governor
+from registry.registry_service import get_discord_user_for_governor, get_user_accounts
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +44,15 @@ def _is_admin_or_leadership(actor_roles: set[int], admin_role_ids: set[int]) -> 
 
 
 def get_linked_governors_for_user(discord_user_id: int) -> list[dict[str, str]]:
-    registry = load_registry() or {}
-    block = registry.get(str(discord_user_id)) or registry.get(discord_user_id) or {}
-    accounts = block.get("accounts") or {}
+    try:
+        accounts = get_user_accounts(int(discord_user_id))
+    except Exception:
+        logger.exception(
+            "mge_signup_registry_accounts_lookup_failed discord_user_id=%s",
+            discord_user_id,
+        )
+        return []
+
     rows: list[dict[str, str]] = []
     seen: set[str] = set()
 

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -1,10 +1,60 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 
 from mge import mge_publish_service
+
+
+class _MessageRef:
+    def __init__(self, message_id: int, channel_id: int) -> None:
+        self.message_id = int(message_id)
+        self.channel_id = int(channel_id)
+
+
+class _IoResult:
+    def __init__(self, status: str, message_ref: _MessageRef | None = None) -> None:
+        self.status = status
+        self.message_ref = message_ref
+
+
+class _RefreshAdapter:
+    default_award_channel_id = 999
+
+    def __init__(self, channel: _Channel | None) -> None:
+        self.channel = channel
+
+    async def send_awards_embed(self, **kwargs):
+        return _IoResult("sent", _MessageRef(1, 999))
+
+    async def send_republish_change_log(self, **kwargs):
+        return _IoResult("sent")
+
+    async def send_award_reminders_embed(self, *, channel_id: int, **kwargs):
+        if self.channel is None:
+            return _IoResult("channel_unavailable")
+        msg = await self.channel.send(
+            content="@everyone", embed=object(), allowed_mentions=object()
+        )
+        return _IoResult("sent", _MessageRef(msg.id, self.channel.id))
+
+    async def update_award_reminders_embed(self, *, channel_id: int, message_id: int, **kwargs):
+        if self.channel is None:
+            return _IoResult("channel_unavailable")
+        try:
+            message = await self.channel.fetch_message(message_id)
+        except Exception:
+            return _IoResult("not_found")
+        await message.edit(content="@everyone", embed=object(), allowed_mentions=object())
+        return _IoResult("updated", _MessageRef(message_id, self.channel.id))
+
+    async def delete_message(self, **kwargs):
+        return _IoResult("deleted")
+
+    async def refresh_boards(self, **kwargs):
+        return {"public": True, "leadership": True, "awards": True}
+
+    async def send_award_mail(self, **kwargs):
+        return type("_MailResult", (), {"sent": False, "status": "skipped_no_recipient"})()
 
 
 def _ctx(**overrides):
@@ -44,7 +94,7 @@ class _Channel:
 
     async def fetch_message(self, message_id: int):
         if self.missing:
-            raise mge_publish_service.discord.NotFound()
+            raise LookupError("missing")
         return self.message
 
     async def send(self, **kwargs):
@@ -71,10 +121,9 @@ async def test_refresh_updates_existing_reminder_message(monkeypatch):
         "update_event_award_reminders_text",
         lambda **kwargs: updates.append(kwargs) or True,
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
 
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )
@@ -88,12 +137,8 @@ async def test_refresh_updates_existing_reminder_message(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_refresh_reposts_missing_message_and_persists_ids(monkeypatch):
-    class _NotFound(Exception):
-        pass
-
     channel = _Channel(missing=True)
     ids = {}
-    monkeypatch.setattr(mge_publish_service.discord, "NotFound", _NotFound)
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
         "fetch_event_publish_context",
@@ -119,10 +164,8 @@ async def test_refresh_reposts_missing_message_and_persists_ids(monkeypatch):
         "mark_award_reminders_sent",
         lambda **kwargs: True,
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
-
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )
@@ -153,10 +196,9 @@ async def test_refresh_persists_default_text_only_after_successful_discord_updat
         "update_event_award_reminders_text",
         lambda **kwargs: updates.append(kwargs) or True,
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
 
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )
@@ -169,6 +211,7 @@ async def test_refresh_persists_default_text_only_after_successful_discord_updat
 
 @pytest.mark.asyncio
 async def test_refresh_does_not_persist_default_text_when_discord_update_fails(monkeypatch):
+    channel = None
     updates = []
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
@@ -185,10 +228,8 @@ async def test_refresh_does_not_persist_default_text_when_discord_update_fails(m
         "update_event_award_reminders_text",
         lambda **kwargs: updates.append(kwargs) or True,
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: None, fetch_channel=lambda _cid: None)
-
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )
@@ -211,10 +252,9 @@ async def test_refresh_does_not_duplicate_when_message_exists(monkeypatch):
         "fetch_default_award_reminders_text",
         lambda mode: "latest reminders",
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: channel, fetch_channel=lambda _cid: channel)
 
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )
@@ -226,15 +266,14 @@ async def test_refresh_does_not_duplicate_when_message_exists(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_refresh_refuses_when_awards_not_published(monkeypatch):
+    channel = None
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
         "fetch_event_publish_context",
         lambda event_id: _ctx(PublishVersion=0),
     )
-    bot = SimpleNamespace(get_channel=lambda _cid: None, fetch_channel=lambda _cid: None)
-
     result = await mge_publish_service.refresh_award_reminders(
-        bot=bot,
+        adapter=_RefreshAdapter(channel),
         event_id=10,
         actor_discord_id=1,
     )

--- a/tests/test_mge_publish_service.py
+++ b/tests/test_mge_publish_service.py
@@ -68,6 +68,9 @@ class _PublishAdapter:
     async def delete_message(self, *, channel_id: int, message_id: int):
         return _IoResult("deleted")
 
+    async def check_award_channel_available(self, channel_id: int) -> bool:
+        return self._channel(channel_id) is not None
+
     async def refresh_boards(self, **kwargs):
         self.refresh_calls.append(kwargs)
         return {"public": True, "leadership": True, "awards": True}
@@ -279,7 +282,6 @@ def test_manual_override_persists_only_for_awarded_rows(monkeypatch: pytest.Monk
 async def test_publish_increments_version_and_refreshes_all_boards(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -367,10 +369,56 @@ async def test_publish_blocked_when_readiness_fails(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_publish_channel_unavailable_before_persist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable award channel must abort before apply_publish_atomic is called."""
+    persist_called = {"value": False}
+
+    def _apply_publish_atomic(**kwargs):
+        persist_called["value"] = True
+        return 1
+
+    monkeypatch.setattr(
+        mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal,
+        "fetch_event_publish_context",
+        lambda event_id: {
+            "EventId": event_id,
+            "EventName": "E0",
+            "VariantName": "Infantry",
+            "PublishVersion": 0,
+        },
+    )
+    monkeypatch.setattr(
+        mge_publish_service,
+        "_build_publish_sets",
+        lambda event_id: (
+            [{"AwardId": 1, "FinalAwardedRank": 1, "TargetScore": 8_000_000}],
+            [],
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        mge_publish_service.mge_publish_dal, "apply_publish_atomic", _apply_publish_atomic
+    )
+
+    bot = SimpleNamespace(get_channel=lambda _x: None, fetch_channel=lambda _x: None)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot), event_id=1, actor_discord_id=2
+    )
+
+    assert res.success is False
+    assert "channel unavailable" in res.message.lower()
+    assert persist_called["value"] is False
+
+
+@pytest.mark.asyncio
 async def test_publish_excludes_unassigned_rows_from_final_publish_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "654")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -444,7 +492,7 @@ async def test_publish_excludes_unassigned_rows_from_final_publish_set(
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
     res = await mge_publish_service.publish_event_awards(
-        adapter=_PublishAdapter(bot), event_id=5, actor_discord_id=9
+        adapter=_PublishAdapter(bot, default_award_channel_id=654), event_id=5, actor_discord_id=9
     )
 
     assert res.success is True
@@ -456,7 +504,6 @@ async def test_publish_excludes_unassigned_rows_from_final_publish_set(
 async def test_publish_sends_reminders_once_and_marks_sent(monkeypatch: pytest.MonkeyPatch) -> None:
     sent_payloads = []
     marked = {}
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -552,7 +599,6 @@ async def test_publish_sends_reminders_once_and_marks_sent(monkeypatch: pytest.M
 async def test_republish_skips_reminders_when_already_sent(monkeypatch: pytest.MonkeyPatch) -> None:
     sent_payloads = []
     mark_called = {"value": False}
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -633,7 +679,6 @@ async def test_publish_reminders_persist_failure_skips_second_embed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sent_payloads = []
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -716,7 +761,6 @@ async def test_publish_reminders_mark_sent_failure_reports_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sent_payloads = []
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -810,7 +854,6 @@ async def test_publish_reminders_message_id_persist_failure_reports_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sent_payloads = []
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -904,7 +947,6 @@ async def test_publish_reminders_id_and_mark_failure_reports_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sent_payloads = []
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )
@@ -1068,9 +1110,8 @@ def test_republish_generates_change_summary() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _base_publish_monkeypatches(monkeypatch: pytest.MonkeyPatch, channel_id: str = "999") -> None:
+def _base_publish_monkeypatches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Apply the standard publish-flow monkeypatches shared by DM tests."""
-    monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", channel_id)
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
     )

--- a/tests/test_mge_publish_service.py
+++ b/tests/test_mge_publish_service.py
@@ -373,10 +373,10 @@ async def test_publish_channel_unavailable_before_persist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Unavailable award channel must abort before apply_publish_atomic is called."""
-    persist_called = {"value": False}
+    persist_called = SimpleNamespace(value=False)
 
     def _apply_publish_atomic(**kwargs):
-        persist_called["value"] = True
+        persist_called.value = True
         return 1
 
     monkeypatch.setattr(
@@ -412,7 +412,7 @@ async def test_publish_channel_unavailable_before_persist(
 
     assert res.success is False
     assert "channel unavailable" in res.message.lower()
-    assert persist_called["value"] is False
+    assert persist_called.value is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_mge_publish_service.py
+++ b/tests/test_mge_publish_service.py
@@ -7,6 +7,93 @@ import pytest
 from mge import mge_embed_manager, mge_publish_service
 
 
+class _MessageRef:
+    def __init__(self, message_id: int, channel_id: int) -> None:
+        self.message_id = int(message_id)
+        self.channel_id = int(channel_id)
+
+
+class _IoResult:
+    def __init__(self, status: str, message_ref: _MessageRef | None = None) -> None:
+        self.status = status
+        self.message_ref = message_ref
+
+
+class _MailResult:
+    def __init__(self, sent: bool, status: str) -> None:
+        self.sent = sent
+        self.status = status
+
+
+class _PublishAdapter:
+    def __init__(
+        self,
+        bot,
+        *,
+        default_award_channel_id: int = 999,
+        mail_user_ids: list[int] | None = None,
+    ) -> None:
+        self.bot = bot
+        self._default_award_channel_id = int(default_award_channel_id)
+        self.mail_user_ids = list(mail_user_ids or [])
+        self.refresh_calls = []
+
+    @property
+    def default_award_channel_id(self) -> int:
+        return self._default_award_channel_id
+
+    def _channel(self, channel_id: int):
+        return self.bot.get_channel(channel_id)
+
+    async def send_awards_embed(self, *, channel_id: int, **kwargs):
+        channel = self._channel(channel_id)
+        if channel is None:
+            return _IoResult("channel_unavailable")
+        msg = await channel.send(content=None, embed=object(), allowed_mentions=object())
+        return _IoResult("sent", _MessageRef(msg.id, channel.id))
+
+    async def send_republish_change_log(self, *, channel_id: int, change_lines: list[str]):
+        return _IoResult("sent")
+
+    async def send_award_reminders_embed(self, *, channel_id: int, **kwargs):
+        channel = self._channel(channel_id)
+        if channel is None:
+            return _IoResult("channel_unavailable")
+        msg = await channel.send(content="@everyone", embed=object(), allowed_mentions=object())
+        return _IoResult("sent", _MessageRef(msg.id, channel.id))
+
+    async def update_award_reminders_embed(self, *, channel_id: int, message_id: int, **kwargs):
+        return _IoResult("not_found")
+
+    async def delete_message(self, *, channel_id: int, message_id: int):
+        return _IoResult("deleted")
+
+    async def refresh_boards(self, **kwargs):
+        self.refresh_calls.append(kwargs)
+        return {"public": True, "leadership": True, "awards": True}
+
+    async def send_award_mail(self, *, event_id: int, dm_text: str):
+        if not self.mail_user_ids:
+            return _MailResult(False, "skipped_no_recipient")
+        sent_count = 0
+        fail_count = 0
+        for uid in self.mail_user_ids:
+            try:
+                user = await self.bot.fetch_user(uid)
+                await user.send(
+                    dm_text,
+                    allowed_mentions=SimpleNamespace(everyone=False, users=False, roles=False),
+                )
+                sent_count += 1
+            except Exception:
+                fail_count += 1
+        if fail_count == 0:
+            return _MailResult(True, f"sent:{sent_count}")
+        if sent_count > 0:
+            return _MailResult(True, f"partial:{sent_count}_ok_{fail_count}_failed")
+        return _MailResult(False, f"all_failed:{fail_count}")
+
+
 def _ready_payload():
     return {
         "total_signups": 1,
@@ -192,7 +279,6 @@ def test_manual_override_persists_only_for_awarded_rows(monkeypatch: pytest.Monk
 async def test_publish_increments_version_and_refreshes_all_boards(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    refresh_calls = []
     monkeypatch.setattr(mge_publish_service, "MGE_AWARD_CHANNEL_ID", "999")
     monkeypatch.setattr(
         mge_publish_service, "evaluate_publish_readiness", lambda event_id: _ready_payload()
@@ -240,11 +326,6 @@ async def test_publish_increments_version_and_refreshes_all_boards(
         mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
     )
 
-    async def _refresh(**kwargs):
-        refresh_calls.append(kwargs)
-
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", _refresh)
-
     class _Msg:
         id = 123
 
@@ -255,10 +336,13 @@ async def test_publish_increments_version_and_refreshes_all_boards(
             return _Msg()
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=1, actor_discord_id=2)
+    adapter = _PublishAdapter(bot)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=adapter, event_id=1, actor_discord_id=2
+    )
     assert res.success is True
     assert res.publish_version == 1
-    assert refresh_calls[0]["refresh_awards"] is True
+    assert adapter.refresh_calls[0]["refresh_awards"] is True
 
 
 @pytest.mark.asyncio
@@ -274,7 +358,9 @@ async def test_publish_blocked_when_readiness_fails(monkeypatch: pytest.MonkeyPa
     )
 
     bot = SimpleNamespace(get_channel=lambda _x: None, fetch_channel=lambda _x: None)
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=1, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot), event_id=1, actor_discord_id=2
+    )
 
     assert res.success is False
     assert "publish blocked" in res.message.lower()
@@ -347,8 +433,6 @@ async def test_publish_excludes_unassigned_rows_from_final_publish_set(
         mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
     )
 
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
-
     class _Msg:
         id = 321
 
@@ -359,7 +443,9 @@ async def test_publish_excludes_unassigned_rows_from_final_publish_set(
             return _Msg()
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=5, actor_discord_id=9)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot), event_id=5, actor_discord_id=9
+    )
 
     assert res.success is True
     assert [row["AwardId"] for row in captured["publish_rows"]] == [10]
@@ -424,7 +510,6 @@ async def test_publish_sends_reminders_once_and_marks_sent(monkeypatch: pytest.M
         "update_award_reminder_message_ids",
         lambda **kwargs: True,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
         "update_event_award_reminders_text",
@@ -449,7 +534,7 @@ async def test_publish_sends_reminders_once_and_marks_sent(monkeypatch: pytest.M
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
 
     res = await mge_publish_service.publish_event_awards(
-        bot=bot,
+        adapter=_PublishAdapter(bot),
         event_id=2,
         actor_discord_id=42,
         reminders_text_override="event-specific reminders",
@@ -521,7 +606,6 @@ async def test_republish_skips_reminders_when_already_sent(monkeypatch: pytest.M
         "mark_award_reminders_sent",
         lambda **kwargs: mark_called.update(value=True) or True,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
     class _Msg:
         id = 888
@@ -534,7 +618,9 @@ async def test_republish_skips_reminders_when_already_sent(monkeypatch: pytest.M
             return _Msg()
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=3, actor_discord_id=9)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot), event_id=3, actor_discord_id=9
+    )
 
     assert res.success is True
     assert res.reminders_embed_status == "already_sent"
@@ -601,7 +687,6 @@ async def test_publish_reminders_persist_failure_skips_second_embed(
         "update_event_award_reminders_text",
         lambda **kwargs: False,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
     class _Msg:
         id = 1001
@@ -615,7 +700,7 @@ async def test_publish_reminders_persist_failure_skips_second_embed(
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
     res = await mge_publish_service.publish_event_awards(
-        bot=bot,
+        adapter=_PublishAdapter(bot),
         event_id=4,
         actor_discord_id=9,
         reminders_text_override="custom text",
@@ -695,7 +780,6 @@ async def test_publish_reminders_mark_sent_failure_reports_status(
         "mark_award_reminders_sent",
         lambda **kwargs: False,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
     class _Msg:
         id = 1002
@@ -709,7 +793,7 @@ async def test_publish_reminders_mark_sent_failure_reports_status(
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
     res = await mge_publish_service.publish_event_awards(
-        bot=bot,
+        adapter=_PublishAdapter(bot),
         event_id=5,
         actor_discord_id=9,
         reminders_text_override="custom text",
@@ -790,7 +874,6 @@ async def test_publish_reminders_message_id_persist_failure_reports_status(
         "mark_award_reminders_sent",
         lambda **kwargs: True,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
     class _Msg:
         id = 1003
@@ -804,7 +887,7 @@ async def test_publish_reminders_message_id_persist_failure_reports_status(
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
     res = await mge_publish_service.publish_event_awards(
-        bot=bot,
+        adapter=_PublishAdapter(bot),
         event_id=6,
         actor_discord_id=9,
         reminders_text_override="custom text",
@@ -885,7 +968,6 @@ async def test_publish_reminders_id_and_mark_failure_reports_status(
         "mark_award_reminders_sent",
         lambda **kwargs: False,
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
     class _Msg:
         id = 1004
@@ -899,7 +981,7 @@ async def test_publish_reminders_id_and_mark_failure_reports_status(
 
     bot = SimpleNamespace(get_channel=lambda x: _Channel(), fetch_channel=lambda x: _Channel())
     res = await mge_publish_service.publish_event_awards(
-        bot=bot,
+        adapter=_PublishAdapter(bot),
         event_id=7,
         actor_discord_id=9,
         reminders_text_override="custom text",
@@ -913,7 +995,6 @@ async def test_publish_reminders_id_and_mark_failure_reports_status(
 
 @pytest.mark.asyncio
 async def test_unpublish_preserves_state_and_refreshes(monkeypatch: pytest.MonkeyPatch) -> None:
-    refresh_calls = []
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal,
         "fetch_event_publish_context",
@@ -933,16 +1014,14 @@ async def test_unpublish_preserves_state_and_refreshes(monkeypatch: pytest.Monke
         },
     )
 
-    async def _refresh(**kwargs):
-        refresh_calls.append(kwargs)
-
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", _refresh)
-
     bot = SimpleNamespace(get_channel=lambda _x: None, fetch_channel=lambda _x: None)
-    res = await mge_publish_service.unpublish_event_awards(bot=bot, event_id=1, actor_discord_id=2)
+    adapter = _PublishAdapter(bot)
+    res = await mge_publish_service.unpublish_event_awards(
+        adapter=adapter, event_id=1, actor_discord_id=2
+    )
 
     assert res.success is True
-    assert refresh_calls[0]["refresh_awards"] is True
+    assert adapter.refresh_calls[0]["refresh_awards"] is True
     assert "rolled back" in res.message.lower()
 
 
@@ -1038,7 +1117,6 @@ def _base_publish_monkeypatches(monkeypatch: pytest.MonkeyPatch, channel_id: str
     monkeypatch.setattr(
         mge_publish_service.mge_publish_dal, "update_award_embed_ids", lambda **kwargs: True
     )
-    monkeypatch.setattr(mge_publish_service, "refresh_mge_boards", lambda **kwargs: None)
 
 
 @pytest.mark.asyncio
@@ -1069,7 +1147,11 @@ async def test_dm_failure_does_not_block_publish(monkeypatch: pytest.MonkeyPatch
         fetch_user=_fetch_user,
     )
 
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=10, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot, mail_user_ids=[888999]),
+        event_id=10,
+        actor_discord_id=2,
+    )
 
     assert res.success is True, f"Publish must succeed despite DM failure, got: {res.message}"
     assert res.award_mail_dm_sent is False
@@ -1104,7 +1186,11 @@ async def test_dm_sent_flag_true_when_dm_succeeds(monkeypatch: pytest.MonkeyPatc
         fetch_user=_fetch_user,
     )
 
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=11, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot, mail_user_ids=[888999]),
+        event_id=11,
+        actor_discord_id=2,
+    )
 
     assert res.success is True
     assert res.award_mail_dm_sent is True
@@ -1139,7 +1225,11 @@ async def test_dm_sent_to_multiple_recipients(monkeypatch: pytest.MonkeyPatch) -
         fetch_user=_fetch_user,
     )
 
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=13, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot, mail_user_ids=[111111, 222222]),
+        event_id=13,
+        actor_discord_id=2,
+    )
 
     assert res.success is True
     assert res.award_mail_dm_sent is True
@@ -1185,7 +1275,11 @@ async def test_dm_partial_failure_still_marks_sent(monkeypatch: pytest.MonkeyPat
         fetch_user=_fetch_user,
     )
 
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=14, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot, mail_user_ids=[111111, 222222]),
+        event_id=14,
+        actor_discord_id=2,
+    )
 
     assert res.success is True
     assert res.award_mail_dm_sent is True
@@ -1212,7 +1306,9 @@ async def test_dm_skipped_when_no_recipient_configured(monkeypatch: pytest.Monke
         fetch_channel=lambda x: _Channel(),
     )
 
-    res = await mge_publish_service.publish_event_awards(bot=bot, event_id=12, actor_discord_id=2)
+    res = await mge_publish_service.publish_event_awards(
+        adapter=_PublishAdapter(bot), event_id=12, actor_discord_id=2
+    )
 
     assert res.success is True
     assert res.award_mail_dm_sent is False

--- a/tests/test_mge_signup_service.py
+++ b/tests/test_mge_signup_service.py
@@ -82,6 +82,36 @@ def _patch_signup_happy_path(monkeypatch):
     )
 
 
+def test_get_linked_governors_uses_registry_service_boundary(monkeypatch):
+    calls = []
+
+    def _get_user_accounts(discord_user_id):
+        calls.append(discord_user_id)
+        return {
+            "Main": {"GovernorID": 100, "GovernorName": "Main Gov"},
+            "Alt 1": {"GovernorID": "200", "GovernorName": "Alt Gov"},
+        }
+
+    monkeypatch.setattr(mge_signup_service, "get_user_accounts", _get_user_accounts)
+
+    result = mge_signup_service.get_linked_governors_for_user(123)
+
+    assert calls == [123]
+    assert result == [
+        {"GovernorID": "100", "GovernorName": "Main Gov"},
+        {"GovernorID": "200", "GovernorName": "Alt Gov"},
+    ]
+
+
+def test_get_linked_governors_returns_empty_on_registry_failure(monkeypatch):
+    def _raise(_discord_user_id):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(mge_signup_service, "get_user_accounts", _raise)
+
+    assert mge_signup_service.get_linked_governors_for_user(123) == []
+
+
 def test_admin_signup_resolves_discord_identity_from_registry(monkeypatch):
     _patch_signup_happy_path(monkeypatch)
     captured: dict[str, object] = {}
@@ -205,14 +235,10 @@ class _FakeGuild:
 
 
 def test_member_role_ids_from_member_user(monkeypatch):
-    import discord
-
-    class FakeDiscordMember(discord.Member):  # pragma: no cover
-        pass
-
     member = _FakeMember(1, [_FakeRole(10), _FakeRole(20)])
     interaction = SimpleNamespace(user=member, guild=None)
 
+    # architecture-check: allow - test patches Discord Member type.
     monkeypatch.setattr("discord.Member", _FakeMember)
     role_ids = _member_role_ids(interaction)
     assert role_ids == {10, 20}
@@ -224,6 +250,7 @@ def test_member_role_ids_falls_back_to_guild_lookup(monkeypatch):
     guild = _FakeGuild(member)
     interaction = SimpleNamespace(user=user, guild=guild)
 
+    # architecture-check: allow - test patches Discord Member type.
     monkeypatch.setattr("discord.Member", _FakeMember)
     role_ids = _member_role_ids(interaction)
     assert role_ids == {5}
@@ -234,6 +261,7 @@ def test_member_role_ids_empty_when_no_member(monkeypatch):
     guild = _FakeGuild(None)
     interaction = SimpleNamespace(user=user, guild=guild)
 
+    # architecture-check: allow - test patches Discord Member type.
     monkeypatch.setattr("discord.Member", _FakeMember)
     role_ids = _member_role_ids(interaction)
     assert role_ids == set()

--- a/ui/views/mge_publish_view.py
+++ b/ui/views/mge_publish_view.py
@@ -8,7 +8,10 @@ import discord
 from core.interaction_safety import send_ephemeral
 from core.mge_permissions import is_admin_or_leadership_interaction
 from mge import mge_publish_service
+
+# architecture-check: allow - existing publish view reads DAL state for UI prompts.
 from mge.dal import mge_publish_dal
+from mge.mge_publish_discord_adapter import MgePublishDiscordAdapter
 
 MAX_REMINDERS_TEXT_LENGTH = 4000
 
@@ -82,7 +85,7 @@ class _ConfirmUnpublishView(discord.ui.View):
 
         await interaction.response.defer(ephemeral=True)
         res = await mge_publish_service.unpublish_event_awards(
-            bot=interaction.client,
+            adapter=MgePublishDiscordAdapter(interaction.client),
             event_id=self.event_id,
             actor_discord_id=int(interaction.user.id),
         )
@@ -349,7 +352,7 @@ class MgePublishView(discord.ui.View):
         reminders_text_override: str | None,
     ) -> None:
         res = await mge_publish_service.publish_event_awards(
-            bot=interaction.client,
+            adapter=MgePublishDiscordAdapter(interaction.client),
             event_id=self.event_id,
             actor_discord_id=int(interaction.user.id),
             reminders_text_override=reminders_text_override,

--- a/ui/views/mge_simplified_leadership_view.py
+++ b/ui/views/mge_simplified_leadership_view.py
@@ -18,7 +18,10 @@ from mge import (
     mge_roster_service,
     mge_simplified_leadership_service,
 )
+
+# architecture-check: allow - existing leadership view reads signup DAL for admin-add gating.
 from mge.dal import mge_signup_dal
+from mge.mge_publish_discord_adapter import MgePublishDiscordAdapter
 from ui.views.mge_admin_view import ConfirmSwitchFixedView, ConfirmSwitchOpenView, MGEAdminViewDeps
 
 logger = logging.getLogger(__name__)
@@ -251,7 +254,7 @@ class _PublishConfirmView(_SingleActionConfirmView):
             return
         await interaction.response.defer(ephemeral=True)
         result = await mge_publish_service.publish_event_awards(
-            bot=interaction.client,
+            adapter=MgePublishDiscordAdapter(interaction.client),
             event_id=self.event_id,
             actor_discord_id=int(interaction.user.id),
         )
@@ -277,7 +280,7 @@ class _UnpublishConfirmView(_SingleActionConfirmView):
             return
         await interaction.response.defer(ephemeral=True)
         result = await mge_publish_service.unpublish_event_awards(
-            bot=interaction.client,
+            adapter=MgePublishDiscordAdapter(interaction.client),
             event_id=self.event_id,
             actor_discord_id=int(interaction.user.id),
         )


### PR DESCRIPTION
## Summary

- Move MGE signup account resolution onto the registry service boundary via `get_user_accounts()` while preserving admin-add reverse lookup behavior.
- Extract Discord message fetch/send/edit/delete/DM work from `mge_publish_service.py` into a dedicated Discord IO adapter.
- Update command/view orchestration to pass the adapter and keep publish state decisions/persistence in the service layer.
- Include Phase 2 initiation/deferred-optimisation documentation updates.

## Impact

This keeps existing MGE behavior intact while tightening service boundaries around registry lookup and publish Discord IO. Award reminder refresh remains idempotent, commander/history behavior is untouched, and no SQL is added to Discord command or view modules.

## Validation

- `./.venv/Scripts/python.exe -m pytest -q (Get-ChildItem tests/test_mge_*.py).FullName tests/test_dl_bot_mge_auto_import.py` -> 285 passed
- `./.venv/Scripts/python.exe -m pytest -q tests` -> 1298 passed, 8 skipped
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py` -> passed
- `./.venv/Scripts/python.exe scripts/select_tests.py` -> passed
- `./.venv/Scripts/python.exe scripts/smoke_imports.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` -> passed
- `./.venv/Scripts/python.exe -m ruff check mge commands ui tests` -> passed
- `./.venv/Scripts/python.exe -m black --check mge commands ui tests` -> passed
- `git diff --check` -> passed