### PR TITLE
[codex] Extract registry command services

### DIFF
--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -2,10 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from decimal import Decimal, InvalidOperation
-import io
 import logging
-import re
 from typing import Any
 
 import discord
@@ -15,24 +12,28 @@ from bot_config import GUILD_ID
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import is_admin_and_notify_channel, track_usage
 from registry.account_slots import ACCOUNT_ORDER
+from registry.dal.audit_dal import get_active_players
 from registry.governor_registry import (
     ConfirmRemoveView,
     ModifyGovernorView,
     RegisterGovernorView,
 )
-from registry.registry_io import (
-    apply_import_plan,
-    build_error_csv_bytes,
-    build_error_xlsx_bytes,
-    export_registration_audit_files,
-    export_registration_audit_xlsx_bytes,
-    parse_csv_bytes,
-    parse_xlsx_bytes,
-    prepare_import_plan,
-    rows_to_xlsx_bytes,
+from registry.registry_command_service import (
+    apply_import_changes,
+    build_import_preview,
+    build_import_summary_file_bytes,
+    build_import_summary_text,
+    build_registration_audit_payload,
+    build_registration_export_payload,
+    parse_attachment_bytes,
 )
 import registry.registry_service as registry_service
-from registry.registry_service import VALID_ACCOUNT_TYPES
+from registry.registry_service import (
+    VALID_ACCOUNT_TYPES,
+    admin_register_or_replace,
+    get_user_accounts,
+    remove_governor,
+)
 from services.governor_account_service import (
     filter_account_slots,
     get_accounts_for_user as get_user_accounts_async,
@@ -50,26 +51,6 @@ logger = logging.getLogger(__name__)
 def register_registry(bot: ext_commands.Bot) -> None:
 
     # --- helpers (reuse if already present) ---
-    # --- shared attachment parser ---
-    def _parse_attachment(raw: bytes, ftype: str) -> list[dict]:
-        """Parse CSV or XLSX bytes to rows. Returns empty list on failure."""
-        if ftype == "csv":
-            return parse_csv_bytes(raw)
-        if ftype == "xlsx":
-            try:
-                return parse_xlsx_bytes(raw)
-            except Exception:
-                logger.exception("[IMPORT] XLSX parse failed, attempting CSV fallback")
-                return parse_csv_bytes(raw)
-        # unknown: try CSV first, then XLSX
-        rows = parse_csv_bytes(raw)
-        if not rows:
-            try:
-                rows = parse_xlsx_bytes(raw)
-            except Exception:
-                rows = []
-        return rows
-
     # --- UNIFIED autocomplete for account_type (works with both commands) ---
     async def _account_type_ac(ctx: discord.AutocompleteContext):
         try:
@@ -310,8 +291,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
             if isinstance(discord_user, discord.User)
             else f"`{target_user_id}`"
         )
-
-        from registry.registry_service import get_user_accounts, remove_governor
 
         # Pre-check: confirm slot exists so we can give a clear message before acting
         accounts = await asyncio.to_thread(get_user_accounts, target_user_id)
@@ -600,7 +579,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
         # Write via service layer.
         # admin_register_or_replace overwrites an existing slot if present,
         # rather than rejecting with RC_DUPE_SLOT.
-        from registry.registry_service import admin_register_or_replace
 
         ok, err = admin_register_or_replace(
             target_discord_user_id=discord_user.id,
@@ -664,8 +642,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
           2) unregistered_current_governors.csv – CURRENT (SQL view) governors missing from registry
           3) members_without_registration.csv – guild members without any registration
         """
-        from decimal import ROUND_HALF_UP
-
         await safe_defer(ctx, ephemeral=True)
 
         guild: discord.Guild | None = ctx.guild
@@ -674,74 +650,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 content="❌ This command must be used in a server."
             )
             return
-
-        # ---------- GovernorID normalizer & extractor ----------
-        def _norm_gid(val) -> str:
-            """
-            Normalize GovernorID to a canonical string:
-            - safe on None
-            - unwrap Excel-safe form ="12345"
-            - if numeric (int/float/Decimal or numeric-looking string), convert via Decimal(...).to_integral_value()
-            - strip leading zeros
-            """
-            if val is None:
-                return ""
-            # numeric types first
-            if isinstance(val, int):
-                s = str(val)
-            elif isinstance(val, float):
-                try:
-                    s = str(Decimal(str(val)).to_integral_value(rounding=ROUND_HALF_UP))
-                except Exception:
-                    s = str(int(val))
-            elif isinstance(val, Decimal):
-                s = str(val.to_integral_value(rounding=ROUND_HALF_UP))
-            else:
-                s = str(val).strip()
-                if s.startswith('="') and s.endswith('"') and len(s) >= 3:
-                    s = s[2:-1]
-                s = s.replace(",", "")  # strip thousands separators if any
-                # numeric-looking string? handle decimals/scientific
-                if re.fullmatch(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?", s):
-                    try:
-                        s = str(Decimal(s).to_integral_value(rounding=ROUND_HALF_UP))
-                    except (InvalidOperation, ValueError):
-                        pass
-            # finally, ensure digits & remove leading zeros
-            digits = re.findall(r"\d+", s)
-            if digits:
-                s = "".join(digits)
-            return s.lstrip("0") or ("0" if s else "")
-
-        def _extract_gov_id(details: dict) -> str:
-            """
-            Pull a GovernorID out of a registry account dict.
-            Accepts many key spellings: 'GovernorID', 'Governor ID', 'GovernorId', 'gov_id', 'govid', etc.
-            """
-            if not isinstance(details, dict):
-                return ""
-            for k in (
-                "GovernorID",
-                "Governor Id",
-                "GovernorId",
-                "gov_id",
-                "govid",
-                "GovID",
-                "Gov Id",
-            ):
-                if details.get(k):
-                    return str(details[k])
-            for k, v in details.items():
-                nk = re.sub(r"[^a-z0-9]", "", str(k).lower())
-                if (
-                    ("governor" in nk and "id" in nk)
-                    or nk in ("govid", "govidnumber", "governorid")
-                ) and v:
-                    return str(v)
-            return ""
-
-        # ---------- SQL via audit_dal ----------
-        from registry.dal.audit_dal import get_active_players
 
         try:
             sql_rows = await asyncio.to_thread(get_active_players)
@@ -787,210 +695,41 @@ def register_registry(bot: ext_commands.Bot) -> None:
             names = [r.name for r in member.roles if r.name != "@everyone"]
             return ";".join(names), (member.top_role.name if names else "")
 
-        def excel_safe_formula(value: str) -> str:
-            v = (value or "").strip()
-            return f'="{v}"' if v else ""
+        members_info: dict[str, dict] = {}
+        for member in (m for m in guild.members if not getattr(m, "bot", False)):
+            roles_str, top_role = role_names(member)
+            members_info[str(member.id)] = {
+                "discord_user": str(member),
+                "roles": roles_str,
+                "top_role": top_role,
+            }
 
-        cached_members: dict[str, discord.Member] = (
-            {str(m.id): m for m in guild.members} if guild.members else {}
-        )
-        fetch_cache: dict[str, discord.Member | None] = {}
-
-        async def get_member(uid_str: str):
-            m = cached_members.get(uid_str)
-            if m is not None:
-                return m
-            if uid_str in fetch_cache:
-                return fetch_cache[uid_str]
-            try:
-                m = await guild.fetch_member(int(uid_str))
-            except Exception:
-                m = None
-            fetch_cache[uid_str] = m
-            return m
-
-        # ---------- Build REGISTERED rows + set of normalized registered GovernorIDs ----------
-        registered_ids: set[str] = set()
-        registered_rows: list[dict] = []
-        registered_rows_with_id = 0  # diagnostics
-
-        for uid, data in registry.items():
-            uid_str = str(uid).strip()
-            accounts = data.get("accounts", {})
-            if not isinstance(accounts, dict):
-                continue
-            for acc_type, details in accounts.items():
-                gov_id_raw = _extract_gov_id(details)
-                gov_id_norm = _norm_gid(gov_id_raw)
-                gov_name = str(details.get("GovernorName") or "Unknown").strip()
-
-                if gov_id_norm:
-                    registered_ids.add(gov_id_norm)
-                    registered_rows_with_id += 1
-
-                registered_rows.append(
-                    {
-                        "discord_id": uid_str,
-                        "discord_id_excel": excel_safe_formula(uid_str),
-                        "discord_user": str(data.get("discord_name", uid_str)).strip(),
-                        "account_type": str(acc_type).strip(),
-                        "governor_id": str(gov_id_raw or "").strip(),  # raw for humans
-                        "governor_id_excel": excel_safe_formula(str(gov_id_raw or "")),
-                        "governor_name": gov_name,
-                        "_member": None,
-                        "roles": "",
-                        "top_role": "",
-                    }
-                )
-
-        # Resolve member objects for registered rows (roles/top_role)
-        for row in registered_rows:
-            uid = row["discord_id"]
-            member = cached_members.get(uid) or await get_member(uid)
-            row["_member"] = member
-        for row in registered_rows:
-            roles_str, top = role_names(row["_member"])
-            row["roles"], row["top_role"] = roles_str, top
-            row.pop("_member", None)
-
-        # ---------- CURRENT governors from SQL → normalized sets & lookup ----------
-        # SQL now returns BIGINT for GovernorID, so just stringify it.
-        current_ids: set[str] = set()
-        row_by_id: dict[str, dict] = {}
-
-        for r in sql_rows:
-            gid_val = r.get("GovernorID")
-            if gid_val is None:
-                continue
-            gid_sql = str(int(gid_val))  # bigint -> "123456"
-            current_ids.add(gid_sql)
-            if gid_sql not in row_by_id:
-                row_by_id[gid_sql] = r
-
-        unregistered_ids = sorted(current_ids - registered_ids)
+        audit_payload = build_registration_audit_payload(registry, members_info, sql_rows)
 
         logger.info(
-            "[registration_audit] SQL current=%d, registry=%d (with_gov_id=%d), unmatched=%d",
-            len(current_ids),
-            len(registry),
-            len(registered_ids),
-            len(unregistered_ids),
+            "[registration_audit] registered_accounts=%d unregistered_current=%d members_without_registration=%d",
+            audit_payload.registered_accounts_total,
+            audit_payload.unregistered_current_governors_count,
+            audit_payload.members_without_registration_count,
         )
-        if registered_ids and len(unregistered_ids) == len(current_ids):
-            sample_sql = list(sorted(current_ids))[:5]
-            sample_reg = list(sorted(registered_ids))[:5]
-            logger.exception(
-                "[registration_audit] All current appear unregistered. Sample SQL: %s | Sample REG: %s",
-                sample_sql,
-                sample_reg,
-            )
-
-        # ---------- Guild members without any registration ----------
-        try:
-            members = [m for m in guild.members if not m.bot]
-        except Exception:
-            members = []
-        registered_user_ids = set(str(k).strip() for k in registry.keys())
-        members_without_reg = [m for m in members if str(m.id) not in registered_user_ids]
-
-        # ---------- Build members_info mapping and files via registry_io (CSV + XLSX) ----------
-        members_info: dict[str, dict] = {}
-        all_members_source = {str(m.id): m for m in guild.members} if guild.members else {}
-        for uid in set(list(all_members_source.keys()) + [str(m.id) for m in members_without_reg]):
-            mem = all_members_source.get(uid)
-            if mem:
-                roles_str, top_role = role_names(mem)
-                members_info[uid] = {
-                    "discord_user": str(mem),
-                    "roles": roles_str,
-                    "top_role": top_role,
-                }
-            else:
-                members_info[uid] = {"discord_user": uid, "roles": "", "top_role": ""}
-
-        files = export_registration_audit_files(registry, members_info, sql_rows)
-        # Also produce an XLSX workbook with three sheets
-        try:
-            xlsx_bytes = export_registration_audit_xlsx_bytes(registry, members_info, sql_rows)
-        except Exception:
-            logger.exception("Failed to produce XLSX audit workbook")
-            xlsx_bytes = None
-
-        # ---------- Compute counts for the audit embed ----------
-        # Total registered account rows (accounts per user)
-        registered_accounts_total = 0
-        registered_ids_set: set[str] = set()
-        for uid, data in (registry or {}).items():
-            accs = data.get("accounts") or {}
-            if isinstance(accs, dict):
-                registered_accounts_total += len(accs)
-                for det in accs.values():
-                    # attempt to find GovernorID from common keys
-                    gid = ""
-                    if isinstance(det, dict):
-                        for k in (
-                            "GovernorID",
-                            "Governor Id",
-                            "GovernorId",
-                            "gov_id",
-                            "govid",
-                            "GovID",
-                            "Gov Id",
-                        ):
-                            v = det.get(k)
-                            if v:
-                                gid = str(v).strip()
-                                break
-                        if not gid:
-                            # fallback: check any value keys containing governor+id
-                            for k2, v2 in det.items():
-                                nk = re.sub(r"[^a-z0-9]", "", str(k2).lower())
-                                if (
-                                    ("governor" in nk and "id" in nk)
-                                    or nk in ("govid", "governorid")
-                                ) and v2:
-                                    gid = str(v2).strip()
-                                    break
-                    if gid:
-                        # normalize numeric-like from audit normalizer (strip wrappers/commas)
-                        try:
-                            gid_norm = _norm_gid(gid)
-                        except Exception:
-                            gid_norm = gid
-                        if gid_norm:
-                            registered_ids_set.add(gid_norm)
-
-        # compute current IDs from SQL rows (as per prior logic)
-        current_ids: set[str] = set()
-        for r in sql_rows:
-            gid_val = r.get("GovernorID")
-            if gid_val is None:
-                continue
-            try:
-                gid_sql = str(int(gid_val))
-            except Exception:
-                gid_sql = str(gid_val)
-            current_ids.add(gid_sql)
-
-        unregistered_ids = sorted(current_ids - registered_ids_set)
-        unregistered_count = len(unregistered_ids)
-        members_without_registration_count = len(members_without_reg)
 
         # ---------- Summary embed ----------
         embed = discord.Embed(
             title="🧾 Registration Audit (Current Governors)", color=discord.Color.blurple()
         )
         embed.add_field(
-            name="Registered accounts", value=f"{registered_accounts_total:,}", inline=True
+            name="Registered accounts",
+            value=f"{audit_payload.registered_accounts_total:,}",
+            inline=True,
         )
         embed.add_field(
             name="Unregistered current governors (SQL)",
-            value=f"{unregistered_count:,}",
+            value=f"{audit_payload.unregistered_current_governors_count:,}",
             inline=True,
         )
         embed.add_field(
             name="Discord members without registration",
-            value=f"{members_without_registration_count:,}",
+            value=f"{audit_payload.members_without_registration_count:,}",
             inline=True,
         )
         embed.set_footer(
@@ -1002,18 +741,23 @@ def register_registry(bot: ext_commands.Bot) -> None:
         send_files = []
         try:
             send_files = [
-                discord.File(files["registered_accounts.csv"], filename="registered_accounts.csv"),
                 discord.File(
-                    files["unregistered_current_governors.csv"],
+                    audit_payload.files["registered_accounts.csv"],
+                    filename="registered_accounts.csv",
+                ),
+                discord.File(
+                    audit_payload.files["unregistered_current_governors.csv"],
                     filename="unregistered_current_governors.csv",
                 ),
                 discord.File(
-                    files["members_without_registration.csv"],
+                    audit_payload.files["members_without_registration.csv"],
                     filename="members_without_registration.csv",
                 ),
             ]
-            if xlsx_bytes:
-                send_files.append(discord.File(xlsx_bytes, filename="registration_audit.xlsx"))
+            if audit_payload.xlsx_bytes:
+                send_files.append(
+                    discord.File(audit_payload.xlsx_bytes, filename="registration_audit.xlsx")
+                )
 
             await ctx.followup.send(files=send_files, ephemeral=True)
         except Exception:
@@ -1044,8 +788,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
           - Dual ID columns: raw + Excel-safe formula form (e.g., =\"123...\")
           - Stable sorting for easier audits (discord_user, then account_type)
         """
