### PR TITLE
[codex] Document Codex skill usage

### DIFF
--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -168,13 +168,13 @@ GitHub should allow a normal comparison because the branch is based on `K98-bot/
 
 #### If needed to push again
 
-1. 
+1.
 ```powershell
 git switch main
 git branch -D prod/<branch-name>
 ```
 
-2. 
+2.
 ```powershell
 cd C:\discord_file_downloader
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
@@ -222,7 +222,7 @@ git pull origin main
 git status
 ```
 
-2. Merge the production PR into `K98-bot/main`. 
+2. Merge the production PR into `K98-bot/main`.
 3. Deploy only from `K98-bot/main` on the bot machine.
 
 Deployment machine:

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -42,7 +42,7 @@ SQL repo evidence with the promotion notes.
 ```powershell
 cd C:\discord_file_downloader
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-.\venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 .\dev.ps1
 
 git fetch origin
@@ -52,15 +52,18 @@ git status
 git log --oneline origin/main..HEAD
 git diff --name-status origin/main...HEAD
 git diff --stat origin/main...HEAD
-```
 
-If SQL changes are involved:
-
-```powershell
 cd C:\K98-bot-SQL-Server
 git pull
 git status
 git log --oneline -5
+```
+
+or if required as there are SQL differences use:
+```powershell
+cd C:\K98-bot-SQL-Server
+git restore .
+git pull
 ```
 
 ### 2. Run Local Validation
@@ -71,14 +74,22 @@ any skipped validation with a reason before promotion.
 Use targeted validation for small changes and full validation before production promotion:
 
 ```powershell
+cd C:\discord_file_downloader
 python scripts/validate_architecture_boundaries.py
 python scripts/validate_deferred_items.py
 python scripts/select_tests.py
 python scripts/smoke_imports.py
 python scripts/validate_command_registration.py
-python -m pytest -q tests
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
 git diff --check
 git status
+```
+
+if pre-commit triggers files reformat or changes:
+```powershell
+git commit -a
+git push
 ```
 
 ### 3. Confirm Remotes
@@ -108,6 +119,9 @@ validation evidence, SQL/config sequencing, bot-machine readiness, and rollback 
 promote if it reports blocking issues.
 
 ```powershell
+cd C:\discord_file_downloader
+git config core.quotePath false
+
 .\scripts\promote-to-production.ps1 `
   -SourceBranch codex/<branch-name> `
   -ProductionBranch prod/<branch-name>
@@ -136,13 +150,79 @@ Open:
 K98-bot: prod/<branch-name> -> main
 ```
 
-### 6. Merge And Deploy
+### 6. Test on local BOT Machine before merge
+
+```powershell
+cd C:\discord_file_downloader
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\venv\Scripts\Activate.ps1
+.\dev.ps1
+git merge --quit
+git switch main
+git fetch
+git switch prod/<branch-name>
+git pull
+```
+
+GitHub should allow a normal comparison because the branch is based on `K98-bot/main`.
+
+# If needed to push again 
+
+1. 
+```powershell
+git switch main
+git branch -D prod/<branch-name>
+```
+
+2. 
+```powershell
+cd C:\discord_file_downloader
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\.venv\Scripts\Activate.ps1
+.\dev.ps1
+
+git fetch origin
+git switch codex/<branch-name>
+git pull origin codex/<branch-name>
+
+.\scripts\promote-to-production.ps1 `
+  -SourceBranch codex/<branch-name> `
+  -ProductionBranch prod/<branch-name>
+```
+
+3. (on the bot machine)
+```powershell
+cd C:\discord_file_downloader
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\venv\Scripts\Activate.ps1
+.\dev.ps1
+
+git merge --abort 2>$null
+git fetch origin
+git switch prod/<branch-name>
+git reset --hard origin/prod/<branch-name>
+git clean -fd
+git status
+git log --oneline -5
+```
+
+
+
+
+### 7. Merge And Deploy
 
 Before bot-machine deployment, rerun or refresh `k98-promotion-check` when the change includes SQL,
 config, dependency, startup, scheduler, persistence, rehydration, or cache implications.
 
 1. Merge the mirror PR into `K98-bot-mirror/main`.
-2. Merge the production PR into `K98-bot/main`.
+Then update local mirror main:
+```powershell
+git switch main
+git pull origin main
+git status
+```
+
+2. Merge the production PR into `K98-bot/main`. 
 3. Deploy only from `K98-bot/main` on the bot machine.
 
 Deployment machine:
@@ -162,6 +242,44 @@ pytest -q tests
 
 If validation changes files on the production branch, commit and push those intended changes before
 deploying.
+
+```powershell
+git commit -a
+git push
+```
+
+### 8. Post-Production Sync & Alignment (NEW)
+
+```powershell
+cd C:\discord_file_downloader
+git fetch origin
+git fetch production
+git switch main
+git reset --hard origin/main
+git clean -fd
+
+cd C:\K98-bot-SQL-Server
+git pull
+```
+
+
+### 9. Cleanup
+
+```powershell
+cd C:\discord_file_downloader
+git switch main
+git pull origin main
+git branch --delete codex/<branch-name>
+git branch --delete prod/<branch-name>
+git fetch origin --prune
+git fetch production --prune
+
+cd C:\K98-bot-SQL-Server
+git switch main
+git pull
+git status
+git fetch origin --prune
+```
 
 ## Troubleshooting
 

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -166,7 +166,7 @@ git pull
 
 GitHub should allow a normal comparison because the branch is based on `K98-bot/main`.
 
-# If needed to push again 
+#### If needed to push again
 
 1. 
 ```powershell

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -59,7 +59,7 @@ git status
 git log --oneline -5
 ```
 
-or if required as there are SQL differences use:
+If there are SQL differences, run:
 ```powershell
 cd C:\K98-bot-SQL-Server
 git restore .

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -17,9 +17,27 @@ git push production <mirror-feature-branch>
 
 Use the patch-based promotion script instead.
 
