### PR TITLE
Refactor stats commands through service boundaries

### DIFF
--- a/commands/stats_cmds.py
+++ b/commands/stats_cmds.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 import logging
-import os
 import time
 
 import discord
@@ -33,18 +32,13 @@ from honor_rankings_view import HonorRankingView, build_honor_rankings_embed
 from kvk.services import kvk_admin_service
 from profile_cache import autocomplete_choices
 from registry.account_slots import ACCOUNT_ORDER
-from registry.governor_registry import get_user_main_governor_name, load_registry
-from services import kvk_history_service
+from services import kvk_history_service, stats_account_service, stats_export_service
 from stats_alerts.embeds.kvk import send_kvk_embed
 from stats_alerts.honors import get_latest_honor_top, purge_latest_honor_scan
 from stats_alerts.interface import send_stats_update_embed
 from stats_alerts.kvk_meta import is_currently_kvk
 from stats_cache_helpers import load_last_kvk_map
-from stats_service import (
-    get_registered_governor_ids_for_discord,
-    get_registered_governor_names_for_discord,
-    get_stats_payload,
-)
+from stats_service import get_stats_payload
 from ui.views.kvk_history_view import KVKHistoryView
 from ui.views.kvk_personal_views import MyKVKStatsSelectView
 from ui.views.registry_views import MyRegsActionView
@@ -55,10 +49,6 @@ from versioning import versioned
 logger = logging.getLogger(__name__)
 bot: ext_commands.Bot | None = None
 # ACCOUNT_ORDER imported from account_picker — single canonical definition.
-
-
-async def async_load_registry():
-    return await asyncio.to_thread(load_registry)
 
 
 # MyKVKStatsSelectView is defined canonically in ui.views.kvk_personal_views and imported above.
@@ -262,22 +252,14 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         # We always keep the selector private to the caller
         await safe_defer(ctx, ephemeral=True)
 
-        # Load registry (support str/int keys)
-        try:
-            # Offload file/IO-bound registry load to a thread to avoid blocking the event loop
-            registry = await asyncio.to_thread(load_registry)
-            registry = registry or {}
-        except Exception as e:
-            logger.exception("[/mykvkstats] load_registry failed")
+        account_summary = await stats_account_service.get_account_summary_for_user(ctx.user.id)
+        if not account_summary.ok:
             await ctx.interaction.edit_original_response(
-                content=f"❌ Could not load registry: `{type(e).__name__}: {e}`"
+                content=f"❌ Could not load registry: `{account_summary.error}`"
             )
             return
 