-        import csv as _csv
-
         await safe_defer(ctx, ephemeral=True)
 
         guild: discord.Guild | None = ctx.guild
@@ -1081,7 +823,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        # Helper: stringify a member's roles (exclude @everyone)
         def role_names(member: discord.Member | None) -> tuple[str, str]:
             if member is None:
                 return "", ""
@@ -1090,118 +831,39 @@ def register_registry(bot: ext_commands.Bot) -> None:
             top = member.top_role.name if names else ""
             return roles_str, top
 
-        # Helper: Excel-safe formula wrapper to prevent numeric coercion on open
-        def excel_safe_formula(value: str) -> str:
-            v = (value or "").strip()
-            return f'="{v}"' if v else ""
-
-        # Build a quick lookup from cached members (best case when Members Intent is enabled)
-        # Use len(guild.members) to avoid relying on private attributes.
+        members_info: dict[str, dict] = {}
         cached_members: dict[str, discord.Member] = (
             {str(m.id): m for m in guild.members} if guild.members else {}
         )
+        missing_ids = {
+            str(uid).strip() for uid in registry.keys() if str(uid).strip() not in cached_members
+        }
+        fetched: dict[str, discord.Member | None] = {}
+        for uid in missing_ids:
+            try:
+                fetched[uid] = await guild.fetch_member(int(uid))
+            except Exception:
+                fetched[uid] = None
 
