### PR TITLE
[codex] Close telemetry optimisation docs

### DIFF
--- a/docs/Telemetry Commands Full Optimisation & Standardisation — Codex Task Pack.md
+++ b/docs/Telemetry Commands Full Optimisation & Standardisation — Codex Task Pack.md
@@ -1,5 +1,53 @@
 # Telemetry Commands Full Optimisation & Standardisation — Codex Task Pack
 
+## Deployment Closure
+
+Status: complete and deployed.
+
+Final delivery:
+
+* PR: `cwatts6/K98-bot-mirror#76`
+* Mirror merge: `e474962e7f2664738726cb0dbf1fba04c49f2ea6`
+* Production main: `a0ec587c1651e9383f3ed428ad2d7419dc0fbad3`
+* Mirror sync commit: `fbc259415cc30eb98faf56e4d469d32c9f062bc4`
+* Deployment smoke test: completed after merge and production promotion.
+
+Delivered architecture:
+
+* `commands/telemetry_cmds.py` is now a thinner command registration and command-flow wrapper.
+* Player profile posting moved to `commands/player_profile_flow.py`.
+* CrystalTech interaction orchestration moved to `commands/crystaltech_flow.py`.
+* Registry account selection now routes through `services/governor_account_service.py`, backed by `registry.registry_service.get_user_accounts()`.
+* CrystalTech governor session locking now routes through `services/governor_session_lock_service.py` and `registry/dal/governor_session_lock_dal.py`.
+* Restart-safe lock persistence is represented by `sql/governor_session_locks_schema.sql` and the deployed `dbo.GovernorSessionLocks` table.
+* Adjacent account-selection paths in `account_picker.py`, `kvk_ui.py`, selected KVK personal views, selected registry views, and Ark registration were aligned away from telemetry-local registry parsing.
+
+Resolved GitHub issues:
+
+* #26 — telemetry command SQL usage.
+* #33 — telemetry scope of command-layer SQL separation.
+* #47 — restart-safe governor session locking pattern.
+
+Related issues intentionally left open:
+
+* #27 — broader dict-style registry access outside the delivered telemetry-adjacent paths.
+* #28 — full legacy registry view removal.
+* #29 and #32 — stats-service registry/service consolidation.
+* #31 — broader governor registry architecture refactor pack.
+* #42 — KVK admin SQL extraction.
+* #46 — stats export SQL extraction.
+
+Validation completed on the final deployed version:
+
+* `python -m pytest -q tests` — 1306 passed, 8 skipped.
+* `python scripts/validate_command_registration.py` — no duplicates.
+* `python scripts/smoke_imports.py` — passed.
+* Focused telemetry/registry/Ark test subset — 42 passed.
+
+This document is retained as the task pack plus final completion record.
+
+---
+
 ## Objective
 
 Perform a full audit, optimisation, standardisation, and architectural cleanup of the telemetry command subsystem centred around:

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -54,13 +54,18 @@
 
 ## Recently Resolved
 
-- Telemetry Commands Full Optimisation phase resolved the telemetry portions of GitHub issues #26, #33, and #47:
-  - `commands/telemetry_cmds.py` no longer imports the KVK DAL current-KVK resolver.
+- Telemetry Commands Full Optimisation & Standardisation was implemented, merged, production promoted, and smoke-tested via PR #76.
+- The following telemetry deferred items are closed and complete:
+  - `commands/telemetry_cmds.py` no longer imports or wraps the KVK DAL current-KVK resolver, resolving GitHub issue #26.
+  - The telemetry scope of command-layer SQL separation is complete, resolving GitHub issue #33.
+  - CrystalTech governor session locking is now restart-safe and service/DAL-backed, resolving GitHub issue #47.
   - `/mykvktargets` and `/mykvkcrystaltech` resolve linked accounts through `services/governor_account_service.py`, which delegates to `registry_service.get_user_accounts()`.
-  - CrystalTech governor session locking now routes through `services/governor_session_lock_service.py` and `registry/dal/governor_session_lock_dal.py` with UTC expiry and cleanup support.
-  - Player profile posting and CrystalTech interaction orchestration were moved behind command-adjacent helper modules.
+  - CrystalTech governor session locking now routes through `services/governor_session_lock_service.py` and `registry/dal/governor_session_lock_dal.py` with UTC expiry, release, refresh, contention, and cleanup support.
+  - Player profile posting moved to `commands/player_profile_flow.py`.
+  - CrystalTech interaction orchestration moved to `commands/crystaltech_flow.py`.
   - `account_picker.py`, `kvk_ui.py`, selected KVK personal views, selected registry views, and Ark registration account lookup were aligned away from direct registry dict traversal where touched.
-- Remaining related GitHub issues intentionally stay open for separate batches: #28 legacy registry view removal, #29/#32 stats-service registry alignment, #42 KVK admin SQL extraction, #46 stats export SQL extraction, and the broader untouched portions of #27/#31 outside telemetry-adjacent paths.
+  - Final deployed validation: `python -m pytest -q tests` reported 1306 passed and 8 skipped; command registration and import smoke validation passed; post-deploy Discord smoke testing was completed.
+- Related issues intentionally remain open for separate non-telemetry batches: #27 broader dict-style registry access, #28 legacy registry view removal, #29/#32 stats-service registry alignment, #31 broader governor registry architecture refactor, #42 KVK admin SQL extraction, and #46 stats export SQL extraction.
 - MGE Process Polish Phase 2 was implemented, production deployed, and smoke-tested via PR #75.
 - `mge/mge_signup_service.py` self-signup account resolution now uses `registry_service.get_user_accounts()` instead of the legacy registry dict shape. Admin-add reverse owner lookup remains on `get_discord_user_for_governor()`.
 - `mge/mge_publish_service.py` no longer performs direct Discord message fetch/send/edit/delete/DM IO. Publish, republish, reminder refresh, unpublish, award DM, and board refresh paths now route Discord operations through `mge/mge_publish_discord_adapter.py`.


### PR DESCRIPTION
## Summary

Documents the deployed final state of the telemetry optimisation work:

- Adds a deployment closure section to the telemetry task pack with PR, production, mirror, smoke-test, architecture, validation, and issue status details.
- Updates `docs/deferred_optimisations.md` so the delivered telemetry items are marked closed and complete.
- Separates still-open broader registry/stats/SQL cleanup batches from the now-closed telemetry scope.

## GitHub Issues

Closed as completed after deployment validation:

- #26
- #33
- #47

Left open intentionally for non-telemetry follow-up batches:

- #27
- #28
- #29/#32
- #31
- #42
- #46

## Validation

- `python scripts/validate_deferred_items.py`