-        uid_str, uid_int = str(ctx.user.id), ctx.user.id
-        user_data = registry.get(uid_str) or registry.get(uid_int)
-
-        if not user_data or not user_data.get("accounts"):
+        if not account_summary.governor_ids:
             # Reuse your existing action view as a nice fallback
             view = MyRegsActionView(author_id=ctx.user.id, has_regs=False)
             msg = await ctx.interaction.edit_original_response(
@@ -287,7 +269,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             view.set_message_ref(msg)
             return
 
-        accounts = user_data["accounts"]
+        accounts = account_summary.ordered_accounts
 
         # Best-effort: load last-KVK cache via the TTL-backed in-process cache helper.
         last_kvk_map = {}
@@ -512,7 +494,15 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         user_obj, guild_obj = _actor_from_ctx(ctx)
         user_id = user_obj.id
 
-        gov_ids = await get_registered_governor_ids_for_discord(user_id)
+        account_summary = await stats_account_service.get_account_summary_for_user(user_id)
+        if not account_summary.ok:
+            await ctx.followup.send(
+                f"Registry is temporarily unavailable: `{account_summary.error}`",
+                ephemeral=True,
+            )
+            return
+
+        gov_ids = account_summary.governor_ids
         if not gov_ids:
             await ctx.followup.send(
                 "I don’t see any governor accounts linked to you. Use `/link_account` first.",
@@ -521,31 +511,14 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             return
 
         # Friendly account names for the dropdown
-        account_names = await get_registered_governor_names_for_discord(user_id)
-
-        # Build name -> id map from the same registry
-        reg = await asyncio.to_thread(load_registry)
-        block = reg.get(str(user_id)) or {}
-        name_to_id: dict[str, int] = {}
-        for slot, acc in (block.get("accounts") or {}).items():
-            if not acc:
-                continue
-            gname = str(acc.get("GovernorName") or "").strip()
-            gid = acc.get("GovernorID")
-            if gname and gid:
-                name_to_id[gname] = int(gid)
+        account_names = account_summary.account_names
+        name_to_id = account_summary.name_to_id
 
         # Initial slice & payload
         slice_key = "wtd"
 
         # Find the user's Main from the same registry block
-        main_name = get_user_main_governor_name(reg, user_id)
-        if main_name and main_name in name_to_id:
-            default_choice = main_name
-        elif account_names:
-            default_choice = account_names[0]
-        else:
-            default_choice = "ALL"
+        default_choice = account_summary.default_choice
 
         # Governor IDs to load for the initial render
         if default_choice == "ALL":
@@ -660,228 +633,73 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         """
         await safe_defer(ctx, ephemeral=True)
 
-        # Track temp files for cleanup
-        temp_dir = None
-        file_path = None
+        export_file = None
 
         try:
-            from datetime import datetime
-            import tempfile
-
-            import pandas as pd
-
-            from file_utils import emit_telemetry_event, get_conn_with_retries
-            from stats_exporter import build_user_stats_excel
-            from stats_exporter_csv import build_user_stats_csv
-            from stats_service import get_registered_governor_ids_for_discord
-
             user_id = ctx.author.id
             username = ctx.author.display_name or ctx.author.name
 
-            # Use existing stats_service function
-            governor_ids = await get_registered_governor_ids_for_discord(user_id)
-
-            if not governor_ids:
-                await ctx.respond(
-                    "❌ You have no registered accounts. Use `/register_governor` first.",
+            outcome = await stats_export_service.build_personal_stats_export(
+                discord_user_id=user_id,
+                display_name=username,
+                requested_format=format,
+                days=days,
+            )
+            if outcome.status != "ok" or outcome.export_file is None:
+                await ctx.followup.send(
+                    f"Error: {outcome.message or 'Export could not be prepared.'}",
                     ephemeral=True,
                 )
                 return
 
-            # Fetch daily stats from DB
-            def _fetch_daily():
-                conn = get_conn_with_retries()
-                try:
-                    cursor = conn.cursor()
-                    placeholders = ",".join("?" * len(governor_ids))
-                    query = f"""  # architecture-check: allow
-                    SELECT GovernorID, GovernorName, Alliance, AsOfDate,
-                        Power, PowerDelta, TroopPower, TroopPowerDelta,
-                        KillPoints, KillPointsDelta, Deads, DeadsDelta,
-                        RSS_Gathered, RSS_GatheredDelta, RSSAssist, RSSAssistDelta,
-                        Helps, HelpsDelta, BuildingMinutes, TechDonations,
-                        FortsTotal, FortsLaunched, FortsJoined,
-                        AOOJoined, AOOJoinedDelta, AOOWon, AOOWonDelta,
-                        AOOAvgKill, AOOAvgKillDelta, AOOAvgDead, AOOAvgDeadDelta,
-                        AOOAvgHeal, AOOAvgHealDelta,
-                        T4_Kills, T4_KillsDelta, T5_Kills, T5_KillsDelta,
-                        T4T5_Kills, T4T5_KillsDelta,
-                        HealedTroops, HealedTroopsDelta,
-                        RangedPoints, RangedPointsDelta,
-                        HighestAcclaim, HighestAcclaimDelta,
-                        AutarchTimes, AutarchTimesDelta
-                    FROM vDaily_PlayerExport
-                    WHERE GovernorID IN ({placeholders})
-                    ORDER BY GovernorID, AsOfDate DESC
-                    """
-                    cursor.execute(query, governor_ids)
+            export_file = outcome.export_file
+            file_obj = discord.File(export_file.file_path, filename=export_file.filename)
 
-                    columns = [desc[0] for desc in cursor.description]
-                    rows = cursor.fetchall()
-
-                    return pd.DataFrame.from_records(rows, columns=columns)
-                finally:
-                    conn.close()
-
-            # Offload to thread
-            df_daily = await asyncio.to_thread(_fetch_daily)
-
-            if df_daily.empty:
-                await ctx.respond("❌ No stats data found for your accounts.", ephemeral=True)
-                return
-
-            # Generate temp directory and filename
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            temp_dir = tempfile.mkdtemp()
-
-            # Build file based on format
-            if format == "CSV":
-                file_path = os.path.join(temp_dir, f"stats_{username}_{timestamp}.csv")
-                await asyncio.to_thread(
-                    build_user_stats_csv,
-                    df_daily,
-                    None,  # df_targets (not used)
-                    out_path=file_path,
-                    days_for_daily_table=days,
-                )
-                file_obj = discord.File(file_path, filename=f"stats_{username}_{timestamp}.csv")
-                format_emoji = "📄"
-                format_name = "CSV"
-                description = "**Lightweight text-based format**\nOpen with any spreadsheet app."
-                instructions = (
-                    "**💻 Desktop:**\n"
-                    "1. Download the attached file\n"
-                    "2. Open with Excel, Google Sheets, or any spreadsheet app\n\n"
-                    "**📱 Mobile:**\n"
-                    "• **iPhone/iPad:** Tap attachment → Share → Save to Files → Open with Numbers or Google Sheets\n"
-                    "• **Android:** Tap attachment → Download → Open with Google Sheets or Excel"
-                )
-
-            elif format == "GoogleSheets":
-                # Generate Excel file (Google Sheets natively imports .xlsx)
-                file_path = os.path.join(temp_dir, f"stats_{username}_{timestamp}.xlsx")
-                await asyncio.to_thread(
-                    build_user_stats_excel,
-                    df_daily,
-                    None,  # df_targets (not used)
-                    out_path=file_path,
-                    days_for_daily_table=days,
-                )
-                file_obj = discord.File(file_path, filename=f"stats_{username}_{timestamp}.xlsx")
-                format_emoji = "📊"
-                format_name = "Google Sheets"
-                description = (
-                    "**Google Sheets-compatible format**\nUpload to Google Drive to open in Sheets."
-                )
-                instructions = (
-                    "**💻 Desktop:**\n"
-                    "1. Download the attached file\n"
-                    "2. Go to [drive.google.com](https://drive.google.com)\n"
-                    "3. Click **New** → **File upload**\n"
-                    "4. Upload this file → Double-click to open in Google Sheets\n\n"
-                    "**📱 Mobile:**\n"
-                    "• **iPhone/iPad:**\n"
-                    "  1. Tap attachment → Share → Save to Files\n"
-                    "  2. Open Google Drive app\n"
-                    # architecture-check: allow
-                    "  3. Tap **+** → **Upload** → Select file from Files\n"
-                    "  4. Tap file in Drive to open in Sheets\n\n"
-                    "• **Android:**\n"
-                    "  1. Tap attachment → Download\n"
-                    "  2. Open Google Drive app\n"
-                    # architecture-check: allow
-                    "  3. Tap **+** → **Upload** → Select downloaded file\n"
-                    "  4. Tap file in Drive to open in Sheets"
-                )
-
-            else:  # Excel (default)
-                file_path = os.path.join(temp_dir, f"stats_{username}_{timestamp}.xlsx")
-                await asyncio.to_thread(
-                    build_user_stats_excel,
-                    df_daily,
-                    None,  # df_targets (not used)
-                    out_path=file_path,
-                    days_for_daily_table=days,
-                )
-                file_obj = discord.File(file_path, filename=f"stats_{username}_{timestamp}.xlsx")
-                format_emoji = "📗"
-                format_name = "Excel"
-                description = "**Full-featured Excel workbook**\nIncludes charts, formatting, and multiple sheets."
-                instructions = (
-                    "**💻 Desktop:**\n"
-                    "1. Download the attached file\n"
-                    "2. Open with Microsoft Excel, LibreOffice, or Numbers\n\n"
-                    "**📱 Mobile:**\n"
-                    "• **iPhone/iPad:** Tap attachment → Share → Open in Excel or Numbers\n"
-                    "• **Android:** Tap attachment → Open with Excel or Google Sheets"
-                )
-
-            # Build response embed
             embed = discord.Embed(
-                title=f"{format_emoji} Stats Export ({format_name})",
-                description=description,
+                title=f"{export_file.format_emoji} Stats Export ({export_file.format_name})",
+                description=export_file.description,
                 color=0x2ECC71,
             )
             embed.add_field(
-                name="📂 File Info",
+                name="File Info",
                 value=(
-                    f"**Accounts:** {len(governor_ids)}\n"
-                    f"**Daily Records:** {len(df_daily):,}\n"
-                    f"**Date Range:** {days} days"
+                    f"**Accounts:** {len(export_file.governor_ids)}\n"
+                    f"**Daily Records:** {export_file.row_count:,}\n"
+                    f"**Date Range:** {export_file.days} days"
                 ),
                 inline=False,
             )
             embed.add_field(
-                name="📖 How to Open",
-                value=instructions,
+                name="How to Open",
+                value=export_file.instructions,
                 inline=False,
             )
             embed.set_footer(
                 text=(
-                    f"Exported {len(df_daily):,} records for {len(governor_ids)} account(s) • "
-                    f"Data refreshed daily at ~06:00 UTC"
+                    f"Exported {export_file.row_count:,} records for "
+                    f"{len(export_file.governor_ids)} account(s) - "
+                    "Data refreshed daily at ~06:00 UTC"
                 )
             )
 
-            await ctx.respond(embed=embed, file=file_obj, ephemeral=True)
+            await ctx.followup.send(embed=embed, file=file_obj, ephemeral=True)
 
-            # Emit telemetry
             try:
-                emit_telemetry_event(
-                    {
-                        "event": "my_stats_export",
-                        "user_id": user_id,
-                        "format": format,
-                        "days": days,
-                        "num_governors": len(governor_ids),
-                        "num_rows": len(df_daily),
-                    }
-                )
+                from file_utils import emit_telemetry_event
+
+                emit_telemetry_event(export_file.telemetry)
             except Exception:
                 pass
 
         except Exception as exc:
             logger.exception("Failed to export stats for user %s", ctx.author.id)
-            await ctx.respond(
-                f"❌ Export failed: {type(exc).__name__}\n\nPlease try again or contact support.",
+            await ctx.followup.send(
+                f"Export failed: {type(exc).__name__}\n\nPlease try again or contact support.",
                 ephemeral=True,
             )
 
         finally:
-            # CRITICAL: Always cleanup temp files, even on error
-            if file_path and os.path.exists(file_path):
-                try:
-                    os.unlink(file_path)
-                    logger.debug("Cleaned up temp file: %s", file_path)
-                except Exception as e:
-                    logger.warning("Failed to cleanup temp file %s: %s", file_path, e)
-
-            if temp_dir and os.path.exists(temp_dir):
-                try:
-                    os.rmdir(temp_dir)
-                    logger.debug("Cleaned up temp directory: %s", temp_dir)
-                except Exception as e:
-                    logger.warning("Failed to cleanup temp directory %s: %s", temp_dir, e)
+            stats_export_service.cleanup_export_file(export_file)
 
     @bot.slash_command(
         name="player_stats",
@@ -1031,13 +849,17 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             int, "Governor ID (optional)", required=False, default=None
         ),
     ):
-        await ctx.defer(ephemeral=ephemeral)
+        await safe_defer(ctx, ephemeral=ephemeral)
 
-        registry = await asyncio.to_thread(load_registry) or {}
-        user_id = str(ctx.user.id)
-        payload = registry.get(user_id) or {}
+        account_summary = await stats_account_service.get_account_summary_for_user(ctx.user.id)
+        if not account_summary.ok and not governor_id:
+            await ctx.followup.send(
+                f"Registry is temporarily unavailable: `{account_summary.error}`",
+                ephemeral=True,
+            )
+            return
         account_map = kvk_history_service.build_ordered_account_map(
-            payload.get("accounts") or {}
+            account_summary.ordered_accounts
         )  # {label: {GovernorID, GovernorName}}
 
         # If a Governor ID is provided, build a minimal map for it (works even with no registry)
@@ -1057,7 +879,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
                 gov_name = str(governor_id)
             account_map = {"Lookup": {"GovernorID": int(governor_id), "GovernorName": gov_name}}
         elif not account_map:
-            await ctx.respond(
+            await ctx.followup.send(
                 "❌ You haven't registered any accounts yet. Use `/register_governor` or pass a Governor ID here.",
                 ephemeral=True,
             )
@@ -1070,7 +892,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             else kvk_history_service.pick_default_governor_id(account_map)
         )
         if not default_id:
-            await ctx.respond(
+            await ctx.followup.send(
                 "❌ I couldn't find a valid Governor ID in your registered accounts.",
                 ephemeral=True,
             )
@@ -1108,12 +930,12 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
 
         Users can change sort metric and limit via dropdown/buttons.
         """
-        await ctx.defer()
+        await safe_defer(ctx, ephemeral=False)
 
         cache = load_stat_cache()
         rows = [r for k, r in cache.items() if k != "_meta"]
         if not rows:
-            await ctx.respond(
+            await ctx.followup.send(
                 "⚠️ No stats cache available yet. Try again after the next scan/export."
             )
             return
@@ -1127,7 +949,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             last_ref = cache.get("_meta", {}).get("generated_at") or "unknown"
             embed.set_footer(text=f"Last refreshed: {last_ref}")
 
-        resp = await ctx.respond(embed=embed, view=view)
+        resp = await ctx.followup.send(embed=embed, view=view)
         try:
             view.message = await ctx.interaction.original_response()
         except Exception:
@@ -1390,12 +1212,12 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
 
         if not rows:
             # graceful response if DB has no honor data
-            await ctx.respond("No honor data found for the latest KVK.", ephemeral=False)
+            await ctx.followup.send("No honor data found for the latest KVK.", ephemeral=False)
             return
 
         embed = build_honor_rankings_embed(rows, limit=initial_limit)
         view = HonorRankingView()
-        await ctx.respond(embed=embed, view=view, ephemeral=False)
+        await ctx.followup.send(embed=embed, view=view, ephemeral=False)
 
     @bot.slash_command(
         name="honor_purge_last",
@@ -1407,7 +1229,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
     @safe_command
     @track_usage()
     async def honor_purge_last(ctx: discord.ApplicationContext):
-        await ctx.defer(ephemeral=True)
+        await safe_defer(ctx, ephemeral=True)
 
         deleted = await asyncio.to_thread(purge_latest_honor_scan)
 
@@ -1421,4 +1243,4 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             color = discord.Color.dark_grey()
 
         embed = discord.Embed(title=title, description=desc, color=color)
-        await ctx.respond(embed=embed, ephemeral=True)
+        await ctx.followup.send(embed=embed, ephemeral=True)

--- a/docs/Codex Task Pack — Stats Commands Full Optimisation & Standardisation.md
+++ b/docs/Codex Task Pack — Stats Commands Full Optimisation & Standardisation.md
@@ -1,0 +1,448 @@
+
+# Codex Task Pack — Stats Commands Full Optimisation & Standardisation
+
+## Goal
+
+Perform a full standards-alignment, optimisation, architecture review, and cleanup pass over `commands/stats_cmds.py` and all directly associated stats command files.
+
+This is intended to be a complete polish batch, not a narrow bug fix.
+
+The end state should leave the stats command subsystem fully aligned to current engineering standards, service/DAL boundaries, restart-safety expectations, testing standards, and command-layer architecture rules.
+
+---
+
+# 🧭 Context
+
+This project uses two repositories:
+
+| Repo                         | Purpose                                |
+| ---------------------------- | -------------------------------------- |
+| `cwatts6/K98-bot-mirror`     | Python Discord bot                     |
+| `cwatts6/K98-bot-SQL-Server` | SQL Server schema and database objects |
+
+---
+
+# 📚 Required Reading Order (MANDATORY)
+
+Before implementation, review in this order:
+AGENTS.md
+1. feature specification or task overview
+2. `K98 Bot — Project Engineering Standards.md`
+3. `K98 Bot — Coding Execution Guidelines.md`
+4. `K98 Bot — Testing Standards.md`
+5. `K98 Bot — Skills & Refactor Triggers.md`
+6. `K98 Bot — Deferred Optimisation Framework.md`
+7. `docs/deferred_optimisations.md`
+8. `commands/stats_cmds.py`
+
+If documents conflict, follow the priority defined in Coding Execution Guidelines.
+
+---
+
+# ⚠️ Critical Execution Rules
+
+## Scope Control
+
+* Do NOT expand scope beyond the requested task
+* Do NOT silently ignore improvements
+* ALL out-of-scope improvements MUST be captured using the Deferred Optimisation Framework
+
+---
+
+# 🔍 Mandatory Working Method
+
+# Step 1 — Audit First (MANDATORY)
+
+STOP after this step unless explicitly asked to proceed in one pass.
+
+You MUST:
+
+## Analyse the current implementation
+
+Identify:
+
+* direct SQL in commands/views
+* business logic in interaction layers
+* duplicate helpers
+* dead code from prior iterations
+* weak validation or logging
+* restart/persistence risks
+* inconsistent interaction response handling
+* inconsistent defer/respond/followup flows
+* direct registry dict traversal
+* duplicated governor/account resolution logic
+* duplicated cache access patterns
+* embed/view ownership inconsistencies
+* service/DAL boundary violations
+* long command handlers that should be decomposed
+* commands performing orchestration and business logic together
+
+## Also map:
+
+* modules involved
+* services
+* SQL objects
+* views
+* caches
+* restart implications
+* export pipelines
+* registry dependencies
+* embed builders
+* exporters
+* DAL/service ownership
+
+## SQL Validation (MANDATORY)
+
+Before implementation:
+
+1. Search the SQL repo:
+   `C:\K98-bot-SQL-Server`
+
+2. Validate:
+
+   * procedure dependencies
+   * table schemas
+   * expected output columns
+   * dynamic SQL targets
+   * ProcConfig usage
+
+3. If live SQL access fails:
+
+   * use the SQL repo as the authoritative source
+   * do NOT fall back to guessed schema
+
+## Required Step 1 Output
+
+Provide:
+
+1. Files inspected
+2. Related GitHub issues found
+3. Deferred optimisations found
+4. Architecture violations identified
+5. Restart/state risks
+6. Proposed implementation plan
+7. Risk assessment
+
+STOP after Step 1.
+
+Do NOT code until confirmed.
+
+---
+
+# Step 2 — Deferred Optimisation Capture (MANDATORY)
+
+For ALL out-of-scope findings:
+
+```md
+### Deferred Optimisation
+- Area: <module/file>
+- Type: performance | architecture | cleanup | refactor | consistency
+- Description: <issue>
+- Suggested Fix: <proposal>
+- Impact: low | medium | high
+- Risk: low | medium | high
+- Dependencies: <optional>
+```
+
+## Rules
+
+* Do NOT leave unstructured notes
+* Do NOT say “could be improved later”
+* Group related items where possible
+* Do NOT implement unless approved
+
+---
+
+# Step 3 — Architecture Validation
+
+STOP and confirm before coding.
+
+Validate:
+
+* correct layer placement
+* services own business logic
+* commands/views remain thin
+* SQL is not in command/view layers
+* helper reuse has been checked
+* restart safety implications reviewed
+* registry service boundaries respected
+* cache access patterns centralised where practical
+
+---
+
+# Step 4 — Implementation Plan
+
+STOP and confirm before coding.
+
+Provide:
+
+* files to create
+* files to modify
+* SQL changes
+* services/repositories required
+* helpers to reuse
+* logging plan
+* restart safety approach
+* testing plan
+* refactor items to fix now vs defer
+
+---
+
+# Step 5 — Implementation
+
+Must:
+
+* follow engineering standards
+* keep commands/views thin
+* move business logic into services
+* avoid direct SQL in commands/views
+* reuse helpers
+* maintain restart safety
+* add logging
+* preserve existing Discord UX unless explicitly improving consistency
+* preserve existing command outputs unless fixing bugs or inconsistencies
+
+---
+
+# Step 6 — Testing
+
+Must include:
+
+* happy path
+* negative path
+* regression
+* restart/persistence where relevant
+
+## Required Stats Coverage
+
+Add or update focused tests for:
+
+* stats export service/DAL boundary
+* no registered accounts
+* empty export data
+* export format selection
+* registry/account resolution
+* command/service handoff
+* KVK history account-map fallback
+* rankings cache empty path
+* interaction defer/respond safety where testable
+* embed/view orchestration behaviour where practical
+
+## DB Test Rules
+
+Where live DB is required:
+
+* mark as integration
+* gate behind `RUN_DB_TESTS=1`
+
+If not implemented:
+
+* explicitly justify
+* capture as deferred optimisation if appropriate
+
+---
+
+# Step 7 — Codex Review Pass (MANDATORY)
+
+After implementation and testing:
+
+Perform a read-only audit.
+
+## MUST validate
+
+* architecture compliance
+* refactor triggers
+* test coverage correctness
+* restart/state safety
+* logging quality
+* service/DAL boundaries
+* command thinness
+* helper reuse
+
+## MUST NOT
+
+* expand scope
+* add features
+* perform large refactors
+
+## Required Output
+
+```md
+## Codex Review Summary
+
+### What is correct
+
+### Issues found (fix now)
+
+### Deferred Optimisations
+
+### Test Gaps
+
+### Restart / State Risks
+
+### Overall Assessment
+```
+
+---
+
+# 🎯 Required Scope
+
+Review and resolve all stats-related deferred optimisations and GitHub issues, including:
+
+* #27 dict-style registry access
+* #28 legacy registry views (where touched by stats flows)
+* #29 stats-service registry alignment
+* #31 governor registry architecture refactor (stats-related parts only)
+* #32 service layer consolidation (stats-related parts only)
+* #42 remaining KVK admin SQL/service extraction
+* #46 extract `/my_stats_export` SQL into service/DAL
+
+Also review:
+
+* `docs/deferred_optimisations.md`
+
+Resolve or update any stats-related entries.
+
+---
+
+# 🎯 Target Outcomes
+
+## 1. Thin Command Layer
+
+`commands/stats_cmds.py` should only handle:
+
+* slash command registration
+* permission/decorator flow
+* defer/respond/followup behaviour
+* calling services
+* presenting final embeds/views/files
+
+Move business logic into services/helpers.
+
+---
+
+## 2. Remove Direct SQL From Commands
+
+Extract `/my_stats_export` direct SQL into a dedicated service/DAL boundary.
+
+Suggested structure:
+
+* `stats/dal/stats_export_dal.py`
+* `services/stats_export_service.py`
+
+The command should delegate entirely to service orchestration.
+
+---
+
+## 3. Registry Alignment
+
+Remove direct `load_registry()` and dict traversal from stats command flows where practical.
+
+Prefer canonical service boundaries:
+
+* `registry_service.get_user_accounts()`
+* existing governor/account services
+* shared account mapping helpers
+
+Likely affected:
+
+* `/mykvkstats`
+* `/my_stats`
+* `/my_stats_export`
+* `/player_stats`
+* `/mykvkhistory`
+
+---
+
+## 4. Consolidate Duplicate Account Resolution Logic
+
+Avoid each command rebuilding:
+
+* Governor ID lists
+* Governor name maps
+* Main/default account selection
+* ordered account maps
+* fallback account resolution
+
+Introduce reusable helpers/services where sensible.
+
+---
+
+## 5. Interaction Safety Consistency
+
+Audit every command for:
+
+* `safe_defer` vs raw `ctx.defer`
+* `ctx.respond` after defer problems
+* ephemeral/public consistency
+* fallback send/edit behaviour
+* timeout/message-reference handling
+
+Do not regress UX.
+
+---
+
+## 6. Preserve Discord UX
+
+Do NOT regress:
+
+* `/mykvkstats`
+* `/my_stats`
+* `/my_stats_export`
+* `/player_stats`
+* `/mykvkhistory`
+* `/kvk_rankings`
+* `/kvk_export_all`
+* `/kvk_recompute`
+* `/kvk_list_scans`
+* `/test_kvk_embed`
+* `/kvk_window_preview`
+* `/honor_rankings`
+* `/honor_purge_last`
+
+Preserve existing output copy unless improving consistency or fixing defects.
+
+---
+
+# 📦 Required Delivery Format
+
+You MUST include:
+
+* summary
+* file manifest
+* new files
+* modified files
+* SQL changes
+* helpers reused
+* refactor findings
+* test plan
+* deployment steps
+* Deferred Optimisations (MANDATORY structured section)
+
+---
+
+# 🚨 Failure Conditions
+
+The task is NOT complete if:
+
+* ❌ Deferred optimisations are missing
+* ❌ Notes are unstructured
+* ❌ Technical debt is silently ignored
+* ❌ Scope expanded without approval
+* ❌ Direct SQL remains in command/view layers unnecessarily
+* ❌ Registry dict traversal remains where service boundaries exist
+* ❌ Restart/state risks are not reviewed
+
+---
+
+# 🎯 Goal
+
+Deliver output that is:
+
+* architecture-compliant
+* production-quality
+* restart-safe
+* test-backed
+* explicit about refactor decisions
+* structured for future optimisation batching
+* fully aligned to current K98 engineering standards

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -35,15 +35,6 @@
 - Dependencies: Confirm no production reports or manual SQL workflows still depend on scan-window phase objects.
 
 ### Deferred Optimisation
-- Area: `commands/stats_cmds.py` `/my_stats_export`
-- Type: architecture
-- Description: The non-KVK `/my_stats_export` path still contains direct SQL for `vDaily_PlayerExport` inside the command handler.
-- Suggested Fix: Extract daily stats export data access into a stats export DAL/service and leave the command responsible only for permission, defer, file-send, and response flow.
-- Impact: medium
-- Risk: medium
-- Dependencies: Future stats command cleanup; preserve existing Excel/CSV/Google Sheets-compatible output copy and file workflow.
-
-### Deferred Optimisation
 - Area: `DL_bot.py` KVK_ALL upload routing
 - Type: architecture
 - Description: KVK_ALL upload routing still lives in the legacy root bot listener with attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling mixed together.
@@ -54,6 +45,7 @@
 
 ## Recently Resolved
 
+- Stats Commands Full Optimisation & Standardisation extracted `/my_stats_export` SQL into `stats/dal/stats_export_dal.py` and `services/stats_export_service.py`, aligned stats account resolution through the SQL-backed registry service boundary, and added the missing SQL source contract for `dbo.IntList`.
 - Telemetry Commands Full Optimisation & Standardisation was implemented, merged, production promoted, and smoke-tested via PR #76.
 - The following telemetry deferred items are closed and complete:
   - `commands/telemetry_cmds.py` no longer imports or wraps the KVK DAL current-KVK resolver, resolving GitHub issue #26.

--- a/services/kvk_personal_service.py
+++ b/services/kvk_personal_service.py
@@ -14,6 +14,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from registry import registry_service
 import stats_cache_helpers
 
 if TYPE_CHECKING:
@@ -32,12 +33,8 @@ async def resolve_user_accounts(user_id: int) -> dict:
     Logs the outcome with user_id.
     """
     try:
-        from registry.governor_registry import load_registry
-
-        registry = await asyncio.to_thread(load_registry)
-        registry = registry or {}
-        user_block = registry.get(str(user_id)) or registry.get(user_id) or {}
-        accounts = user_block.get("accounts") or {}
+        accounts = await asyncio.to_thread(registry_service.get_user_accounts, int(user_id))
+        accounts = accounts or {}
         logger.debug(
             "[kvk_personal_service] resolve_user_accounts user_id=%s accounts_count=%s",
             user_id,

--- a/services/stats_account_service.py
+++ b/services/stats_account_service.py
@@ -1,0 +1,97 @@
+"""Canonical account resolution helpers for stats command flows."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+
+from registry import registry_service
+from registry.account_slots import ACCOUNT_ORDER
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class StatsAccountSummary:
+    ok: bool
+    accounts: dict[str, dict[str, str]]
+    ordered_accounts: dict[str, dict[str, str]]
+    governor_ids: list[int]
+    account_names: list[str]
+    name_to_id: dict[str, int]
+    default_choice: str
+    error: str | None = None
+
+    @property
+    def has_accounts(self) -> bool:
+        return bool(self.governor_ids)
+
+
+def order_accounts(accounts: dict[str, dict[str, str]]) -> dict[str, dict[str, str]]:
+    ordered: dict[str, dict[str, str]] = {}
+    for slot in ACCOUNT_ORDER:
+        if slot in accounts:
+            ordered[slot] = dict(accounts[slot] or {})
+    for slot in sorted(accounts):
+        if slot not in ordered:
+            ordered[slot] = dict(accounts[slot] or {})
+    return ordered
+
+
+def summarize_accounts(accounts: dict[str, dict[str, str]]) -> StatsAccountSummary:
+    ordered_accounts = order_accounts(accounts or {})
+    governor_ids: list[int] = []
+    account_names: list[str] = []
+    name_to_id: dict[str, int] = {}
+
+    for info in ordered_accounts.values():
+        try:
+            gid = int(str(info.get("GovernorID") or info.get("GovernorId") or "").strip())
+        except (TypeError, ValueError):
+            continue
+        if gid <= 0:
+            continue
+        if gid not in governor_ids:
+            governor_ids.append(gid)
+        name = str(info.get("GovernorName") or info.get("governor_name") or "").strip()
+        if name:
+            account_names.append(name)
+            name_to_id[name] = gid
+
+    default_choice = "ALL"
+    main = ordered_accounts.get("Main") or {}
+    main_name = str(main.get("GovernorName") or "").strip()
+    if main_name and main_name in name_to_id:
+        default_choice = main_name
+    elif account_names:
+        default_choice = account_names[0]
+
+    return StatsAccountSummary(
+        ok=True,
+        accounts=dict(accounts or {}),
+        ordered_accounts=ordered_accounts,
+        governor_ids=governor_ids,
+        account_names=account_names,
+        name_to_id=name_to_id,
+        default_choice=default_choice,
+    )
+
+
+async def get_account_summary_for_user(discord_user_id: int) -> StatsAccountSummary:
+    """Load and normalize registered stats accounts for one Discord user."""
+    try:
+        accounts = await asyncio.to_thread(registry_service.get_user_accounts, int(discord_user_id))
+    except Exception as exc:
+        logger.exception("stats_account_lookup_failed discord_user_id=%s", discord_user_id)
+        return StatsAccountSummary(
+            ok=False,
+            accounts={},
+            ordered_accounts={},
+            governor_ids=[],
+            account_names=[],
+            name_to_id={},
+            default_choice="ALL",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    return summarize_accounts(dict(accounts or {}))

--- a/services/stats_export_service.py
+++ b/services/stats_export_service.py
@@ -56,7 +56,7 @@ def cleanup_export_file(export_file: StatsExportFile | None) -> None:
             )
     if export_file.temp_dir and os.path.exists(export_file.temp_dir):
         try:
-            shutil.rmtree(export_file.temp_dir, ignore_errors=True)
+            shutil.rmtree(export_file.temp_dir)
             logger.debug("stats_export_temp_dir_cleaned path=%s", export_file.temp_dir)
         except Exception:
             logger.warning(
@@ -204,7 +204,7 @@ async def _build_export_file(
 
 
 def _build_export_target(*, export_format: str, safe_name: str, timestamp: str, temp_dir: str) -> tuple[str, str]:
-    """Build the export filename and absolute path for the selected format."""
+    """Build export target and return (filename, absolute_path)."""
     extension = ".csv" if export_format == "CSV" else ".xlsx"
     filename = f"stats_{safe_name}_{timestamp}{extension}"
     return filename, os.path.join(temp_dir, filename)

--- a/services/stats_export_service.py
+++ b/services/stats_export_service.py
@@ -106,6 +106,7 @@ async def build_personal_stats_export(
     try:
         export_file = await _build_export_file(
             df_daily=df_daily,
+            temp_dir=temp_dir,
             file_path=file_path,
             filename=filename,
             export_format=export_format,
@@ -151,6 +152,7 @@ async def _fetch_daily(governor_ids: list[int]) -> pd.DataFrame:
 async def _build_export_file(
     *,
     df_daily: pd.DataFrame,
+    temp_dir: str,
     file_path: str,
     filename: str,
     export_format: str,
@@ -188,7 +190,7 @@ async def _build_export_file(
     }
     return StatsExportFile(
         file_path=file_path,
-        temp_dir=os.path.dirname(file_path),
+        temp_dir=temp_dir,
         filename=filename,
         format_name=meta["name"],
         format_emoji=meta["emoji"],
@@ -202,6 +204,7 @@ async def _build_export_file(
 
 
 def _build_export_target(*, export_format: str, safe_name: str, timestamp: str, temp_dir: str) -> tuple[str, str]:
+    """Build the export filename and absolute path for the selected format."""
     extension = ".csv" if export_format == "CSV" else ".xlsx"
     filename = f"stats_{safe_name}_{timestamp}{extension}"
     return filename, os.path.join(temp_dir, filename)

--- a/services/stats_export_service.py
+++ b/services/stats_export_service.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import logging
 import os
+import shutil
 import tempfile
 
 import pandas as pd
@@ -55,7 +56,7 @@ def cleanup_export_file(export_file: StatsExportFile | None) -> None:
             )
     if export_file.temp_dir and os.path.exists(export_file.temp_dir):
         try:
-            os.rmdir(export_file.temp_dir)
+            shutil.rmtree(export_file.temp_dir, ignore_errors=True)
             logger.debug("stats_export_temp_dir_cleaned path=%s", export_file.temp_dir)
         except Exception:
             logger.warning(
@@ -95,13 +96,18 @@ async def build_personal_stats_export(
     timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
     safe_name = _safe_filename_part(display_name) or "user"
     temp_dir = tempfile.mkdtemp()
+    filename, file_path = _build_export_target(
+        export_format=export_format,
+        safe_name=safe_name,
+        timestamp=timestamp,
+        temp_dir=temp_dir,
+    )
 
     try:
         export_file = await _build_export_file(
             df_daily=df_daily,
-            temp_dir=temp_dir,
-            safe_name=safe_name,
-            timestamp=timestamp,
+            file_path=file_path,
+            filename=filename,
             export_format=export_format,
             days=days,
             governor_ids=account_summary.governor_ids,
@@ -110,9 +116,9 @@ async def build_personal_stats_export(
     except Exception:
         cleanup_export_file(
             StatsExportFile(
-                file_path="",
+                file_path=file_path,
                 temp_dir=temp_dir,
-                filename="",
+                filename=filename,
                 format_name=export_format,
                 format_emoji="",
                 description="",
@@ -145,9 +151,8 @@ async def _fetch_daily(governor_ids: list[int]) -> pd.DataFrame:
 async def _build_export_file(
     *,
     df_daily: pd.DataFrame,
-    temp_dir: str,
-    safe_name: str,
-    timestamp: str,
+    file_path: str,
+    filename: str,
     export_format: str,
     days: int,
     governor_ids: list[int],
@@ -156,8 +161,6 @@ async def _build_export_file(
     import asyncio
 
     if export_format == "CSV":
-        filename = f"stats_{safe_name}_{timestamp}.csv"
-        file_path = os.path.join(temp_dir, filename)
         await asyncio.to_thread(
             build_user_stats_csv,
             df_daily,
@@ -166,8 +169,6 @@ async def _build_export_file(
             days_for_daily_table=days,
         )
     else:
-        filename = f"stats_{safe_name}_{timestamp}.xlsx"
-        file_path = os.path.join(temp_dir, filename)
         await asyncio.to_thread(
             build_user_stats_excel,
             df_daily,
@@ -187,7 +188,7 @@ async def _build_export_file(
     }
     return StatsExportFile(
         file_path=file_path,
-        temp_dir=temp_dir,
+        temp_dir=os.path.dirname(file_path),
         filename=filename,
         format_name=meta["name"],
         format_emoji=meta["emoji"],
@@ -198,6 +199,12 @@ async def _build_export_file(
         days=days,
         telemetry=telemetry,
     )
+
+
+def _build_export_target(*, export_format: str, safe_name: str, timestamp: str, temp_dir: str) -> tuple[str, str]:
+    extension = ".csv" if export_format == "CSV" else ".xlsx"
+    filename = f"stats_{safe_name}_{timestamp}{extension}"
+    return filename, os.path.join(temp_dir, filename)
 
 
 def _normalize_format(value: str) -> str:

--- a/services/stats_export_service.py
+++ b/services/stats_export_service.py
@@ -1,0 +1,266 @@
+"""Service orchestration for personal stats exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import logging
+import os
+import tempfile
+
+import pandas as pd
+
+from services import stats_account_service
+from stats.dal import stats_export_dal
+from stats_exporter import build_user_stats_excel
+from stats_exporter_csv import build_user_stats_csv
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class StatsExportFile:
+    file_path: str
+    temp_dir: str
+    filename: str
+    format_name: str
+    format_emoji: str
+    description: str
+    instructions: str
+    governor_ids: list[int]
+    row_count: int
+    days: int
+    telemetry: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class StatsExportOutcome:
+    status: str
+    message: str | None = None
+    export_file: StatsExportFile | None = None
+
+
+def cleanup_export_file(export_file: StatsExportFile | None) -> None:
+    if export_file is None:
+        return
+    if export_file.file_path and os.path.exists(export_file.file_path):
+        try:
+            os.unlink(export_file.file_path)
+            logger.debug("stats_export_temp_file_cleaned path=%s", export_file.file_path)
+        except Exception:
+            logger.warning(
+                "stats_export_temp_file_cleanup_failed path=%s",
+                export_file.file_path,
+                exc_info=True,
+            )
+    if export_file.temp_dir and os.path.exists(export_file.temp_dir):
+        try:
+            os.rmdir(export_file.temp_dir)
+            logger.debug("stats_export_temp_dir_cleaned path=%s", export_file.temp_dir)
+        except Exception:
+            logger.warning(
+                "stats_export_temp_dir_cleanup_failed path=%s",
+                export_file.temp_dir,
+                exc_info=True,
+            )
+
+
+async def build_personal_stats_export(
+    *,
+    discord_user_id: int,
+    display_name: str,
+    requested_format: str,
+    days: int,
+) -> StatsExportOutcome:
+    account_summary = await stats_account_service.get_account_summary_for_user(discord_user_id)
+    if not account_summary.ok:
+        return StatsExportOutcome(
+            status="registry_error",
+            message=f"Registry is temporarily unavailable: `{account_summary.error}`",
+        )
+    if not account_summary.governor_ids:
+        return StatsExportOutcome(
+            status="no_accounts",
+            message="You have no registered accounts. Use `/register_governor` first.",
+        )
+
+    df_daily = await _fetch_daily(account_summary.governor_ids)
+    if df_daily.empty:
+        return StatsExportOutcome(
+            status="no_data",
+            message="No stats data found for your accounts.",
+        )
+
+    export_format = _normalize_format(requested_format)
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    safe_name = _safe_filename_part(display_name) or "user"
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        export_file = await _build_export_file(
+            df_daily=df_daily,
+            temp_dir=temp_dir,
+            safe_name=safe_name,
+            timestamp=timestamp,
+            export_format=export_format,
+            days=days,
+            governor_ids=account_summary.governor_ids,
+            discord_user_id=discord_user_id,
+        )
+    except Exception:
+        cleanup_export_file(
+            StatsExportFile(
+                file_path="",
+                temp_dir=temp_dir,
+                filename="",
+                format_name=export_format,
+                format_emoji="",
+                description="",
+                instructions="",
+                governor_ids=account_summary.governor_ids,
+                row_count=len(df_daily),
+                days=days,
+                telemetry={},
+            )
+        )
+        raise
+
+    logger.info(
+        "stats_export_ready user_id=%s format=%s days=%s governors=%s rows=%s",
+        discord_user_id,
+        export_format,
+        days,
+        len(account_summary.governor_ids),
+        len(df_daily),
+    )
+    return StatsExportOutcome(status="ok", export_file=export_file)
+
+
+async def _fetch_daily(governor_ids: list[int]) -> pd.DataFrame:
+    import asyncio
+
+    return await asyncio.to_thread(stats_export_dal.fetch_daily_player_export, governor_ids)
+
+
+async def _build_export_file(
+    *,
+    df_daily: pd.DataFrame,
+    temp_dir: str,
+    safe_name: str,
+    timestamp: str,
+    export_format: str,
+    days: int,
+    governor_ids: list[int],
+    discord_user_id: int,
+) -> StatsExportFile:
+    import asyncio
+
+    if export_format == "CSV":
+        filename = f"stats_{safe_name}_{timestamp}.csv"
+        file_path = os.path.join(temp_dir, filename)
+        await asyncio.to_thread(
+            build_user_stats_csv,
+            df_daily,
+            None,
+            out_path=file_path,
+            days_for_daily_table=days,
+        )
+    else:
+        filename = f"stats_{safe_name}_{timestamp}.xlsx"
+        file_path = os.path.join(temp_dir, filename)
+        await asyncio.to_thread(
+            build_user_stats_excel,
+            df_daily,
+            None,
+            out_path=file_path,
+            days_for_daily_table=days,
+        )
+
+    meta = _format_metadata(export_format)
+    telemetry = {
+        "event": "my_stats_export",
+        "user_id": discord_user_id,
+        "format": export_format,
+        "days": days,
+        "num_governors": len(governor_ids),
+        "num_rows": len(df_daily),
+    }
+    return StatsExportFile(
+        file_path=file_path,
+        temp_dir=temp_dir,
+        filename=filename,
+        format_name=meta["name"],
+        format_emoji=meta["emoji"],
+        description=meta["description"],
+        instructions=meta["instructions"],
+        governor_ids=list(governor_ids),
+        row_count=len(df_daily),
+        days=days,
+        telemetry=telemetry,
+    )
+
+
+def _normalize_format(value: str) -> str:
+    cleaned = (value or "Excel").strip()
+    if cleaned in {"CSV", "GoogleSheets"}:
+        return cleaned
+    return "Excel"
+
+
+def _safe_filename_part(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value.strip())
+    return cleaned.strip("_")[:80]
+
+
+def _format_metadata(export_format: str) -> dict[str, str]:
+    if export_format == "CSV":
+        return {
+            "emoji": "📄",
+            "name": "CSV",
+            "description": "**Lightweight text-based format**\nOpen with any spreadsheet app.",
+            "instructions": (
+                "**💻 Desktop:**\n"
+                "1. Download the attached file\n"
+                "2. Open with Excel, Google Sheets, or any spreadsheet app\n\n"
+                "**📱 Mobile:**\n"
+                "• **iPhone/iPad:** Tap attachment → Share → Save to Files → Open with Numbers or Google Sheets\n"
+                "• **Android:** Tap attachment → Download → Open with Google Sheets or Excel"
+            ),
+        }
+    if export_format == "GoogleSheets":
+        return {
+            "emoji": "📊",
+            "name": "Google Sheets",
+            "description": "**Google Sheets-compatible format**\nUpload to Google Drive to open in Sheets.",
+            "instructions": (
+                "**💻 Desktop:**\n"
+                "1. Download the attached file\n"
+                "2. Go to [drive.google.com](https://drive.google.com)\n"
+                "3. Click **New** → **File upload**\n"
+                "4. Upload this file → Double-click to open in Google Sheets\n\n"
+                "**📱 Mobile:**\n"
+                "• **iPhone/iPad:**\n"
+                "  1. Tap attachment → Share → Save to Files\n"
+                "  2. Open Google Drive app\n"
+                "  3. Tap **+** → **Upload** → Select file from Files\n"
+                "  4. Tap file in Drive to open in Sheets\n\n"
+                "• **Android:**\n"
+                "  1. Tap attachment → Download\n"
+                "  2. Open Google Drive app\n"
+                "  3. Tap **+** → **Upload** → Select downloaded file\n"
+                "  4. Tap file in Drive to open in Sheets"
+            ),
+        }
+    return {
+        "emoji": "📘",
+        "name": "Excel",
+        "description": "**Full-featured Excel workbook**\nIncludes charts, formatting, and multiple sheets.",
+        "instructions": (
+            "**💻 Desktop:**\n"
+            "1. Download the attached file\n"
+            "2. Open with Microsoft Excel, LibreOffice, or Numbers\n\n"
+            "**📱 Mobile:**\n"
+            "• **iPhone/iPad:** Tap attachment → Share → Open in Excel or Numbers\n"
+            "• **Android:** Tap attachment → Open with Excel or Google Sheets"
+        ),
+    }

--- a/services/stats_export_service.py
+++ b/services/stats_export_service.py
@@ -203,7 +203,9 @@ async def _build_export_file(
     )
 
 
-def _build_export_target(*, export_format: str, safe_name: str, timestamp: str, temp_dir: str) -> tuple[str, str]:
+def _build_export_target(
+    *, export_format: str, safe_name: str, timestamp: str, temp_dir: str
+) -> tuple[str, str]:
     """Build export target and return (filename, absolute_path)."""
     extension = ".csv" if export_format == "CSV" else ".xlsx"
     filename = f"stats_{safe_name}_{timestamp}{extension}"

--- a/stats/__init__.py
+++ b/stats/__init__.py
@@ -1,0 +1,2 @@
+"""Stats subsystem package."""
+

--- a/stats/__init__.py
+++ b/stats/__init__.py
@@ -1,2 +1,1 @@
 """Stats subsystem package."""
-

--- a/stats/dal/__init__.py
+++ b/stats/dal/__init__.py
@@ -1,0 +1,2 @@
+"""Stats data-access layer."""
+

--- a/stats/dal/__init__.py
+++ b/stats/dal/__init__.py
@@ -1,2 +1,1 @@
 """Stats data-access layer."""
-

--- a/stats/dal/stats_export_dal.py
+++ b/stats/dal/stats_export_dal.py
@@ -1,0 +1,93 @@
+"""Data access for personal stats exports."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import logging
+
+import pandas as pd
+
+from file_utils import get_conn_with_retries
+
+logger = logging.getLogger(__name__)
+
+EXPORT_COLUMNS = [
+    "GovernorID",
+    "GovernorName",
+    "Alliance",
+    "AsOfDate",
+    "Power",
+    "PowerDelta",
+    "TroopPower",
+    "TroopPowerDelta",
+    "KillPoints",
+    "KillPointsDelta",
+    "Deads",
+    "DeadsDelta",
+    "RSS_Gathered",
+    "RSS_GatheredDelta",
+    "RSSAssist",
+    "RSSAssistDelta",
+    "Helps",
+    "HelpsDelta",
+    "BuildingMinutes",
+    "TechDonations",
+    "FortsTotal",
+    "FortsLaunched",
+    "FortsJoined",
+    "AOOJoined",
+    "AOOJoinedDelta",
+    "AOOWon",
+    "AOOWonDelta",
+    "AOOAvgKill",
+    "AOOAvgKillDelta",
+    "AOOAvgDead",
+    "AOOAvgDeadDelta",
+    "AOOAvgHeal",
+    "AOOAvgHealDelta",
+    "T4_Kills",
+    "T4_KillsDelta",
+    "T5_Kills",
+    "T5_KillsDelta",
+    "T4T5_Kills",
+    "T4T5_KillsDelta",
+    "HealedTroops",
+    "HealedTroopsDelta",
+    "RangedPoints",
+    "RangedPointsDelta",
+    "HighestAcclaim",
+    "HighestAcclaimDelta",
+    "AutarchTimes",
+    "AutarchTimesDelta",
+]
+
+
+def empty_export_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=EXPORT_COLUMNS)
+
+
+def fetch_daily_player_export(governor_ids: Sequence[int]) -> pd.DataFrame:
+    """Return personal daily export rows for the supplied governor IDs."""
+    ids = [int(gid) for gid in governor_ids if int(gid) > 0]
+    if not ids:
+        return empty_export_frame()
+
+    placeholders = ",".join("?" for _ in ids)
+    columns_sql = ", ".join(EXPORT_COLUMNS)
+    query = f"""
+    SELECT {columns_sql}
+    FROM dbo.vDaily_PlayerExport
+    WHERE GovernorID IN ({placeholders})
+    ORDER BY GovernorID, AsOfDate DESC;
+    """
+
+    logger.debug("stats_export_fetch governor_count=%s", len(ids))
+    conn = get_conn_with_retries()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(query, ids)
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description] if cursor.description else EXPORT_COLUMNS
+        return pd.DataFrame.from_records(rows, columns=columns)
+    finally:
+        conn.close()

--- a/stats_service.py
+++ b/stats_service.py
@@ -12,7 +12,7 @@ from file_utils import (
     fetch_one_dict,
     get_conn_with_retries,
 )
-from registry.governor_registry import load_registry
+from services import stats_account_service
 from stats_helpers import is_single_day_slice
 from utils import csv_from_ids, ensure_aware_utc, to_ints
 
@@ -35,60 +35,15 @@ def _key(discord_id: int, slice_key: str, gov_ids: list[int]) -> tuple[int, str,
 
 
 async def get_registered_governor_ids_for_discord(discord_id: int) -> list[int]:
-    """Read accounts from governor_registry.JSON (not SQL)."""
-    try:
-        from file_utils import run_blocking_in_thread
-    except Exception:
-        run_blocking_in_thread = None
-
-    if run_blocking_in_thread is not None:
-        reg = await run_blocking_in_thread(
-            load_registry,
-            name="load_registry_for_ids",
-            meta={"discord_id": discord_id},
-        )
-    else:
-        reg = await asyncio.to_thread(load_registry)
-    reg = reg or {}
-    block = reg.get(str(discord_id)) or reg.get(discord_id) or {}
-    accounts = block.get("accounts") or {}
-    raw_ids = [acc.get("GovernorID") for acc in accounts.values() if acc]
-    return to_ints(raw_ids)
+    """Read registered account IDs through the SQL-backed registry service boundary."""
+    summary = await stats_account_service.get_account_summary_for_user(discord_id)
+    return to_ints(summary.governor_ids)
 
 
 async def get_registered_governor_names_for_discord(discord_id: int) -> list[str]:
-    """Handy for the dropdown labels (GovernorName)."""
-    try:
-        from file_utils import run_blocking_in_thread
-    except Exception:
-        run_blocking_in_thread = None
-
-    if run_blocking_in_thread is not None:
-        reg = await run_blocking_in_thread(
-            load_registry,
-            name="load_registry_for_names",
-            meta={"discord_id": discord_id},
-        )
-    else:
-        reg = await asyncio.to_thread(load_registry)
-    reg = reg or {}
-    block = reg.get(str(discord_id)) or reg.get(discord_id) or {}
-    accounts = block.get("accounts") or {}
-    names = []
-    for slot, acc in accounts.items():
-        gname = (acc or {}).get("GovernorName")
-        if gname:
-            names.append(str(gname))
-    # Keep a stable order: Main, Alt 1..n, Farm 1..n, then the rest
-    preferred = ["Main"] + [f"Alt {i}" for i in range(1, 10)] + [f"Farm {i}" for i in range(1, 20)]
-
-    def slot_rank(item):
-        for i, s in enumerate(preferred):
-            if s in accounts and accounts[s].get("GovernorName") == item:
-                return i
-        return 10_000
-
-    return sorted(set(names), key=slot_rank)
+    """Return registered account names in canonical slot order."""
+    summary = await stats_account_service.get_account_summary_for_user(discord_id)
+    return summary.account_names
 
 
 def _fetch_proc_sync(gov_ids: list[int], slices_csv: str, include_aggregate: bool) -> list[dict]:

--- a/tests/test_kvk_personal_service.py
+++ b/tests/test_kvk_personal_service.py
@@ -82,34 +82,26 @@ class DummyBot:
 @pytest.mark.asyncio
 async def test_resolve_user_accounts_happy_path(monkeypatch):
     """Returns the accounts dict for a known user."""
-    fake_registry = {"42": {"accounts": {"Main": {"GovernorID": "999", "GovernorName": "X"}}}}
 
-    def fake_load_registry():
-        return fake_registry
+    def fake_get_user_accounts(discord_user_id):
+        assert discord_user_id == 42
+        return {"Main": {"GovernorID": "999", "GovernorName": "X"}}
 
     async def fake_to_thread(fn, *a, **kw):
         return fn(*a, **kw)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    import sys
+    from services import kvk_personal_service
 
-    # Ensure fresh import for module-level patching
-    mod_name = "registry.governor_registry"
-    orig = sys.modules.get(mod_name)
-    stub = types.ModuleType(mod_name)
-    stub.load_registry = fake_load_registry
-    sys.modules[mod_name] = stub
-    try:
-        from services import kvk_personal_service
+    monkeypatch.setattr(
+        kvk_personal_service.registry_service,
+        "get_user_accounts",
+        fake_get_user_accounts,
+    )
 
-        result = await kvk_personal_service.resolve_user_accounts(42)
-        assert result == {"Main": {"GovernorID": "999", "GovernorName": "X"}}
-    finally:
-        if orig is not None:
-            sys.modules[mod_name] = orig
-        else:
-            del sys.modules[mod_name]
+    result = await kvk_personal_service.resolve_user_accounts(42)
+    assert result == {"Main": {"GovernorID": "999", "GovernorName": "X"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_my_stats_export_command.py
+++ b/tests/test_my_stats_export_command.py
@@ -4,27 +4,11 @@ tests/test_my_stats_export_command.py
 Focused tests for /my_stats_export command/service handoff.
 """
 
-import os
-import tempfile
 import types
 
 import pytest
 
 from services import stats_export_service
-
-
-@pytest.fixture
-def mock_temp_dir():
-    """Fixture to create and cleanup temp directory."""
-    temp_dir = tempfile.mkdtemp()
-    yield temp_dir
-    # Cleanup
-    try:
-        for file in os.listdir(temp_dir):
-            os.unlink(os.path.join(temp_dir, file))
-        os.rmdir(temp_dir)
-    except Exception:
-        pass
 
 
 class DummyAuthor:

--- a/tests/test_my_stats_export_command.py
+++ b/tests/test_my_stats_export_command.py
@@ -1,22 +1,16 @@
 """
 tests/test_my_stats_export_command.py
 
-Integration tests for /my_stats_export command with format options.
-
-NOTE: Integration tests are currently skipped because my_stats_export is defined
-inside register_commands() and cannot be directly imported. These will be enabled
-after the planned Commands.py refactor that extracts commands to module level.
-
-For now, rely on:
-- Unit tests in test_stats_exporter_csv.py (passing)
-- Unit tests in test_stats_export.py (passing)
-- Manual testing in Discord
+Focused tests for /my_stats_export command/service handoff.
 """
 
 import os
 import tempfile
+import types
 
 import pytest
+
+from services import stats_export_service
 
 
 @pytest.fixture
@@ -33,58 +27,110 @@ def mock_temp_dir():
         pass
 
 
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
+class DummyAuthor:
+    id = 123
+    display_name = "Tester"
+    name = "Tester"
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, *args, **kwargs):
+        self.sent.append({"args": args, "kwargs": kwargs})
+        return types.SimpleNamespace(id="msg")
+
+
+class DummyCtx:
+    def __init__(self):
+        self.author = DummyAuthor()
+        self.user = self.author
+        self.followup = DummyFollowup()
+
+
+def _get_stats_export_handler():
+    import commands.stats_cmds as C
+
+    fake_bot = types.SimpleNamespace(registered={})
+
+    def slash_command(*, name=None, description=None, guild_ids=None):
+        def decorator(fn):
+            fake_bot.registered[name] = fn
+            return fn
+
+        return decorator
+
+    fake_bot.slash_command = slash_command
+    C.register_stats(fake_bot)
+    fn = fake_bot.registered["my_stats_export"]
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return C, fn
+
+
 @pytest.mark.asyncio
-async def test_my_stats_export_excel_format(mock_temp_dir):
-    """Test /my_stats_export with Excel format."""
-    pass
+async def test_my_stats_export_delegates_to_service(monkeypatch, tmp_path):
+    C, handler = _get_stats_export_handler()
+    export_path = tmp_path / "stats.csv"
+    export_path.write_text("data", encoding="utf-8")
+    export_file = stats_export_service.StatsExportFile(
+        file_path=str(export_path),
+        temp_dir=str(tmp_path),
+        filename="stats.csv",
+        format_name="CSV",
+        format_emoji="CSV",
+        description="desc",
+        instructions="instructions",
+        governor_ids=[123],
+        row_count=1,
+        days=30,
+        telemetry={"event": "my_stats_export"},
+    )
+    called = {}
+
+    async def fake_build_personal_stats_export(**kwargs):
+        called.update(kwargs)
+        return stats_export_service.StatsExportOutcome(status="ok", export_file=export_file)
+
+    monkeypatch.setattr(C, "safe_defer", lambda ctx, ephemeral=True: C.asyncio.sleep(0))
+    monkeypatch.setattr(
+        C.stats_export_service,
+        "build_personal_stats_export",
+        fake_build_personal_stats_export,
+    )
+    monkeypatch.setattr(C.stats_export_service, "cleanup_export_file", lambda _export: None)
+
+    ctx = DummyCtx()
+    await handler(ctx, format="CSV", days=30)
+
+    assert called["discord_user_id"] == 123
+    assert called["requested_format"] == "CSV"
+    assert ctx.followup.sent
+    assert ctx.followup.sent[0]["kwargs"]["ephemeral"] is True
 
 
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
 @pytest.mark.asyncio
-async def test_my_stats_export_csv_format(mock_temp_dir):
-    """Test /my_stats_export with CSV format."""
-    pass
+async def test_my_stats_export_no_registered_accounts(monkeypatch):
+    C, handler = _get_stats_export_handler()
 
+    async def fake_build_personal_stats_export(**_kwargs):
+        return stats_export_service.StatsExportOutcome(
+            status="no_accounts",
+            message="You have no registered accounts. Use `/register_governor` first.",
+        )
 
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
-@pytest.mark.asyncio
-async def test_my_stats_export_no_registrations():
-    """Test /my_stats_export when user has no registrations."""
-    pass
+    monkeypatch.setattr(C, "safe_defer", lambda ctx, ephemeral=True: C.asyncio.sleep(0))
+    monkeypatch.setattr(
+        C.stats_export_service,
+        "build_personal_stats_export",
+        fake_build_personal_stats_export,
+    )
 
+    ctx = DummyCtx()
+    await handler(ctx, format="Excel", days=90)
 
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
-@pytest.mark.asyncio
-async def test_my_stats_export_googlesheets_format(mock_temp_dir):
-    """Test /my_stats_export with GoogleSheets format."""
-    pass
-
-
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
-@pytest.mark.asyncio
-async def test_my_stats_export_custom_days(mock_temp_dir):
-    """Test /my_stats_export with custom days parameter."""
-    pass
-
-
-@pytest.mark.skip(
-    reason="Command is nested in register_commands() - will be enabled after Commands.py refactor"
-)
-@pytest.mark.asyncio
-async def test_my_stats_export_cleanup_on_error():
-    """Test that temp files are cleaned up even when export fails."""
-    pass
+    assert "no registered accounts" in ctx.followup.sent[0]["args"][0]
 
 
 if __name__ == "__main__":

--- a/tests/test_mykvkstats.py
+++ b/tests/test_mykvkstats.py
@@ -109,16 +109,19 @@ async def test_no_registered_accounts_shows_registration_prompt(monkeypatch):
     async def fake_load_last_kvk_map():
         return {}
 
-    # Fake load_registry as synchronous but invoked through asyncio.to_thread below
-    def fake_load_registry():
-        return {str(10): {"accounts": {}}}
+    async def fake_get_account_summary_for_user(_user_id):
+        return C.stats_account_service.summarize_accounts({})
 
     # Provide an async-to-thread shim so `await asyncio.to_thread(load_registry)` works
     async def fake_to_thread(fn, *a, **k):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "load_registry", fake_load_registry)
+    monkeypatch.setattr(
+        C.stats_account_service,
+        "get_account_summary_for_user",
+        fake_get_account_summary_for_user,
+    )
     monkeypatch.setattr(C, "load_last_kvk_map", fake_load_last_kvk_map)
     monkeypatch.setattr(
         C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False
@@ -155,14 +158,20 @@ async def test_single_account_sends_public_embed(monkeypatch):
     async def fake_load_last_kvk_map():
         return {}
 
-    def fake_load_registry():
-        return {str(11): {"accounts": {"Main": {"GovernorID": "123", "GovernorName": "X"}}}}
+    async def fake_get_account_summary_for_user(_user_id):
+        return C.stats_account_service.summarize_accounts(
+            {"Main": {"GovernorID": "123", "GovernorName": "X"}}
+        )
 
     async def fake_to_thread(fn, *a, **k):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "load_registry", fake_load_registry)
+    monkeypatch.setattr(
+        C.stats_account_service,
+        "get_account_summary_for_user",
+        fake_get_account_summary_for_user,
+    )
     monkeypatch.setattr(C, "load_last_kvk_map", fake_load_last_kvk_map)
     monkeypatch.setattr(C, "normalize_governor_id", lambda v: str(v))
     # Make load_stat_row sync but called via await asyncio.to_thread inside handler
@@ -186,21 +195,23 @@ async def test_multi_account_builds_selector(monkeypatch):
     async def fake_load_last_kvk_map():
         return {}
 
-    def fake_load_registry():
-        return {
-            str(12): {
-                "accounts": {
-                    "Main": {"GovernorID": 1, "GovernorName": "A"},
-                    "Alt 1": {"GovernorID": 2, "GovernorName": "B"},
-                }
+    async def fake_get_account_summary_for_user(_user_id):
+        return C.stats_account_service.summarize_accounts(
+            {
+                "Main": {"GovernorID": 1, "GovernorName": "A"},
+                "Alt 1": {"GovernorID": 2, "GovernorName": "B"},
             }
-        }
+        )
 
     async def fake_to_thread(fn, *a, **k):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "load_registry", fake_load_registry)
+    monkeypatch.setattr(
+        C.stats_account_service,
+        "get_account_summary_for_user",
+        fake_get_account_summary_for_user,
+    )
     monkeypatch.setattr(C, "load_last_kvk_map", fake_load_last_kvk_map)
     monkeypatch.setattr(
         C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False

--- a/tests/test_stats_account_service.py
+++ b/tests/test_stats_account_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from services import stats_account_service
+
+
+def test_summarize_accounts_orders_ids_names_and_default_main() -> None:
+    accounts = {
+        "Farm 1": {"GovernorID": "300", "GovernorName": "Farm"},
+        "Main": {"GovernorID": "100", "GovernorName": "Main"},
+        "Alt 1": {"GovernorID": "200", "GovernorName": "Alt"},
+    }
+
+    summary = stats_account_service.summarize_accounts(accounts)
+
+    assert list(summary.ordered_accounts) == ["Main", "Alt 1", "Farm 1"]
+    assert summary.governor_ids == [100, 200, 300]
+    assert summary.account_names == ["Main", "Alt", "Farm"]
+    assert summary.name_to_id == {"Main": 100, "Alt": 200, "Farm": 300}
+    assert summary.default_choice == "Main"
+
+
+@pytest.mark.asyncio
+async def test_get_account_summary_uses_registry_service(monkeypatch) -> None:
+    called = {}
+
+    def fake_get_user_accounts(discord_user_id: int):
+        called["discord_user_id"] = discord_user_id
+        return {"Main": {"GovernorID": "123", "GovernorName": "Player"}}
+
+    monkeypatch.setattr(
+        stats_account_service.registry_service,
+        "get_user_accounts",
+        fake_get_user_accounts,
+    )
+
+    summary = await stats_account_service.get_account_summary_for_user(42)
+
+    assert called == {"discord_user_id": 42}
+    assert summary.ok is True
+    assert summary.governor_ids == [123]
+
+
+@pytest.mark.asyncio
+async def test_get_account_summary_returns_error_on_registry_failure(monkeypatch) -> None:
+    def fake_get_user_accounts(_discord_user_id: int):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(
+        stats_account_service.registry_service,
+        "get_user_accounts",
+        fake_get_user_accounts,
+    )
+
+    summary = await stats_account_service.get_account_summary_for_user(42)
+
+    assert summary.ok is False
+    assert summary.governor_ids == []
+    assert "RuntimeError" in (summary.error or "")

--- a/tests/test_stats_export_service.py
+++ b/tests/test_stats_export_service.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from services import stats_export_service
+
+
+def _daily_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "GovernorID": 123,
+                "GovernorName": "Player",
+                "Alliance": "K98",
+                "AsOfDate": "2026-05-01",
+                "Power": 100,
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_personal_stats_export_no_registered_accounts(monkeypatch) -> None:
+    async def fake_summary(_discord_user_id: int):
+        return stats_export_service.stats_account_service.summarize_accounts({})
+
+    monkeypatch.setattr(
+        stats_export_service.stats_account_service,
+        "get_account_summary_for_user",
+        fake_summary,
+    )
+
+    outcome = await stats_export_service.build_personal_stats_export(
+        discord_user_id=1,
+        display_name="User",
+        requested_format="Excel",
+        days=90,
+    )
+
+    assert outcome.status == "no_accounts"
+    assert outcome.export_file is None
+
+
+@pytest.mark.asyncio
+async def test_build_personal_stats_export_empty_data(monkeypatch) -> None:
+    async def fake_summary(_discord_user_id: int):
+        return stats_export_service.stats_account_service.summarize_accounts(
+            {"Main": {"GovernorID": "123", "GovernorName": "Player"}}
+        )
+
+    async def fake_fetch_daily(_governor_ids: list[int]):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        stats_export_service.stats_account_service,
+        "get_account_summary_for_user",
+        fake_summary,
+    )
+    monkeypatch.setattr(stats_export_service, "_fetch_daily", fake_fetch_daily)
+
+    outcome = await stats_export_service.build_personal_stats_export(
+        discord_user_id=1,
+        display_name="User",
+        requested_format="CSV",
+        days=90,
+    )
+
+    assert outcome.status == "no_data"
+
+
+@pytest.mark.asyncio
+async def test_build_personal_stats_export_selects_csv_builder(monkeypatch, tmp_path) -> None:
+    async def fake_summary(_discord_user_id: int):
+        return stats_export_service.stats_account_service.summarize_accounts(
+            {"Main": {"GovernorID": "123", "GovernorName": "Player"}}
+        )
+
+    async def fake_fetch_daily(_governor_ids: list[int]):
+        return _daily_frame()
+
+    def fake_mkdtemp():
+        export_dir = tmp_path / "export"
+        export_dir.mkdir()
+        return str(export_dir)
+
+    def fake_csv_builder(_df_daily, _df_targets, *, out_path: str, days_for_daily_table: int):
+        Path(out_path).write_text("csv", encoding="utf-8")
+        assert days_for_daily_table == 30
+
+    monkeypatch.setattr(
+        stats_export_service.stats_account_service,
+        "get_account_summary_for_user",
+        fake_summary,
+    )
+    monkeypatch.setattr(stats_export_service, "_fetch_daily", fake_fetch_daily)
+    monkeypatch.setattr(stats_export_service.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(stats_export_service, "build_user_stats_csv", fake_csv_builder)
+
+    outcome = await stats_export_service.build_personal_stats_export(
+        discord_user_id=1,
+        display_name="Test User",
+        requested_format="CSV",
+        days=30,
+    )
+
+    assert outcome.status == "ok"
+    assert outcome.export_file is not None
+    assert outcome.export_file.filename.endswith(".csv")
+    assert outcome.export_file.telemetry["format"] == "CSV"
+
+    stats_export_service.cleanup_export_file(outcome.export_file)
+    assert not Path(outcome.export_file.temp_dir).exists()

--- a/tests/test_stats_export_service.py
+++ b/tests/test_stats_export_service.py
@@ -113,3 +113,44 @@ async def test_build_personal_stats_export_selects_csv_builder(monkeypatch, tmp_
 
     stats_export_service.cleanup_export_file(outcome.export_file)
     assert not Path(outcome.export_file.temp_dir).exists()
+
+
+@pytest.mark.asyncio
+async def test_build_personal_stats_export_cleans_partial_file_on_builder_failure(
+    monkeypatch, tmp_path
+) -> None:
+    async def fake_summary(_discord_user_id: int):
+        return stats_export_service.stats_account_service.summarize_accounts(
+            {"Main": {"GovernorID": "123", "GovernorName": "Player"}}
+        )
+
+    async def fake_fetch_daily(_governor_ids: list[int]):
+        return _daily_frame()
+
+    def fake_mkdtemp():
+        export_dir = tmp_path / "failed_export"
+        export_dir.mkdir()
+        return str(export_dir)
+
+    def fake_csv_builder(_df_daily, _df_targets, *, out_path: str, days_for_daily_table: int):
+        Path(out_path).write_text("partial", encoding="utf-8")
+        raise RuntimeError("writer failed")
+
+    monkeypatch.setattr(
+        stats_export_service.stats_account_service,
+        "get_account_summary_for_user",
+        fake_summary,
+    )
+    monkeypatch.setattr(stats_export_service, "_fetch_daily", fake_fetch_daily)
+    monkeypatch.setattr(stats_export_service.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(stats_export_service, "build_user_stats_csv", fake_csv_builder)
+
+    with pytest.raises(RuntimeError, match="writer failed"):
+        await stats_export_service.build_personal_stats_export(
+            discord_user_id=1,
+            display_name="Test User",
+            requested_format="CSV",
+            days=30,
+        )
+
+    assert not (tmp_path / "failed_export").exists()


### PR DESCRIPTION
## Summary
- Extract `/my_stats_export` SQL/data access into a stats DAL and export service.
- Add shared stats account resolution through the registry service and apply it across stats/KVK personal flows.
- Keep stats command handlers thinner, align defer/followup safety, and update focused regression coverage.
- Update deferred optimisation tracking for the resolved stats export and registry-alignment work.
- Add the stats optimisation task-pack document used for this cleanup batch.

## SQL note
- The missing `dbo.IntList` table type source is no longer handled by a companion PR. The production DB export script has been updated to include user-defined table types, and the SQL repo has been refreshed from that source.

## Validation
- `python -m pytest -q tests` -> 1314 passed, 2 skipped
- `ruff check ...` -> passed
- `black --check ...` -> passed
- `python scripts/validate_architecture_boundaries.py` -> passed
- `python scripts/validate_deferred_items.py` -> passed
- `python scripts/smoke_imports.py` -> passed
- `python scripts/validate_command_registration.py` -> passed