-        rows = []
-        missing_ids: set[str] = set()  # users not in cache; we'll try fetching lazily
+        for uid, member in {**cached_members, **fetched}.items():
+            roles_str, top = role_names(member)
+            members_info[uid] = {"roles": roles_str, "top_role": top}
 
-        for uid, data in registry.items():
-            uid_str = str(uid).strip()
-            member = cached_members.get(uid_str)
-            if member is None:
-                missing_ids.add(uid_str)
-
-            accounts = data.get("accounts", {})
-            if not isinstance(accounts, dict):
-                continue
-
-            for acc_type, details in accounts.items():
-                gov_id_raw = str(details.get("GovernorID", "")).strip()
-                rows.append(
-                    {
-                        "discord_id": uid_str,
-                        "discord_id_excel": excel_safe_formula(uid_str),
-                        "discord_user": data.get("discord_name", uid_str),
-                        "account_type": str(acc_type).strip(),
-                        "governor_id": gov_id_raw,
-                        "governor_id_excel": excel_safe_formula(gov_id_raw),
-                        "governor_name": details.get("GovernorName", ""),
-                        "_roles_member": member,  # temp; fill roles/top_role later
-                        "roles": "",
-                        "top_role": "",
-                    }
-                )
-
-        # Try to fetch any members that weren't cached (if Members Intent isn’t populating guild.members)
-        if missing_ids:
-            fetched: dict[str, discord.Member | None] = {}
-            for uid in list(missing_ids):
-                try:
-                    m = await guild.fetch_member(int(uid))
-                    fetched[uid] = m
-                except Exception:
-                    fetched[uid] = None  # keep None if not found (left the server, etc.)
-
-            # fill roles/top_role for missing via fetched
-            for r in rows:
-                if r["_roles_member"] is None:
-                    mem = fetched.get(r["discord_id"])
-                    r["_roles_member"] = mem
-
-        # Now populate roles/top_role and strip temp field
-        for r in rows:
-            roles_str, top = role_names(r["_roles_member"])
-            r["roles"] = roles_str
-            r["top_role"] = top
-            r.pop("_roles_member", None)
-
-        if not rows:
+        export_payload = build_registration_export_payload(registry, members_info)
+        if export_payload.row_count == 0:
             await ctx.interaction.edit_original_response(
                 content="📭 No registrations found to export."
             )
             return
 
-        # Stable sort: discord_user (casefolded) then account_type
-        rows.sort(
-            key=lambda r: (
-                str(r.get("discord_user", "")).casefold(),
-                str(r.get("account_type", "")).casefold(),
-            )
-        )
-
-        # Write CSV with UTF-8 BOM (utf-8-sig) so Excel handles Unicode cleanly
-        buf = io.StringIO()
-        headers = [
-            "discord_id",  # raw (machine-readable)
-            "discord_id_excel",  # Excel-safe display (=\"...\")
-            "discord_user",
-            "account_type",
-            "governor_id",  # raw (machine-readable)
-            "governor_id_excel",  # Excel-safe display (=\"...\")
-            "governor_name",
-            "roles",
-            "top_role",
-        ]
-        writer = _csv.DictWriter(buf, fieldnames=headers, lineterminator="\n")
-        writer.writeheader()
-        for r in rows:
-            writer.writerow({k: r.get(k, "") for k in headers})
-
-        # Encode with BOM for Excel
-        csv_bytes = io.BytesIO(buf.getvalue().encode("utf-8-sig"))
-
-        # Also produce XLSX for the same rows (preserve roles, excel-safe columns)
-        try:
-            xlsx_bytes = rows_to_xlsx_bytes(rows, headers, sheet_name="registrations")
-        except Exception:
-            logger.exception("Failed to produce XLSX export for registrations")
-            xlsx_bytes = None
-
         await ctx.interaction.edit_original_response(
             content="📤 Exported current registrations (CSV and XLSX)."
         )
-        send_files = [discord.File(csv_bytes, filename="registrations_export.csv")]
-        if xlsx_bytes:
-            send_files.append(discord.File(xlsx_bytes, filename="registrations_export.xlsx"))
+        send_files = [discord.File(export_payload.csv_bytes, filename="registrations_export.csv")]
+        if export_payload.xlsx_bytes:
+            send_files.append(
+                discord.File(export_payload.xlsx_bytes, filename="registrations_export.xlsx")
+            )
         try:
             await ctx.followup.send(files=send_files, ephemeral=True)
         except Exception:
@@ -1215,7 +877,7 @@ def register_registry(bot: ext_commands.Bot) -> None:
             "[EXPORT] bulk export by %s (%s) — %d registration row(s)",
             ctx.user,
             ctx.user.id,
-            len(rows),
+            export_payload.row_count,
         )
 
     # ===== BULK IMPORT (FOLLOW-UP ATTACHMENT FLOW) =====
@@ -1313,17 +975,15 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        rows = _parse_attachment(raw, ftype)
+        rows = parse_attachment_bytes(raw, ftype)
         if not rows:
             await ctx.interaction.edit_original_response(
                 content="❌ File could not be parsed or appears to have no data."
             )
             return
 
-        from registry.registry_service import load_registry_as_dict
-
         try:
