### PR TITLE
Document stats cleanup delivery

### DIFF
--- a/docs/Codex Task Pack — Stats Commands Full Optimisation & Standardisation.md
+++ b/docs/Codex Task Pack — Stats Commands Full Optimisation & Standardisation.md
@@ -1,6 +1,39 @@
 
 # Codex Task Pack — Stats Commands Full Optimisation & Standardisation
 
+## Delivery Status
+
+Status: Complete
+
+Delivered by: `cwatts6/K98-bot-mirror` PR #78
+
+Production outcome:
+
+* Stats command cleanup was merged, promoted to production, and confirmed working.
+* Automated validation completed successfully before promotion.
+* Manual Discord command smoke testing completed successfully after deployment.
+* The SQL repo now receives user-defined table type definitions from the production DB export process, so the temporary `dbo.IntList` companion PR was retired.
+
+Resolved GitHub issues:
+
+* #27 dict-style registry access, stats-related scope
+* #28 legacy registry views, stats-touched scope
+* #29 stats-service registry alignment
+* #31 governor registry architecture refactor, stats-related scope
+* #32 service layer consolidation, stats-related scope
+* #42 remaining KVK admin SQL/service extraction, stats command batch scope
+* #46 extract `/my_stats_export` SQL into service/DAL
+
+Delivery summary:
+
+* `/my_stats_export` direct SQL was extracted into a DAL/service boundary.
+* Stats account resolution was centralised behind a shared account service using the registry-service boundary.
+* Stats command handlers were reduced to Discord interaction plumbing, service calls, and response presentation.
+* Stats-focused regression tests were added or updated.
+* Deferred optimisation tracking was updated with the completed stats batch.
+
+---
+
 ## Goal
 
 Perform a full standards-alignment, optimisation, architecture review, and cleanup pass over `commands/stats_cmds.py` and all directly associated stats command files.

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -45,7 +45,13 @@
 
 ## Recently Resolved
 
-- Stats Commands Full Optimisation & Standardisation extracted `/my_stats_export` SQL into `stats/dal/stats_export_dal.py` and `services/stats_export_service.py` and aligned stats account resolution through the SQL-backed registry service boundary.
+- Stats Commands Full Optimisation & Standardisation was implemented, merged, production promoted, and smoke-tested via PR #78.
+- The following stats deferred items are closed and complete:
+  - `commands/stats_cmds.py` no longer performs `/my_stats_export` SQL directly; export data access now lives in `stats/dal/stats_export_dal.py` and export orchestration lives in `services/stats_export_service.py`, resolving GitHub issue #46.
+  - Stats account resolution now routes through `services/stats_account_service.py`, which delegates to the SQL-backed registry service boundary and removes stats command/service traversal of the legacy registry dict shape, resolving the stats scope of GitHub issues #27, #29, #31, and #32.
+  - Stats-touched legacy registry view/account-selection paths were aligned with the current registry-service flow where touched by stats commands, resolving the stats scope of GitHub issue #28.
+  - KVK admin/stat command flows touched by the stats cleanup were reviewed and aligned with the current service/DAL boundaries used by the deployed implementation, resolving GitHub issue #42 for the stats command batch.
+  - Production deployment completed successfully and manual Discord command smoke tests passed after deployment.
 - Telemetry Commands Full Optimisation & Standardisation was implemented, merged, production promoted, and smoke-tested via PR #76.
 - The following telemetry deferred items are closed and complete:
   - `commands/telemetry_cmds.py` no longer imports or wraps the KVK DAL current-KVK resolver, resolving GitHub issue #26.
@@ -57,7 +63,7 @@
   - CrystalTech interaction orchestration moved to `commands/crystaltech_flow.py`.
   - `account_picker.py`, `kvk_ui.py`, selected KVK personal views, selected registry views, and Ark registration account lookup were aligned away from direct registry dict traversal where touched.
   - Final deployed validation: `python -m pytest -q tests` reported 1306 passed and 8 skipped; command registration and import smoke validation passed; post-deploy Discord smoke testing was completed.
-- Related issues intentionally remain open for separate non-telemetry batches: #27 broader dict-style registry access, #28 legacy registry view removal, #29/#32 stats-service registry alignment, #31 broader governor registry architecture refactor, #42 KVK admin SQL extraction, and #46 stats export SQL extraction.
+- The stats-related issues from the task pack are now resolved: #27, #28, #29, #31, #32, #42, and #46.
 - MGE Process Polish Phase 2 was implemented, production deployed, and smoke-tested via PR #75.
 - `mge/mge_signup_service.py` self-signup account resolution now uses `registry_service.get_user_accounts()` instead of the legacy registry dict shape. Admin-add reverse owner lookup remains on `get_discord_user_for_governor()`.
 - `mge/mge_publish_service.py` no longer performs direct Discord message fetch/send/edit/delete/DM IO. Publish, republish, reminder refresh, unpublish, award DM, and board refresh paths now route Discord operations through `mge/mge_publish_discord_adapter.py`.

--- a/docs/deferred_optimisations.md
+++ b/docs/deferred_optimisations.md
@@ -67,4 +67,3 @@
 - MGE Process Polish Phase 2 was implemented, production deployed, and smoke-tested via PR #75.
 - `mge/mge_signup_service.py` self-signup account resolution now uses `registry_service.get_user_accounts()` instead of the legacy registry dict shape. Admin-add reverse owner lookup remains on `get_discord_user_for_governor()`.
 - `mge/mge_publish_service.py` no longer performs direct Discord message fetch/send/edit/delete/DM IO. Publish, republish, reminder refresh, unpublish, award DM, and board refresh paths now route Discord operations through `mge/mge_publish_discord_adapter.py`.
-- The remaining open service-consolidation scope from GitHub issues #29 and #32 is stats-service registry alignment, not MGE.


### PR DESCRIPTION
## Summary
- Mark the stats command optimisation task pack as complete and production delivered.
- Update `docs/deferred_optimisations.md` with the delivered stats cleanup outcome.
- Record the resolved GitHub issues from the stats task pack: #27, #28, #29, #31, #32, #42, and #46.

## Validation
- `python scripts/validate_deferred_items.py` -> passed

## Deployment note
- Code changes from PR #78 are already deployed to production and manual Discord smoke tests are green.