+## Codex Skills
+
+Use the local Codex skills as promotion guardrails:
+
+- `k98-pr-review`: use before merge to confirm the mirror change is ready for handoff.
+- `k98-test-selection`: use before promotion to verify the focused and broad validation plan.
+- `k98-sql-validation`: use when SQL-facing bot changes, SQL repo changes, `ProcConfig`, DAL
+  assumptions, staging/output tables, imports, exports, or SQL-backed caches are involved.
+- `k98-promotion-check`: use before creating the production branch or PR, and again before bot
+  machine deployment when SQL, config, dependency, startup, scheduler, persistence, or cache risks
+  exist.
+- `k98-deferred-optimisation-capture`: use when promotion review finds out-of-scope cleanup or
+  follow-up work that should not be mixed into the active promotion.
+
 ## Standard Process
 
 ### 1. Validate Mirror Branch
+
+Before running the branch checks, use `k98-pr-review` for merge readiness and `k98-test-selection`
+to confirm the validation plan. If SQL-facing work is present, use `k98-sql-validation` and keep the
+SQL repo evidence with the promotion notes.
 
 ```powershell
 cd C:\discord_file_downloader
@@ -46,6 +64,9 @@ git log --oneline -5
 ```
 
 ### 2. Run Local Validation
+
+Use `k98-test-selection` to choose focused tests in addition to the baseline gates below. Document
+any skipped validation with a reason before promotion.
 
 Use targeted validation for small changes and full validation before production promotion:
 
@@ -82,6 +103,10 @@ git fetch production
 
 ### 4. Promote Branch
 
+Before creating the production branch, use `k98-promotion-check` to verify remotes, branch state,
+validation evidence, SQL/config sequencing, bot-machine readiness, and rollback notes. Do not
+promote if it reports blocking issues.
+
 ```powershell
 .\scripts\promote-to-production.ps1 `
   -SourceBranch codex/<branch-name> `
@@ -102,6 +127,9 @@ and rerun promotion.
 
 ### 5. Open Production PR
 
+Include the `k98-promotion-check` verdict, validation summary, SQL/config notes, and rollback notes
+in the production PR body.
+
 Open:
 
 ```text
@@ -109,6 +137,9 @@ K98-bot: prod/<branch-name> -> main
 ```
 
 ### 6. Merge And Deploy
+
+Before bot-machine deployment, rerun or refresh `k98-promotion-check` when the change includes SQL,
+config, dependency, startup, scheduler, persistence, rehydration, or cache implications.
 
 1. Merge the mirror PR into `K98-bot-mirror/main`.
 2. Merge the production PR into `K98-bot/main`.

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -167,7 +167,6 @@ git pull
 GitHub should allow a normal comparison because the branch is based on `K98-bot/main`.
 
 #### If needed to push again
-
 1.
 ```powershell
 git switch main

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -75,11 +75,11 @@ Use targeted validation for small changes and full validation before production 
 
 ```powershell
 cd C:\discord_file_downloader
-python scripts/validate_architecture_boundaries.py
-python scripts/validate_deferred_items.py
-python scripts/select_tests.py
-python scripts/smoke_imports.py
-python scripts/validate_command_registration.py
+.\.venv\Scripts\python.exe scripts/validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts/validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts/select_tests.py
+.\.venv\Scripts\python.exe scripts/smoke_imports.py
+.\.venv\Scripts\python.exe scripts/validate_command_registration.py
 .\.venv\Scripts\python.exe -m pre_commit run -a
 .\.venv\Scripts\python.exe -m pytest -q tests
 git diff --check

--- a/docs/templates/Codex Task Pack Template.md
+++ b/docs/templates/Codex Task Pack Template.md
@@ -66,7 +66,34 @@ does not apply.
 - Dependencies:
 ```
 