-            existing = load_registry_as_dict()
+            existing = registry_service.load_registry_as_dict()
         except Exception as e:
             logger.exception("[IMPORT] load_registry_as_dict failed")
             await ctx.interaction.edit_original_response(
@@ -1335,82 +995,73 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        changes, errors, warnings, error_rows = prepare_import_plan(rows, existing)
+        preview = build_import_preview(rows, existing)
 
         logger.info(
             "[IMPORT] dry-run complete — file: %s rows_parsed: %d proposed_changes: %d "
             "errors: %d warnings: %d actor: %s (%s)",
             attach.filename,
             len(rows),
-            len(changes),
-            len(errors),
-            len(warnings),
+            len(preview.changes),
+            len(preview.errors),
+            len(preview.warnings),
             ctx.user,
             ctx.user.id,
         )
 
         send = ctx.followup.send if deferred else ctx.respond
 
-        if errors:
-            err_csv_bytes = build_error_csv_bytes(error_rows)
-            err_xlsx_bytes = None
-            try:
-                err_xlsx_bytes = build_error_xlsx_bytes(error_rows)
-            except Exception:
-                logger.exception("[IMPORT] failed to build XLSX error workbook")
-
-            files = [discord.File(err_csv_bytes, filename="import_errors.csv")]
-            if err_xlsx_bytes:
-                files.append(discord.File(err_xlsx_bytes, filename="import_errors.xlsx"))
+        if preview.errors:
+            files = []
+            if preview.error_csv_bytes:
+                files.append(discord.File(preview.error_csv_bytes, filename="import_errors.csv"))
+            if preview.error_xlsx_bytes:
+                files.append(discord.File(preview.error_xlsx_bytes, filename="import_errors.xlsx"))
 
             short_msg = (
-                f"❌ Validation failed: {len(errors)} error(s). "
+                f"❌ Validation failed: {len(preview.errors)} error(s). "
                 "Correct the highlighted rows and re-upload. See attached file(s) for details."
             )
-            if len(errors) <= 10:
-                content = short_msg + "\n\nErrors:\n" + "\n".join(errors[:10])
+            if len(preview.errors) <= 10:
+                content = short_msg + "\n\nErrors:\n" + "\n".join(preview.errors[:10])
                 if len(content) <= 1900:
                     await send(content=content, files=files, ephemeral=True)
                     return
             await send(content=short_msg, files=files, ephemeral=True)
             return
 
-        # Build preview embed
-        preview = [
-            f"Row {c.get('source_row')}: {c['discord_id']} | "
-            f"{c['account_type']} → {c['governor_id']}"
-            for c in changes[:20]
-        ]
         embed = discord.Embed(
             title="✅ Dry-Run Validation Passed",
             color=discord.Color.green(),
         )
         embed.description = (
-            f"**{len(changes)} change(s) proposed.**\n"
+            f"**{len(preview.changes)} change(s) proposed.**\n"
             f"Conflict behaviour: **Overwrite** — existing active slots will be superseded "
             f"and replaced with the imported values.\n\n"
-            + "\n".join(preview)
-            + (f"\n… and {len(changes) - 20} more" if len(changes) > 20 else "")
+            + "\n".join(preview.preview_lines)
+            + (f"\n… and {len(preview.changes) - 20} more" if len(preview.changes) > 20 else "")
         )
-        if warnings:
+        if preview.warnings:
             embed.add_field(
-                name=f"⚠️ Warnings ({len(warnings)})",
-                value="\n".join(warnings[:10])
-                + (f"\n… and {len(warnings) - 10} more" if len(warnings) > 10 else ""),
+                name=f"⚠️ Warnings ({len(preview.warnings)})",
+                value="\n".join(preview.warnings[:10])
+                + (
+                    f"\n… and {len(preview.warnings) - 10} more"
+                    if len(preview.warnings) > 10
+                    else ""
+                ),
                 inline=False,
             )
         embed.set_footer(text="Click Confirm to apply, or Cancel to abort.")
 
         async def _apply_import(interaction: discord.Interaction):
             try:
-                _new_registry, summary, apply_errors = apply_import_plan(
-                    changes, None, dry_run=False
-                )
-                if apply_errors:
+                apply_result = apply_import_changes(preview.changes)
+                if apply_result.errors:
                     logger.warning(
                         "[IMPORT] %d row(s) failed during apply: %s",
-                        len(apply_errors),
-                        apply_errors,
+                        len(apply_result.errors),
+                        apply_result.errors,
                     )
             except Exception as e:
                 logger.exception("[IMPORT] apply_import_plan failed at confirm")
@@ -1427,17 +1078,20 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 "[IMPORT] confirmed and applied by %s (%s) — %d change(s) from file: %s",
                 interaction.user,
                 interaction.user.id,
-                len(summary),
+                apply_result.applied_count,
                 attach.filename,
             )
 
-            text = f"✅ Import applied: {len(summary)} change(s) made.\n" + "\n".join(summary[:50])
+            text = "✅ " + build_import_summary_text(
+                apply_result,
+                include_apply_errors=False,
+            )
             if len(text) <= 1900:
                 await interaction.followup.send(text, ephemeral=True)
             else:
-                bio = io.BytesIO(("\n".join(summary)).encode("utf-8"))
+                bio = build_import_summary_file_bytes(apply_result)
                 await interaction.followup.send(
-                    f"✅ Import applied: {len(summary)} change(s). Full summary attached.",
+                    f"✅ Import applied: {apply_result.applied_count} change(s). Full summary attached.",
                     file=discord.File(bio, filename="import_summary.txt"),
                     ephemeral=True,
                 )
@@ -1492,17 +1146,15 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        rows = _parse_attachment(raw, ftype)
+        rows = parse_attachment_bytes(raw, ftype)
         if not rows:
             await ctx.interaction.edit_original_response(
                 content="❌ File could not be parsed or appears to have no data."
             )
             return
 
-        from registry.registry_service import load_registry_as_dict
-
         try:
-            existing = load_registry_as_dict()
+            existing = registry_service.load_registry_as_dict()
         except Exception as e:
             logger.exception("[IMPORT] load_registry_as_dict failed")
             await ctx.interaction.edit_original_response(
@@ -1514,34 +1166,32 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        changes, errors, warnings, error_rows = prepare_import_plan(rows, existing)
+        preview = build_import_preview(rows, existing)
 
         send = ctx.followup.send if deferred else ctx.respond
 
-        if errors:
-            err_csv_bytes = build_error_csv_bytes(error_rows)
-            files = [discord.File(err_csv_bytes, filename="import_errors.csv")]
-            try:
-                err_xlsx_bytes = build_error_xlsx_bytes(error_rows)
-                files.append(discord.File(err_xlsx_bytes, filename="import_errors.xlsx"))
-            except Exception:
-                logger.exception("[IMPORT] failed to build XLSX error workbook")
+        if preview.errors:
+            files = []
+            if preview.error_csv_bytes:
+                files.append(discord.File(preview.error_csv_bytes, filename="import_errors.csv"))
+            if preview.error_xlsx_bytes:
+                files.append(discord.File(preview.error_xlsx_bytes, filename="import_errors.xlsx"))
 
             logger.warning(
                 "[IMPORT] live import aborted — validation failed: %d error(s) "
                 "actor: %s (%s) file: %s",
-                len(errors),
+                len(preview.errors),
                 ctx.user,
                 ctx.user.id,
                 attach.filename,
             )
 
             short_msg = (
-                f"❌ Validation failed: {len(errors)} error(s). "
+                f"❌ Validation failed: {len(preview.errors)} error(s). "
                 "No changes have been applied. Correct the highlighted rows and re-upload."
             )
-            if len(errors) <= 10:
-                content = short_msg + "\n\nErrors:\n" + "\n".join(errors[:10])
+            if len(preview.errors) <= 10:
+                content = short_msg + "\n\nErrors:\n" + "\n".join(preview.errors[:10])
                 if len(content) <= 1900:
                     await send(content=content, files=files, ephemeral=True)
                     return
@@ -1549,14 +1199,7 @@ def register_registry(bot: ext_commands.Bot) -> None:
             return
 
         try:
-            _new_registry, summary, apply_errors = apply_import_plan(
-                changes, existing, dry_run=False
-            )
-            text = f"✅ Import applied: {len(summary)} change(s) made.\n" + "\n".join(summary[:50])
-            if apply_errors:
-                text += f"\n\n⚠️ {len(apply_errors)} row(s) failed:\n" + "\n".join(
-                    f"- {e}" for e in apply_errors[:20]
-                )
+            apply_result = apply_import_changes(preview.changes)
         except Exception as e:
             logger.exception("[IMPORT] apply_import_plan failed")
             await send(f"❌ Failed to apply import: {type(e).__name__}: {e}", ephemeral=True)
@@ -1565,26 +1208,21 @@ def register_registry(bot: ext_commands.Bot) -> None:
         logger.info(
             "[IMPORT] live import complete — %d change(s) applied, %d warning(s) "
             "actor: %s (%s) file: %s",
-            len(summary),
-            len(warnings),
+            apply_result.applied_count,
+            len(preview.warnings),
             ctx.user,
             ctx.user.id,
             attach.filename,
         )
 
-        text = f"✅ Import applied: {len(summary)} change(s) made.\n" + "\n".join(summary[:50])
-        if warnings:
-            text += "\n\n⚠️ Warnings:\n" + "\n".join(f"- {w}" for w in warnings[:20])
+        text = "✅ " + build_import_summary_text(apply_result, preview.warnings)
 
         if len(text) <= 1900:
             await send(text, ephemeral=True)
         else:
-            full = "\n".join(summary)
-            if warnings:
-                full += "\n\nWarnings:\n" + "\n".join(warnings)
-            bio = io.BytesIO(full.encode("utf-8"))
+            bio = build_import_summary_file_bytes(apply_result, preview.warnings)
             await send(
-                content=f"✅ Import applied: {len(summary)} change(s). Full summary attached.",
+                content=f"✅ Import applied: {apply_result.applied_count} change(s). Full summary attached.",
                 file=discord.File(bio, filename="import_summary.txt"),
                 ephemeral=True,
             )

--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -703,6 +703,23 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 "roles": roles_str,
                 "top_role": top_role,
             }
+        missing_registered_uids = {
+            str(uid).strip()
+            for uid in (registry or {}).keys()
+            if str(uid).strip() and str(uid).strip() not in members_info
+        }
+        for uid in missing_registered_uids:
+            try:
+                member = await guild.fetch_member(int(uid))
+            except Exception:
+                members_info[uid] = {"discord_user": uid, "roles": "", "top_role": ""}
+                continue
+            roles_str, top_role = role_names(member)
+            members_info[uid] = {
+                "discord_user": str(member),
+                "roles": roles_str,
+                "top_role": top_role,
+            }
 
         audit_payload = build_registration_audit_payload(registry, members_info, sql_rows)
 

--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -12,7 +12,6 @@ from bot_config import GUILD_ID
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import is_admin_and_notify_channel, track_usage
 from registry.account_slots import ACCOUNT_ORDER
-from registry.dal.audit_dal import get_active_players
 from registry.governor_registry import (
     ConfirmRemoveView,
     ModifyGovernorView,
@@ -25,6 +24,7 @@ from registry.registry_command_service import (
     build_import_summary_text,
     build_registration_audit_payload,
     build_registration_export_payload,
+    fetch_active_player_rows,
     parse_attachment_bytes,
 )
 import registry.registry_service as registry_service
@@ -652,7 +652,7 @@ def register_registry(bot: ext_commands.Bot) -> None:
             return
 
         try:
-            sql_rows = await asyncio.to_thread(get_active_players)
+            sql_rows = await asyncio.to_thread(fetch_active_player_rows)
         except Exception as e:
             logger.exception("[registration_audit] SQL fetch failed")
             await ctx.interaction.edit_original_response(

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,15 +51,6 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `commands/registry_cmds.py` registration audit and bulk import/export flows
-- Type: architecture
-- Description: The registry command module still owns substantial audit, bulk export, and bulk import response/report orchestration after the account-slot and GovernorID lookup helpers were centralised.
-- Suggested Fix: Move audit summary construction, export row shaping, import preview/error-response construction, and confirmation apply orchestration into a dedicated registry command service while leaving `registry_cmds.py` responsible for Discord defer/respond/file-send plumbing.
-- Impact: medium
-- Risk: medium
-- Dependencies: Preserve CSV/XLSX compatibility, ephemeral admin responses, and current overwrite confirmation behaviour.
-
-### Deferred Optimisation
 - Area: `registry/governor_registry.py`
 - Type: architecture
 - Description: The legacy registry facade still contains Discord UI view classes alongside backward-compatible persistence helpers, mixing service facade responsibilities with interaction-layer code.
@@ -67,3 +58,12 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Impact: medium
 - Risk: medium
 - Dependencies: Confirm all imports from registry command, telemetry, stats, and UI flows are updated without breaking registration confirmation behavior.
+
+### Deferred Optimisation
+- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `commands/mge_cmds.py`, `commands/stats_cmds.py`, `commands/telemetry_cmds.py`, `commands/inventory_cmds.py`, `inventory/inventory_service.py`
+- Type: consistency
+- Description: PR 84 centralised basic registry account slot helpers and Discord user-id parsing, but richer account resolution is still split across command and subsystem services. Stats has `StatsAccountSummary`, registry has `AccountLookup`, inventory still builds `RegisteredGovernor` lists from the legacy registry facade, and MGE/telemetry paths should be audited for their own GovernorID/name/account-list lookup shapes.
+- Suggested Fix: Design one shared account-resolution summary object that exposes ordered accounts, GovernorIDs as strings and ints, account names, slot metadata, default account selection, lookup errors, and permission-friendly helpers. Migrate stats, telemetry, MGE, registry, and inventory callers to the shared object incrementally with focused tests for each command surface.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve current command output, autocomplete ordering, inventory permission checks, and stats export behaviour while migrating callers.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -337,3 +337,92 @@ Deferred Optimisations
 - Medium risk because registry commands affect player account linking and admin import/export workflows.
 - Rollback by reverting this PR and redeploying the previous bot version.
 - No SQL deployment expected unless audit finds a contract mismatch.
+
+## 18. PR 84 Completion Update
+
+Status: tested successfully and deployed to production.
+
+PR 84 completed the first registry command standardisation pass:
+
+- `commands/registry_cmds.py` now reuses shared account-slot and Discord user-id parsing helpers from `services/governor_account_service.py`.
+- Registry account ordering now uses the canonical `registry/account_slots.py` list, expanded through Farm 20.
+- User-facing GovernorID roster lookups no longer read `target_utils._name_cache` directly from command handlers; they use `target_utils.lookup_governor_row_by_id()`.
+- `/my_registrations` now loads through `registry_service.load_registry_as_dict` instead of the removed legacy `load_registry` facade path.
+- The import-confirm apply path no longer reloads the old facade registry before applying an import plan.
+- Focused tests were added for registry command helper usage, GovernorID lookup, account slots, and the `/my_registrations` loader regression.
+- The task pack was added to the PR and later cleaned for trailing whitespace so production promotion validation passes.
+
+Validation completed during PR 84:
+
+- `.\.venv\Scripts\python.exe -m py_compile commands/registry_cmds.py services/governor_account_service.py target_utils.py registry/account_slots.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests/test_registry_cmds.py tests/test_governor_account_service.py tests/test_target_utils_governor_lookup.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "registry or registration or governor"`
+- Full suite result reported during the PR: `1323 passed, 2 skipped`.
+
+## 19. Refactor Decision Outcomes
+
+Issue	Decision	Reason
+Duplicate account type lists	complete in PR 84	Canonical account slots now come from `registry/account_slots.py` and command autocomplete uses `services/governor_account_service.py`.
+Direct _name_cache access	complete in PR 84	Command handlers now call `target_utils.lookup_governor_row_by_id()` instead of reading `target_utils._name_cache`.
+Duplicate GovernorID normalisation	partially complete / defer	User-facing registration lookup paths were standardised, but audit/import/export still contain local GovernorID extraction and normalisation logic.
+Duplicate Excel-safe helpers	defer	Excel-safe export formatting remains inside the command-heavy audit/export flows and should move with the next registry command service extraction.
+Heavy audit logic in command	defer	Captured in `docs/reference/deferred_optimisations.md` as the registry audit and bulk import/export service extraction item.
+Heavy import dry-run/apply logic in command	defer	Captured in `docs/reference/deferred_optimisations.md`; preserve CSV/XLSX and overwrite-confirm behaviour during extraction.
+Mixed registry load methods	complete in PR 84 for registry commands	`/my_registrations` and touched import-confirm paths no longer rely on the old `load_registry` facade reference.
+Inline imports inside command functions	defer	Some admin remove paths still import registry service functions inline; clean this up during the next command-service extraction.
+Response/defer inconsistency	defer	PR 84 preserved player-facing behaviour; a full response sequencing pass should happen with the command-service extraction.
+Test gaps	partially complete / defer	Focused helper and regression coverage was added; broader audit/import/export behavioural coverage remains part of the next phase.
+
+## 20. Deferred To Next Phase
+
+Carry these items into the next registry/account-resolution optimisation PR:
+
+- Extract registry audit, bulk export, bulk import preview/error-response construction, and import apply orchestration into a dedicated registry command service.
+- Move `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` out of `registry/governor_registry.py` into the UI layer, keeping the facade persistence-only.
+- Consolidate richer account resolution across registry, stats, telemetry, MGE, and inventory into one shared summary object. PR 84 introduced basic helpers, but `StatsAccountSummary`, `AccountLookup`, inventory `RegisteredGovernor` resolution, and any MGE/telemetry account lookup paths are still separate shapes.
+- Remove remaining inline imports in `commands/registry_cmds.py` once service ownership is clearer.
+- Move local GovernorID extraction/normalisation and Excel-safe formatting out of command handlers as part of the audit/export/import extraction.
+- Add focused tests for audit summary construction, export row shaping, import dry-run validation, import error-file generation, and confirmation apply orchestration.
+
+## 21. Next Phase Chat Starter
+
+Use this in a fresh Codex chat:
+
+```text
+Codex, start the next phase after PR 84 (`registry-cmds-audit-and-optimisation`) was tested and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: implement the deferred phase from PR 84. Focus on extracting registry audit, bulk export, and bulk import dry-run/apply orchestration out of `commands/registry_cmds.py` into a service/helper layer, and design the shared richer account-resolution summary object for registry/stats/telemetry/MGE/inventory. Keep the work PR-sized: if both themes are too large, scope and propose the split before coding.
+
+Important context:
+- PR 84 already centralised basic account slots, Discord user-id parsing, and public GovernorID roster lookup.
+- Do not regress `/my_registrations`; it must use `registry_service.load_registry_as_dict`.
+- Preserve command names, permissions, ephemeral/admin behaviour, CSV/XLSX compatibility, and overwrite confirmation behaviour.
+- Check whether `StatsAccountSummary`, `AccountLookup`, inventory `RegisteredGovernor` resolution, and any MGE/telemetry account lookup paths can share one richer summary object.
+- Update deferred items as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
+```
+
+## 22. PR 85A Scope Update
+
+Split decision: the next phase is divided into two PR-sized changes.
+
+PR 85A implements the registry command-service extraction only:
+
+- Extract registration audit summary/file construction into a Discord-free registry command service.
+- Extract bulk registration export row/file construction into the same service.
+- Extract bulk import dry-run preview/error-file construction and apply summary shaping into the same service.
+- Keep `commands/registry_cmds.py` responsible for slash command registration, permissions, safe defer/respond/followup handling, attachment waiting/reading, embeds, Discord files, and confirmation views.
+- Preserve `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- Preserve command names, admin-only restrictions, ephemeral/admin behavior, CSV/XLSX compatibility, and overwrite confirmation behavior.
+- Remove the matching active deferred item from `docs/reference/deferred_optimisations.md` once implemented.
+
+PR 85B remains deferred:
+
+- Design and migrate the richer shared account-resolution summary object across registry, stats, telemetry, MGE, and inventory.
+- Preserve `StatsAccountSummary`, `AccountLookup`, and inventory `RegisteredGovernor` behavior until each command surface has focused migration tests.

--- a/registry/registry_command_service.py
+++ b/registry/registry_command_service.py
@@ -84,7 +84,16 @@ class RegistryImportApplyResult:
 
 def excel_safe_formula(value: object) -> str:
     v = str(value or "").strip()
+    if len(v) >= 3 and v.startswith('="') and v.endswith('"'):
+        return v
     return f'="{v}"' if v else ""
+
+
+def fetch_active_player_rows() -> list[dict[str, Any]]:
+    """Fetch current active player rows for registration audit workflows."""
+    from registry.dal.audit_dal import get_active_players
+
+    return get_active_players()
 
 
 def normalize_registry_governor_id(value: object) -> str:

--- a/registry/registry_command_service.py
+++ b/registry/registry_command_service.py
@@ -1,0 +1,338 @@
+"""Discord-free orchestration helpers for registry admin commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import csv
+import io
+import logging
+import re
+from typing import Any
+
+from registry.registry_io import (
+    apply_import_plan,
+    build_error_csv_bytes,
+    build_error_xlsx_bytes,
+    export_registration_audit_files,
+    export_registration_audit_xlsx_bytes,
+    parse_csv_bytes,
+    parse_xlsx_bytes,
+    prepare_import_plan,
+    rows_to_xlsx_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+EXPORT_REGISTRATION_HEADERS = [
+    "discord_id",
+    "discord_id_excel",
+    "discord_user",
+    "account_type",
+    "governor_id",
+    "governor_id_excel",
+    "governor_name",
+    "roles",
+    "top_role",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryAuditPayload:
+    files: dict[str, io.BytesIO]
+    xlsx_bytes: io.BytesIO | None
+    registered_accounts_total: int
+    unregistered_current_governors_count: int
+    members_without_registration_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryExportPayload:
+    rows: list[dict[str, object]]
+    csv_bytes: io.BytesIO
+    xlsx_bytes: io.BytesIO | None
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryImportPreview:
+    changes: list[dict[str, Any]]
+    errors: list[str]
+    warnings: list[str]
+    error_rows: list[dict[str, str]]
+    error_csv_bytes: io.BytesIO | None
+    error_xlsx_bytes: io.BytesIO | None
+    preview_lines: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryImportApplyResult:
+    summary: list[str]
+    errors: list[str]
+
+    @property
+    def applied_count(self) -> int:
+        return len(self.summary)
+
+
+def excel_safe_formula(value: object) -> str:
+    v = str(value or "").strip()
+    return f'="{v}"' if v else ""
+
+
+def normalize_registry_governor_id(value: object) -> str:
+    """Normalize GovernorID-like values used in registry audit/export comparisons."""
+    if value is None:
+        return ""
+    if isinstance(value, int):
+        text = str(value)
+    elif isinstance(value, float):
+        try:
+            text = str(Decimal(str(value)).to_integral_value(rounding=ROUND_HALF_UP))
+        except Exception:
+            text = str(int(value))
+    elif isinstance(value, Decimal):
+        text = str(value.to_integral_value(rounding=ROUND_HALF_UP))
+    else:
+        text = str(value).strip()
+        if text.startswith('="') and text.endswith('"') and len(text) >= 3:
+            text = text[2:-1]
+        text = text.replace(",", "")
+        if re.fullmatch(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?", text):
+            try:
+                text = str(Decimal(text).to_integral_value(rounding=ROUND_HALF_UP))
+            except (InvalidOperation, ValueError):
+                pass
+    digits = re.findall(r"\d+", text)
+    if digits:
+        text = "".join(digits)
+    return text.lstrip("0") or ("0" if text else "")
+
+
+def extract_governor_id(details: dict[str, Any] | None) -> str:
+    """Pull a GovernorID out of a registry account dict with legacy key tolerance."""
+    if not isinstance(details, dict):
+        return ""
+    for key in (
+        "GovernorID",
+        "Governor Id",
+        "GovernorId",
+        "gov_id",
+        "govid",
+        "GovID",
+        "Gov Id",
+    ):
+        if details.get(key):
+            return str(details[key])
+    for key, value in details.items():
+        normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+        if (
+            ("governor" in normalized_key and "id" in normalized_key)
+            or normalized_key in ("govid", "govidnumber", "governorid")
+        ) and value:
+            return str(value)
+    return ""
+
+
+def parse_attachment_bytes(raw: bytes, file_type: str) -> list[dict[str, str]]:
+    """Parse CSV/XLSX import bytes. Unknown files try CSV first, then XLSX."""
+    if file_type == "csv":
+        return parse_csv_bytes(raw)
+    if file_type == "xlsx":
+        try:
+            return parse_xlsx_bytes(raw)
+        except Exception:
+            logger.exception("[IMPORT] XLSX parse failed, attempting CSV fallback")
+            return parse_csv_bytes(raw)
+
+    rows = parse_csv_bytes(raw)
+    if rows:
+        return rows
+    try:
+        return parse_xlsx_bytes(raw)
+    except Exception:
+        return []
+
+
+def _registered_governor_ids(registry: dict[str, Any]) -> set[str]:
+    registered_ids: set[str] = set()
+    for data in (registry or {}).values():
+        accounts = data.get("accounts") or {}
+        if not isinstance(accounts, dict):
+            continue
+        for details in accounts.values():
+            governor_id = normalize_registry_governor_id(extract_governor_id(details))
+            if governor_id:
+                registered_ids.add(governor_id)
+    return registered_ids
+
+
+def _current_governor_ids(sql_rows: list[dict[str, object]]) -> set[str]:
+    current_ids: set[str] = set()
+    for row in sql_rows or []:
+        governor_id = normalize_registry_governor_id(row.get("GovernorID"))
+        if governor_id:
+            current_ids.add(governor_id)
+    return current_ids
+
+
+def build_registration_audit_payload(
+    registry: dict[str, Any],
+    members_info: dict[str, dict[str, str]],
+    sql_rows: list[dict[str, object]],
+) -> RegistryAuditPayload:
+    files = export_registration_audit_files(registry, members_info, sql_rows)
+    try:
+        xlsx_bytes = export_registration_audit_xlsx_bytes(registry, members_info, sql_rows)
+    except Exception:
+        logger.exception("Failed to produce XLSX audit workbook")
+        xlsx_bytes = None
+
+    registered_accounts_total = 0
+    for data in (registry or {}).values():
+        accounts = data.get("accounts") or {}
+        if isinstance(accounts, dict):
+            registered_accounts_total += len(accounts)
+
+    registered_ids = _registered_governor_ids(registry)
+    current_ids = _current_governor_ids(sql_rows)
+    registered_user_ids = {str(key).strip() for key in (registry or {}).keys()}
+    members_without_registration_count = sum(
+        1 for uid in (members_info or {}) if str(uid).strip() not in registered_user_ids
+    )
+
+    return RegistryAuditPayload(
+        files=files,
+        xlsx_bytes=xlsx_bytes,
+        registered_accounts_total=registered_accounts_total,
+        unregistered_current_governors_count=len(sorted(current_ids - registered_ids)),
+        members_without_registration_count=members_without_registration_count,
+    )
+
+
+def build_registration_export_payload(
+    registry: dict[str, Any],
+    members_info: dict[str, dict[str, str]],
+) -> RegistryExportPayload:
+    rows: list[dict[str, object]] = []
+    for uid, data in (registry or {}).items():
+        uid_str = str(uid).strip()
+        member_info = members_info.get(uid_str, {})
+        accounts = data.get("accounts", {}) or {}
+        if not isinstance(accounts, dict):
+            continue
+        for account_type, details in accounts.items():
+            if not isinstance(details, dict):
+                continue
+            governor_id = str(details.get("GovernorID") or "").strip()
+            rows.append(
+                {
+                    "discord_id": uid_str,
+                    "discord_id_excel": excel_safe_formula(uid_str),
+                    "discord_user": data.get("discord_name", uid_str),
+                    "account_type": str(account_type).strip(),
+                    "governor_id": governor_id,
+                    "governor_id_excel": excel_safe_formula(governor_id),
+                    "governor_name": details.get("GovernorName", ""),
+                    "roles": member_info.get("roles", ""),
+                    "top_role": member_info.get("top_role", ""),
+                }
+            )
+
+    rows.sort(
+        key=lambda row: (
+            str(row.get("discord_user", "")).casefold(),
+            str(row.get("account_type", "")).casefold(),
+        )
+    )
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=EXPORT_REGISTRATION_HEADERS, lineterminator="\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({header: row.get(header, "") for header in EXPORT_REGISTRATION_HEADERS})
+    csv_bytes = io.BytesIO(buf.getvalue().encode("utf-8-sig"))
+
+    try:
+        xlsx_bytes = rows_to_xlsx_bytes(
+            rows,
+            EXPORT_REGISTRATION_HEADERS,
+            sheet_name="registrations",
+        )
+    except Exception:
+        logger.exception("Failed to produce XLSX export for registrations")
+        xlsx_bytes = None
+
+    return RegistryExportPayload(rows=rows, csv_bytes=csv_bytes, xlsx_bytes=xlsx_bytes)
+
+
+def build_import_preview(
+    rows: list[dict[str, str]],
+    existing_registry: dict[str, Any],
+) -> RegistryImportPreview:
+    changes, errors, warnings, error_rows = prepare_import_plan(rows, existing_registry)
+    error_csv_bytes = None
+    error_xlsx_bytes = None
+    if errors:
+        error_csv_bytes = build_error_csv_bytes(error_rows)
+        try:
+            error_xlsx_bytes = build_error_xlsx_bytes(error_rows)
+        except Exception:
+            logger.exception("[IMPORT] failed to build XLSX error workbook")
+
+    preview_lines = [
+        f"Row {change.get('source_row')}: {change['discord_id']} | "
+        f"{change['account_type']} -> {change['governor_id']}"
+        for change in changes[:20]
+    ]
+    return RegistryImportPreview(
+        changes=changes,
+        errors=errors,
+        warnings=warnings,
+        error_rows=error_rows,
+        error_csv_bytes=error_csv_bytes,
+        error_xlsx_bytes=error_xlsx_bytes,
+        preview_lines=preview_lines,
+    )
+
+
+def apply_import_changes(changes: list[dict[str, Any]]) -> RegistryImportApplyResult:
+    _new_registry, summary, errors = apply_import_plan(changes, None, dry_run=False)
+    return RegistryImportApplyResult(summary=summary, errors=errors)
+
+
+def build_import_summary_text(
+    result: RegistryImportApplyResult,
+    warnings: list[str] | None = None,
+    *,
+    include_apply_errors: bool = True,
+) -> str:
+    text = f"Import applied: {result.applied_count} change(s) made.\n" + "\n".join(
+        result.summary[:50]
+    )
+    if include_apply_errors and result.errors:
+        text += f"\n\n{len(result.errors)} row(s) failed:\n" + "\n".join(
+            f"- {error}" for error in result.errors[:20]
+        )
+    if warnings:
+        text += "\n\nWarnings:\n" + "\n".join(f"- {warning}" for warning in warnings[:20])
+    return text
+
+
+def build_import_summary_file_bytes(
+    result: RegistryImportApplyResult,
+    warnings: list[str] | None = None,
+) -> io.BytesIO:
+    full = "\n".join(result.summary)
+    if result.errors:
+        full += "\n\nApply errors:\n" + "\n".join(result.errors)
+    if warnings:
+        full += "\n\nWarnings:\n" + "\n".join(warnings)
+    return io.BytesIO(full.encode("utf-8"))

--- a/registry/registry_command_service.py
+++ b/registry/registry_command_service.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import csv
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 import io
 import logging
 import re
@@ -212,7 +212,7 @@ def build_registration_audit_payload(
         files=files,
         xlsx_bytes=xlsx_bytes,
         registered_accounts_total=registered_accounts_total,
-        unregistered_current_governors_count=len(sorted(current_ids - registered_ids)),
+        unregistered_current_governors_count=len(current_ids - registered_ids),
         members_without_registration_count=members_without_registration_count,
     )
 
@@ -289,7 +289,7 @@ def build_import_preview(
 
     preview_lines = [
         f"Row {change.get('source_row')}: {change['discord_id']} | "
-        f"{change['account_type']} -> {change['governor_id']}"
+        f"{change['account_type']} → {change['governor_id']}"
         for change in changes[:20]
     ]
     return RegistryImportPreview(
@@ -318,11 +318,11 @@ def build_import_summary_text(
         result.summary[:50]
     )
     if include_apply_errors and result.errors:
-        text += f"\n\n{len(result.errors)} row(s) failed:\n" + "\n".join(
+        text += f"\n\n⚠️ {len(result.errors)} row(s) failed:\n" + "\n".join(
             f"- {error}" for error in result.errors[:20]
         )
     if warnings:
-        text += "\n\nWarnings:\n" + "\n".join(f"- {warning}" for warning in warnings[:20])
+        text += "\n\n⚠️ Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings[:20])
     return text
 
 

--- a/tests/test_registry_cmds.py
+++ b/tests/test_registry_cmds.py
@@ -33,3 +33,9 @@ def test_registration_audit_fetches_missing_registered_members_before_payload() 
     assert "missing_registered_uids" in source
     assert "guild.fetch_member" in source
     assert "build_registration_audit_payload(registry, members_info, sql_rows)" in source
+
+
+def test_registry_cmds_do_not_import_registry_dal_directly() -> None:
+    source = Path("commands/registry_cmds.py").read_text(encoding="utf-8")
+
+    assert "from registry.dal" not in source

--- a/tests/test_registry_cmds.py
+++ b/tests/test_registry_cmds.py
@@ -25,3 +25,11 @@ def test_my_registrations_uses_service_loader_not_removed_facade_import() -> Non
 
     assert "asyncio.to_thread(load_registry)" not in source
     assert "registry_service.load_registry_as_dict" in source
+
+
+def test_registration_audit_fetches_missing_registered_members_before_payload() -> None:
+    source = Path("commands/registry_cmds.py").read_text(encoding="utf-8")
+
+    assert "missing_registered_uids" in source
+    assert "guild.fetch_member" in source
+    assert "build_registration_audit_payload(registry, members_info, sql_rows)" in source

--- a/tests/test_registry_command_service.py
+++ b/tests/test_registry_command_service.py
@@ -88,7 +88,7 @@ def test_build_import_preview_shapes_success_preview_lines() -> None:
     preview = svc.build_import_preview(rows, {})
 
     assert preview.ok
-    assert preview.preview_lines == ["Row 2: 123 | Main -> 100001"]
+    assert preview.preview_lines == ["Row 2: 123 | Main → 100001"]
     assert preview.changes[0]["governor_name"] == "Alpha"
 
 
@@ -101,5 +101,6 @@ def test_build_import_summary_text_includes_apply_errors_and_warnings() -> None:
     text = svc.build_import_summary_text(result, ["Row 2: formula"])
 
     assert "1 change(s) made" in text
-    assert "1 row(s) failed" in text
+    assert "⚠️ 1 row(s) failed" in text
+    assert "⚠️ Warnings" in text
     assert "Row 2: formula" in text

--- a/tests/test_registry_command_service.py
+++ b/tests/test_registry_command_service.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import csv
+import io
+
+from registry import registry_command_service as svc
+
+
+def _sample_registry() -> dict:
+    return {
+        "200": {
+            "discord_name": "BetaUser",
+            "accounts": {"Main": {"GovernorID": "200100", "GovernorName": "Beta"}},
+        },
+        "100": {
+            "discord_name": "AlphaUser",
+            "accounts": {
+                "Main": {"GovernorID": '="100001"', "GovernorName": "Alpha"},
+                "Alt 1": {"GovernorID": "100002", "GovernorName": "AlphaAlt"},
+            },
+        },
+    }
+
+
+def test_build_registration_audit_payload_counts_and_files() -> None:
+    registry = _sample_registry()
+    members_info = {
+        "100": {"discord_user": "AlphaUser", "roles": "R1", "top_role": "R1"},
+        "300": {"discord_user": "NoReg", "roles": "", "top_role": ""},
+    }
+    sql_rows = [
+        {"GovernorID": 100001, "GovernorName": "Alpha"},
+        {"GovernorID": 300300, "GovernorName": "Unregistered"},
+    ]
+
+    payload = svc.build_registration_audit_payload(registry, members_info, sql_rows)
+
+    assert payload.registered_accounts_total == 3
+    assert payload.unregistered_current_governors_count == 1
+    assert payload.members_without_registration_count == 1
+    assert set(payload.files) == {
+        "registered_accounts.csv",
+        "unregistered_current_governors.csv",
+        "members_without_registration.csv",
+    }
+
+
+def test_build_registration_export_payload_sorts_and_preserves_excel_safe_columns() -> None:
+    payload = svc.build_registration_export_payload(
+        _sample_registry(),
+        {
+            "100": {"roles": "R1;R2", "top_role": "R2"},
+            "200": {"roles": "R3", "top_role": "R3"},
+        },
+    )
+
+    text = payload.csv_bytes.getvalue().decode("utf-8-sig")
+    rows = list(csv.DictReader(io.StringIO(text)))
+
+    assert payload.row_count == 3
+    assert [row["discord_user"] for row in rows] == ["AlphaUser", "AlphaUser", "BetaUser"]
+    assert rows[0]["discord_id_excel"] == '="100"'
+    assert rows[0]["governor_id_excel"] == '="100002"'
+    assert rows[0]["roles"] == "R1;R2"
+
+
+def test_build_import_preview_creates_error_files_for_invalid_rows() -> None:
+    rows = [{"discord_id": "123", "account_type": "Main", "governor_id": "not-a-number"}]
+
+    preview = svc.build_import_preview(rows, {})
+
+    assert not preview.ok
+    assert preview.errors
+    assert preview.error_csv_bytes is not None
+    assert "Invalid GovernorID" in preview.errors[0]
+
+
+def test_build_import_preview_shapes_success_preview_lines() -> None:
+    rows = [
+        {
+            "discord_id": "123",
+            "account_type": "Main",
+            "governor_id": "100001",
+            "governor_name": "Alpha",
+        }
+    ]
+
+    preview = svc.build_import_preview(rows, {})
+
+    assert preview.ok
+    assert preview.preview_lines == ["Row 2: 123 | Main -> 100001"]
+    assert preview.changes[0]["governor_name"] == "Alpha"
+
+
+def test_build_import_summary_text_includes_apply_errors_and_warnings() -> None:
+    result = svc.RegistryImportApplyResult(
+        summary=["123: Main -> 100001 (Alpha)"],
+        errors=["Row 3: duplicate"],
+    )
+
+    text = svc.build_import_summary_text(result, ["Row 2: formula"])
+
+    assert "1 change(s) made" in text
+    assert "1 row(s) failed" in text
+    assert "Row 2: formula" in text

--- a/tests/test_registry_command_service.py
+++ b/tests/test_registry_command_service.py
@@ -62,6 +62,14 @@ def test_build_registration_export_payload_sorts_and_preserves_excel_safe_column
     assert rows[0]["discord_id_excel"] == '="100"'
     assert rows[0]["governor_id_excel"] == '="100002"'
     assert rows[0]["roles"] == "R1;R2"
+    main_row = next(row for row in rows if row["account_type"] == "Main")
+    assert main_row["governor_id"] == '="100001"'
+    assert main_row["governor_id_excel"] == '="100001"'
+
+
+def test_excel_safe_formula_does_not_double_wrap_existing_formula() -> None:
+    assert svc.excel_safe_formula('="100001"') == '="100001"'
+    assert svc.excel_safe_formula("100001") == '="100001"'
 
 
 def test_build_import_preview_creates_error_files_for_invalid_rows() -> None:


### PR DESCRIPTION
## Summary

- Extracted registration audit, bulk export, and bulk import preview/apply shaping from `commands/registry_cmds.py` into a Discord-free `registry.registry_command_service` module.
- Kept registry commands responsible for Discord permissions, defer/respond/followup handling, file delivery, attachment waiting, embeds, and confirmation views.
- Added focused service tests for audit counts/files, export row shaping, import preview errors, import preview lines, and apply summary text.
- Updated the PR 84 task pack with the agreed PR 85A/85B split and removed the completed registry audit/import/export deferred item while keeping shared account-resolution work deferred for PR 85B.
- Addressed review feedback by restoring `registration_audit` member fetch fallback, restoring admin-facing warning/arrow glyphs, removing an unnecessary sort in audit count construction, routing active-player audit fetches through the service layer, and making Excel-safe export formatting idempotent.

## Behavior Preserved

- Command names and admin-only restrictions are unchanged.
- `/my_registrations` still loads through `registry_service.load_registry_as_dict`.
- CSV/XLSX import/export support is preserved.
- Import overwrite confirmation behavior is preserved.
- Registration audit roles/top-role output still fetches registered users missing from `guild.members` before building audit files.
- Existing Excel-safe GovernorID values are preserved without double-wrapping.
- No SQL schema changes are included.

## Validation

- `.\.venv\Scripts\python.exe -m py_compile commands/registry_cmds.py registry/registry_command_service.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pre_commit run -a`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_registry_cache.py tests/test_registry_cmds.py tests/test_registry_command_service.py tests/test_registry_dal.py tests/test_registry_governor_registry.py tests/test_registry_io.py tests/test_registry_io_error_roundtrip.py tests/test_registry_io_xlsx.py tests/test_registry_service.py tests/test_registry_views_smoke.py` (`106 passed`)
- `.\.venv\Scripts\python.exe -m pytest -q tests -k "registry"` (`121 passed, 1213 deselected`)
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1332 passed, 2 skipped`)

Note: the literal `tests/test_registry_*.py` command recommended by `select_tests.py` does not expand under PowerShell in this environment, so the matching files were passed explicitly.

## Risk / Rollback

- Medium risk because registry admin import/export/audit workflows affect operational account management.
- Roll back by reverting this PR and redeploying the previous bot build.
- No SQL deployment is required.