-## 7. Mandatory Workflow
+## 7. Codex Skills To Use
+
+Use these local Codex skills when they apply to the task. List `not applicable` with a short reason
+instead of deleting a skill silently.
+
+| Skill | Use when |
+|---|---|
+| `k98-architecture-scope` | Always before implementation, unless one-pass execution has already been explicitly approved. Use it to identify affected layers, SQL/persistence implications, refactor triggers, conditional docs, tests, and approval checkpoints. |
+| `k98-discord-command-feature` | The task changes slash commands, Discord views/modals, embeds, buttons, selects, interaction callbacks, command registration, permissions, or user-facing bot flows. |
+| `k98-sql-validation` | The task touches or depends on SQL schema, stored procedures, views, indexes, UDTs, `ProcConfig`, staging/output tables, DAL queries, imports, exports, reports, or SQL-backed caches. |
+| `k98-test-selection` | Always before validation. Use it to combine `scripts/select_tests.py` with risk-based test coverage decisions and skip justifications. |
+| `k98-deferred-optimisation-capture` | Audit or implementation finds out-of-scope debt, refactor triggers, duplicate helpers, direct SQL in commands/views, restart-safety gaps, or cleanup candidates. |
+| `k98-pr-review` | Before merge or PR handoff, to check architecture, SQL alignment, tests, deferred items, Discord safety, and promotion readiness. |
+| `k98-promotion-check` | Before production promotion, production PR creation, production merge, SQL deployment sequencing, or bot-machine deployment. |
+
+### Skill Decisions
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | `<use | not applicable>` | `<why>` |
+| `k98-discord-command-feature` | `<use | not applicable>` | `<why>` |
+| `k98-sql-validation` | `<use | not applicable>` | `<why>` |
+| `k98-test-selection` | `<use | not applicable>` | `<why>` |
+| `k98-deferred-optimisation-capture` | `<use | not applicable>` | `<why>` |
+| `k98-pr-review` | `<use | not applicable>` | `<why>` |
+| `k98-promotion-check` | `<use | not applicable>` | `<why>` |
+
+## 8. Mandatory Workflow
 
 Default workflow:
 
@@ -78,7 +105,7 @@ Default workflow:
 
 Proceed in one pass only when the user explicitly approves it.
 
-## 8. Audit Requirements
+## 9. Audit Requirements
 
 Review the touched area for:
 
@@ -102,7 +129,7 @@ Map the likely:
 - restart implications
 - conditional reference docs
 
-## 9. Architecture Targets
+## 10. Architecture Targets
 
 | Concern | Target |
 |---|---|
@@ -116,7 +143,7 @@ Map the likely:
 | SQL schema | SQL repo `sql_schema/<schema>.<Object>.<Type>.sql` |
 | Tests | `tests/` |
 
-## 10. Likely Files
+## 11. Likely Files
 
 ### Review
 
@@ -130,7 +157,7 @@ Map the likely:
 
 - `<path or none>`
 
-## 11. Implementation Requirements
+## 12. Implementation Requirements
 
 - Keep commands and views thin.
 - Move business logic into services.
@@ -142,7 +169,7 @@ Map the likely:
 - Add or update tests unless the change is documentation-only or tooling-only.
 - Capture new out-of-scope findings as deferred optimisations.
 
-## 12. Refactor Decisions
+## 13. Refactor Decisions
 
 Classify each issue found during audit:
 
@@ -153,7 +180,7 @@ Classify each issue found during audit:
 Deferred items must use the structured format from
 `docs/reference/K98 Bot - Deferred Optimisation Framework.md`.
 
-## 13. Testing Requirements
+## 14. Testing Requirements
 
 Consider each category and either cover it or explain why it does not apply:
 
@@ -183,7 +210,7 @@ consider:
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
 ```
 
-## 14. Acceptance Criteria
+## 15. Acceptance Criteria
 
 - [ ] Scope is complete and no out-of-scope work was mixed in.
 - [ ] Correct architecture/layer ownership is preserved.
@@ -195,7 +222,7 @@ consider:
 - [ ] Quality gates were run or documented.
 - [ ] Deferred optimisations are captured structurally.
 
-## 15. Required Delivery Output
+## 16. Required Delivery Output
 
 Use this delivery shape:
 
@@ -213,7 +240,7 @@ Use this delivery shape:
 For documentation-only work, state that no runtime code, SQL, helper reuse, or restart behaviour
 changed.
 
-## 16. PR Summary Template
+## 17. PR Summary Template
 
 ```md
 ## Summary


### PR DESCRIPTION
## Summary

- Add a Codex skills usage section to the task pack template so skill selection becomes part of normal task setup.
- Add promotion-guide checkpoints for PR review, test selection, SQL validation, promotion readiness, and deferred optimisation capture.

## Changes

- Document when to use `k98-architecture-scope`, `k98-discord-command-feature`, `k98-sql-validation`, `k98-test-selection`, `k98-deferred-optimisation-capture`, `k98-pr-review`, and `k98-promotion-check` in task packs.
- Add promotion-process guidance for using the review, validation, SQL, and promotion skills at the right handoff points.

## Tests

- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `git diff --check`

## Deferred Optimisations

- None.

## Risk / Rollback

- Documentation-only change. Rollback is reverting the docs commit.