### PR TITLE
[codex] Move registry views to UI layer

### DIFF
--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -12,11 +12,6 @@ from bot_config import GUILD_ID
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import is_admin_and_notify_channel, track_usage
 from registry.account_slots import ACCOUNT_ORDER
-from registry.governor_registry import (
-    ConfirmRemoveView,
-    ModifyGovernorView,
-    RegisterGovernorView,
-)
 from registry.registry_command_service import (
     apply_import_changes,
     build_import_preview,
@@ -42,7 +37,12 @@ from services.governor_account_service import (
 )
 import target_utils
 from ui.views.admin_views import ConfirmImportView
-from ui.views.registry_views import MyRegsActionView
+from ui.views.registry_views import (
+    ConfirmRemoveView,
+    ModifyGovernorView,
+    MyRegsActionView,
+    RegisterGovernorView,
+)
 from versioning import versioned
 
 logger = logging.getLogger(__name__)
@@ -354,8 +354,6 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 content="❌ Please paste a valid Discord user ID (15–22 digits) or a mention."
             )
             return
-
-        from registry.registry_service import get_user_accounts, remove_governor
 
         accounts = await asyncio.to_thread(get_user_accounts, target_id)
         if not accounts:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,19 +51,10 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `registry/governor_registry.py`
-- Type: architecture
-- Description: The legacy registry facade still contains Discord UI view classes alongside backward-compatible persistence helpers, mixing service facade responsibilities with interaction-layer code.
-- Suggested Fix: Move `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` into `ui/views/registry_views.py` or a focused registry view module, then keep `registry/governor_registry.py` as a compatibility facade over registry services only.
-- Impact: medium
-- Risk: medium
-- Dependencies: Confirm all imports from registry command, telemetry, stats, and UI flows are updated without breaking registration confirmation behavior.
-
-### Deferred Optimisation
 - Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `commands/mge_cmds.py`, `commands/stats_cmds.py`, `commands/telemetry_cmds.py`, `commands/inventory_cmds.py`, `inventory/inventory_service.py`
 - Type: consistency
-- Description: PR 84 centralised basic registry account slot helpers and Discord user-id parsing, but richer account resolution is still split across command and subsystem services. Stats has `StatsAccountSummary`, registry has `AccountLookup`, inventory still builds `RegisteredGovernor` lists from the legacy registry facade, and MGE/telemetry paths should be audited for their own GovernorID/name/account-list lookup shapes.
+- Description: PR 84 centralised basic registry account slot helpers and Discord user-id parsing, PR 85A extracted registry audit/import/export orchestration, and the registry confirmation views have moved into the UI layer, but richer account resolution is still split across command and subsystem services. Stats has `StatsAccountSummary`, registry has `AccountLookup`, inventory still builds `RegisteredGovernor` lists from the registry facade, and MGE/telemetry paths should be audited for their own GovernorID/name/account-list lookup shapes.
 - Suggested Fix: Design one shared account-resolution summary object that exposes ordered accounts, GovernorIDs as strings and ints, account names, slot metadata, default account selection, lookup errors, and permission-friendly helpers. Migrate stats, telemetry, MGE, registry, and inventory callers to the shared object incrementally with focused tests for each command surface.
 - Impact: medium
 - Risk: medium
-- Dependencies: Preserve current command output, autocomplete ordering, inventory permission checks, and stats export behaviour while migrating callers.
+- Dependencies: Preserve current command output, autocomplete ordering, inventory permission checks, and stats export behaviour while migrating callers. Requires a dedicated cross-subsystem design pass before implementation.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -369,29 +369,38 @@ Validation completed during PR 84:
 Issue	Decision	Reason
 Duplicate account type lists	complete in PR 84	Canonical account slots now come from `registry/account_slots.py` and command autocomplete uses `services/governor_account_service.py`.
 Direct _name_cache access	complete in PR 84	Command handlers now call `target_utils.lookup_governor_row_by_id()` instead of reading `target_utils._name_cache`.
-Duplicate GovernorID normalisation	partially complete / defer	User-facing registration lookup paths were standardised, but audit/import/export still contain local GovernorID extraction and normalisation logic.
-Duplicate Excel-safe helpers	defer	Excel-safe export formatting remains inside the command-heavy audit/export flows and should move with the next registry command service extraction.
-Heavy audit logic in command	defer	Captured in `docs/reference/deferred_optimisations.md` as the registry audit and bulk import/export service extraction item.
-Heavy import dry-run/apply logic in command	defer	Captured in `docs/reference/deferred_optimisations.md`; preserve CSV/XLSX and overwrite-confirm behaviour during extraction.
+Duplicate GovernorID normalisation	complete for registry command audit/import/export in PR 85A	Registry audit, export, and import helper logic now lives in `registry/registry_command_service.py`; broader shared account-resolution normalisation remains deferred as PR 85B.
+Duplicate Excel-safe helpers	complete in PR 85A	Excel-safe export formatting moved into `registry/registry_command_service.py` and was made idempotent after review feedback.
+Heavy audit logic in command	complete in PR 85A	Registration audit summary and file construction now live in `registry/registry_command_service.py`; the command remains Discord response plumbing.
+Heavy import dry-run/apply logic in command	complete in PR 85A	Bulk import preview, error-file construction, apply result shaping, and summary text now live in `registry/registry_command_service.py`.
 Mixed registry load methods	complete in PR 84 for registry commands	`/my_registrations` and touched import-confirm paths no longer rely on the old `load_registry` facade reference.
-Inline imports inside command functions	defer	Some admin remove paths still import registry service functions inline; clean this up during the next command-service extraction.
-Response/defer inconsistency	defer	PR 84 preserved player-facing behaviour; a full response sequencing pass should happen with the command-service extraction.
-Test gaps	partially complete / defer	Focused helper and regression coverage was added; broader audit/import/export behavioural coverage remains part of the next phase.
+Inline imports inside command functions	partially complete / opportunistic cleanup	PR 85A removed DAL access from `commands/registry_cmds.py`; one local registry-service import remains in the admin remove flow and can be cleaned up when that flow is next touched.
+Response/defer inconsistency	preserved / no active deferred item	PR 85A preserved command names, permissions, ephemeral/admin behaviour, CSV/XLSX compatibility, and overwrite confirmation behaviour.
+Test gaps	complete for PR 85A scope	Focused service and command regression coverage was added for audit payloads, export shaping, import preview/apply summaries, member-cache fallback, glyph preservation, Excel-safe formatting, and command-layer DAL boundaries.
 
-## 20. Deferred To Next Phase
+## 20. Remaining Deferred Items After PR 85A
 
-Carry these items into the next registry/account-resolution optimisation PR:
+PR 85A has been smoke tested successfully and deployed to production. It completed the registry command-service extraction for registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping.
 
-- Extract registry audit, bulk export, bulk import preview/error-response construction, and import apply orchestration into a dedicated registry command service.
+Two strategic registry/account optimisation items remained deferred after PR 85A:
+
 - Move `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` out of `registry/governor_registry.py` into the UI layer, keeping the facade persistence-only.
 - Consolidate richer account resolution across registry, stats, telemetry, MGE, and inventory into one shared summary object. PR 84 introduced basic helpers, but `StatsAccountSummary`, `AccountLookup`, inventory `RegisteredGovernor` resolution, and any MGE/telemetry account lookup paths are still separate shapes.
-- Remove remaining inline imports in `commands/registry_cmds.py` once service ownership is clearer.
-- Move local GovernorID extraction/normalisation and Excel-safe formatting out of command handlers as part of the audit/export/import extraction.
-- Add focused tests for audit summary construction, export row shaping, import dry-run validation, import error-file generation, and confirmation apply orchestration.
 
-## 21. Next Phase Chat Starter
+Recommended next item: move the registry view classes out of `registry/governor_registry.py`.
 
-Use this in a fresh Codex chat:
+Rationale:
+
+- It is a tighter PR-sized architecture cleanup than the shared account summary work.
+- It finishes the registry facade cleanup started by PR 84 and PR 85A.
+- It should mostly affect registry imports, view placement, and smoke tests rather than several subsystems at once.
+- It reduces legacy coupling before the shared account summary migration touches registry, stats, telemetry, MGE, and inventory.
+
+Keep the shared richer account-resolution summary deferred for the following phase unless a new task explicitly approves a broader cross-subsystem design PR.
+
+## 21. Historical PR 85A Chat Starter
+
+This starter was used for PR 85A and is retained for history:
 
 ```text
 Codex, start the next phase after PR 84 (`registry-cmds-audit-and-optimisation`) was tested and deployed to production.
@@ -426,3 +435,63 @@ PR 85B remains deferred:
 
 - Design and migrate the richer shared account-resolution summary object across registry, stats, telemetry, MGE, and inventory.
 - Preserve `StatsAccountSummary`, `AccountLookup`, and inventory `RegisteredGovernor` behavior until each command surface has focused migration tests.
+
+## 23. PR 85A Completion Update
+
+Status: smoke tested successfully and deployed to production.
+
+PR 85A delivered:
+
+- `registry/registry_command_service.py` as a Discord-free service/helper layer for registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping.
+- Thinner `commands/registry_cmds.py` handlers that keep Discord permissions, safe defer/respond/followup handling, attachment waiting/reading, embeds, Discord files, and confirmation views in the command layer.
+- Preservation of command names, admin restrictions, ephemeral/admin behaviour, CSV/XLSX compatibility, overwrite confirmation behaviour, and `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- Review fixes for registration audit member-cache fallback, admin-facing warning/arrow glyphs, unnecessary audit-count sorting, command-layer DAL imports, and idempotent Excel-safe formatting.
+- Focused regression coverage in `tests/test_registry_command_service.py` and `tests/test_registry_cmds.py`.
+
+Validation completed during PR 85A:
+
+- `.\.venv\Scripts\python.exe -m py_compile commands/registry_cmds.py registry/registry_command_service.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `.\.venv\Scripts\python.exe -m pytest -q tests/test_registry_cache.py tests/test_registry_cmds.py tests/test_registry_command_service.py tests/test_registry_dal.py tests/test_registry_governor_registry.py tests/test_registry_io.py tests/test_registry_io_error_roundtrip.py tests/test_registry_io_xlsx.py tests/test_registry_service.py tests/test_registry_views_smoke.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "registry"`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+
+## 24. Next Phase Chat Starter
+
+Use this in a fresh Codex chat for the recommended next optimisation:
+
+```text
+Codex, start the next registry optimisation after PR 85A (`registry-command-service-extraction`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: move `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` out of `registry/governor_registry.py` into the UI layer, keeping `registry/governor_registry.py` as a compatibility facade over registry services/persistence only.
+
+Important context:
+- PR 84 centralised basic account slots, Discord user-id parsing, public GovernorID roster lookup, and `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- PR 85A extracted registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping into `registry/registry_command_service.py`.
+- Preserve command names, permissions, ephemeral/admin behaviour, registration confirmation/cancel behaviour, and existing import paths where compatibility shims are needed.
+- Update imports from registry commands, telemetry, stats, UI smoke tests, and any other callers without changing user-facing behaviour.
+- Keep the shared richer account-resolution summary object deferred unless the audit finds a tiny prerequisite that is safe and clearly in scope.
+- Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
+```
+
+## 25. Registry View-Layer Extraction Completion Update
+
+Status: implemented for the next registry optimisation after PR 85A.
+
+This phase delivered:
+
+- `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` now live in `ui/views/registry_views.py`.
+- `registry/governor_registry.py` remains a compatibility facade for registry persistence/service helpers and exposes lazy compatibility re-exports for the moved view classes.
+- `commands/registry_cmds.py` imports registry confirmation views from the UI layer.
+- The remaining inline `registry.registry_service` import inside `remove_registration_by_id` was removed; the command now uses the module-level service imports.
+- Registration confirmation, modification confirmation, removal confirmation, cancel behaviour, ephemeral behaviour, command names, and permission boundaries were preserved.
+- The active deferred item for moving registry view classes was removed from `docs/reference/deferred_optimisations.md`.
+
+The richer shared account-resolution summary remains deferred as a separate cross-subsystem design and migration task.

--- a/registry/governor_registry.py
+++ b/registry/governor_registry.py
@@ -187,6 +187,9 @@ def __getattr__(name: str):
 
 
 __all__ = [
+    "ConfirmRemoveView",  # noqa: F822 - provided lazily by __getattr__
+    "ModifyGovernorView",  # noqa: F822 - provided lazily by __getattr__
+    "RegisterGovernorView",  # noqa: F822 - provided lazily by __getattr__
     "get_discord_name_for_governor",
     "get_user_main_governor_id",
     "get_user_main_governor_name",

--- a/registry/governor_registry.py
+++ b/registry/governor_registry.py
@@ -1,6 +1,6 @@
 # governor_registry.py
 """
-Governor registry façade and Discord UI views.
+Governor registry façade.
 
 Persistence and business logic are now owned by:
   registry_dal.py     — SQL data access layer
@@ -8,19 +8,18 @@ Persistence and business logic are now owned by:
 
 This module is retained for:
   1. Backward-compatible load_registry() signature called throughout the codebase.
-  2. register_account() called by RegisterGovernorView and ModifyGovernorView.
+  2. register_account() called by registry UI confirmation views.
   3. get_discord_name_for_governor() called by stats/embed helpers.
   4. get_user_main_governor_id / get_user_main_governor_name dict-based helpers.
-  5. Discord UI View classes: RegisterGovernorView, ModifyGovernorView, ConfirmRemoveView.
+  5. Backward-compatible lazy re-exports for moved registry UI View classes.
 
 KVKStatsView and KVKAccountButton have been moved to ui/views/stats_views.py.
+RegisterGovernorView, ModifyGovernorView, and ConfirmRemoveView live in ui/views/registry_views.py.
 """
 
 from __future__ import annotations
 
 import logging
-
-import discord
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +61,7 @@ def load_registry() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# register_account — used by RegisterGovernorView and ModifyGovernorView
+# register_account — used by registry UI confirmation views
 # ---------------------------------------------------------------------------
 
 
@@ -81,7 +80,7 @@ def register_account(
 
     Routes to registry_service.register_governor().
     If the slot already exists, automatically calls modify_governor()
-    so that both RegisterGovernorView and ModifyGovernorView can share
+    so that register and modify confirmation views can share
     this single entry point without worrying about which SP to call.
     """
     from registry.registry_service import (
@@ -172,133 +171,25 @@ def get_user_main_governor_name(registry: dict, user_id: str | int) -> str | Non
     return svc_name(int(user_id))
 
 
-# ---------------------------------------------------------------------------
-# Discord UI Views
-# (No persistence logic — all writes go through register_account() above)
-# ---------------------------------------------------------------------------
+_MOVED_VIEW_NAMES = {
+    "RegisterGovernorView",
+    "ModifyGovernorView",
+    "ConfirmRemoveView",
+}
 
 
-class RegisterGovernorView(discord.ui.View):
-    def __init__(self, user, account_type, governor_id, governor_name):
-        super().__init__(timeout=60)
-        self.user = user
-        self.account_type = account_type
-        self.governor_id = governor_id
-        self.governor_name = governor_name
+def __getattr__(name: str):
+    if name in _MOVED_VIEW_NAMES:
+        from ui.views import registry_views
 
-    @discord.ui.button(label="✅ Confirm", style=discord.ButtonStyle.success)
-    async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message(
-                "This isn't your registration to confirm!", ephemeral=True
-            )
-            return
-
-        ok, err = register_account(
-            discord_id=str(self.user.id),
-            discord_name=str(self.user),
-            account_type=self.account_type,
-            governor_id=self.governor_id,
-            governor_name=self.governor_name,
-        )
-
-        if not ok:
-            await interaction.response.edit_message(
-                content=f"❌ Registration failed: {err or 'Unknown error.'}", view=None
-            )
-        else:
-            await interaction.response.edit_message(
-                content=(
-                    f"✅ Registered `{self.account_type}` as "
-                    f"**{self.governor_name}** (ID: `{self.governor_id}`)"
-                ),
-                view=None,
-            )
-
-    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.danger)
-    async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id == self.user.id:
-            await interaction.response.edit_message(content="❌ Registration cancelled.", view=None)
+        return getattr(registry_views, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-class ModifyGovernorView(discord.ui.View):
-    def __init__(self, user, account_type, new_gov_id, new_gov_name):
-        super().__init__(timeout=60)
-        self.user = user
-        self.account_type = account_type
-        self.new_gov_id = new_gov_id
-        self.new_gov_name = new_gov_name
-
-    @discord.ui.button(label="✅ Confirm Change", style=discord.ButtonStyle.success)
-    async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message(
-                "This isn't your registration to change!", ephemeral=True
-            )
-            return
-
-        ok, err = register_account(
-            discord_id=str(self.user.id),
-            discord_name=str(self.user),
-            account_type=self.account_type,
-            governor_id=self.new_gov_id,
-            governor_name=self.new_gov_name,
-        )
-
-        if not ok:
-            await interaction.response.edit_message(
-                content=f"❌ Update failed: {err or 'Unknown error.'}", view=None
-            )
-        else:
-            await interaction.response.edit_message(
-                content=(
-                    f"✅ `{self.account_type}` updated to "
-                    f"**{self.new_gov_name}** (ID: `{self.new_gov_id}`)"
-                ),
-                view=None,
-            )
-
-    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.danger)
-    async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id == self.user.id:
-            await interaction.response.edit_message(content="❌ Modification cancelled.", view=None)
-
-
-class ConfirmRemoveView(discord.ui.View):
-    def __init__(self, user, account_type):
-        super().__init__(timeout=60)
-        self.user = user
-        self.account_type = account_type
-
-    @discord.ui.button(label="✅ Confirm Remove", style=discord.ButtonStyle.danger)
-    async def confirm(self, button, interaction: discord.Interaction):
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message(
-                "You cannot modify someone else's registration.", ephemeral=True
-            )
-            return
-
-        from registry.registry_service import remove_governor
-
-        ok, err = remove_governor(
-            discord_user_id=interaction.user.id,
-            account_type=self.account_type,
-            removed_by=interaction.user.id,
-        )
-
-        if ok:
-            await interaction.response.send_message(
-                f"✅ `{self.account_type}` has been removed from your registered accounts.",
-                ephemeral=True,
-            )
-        else:
-            await interaction.response.send_message(
-                f"❌ {err or 'Could not remove registration.'}", ephemeral=True
-            )
-        self.stop()
-
-    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.secondary)
-    async def cancel(self, button, interaction: discord.Interaction):
-        if interaction.user.id == self.user.id:
-            await interaction.response.edit_message(content="❌ Removal cancelled.", view=None)
-        self.stop()
+__all__ = [
+    "get_discord_name_for_governor",
+    "get_user_main_governor_id",
+    "get_user_main_governor_name",
+    "load_registry",
+    "register_account",
+]

--- a/tests/test_registry_governor_registry.py
+++ b/tests/test_registry_governor_registry.py
@@ -107,6 +107,20 @@ def test_registry_view_compat_imports_resolve_to_ui_views():
     assert ConfirmRemoveView is UiConfirmRemoveView
 
 
+def test_registry_view_compat_import_star_includes_moved_views():
+    namespace = {}
+    exec("from registry.governor_registry import *", namespace)
+    from ui.views.registry_views import (
+        ConfirmRemoveView as UiConfirmRemoveView,
+        ModifyGovernorView as UiModifyGovernorView,
+        RegisterGovernorView as UiRegisterGovernorView,
+    )
+
+    assert namespace["RegisterGovernorView"] is UiRegisterGovernorView
+    assert namespace["ModifyGovernorView"] is UiModifyGovernorView
+    assert namespace["ConfirmRemoveView"] is UiConfirmRemoveView
+
+
 def test_kvkstatsview_not_in_governor_registry():
     """KVKStatsView must have been removed from governor_registry."""
     assert not hasattr(

--- a/tests/test_registry_governor_registry.py
+++ b/tests/test_registry_governor_registry.py
@@ -5,6 +5,7 @@ Unit tests for registry.governor_registry façade.
 Verifies the backward-compat shim behaviour:
   - load_registry() reads from SQL and returns the legacy dict shape.
   - load_registry() returns {} (not raise) on SQL failure and logs at ERROR.
+  - registry Discord views live in ui.views.registry_views with lazy facade compatibility.
   - KVKStatsView has been moved to ui/views/stats_views.py.
 """
 
@@ -79,8 +80,31 @@ def test_load_registry_uses_cache_path(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# KVKStatsView location
+# Moved view locations
 # ---------------------------------------------------------------------------
+
+
+def test_registry_views_not_defined_in_governor_registry():
+    """Registry confirmation views should be owned by ui.views.registry_views."""
+    for name in ("RegisterGovernorView", "ModifyGovernorView", "ConfirmRemoveView"):
+        assert name not in gg.__dict__
+
+
+def test_registry_view_compat_imports_resolve_to_ui_views():
+    from registry.governor_registry import (
+        ConfirmRemoveView,
+        ModifyGovernorView,
+        RegisterGovernorView,
+    )
+    from ui.views.registry_views import (
+        ConfirmRemoveView as UiConfirmRemoveView,
+        ModifyGovernorView as UiModifyGovernorView,
+        RegisterGovernorView as UiRegisterGovernorView,
+    )
+
+    assert RegisterGovernorView is UiRegisterGovernorView
+    assert ModifyGovernorView is UiModifyGovernorView
+    assert ConfirmRemoveView is UiConfirmRemoveView
 
 
 def test_kvkstatsview_not_in_governor_registry():

--- a/tests/test_registry_views_smoke.py
+++ b/tests/test_registry_views_smoke.py
@@ -5,28 +5,15 @@ import os
 import sys
 import types
 
-import discord
-
 
 def _load_registry_views(monkeypatch):
     os.environ.setdefault("OUR_KINGDOM", "0")
     monkeypatch.setitem(sys.modules, "aiofiles", types.SimpleNamespace(open=None))
 
-    # Stub the registry package modules at their new locations.
-    # Both the dotted path and the bare name are registered so that any
-    # import style (import registry.governor_registry / from registry import ...)
-    # resolves to the same stub without importing the real SQL-backed module.
-
+    # Stub the facade dependency used by registry_views without importing SQL-backed code.
     gov_stub = types.ModuleType("registry.governor_registry")
-
-    class _DummyView(discord.ui.View):
-        def __init__(self, *args, **kwargs):
-            super().__init__(timeout=10)
-
-    gov_stub.ConfirmRemoveView = _DummyView
-    gov_stub.ModifyGovernorView = _DummyView
-    gov_stub.RegisterGovernorView = _DummyView
     gov_stub.load_registry = lambda: {}
+    gov_stub.register_account = lambda **_kw: (True, None)
     monkeypatch.setitem(sys.modules, "registry.governor_registry", gov_stub)
 
     # Stub registry_service so any import from it doesn't attempt a SQL connection.
@@ -38,7 +25,9 @@ def _load_registry_views(monkeypatch):
             *[f"Farm {i}" for i in range(1, 21)],
         }
     )
+    svc_stub.check_governor_claimed_by_other = lambda governor_id, owner_discord_id: False
     svc_stub.get_user_accounts = lambda uid: {}
+    svc_stub.remove_governor = lambda **_kw: (True, None)
     monkeypatch.setitem(sys.modules, "registry.registry_service", svc_stub)
 
     utils_stub = types.ModuleType("utils")
@@ -79,11 +68,25 @@ def test_registry_views_instantiate(monkeypatch):
         )
         m2 = rv.EnterGovernorIDModal(author_id=1, mode="register", account_type="Main")
         v4 = rv.GovernorSelectView([("A", 1)], author_id=1)
+        v5 = rv.RegisterGovernorView(_User(1), "Main", "1", "A")
+        v6 = rv.ModifyGovernorView(_User(1), "Main", "2", "B")
+        v7 = rv.ConfirmRemoveView(_User(1), "Main")
         assert v1.author_id == 1
         assert m1.author_id == 1
         assert len(v2.children) == 1
         assert len(v3.children) == 1
         assert m2.account_type == "Main"
         assert len(v4.children) == 1
+        assert v5.governor_id == "1"
+        assert v6.new_gov_id == "2"
+        assert v7.account_type == "Main"
 
     asyncio.run(_run())
+
+
+class _User:
+    def __init__(self, user_id: int):
+        self.id = user_id
+
+    def __str__(self) -> str:
+        return f"User({self.id})"

--- a/tests/test_registry_views_smoke.py
+++ b/tests/test_registry_views_smoke.py
@@ -84,9 +84,164 @@ def test_registry_views_instantiate(monkeypatch):
     asyncio.run(_run())
 
 
+def test_register_governor_confirm_defers_writes_and_edits_prompt(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+    calls = []
+
+    def _register_account(**kwargs):
+        calls.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr(rv, "register_account", _register_account)
+
+    async def _run():
+        view = rv.RegisterGovernorView(_User(1), "Main", "123", "Alice")
+        interaction = _FakeInteraction(_User(1))
+
+        await _button(view, "✅ Confirm").callback(interaction)
+
+        assert interaction.response.deferred_ephemeral is True
+        assert calls == [
+            {
+                "discord_id": "1",
+                "discord_name": "User(1)",
+                "account_type": "Main",
+                "governor_id": "123",
+                "governor_name": "Alice",
+            }
+        ]
+        assert interaction.original_edits[-1]["view"] is None
+        assert "Registered `Main`" in interaction.original_edits[-1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_modify_governor_confirm_defers_writes_and_edits_prompt(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+    calls = []
+
+    def _register_account(**kwargs):
+        calls.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr(rv, "register_account", _register_account)
+
+    async def _run():
+        view = rv.ModifyGovernorView(_User(1), "Alt 1", "456", "Bob")
+        interaction = _FakeInteraction(_User(1))
+
+        await _button(view, "✅ Confirm Change").callback(interaction)
+
+        assert interaction.response.deferred_ephemeral is True
+        assert calls == [
+            {
+                "discord_id": "1",
+                "discord_name": "User(1)",
+                "account_type": "Alt 1",
+                "governor_id": "456",
+                "governor_name": "Bob",
+            }
+        ]
+        assert interaction.original_edits[-1]["view"] is None
+        assert "`Alt 1` updated" in interaction.original_edits[-1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_remove_governor_confirm_defers_write_and_clears_prompt(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+    calls = []
+
+    def _remove_governor(**kwargs):
+        calls.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr(rv, "remove_governor", _remove_governor)
+
+    async def _run():
+        view = rv.ConfirmRemoveView(_User(1), "Farm 1")
+        interaction = _FakeInteraction(_User(1))
+
+        await _button(view, "✅ Confirm Remove").callback(interaction)
+
+        assert interaction.response.deferred_ephemeral is True
+        assert calls == [
+            {
+                "discord_user_id": 1,
+                "account_type": "Farm 1",
+                "removed_by": 1,
+            }
+        ]
+        assert interaction.original_edits[-1]["view"] is None
+        assert "`Farm 1` has been removed" in interaction.original_edits[-1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_confirmation_cancel_callbacks_clear_prompt(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+
+    async def _run():
+        view = rv.RegisterGovernorView(_User(1), "Main", "123", "Alice")
+        interaction = _FakeInteraction(_User(1))
+
+        await _button(view, "❌ Cancel").callback(interaction)
+
+        assert interaction.response.edits[-1]["view"] is None
+        assert "cancelled" in interaction.response.edits[-1]["content"]
+
+    asyncio.run(_run())
+
+
+def _button(view, label: str):
+    return next(child for child in view.children if getattr(child, "label", "") == label)
+
+
 class _User:
     def __init__(self, user_id: int):
         self.id = user_id
 
     def __str__(self) -> str:
         return f"User({self.id})"
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.deferred_ephemeral = None
+        self.done = False
+        self.edits = []
+        self.messages = []
+
+    def is_done(self):
+        return self.done
+
+    async def defer(self, *, ephemeral=False):
+        self.done = True
+        self.deferred_ephemeral = ephemeral
+
+    async def send_message(self, content=None, *, ephemeral=False, **kwargs):
+        self.done = True
+        self.messages.append({"content": content, "ephemeral": ephemeral, **kwargs})
+
+    async def edit_message(self, content=None, *, view=None, **kwargs):
+        self.done = True
+        self.edits.append({"content": content, "view": view, **kwargs})
+
+
+class _FakeFollowup:
+    def __init__(self):
+        self.messages = []
+
+    async def send(self, content=None, *, ephemeral=False, **kwargs):
+        self.messages.append({"content": content, "ephemeral": ephemeral, **kwargs})
+
+
+class _FakeInteraction:
+    def __init__(self, user):
+        self.user = user
+        self.response = _FakeResponse()
+        self.followup = _FakeFollowup()
+        self.original_edits = []
+
+    async def edit_original_response(self, content=None, *, view=None, **kwargs):
+        self.original_edits.append({"content": content, "view": view, **kwargs})

--- a/tests/test_ui_imports.py
+++ b/tests/test_ui_imports.py
@@ -36,7 +36,19 @@ def test_import_all_ui_view_modules_and_instantiate_core_views(monkeypatch, tmp_
     gov_stub.ConfirmRemoveView = _DummyView
     gov_stub.ModifyGovernorView = _DummyView
     gov_stub.RegisterGovernorView = _DummyView
+    gov_stub.register_account = lambda **_kw: (True, None)
     monkeypatch.setitem(sys.modules, "governor_registry", gov_stub)
+
+    registry_gov_stub = types.ModuleType("registry.governor_registry")
+    registry_gov_stub.register_account = lambda **_kw: (True, None)
+    monkeypatch.setitem(sys.modules, "registry.governor_registry", registry_gov_stub)
+
+    registry_service_stub = types.ModuleType("registry.registry_service")
+    registry_service_stub.check_governor_claimed_by_other = (
+        lambda governor_id, owner_discord_id: False
+    )
+    registry_service_stub.remove_governor = lambda **_kw: (True, None)
+    monkeypatch.setitem(sys.modules, "registry.registry_service", registry_service_stub)
 
     utils_stub = types.ModuleType("utils")
     utils_stub.get_next_fights = lambda n: []

--- a/ui/views/registry_views.py
+++ b/ui/views/registry_views.py
@@ -48,6 +48,29 @@ def configure_registry_views(
     _account_order_getter = account_order_getter
 
 
+async def _defer_component(interaction: discord.Interaction) -> None:
+    try:
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=True)
+    except Exception:
+        pass
+
+
+async def _edit_component_prompt(
+    interaction: discord.Interaction,
+    *,
+    content: str,
+    view: discord.ui.View | None = None,
+) -> None:
+    try:
+        await interaction.edit_original_response(content=content, view=view)
+    except Exception:
+        try:
+            await interaction.followup.send(content, ephemeral=True)
+        except Exception:
+            pass
+
+
 class RegisterGovernorView(discord.ui.View):
     def __init__(self, user, account_type, governor_id, governor_name):
         super().__init__(timeout=60)
@@ -64,7 +87,9 @@ class RegisterGovernorView(discord.ui.View):
             )
             return
 
-        ok, err = register_account(
+        await _defer_component(interaction)
+        ok, err = await asyncio.to_thread(
+            register_account,
             discord_id=str(self.user.id),
             discord_name=str(self.user),
             account_type=self.account_type,
@@ -73,11 +98,12 @@ class RegisterGovernorView(discord.ui.View):
         )
 
         if not ok:
-            await interaction.response.edit_message(
-                content=f"❌ Registration failed: {err or 'Unknown error.'}", view=None
+            await _edit_component_prompt(
+                interaction, content=f"❌ Registration failed: {err or 'Unknown error.'}", view=None
             )
         else:
-            await interaction.response.edit_message(
+            await _edit_component_prompt(
+                interaction,
                 content=(
                     f"✅ Registered `{self.account_type}` as "
                     f"**{self.governor_name}** (ID: `{self.governor_id}`)"
@@ -107,7 +133,9 @@ class ModifyGovernorView(discord.ui.View):
             )
             return
 
-        ok, err = register_account(
+        await _defer_component(interaction)
+        ok, err = await asyncio.to_thread(
+            register_account,
             discord_id=str(self.user.id),
             discord_name=str(self.user),
             account_type=self.account_type,
@@ -116,11 +144,12 @@ class ModifyGovernorView(discord.ui.View):
         )
 
         if not ok:
-            await interaction.response.edit_message(
-                content=f"❌ Update failed: {err or 'Unknown error.'}", view=None
+            await _edit_component_prompt(
+                interaction, content=f"❌ Update failed: {err or 'Unknown error.'}", view=None
             )
         else:
-            await interaction.response.edit_message(
+            await _edit_component_prompt(
+                interaction,
                 content=(
                     f"✅ `{self.account_type}` updated to "
                     f"**{self.new_gov_name}** (ID: `{self.new_gov_id}`)"
@@ -148,20 +177,25 @@ class ConfirmRemoveView(discord.ui.View):
             )
             return
 
-        ok, err = remove_governor(
+        await _defer_component(interaction)
+        ok, err = await asyncio.to_thread(
+            remove_governor,
             discord_user_id=interaction.user.id,
             account_type=self.account_type,
             removed_by=interaction.user.id,
         )
 
         if ok:
-            await interaction.response.send_message(
-                f"✅ `{self.account_type}` has been removed from your registered accounts.",
-                ephemeral=True,
+            await _edit_component_prompt(
+                interaction,
+                content=f"✅ `{self.account_type}` has been removed from your registered accounts.",
+                view=None,
             )
         else:
-            await interaction.response.send_message(
-                f"❌ {err or 'Could not remove registration.'}", ephemeral=True
+            await _edit_component_prompt(
+                interaction,
+                content=f"❌ {err or 'Could not remove registration.'}",
+                view=None,
             )
         self.stop()
 

--- a/ui/views/registry_views.py
+++ b/ui/views/registry_views.py
@@ -9,7 +9,8 @@ import logging
 import discord
 from discord import Embed
 
-from registry.governor_registry import ConfirmRemoveView, ModifyGovernorView, RegisterGovernorView
+from registry.governor_registry import register_account
+from registry.registry_service import check_governor_claimed_by_other, remove_governor
 from utils import normalize_governor_id
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,130 @@ def configure_registry_views(
     _name_cache_getter = name_cache_getter
     _send_profile_to_channel = send_profile_to_channel
     _account_order_getter = account_order_getter
+
+
+class RegisterGovernorView(discord.ui.View):
+    def __init__(self, user, account_type, governor_id, governor_name):
+        super().__init__(timeout=60)
+        self.user = user
+        self.account_type = account_type
+        self.governor_id = governor_id
+        self.governor_name = governor_name
+
+    @discord.ui.button(label="✅ Confirm", style=discord.ButtonStyle.success)
+    async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "This isn't your registration to confirm!", ephemeral=True
+            )
+            return
+
+        ok, err = register_account(
+            discord_id=str(self.user.id),
+            discord_name=str(self.user),
+            account_type=self.account_type,
+            governor_id=self.governor_id,
+            governor_name=self.governor_name,
+        )
+
+        if not ok:
+            await interaction.response.edit_message(
+                content=f"❌ Registration failed: {err or 'Unknown error.'}", view=None
+            )
+        else:
+            await interaction.response.edit_message(
+                content=(
+                    f"✅ Registered `{self.account_type}` as "
+                    f"**{self.governor_name}** (ID: `{self.governor_id}`)"
+                ),
+                view=None,
+            )
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.danger)
+    async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if interaction.user.id == self.user.id:
+            await interaction.response.edit_message(content="❌ Registration cancelled.", view=None)
+
+
+class ModifyGovernorView(discord.ui.View):
+    def __init__(self, user, account_type, new_gov_id, new_gov_name):
+        super().__init__(timeout=60)
+        self.user = user
+        self.account_type = account_type
+        self.new_gov_id = new_gov_id
+        self.new_gov_name = new_gov_name
+
+    @discord.ui.button(label="✅ Confirm Change", style=discord.ButtonStyle.success)
+    async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "This isn't your registration to change!", ephemeral=True
+            )
+            return
+
+        ok, err = register_account(
+            discord_id=str(self.user.id),
+            discord_name=str(self.user),
+            account_type=self.account_type,
+            governor_id=self.new_gov_id,
+            governor_name=self.new_gov_name,
+        )
+
+        if not ok:
+            await interaction.response.edit_message(
+                content=f"❌ Update failed: {err or 'Unknown error.'}", view=None
+            )
+        else:
+            await interaction.response.edit_message(
+                content=(
+                    f"✅ `{self.account_type}` updated to "
+                    f"**{self.new_gov_name}** (ID: `{self.new_gov_id}`)"
+                ),
+                view=None,
+            )
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.danger)
+    async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if interaction.user.id == self.user.id:
+            await interaction.response.edit_message(content="❌ Modification cancelled.", view=None)
+
+
+class ConfirmRemoveView(discord.ui.View):
+    def __init__(self, user, account_type):
+        super().__init__(timeout=60)
+        self.user = user
+        self.account_type = account_type
+
+    @discord.ui.button(label="✅ Confirm Remove", style=discord.ButtonStyle.danger)
+    async def confirm(self, button, interaction: discord.Interaction):
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "You cannot modify someone else's registration.", ephemeral=True
+            )
+            return
+
+        ok, err = remove_governor(
+            discord_user_id=interaction.user.id,
+            account_type=self.account_type,
+            removed_by=interaction.user.id,
+        )
+
+        if ok:
+            await interaction.response.send_message(
+                f"✅ `{self.account_type}` has been removed from your registered accounts.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                f"❌ {err or 'Could not remove registration.'}", ephemeral=True
+            )
+        self.stop()
+
+    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, button, interaction: discord.Interaction):
+        if interaction.user.id == self.user.id:
+            await interaction.response.edit_message(content="❌ Removal cancelled.", view=None)
+        self.stop()
 
 
 class MyRegsActionView(discord.ui.View):
@@ -439,8 +564,6 @@ class EnterGovernorIDModal(discord.ui.Modal):
             )
             return
 
-        from registry.registry_service import check_governor_claimed_by_other
-
         try:
             claimed_by_other = await asyncio.to_thread(
                 check_governor_claimed_by_other, governor_id, self.author_id
@@ -567,12 +690,15 @@ class GovernorSelectView(discord.ui.View):
 
 
 __all__ = [
+    "ConfirmRemoveView",
     "EnterGovernorIDModal",
     "GovNameModal",
     "GovernorSelect",
     "GovernorSelectView",
+    "ModifyGovernorView",
     "ModifyStartView",
     "MyRegsActionView",
+    "RegisterGovernorView",
     "RegisterStartView",
     "configure_registry_views",
 ]


### PR DESCRIPTION
## Summary

- Moved `RegisterGovernorView`, `ModifyGovernorView`, and `ConfirmRemoveView` from `registry/governor_registry.py` into `ui/views/registry_views.py`.
- Kept `registry/governor_registry.py` as a compatibility facade for registry persistence/service helpers, with lazy compatibility resolution for the moved view classes.
- Updated registry command imports and removed the remaining inline `registry.registry_service` import in `remove_registration_by_id`.
- Updated deferred optimisation docs and the registry task pack to mark the view-layer extraction complete while keeping the richer shared account-resolution summary deferred.

## Validation

- `\.\.venv\Scripts\python.exe -m py_compile commands/registry_cmds.py registry/governor_registry.py ui/views/registry_views.py tests/test_registry_governor_registry.py tests/test_registry_views_smoke.py tests/test_ui_imports.py`
- `\.\.venv\Scripts\python.exe -m pre_commit run -a`
- `\.\.venv\Scripts\python.exe scripts\select_tests.py`
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests/test_registry_governor_registry.py tests/test_registry_views_smoke.py tests/test_ui_imports.py tests/test_registry_cmds.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests -k "registry"`
- `\.\.venv\Scripts\python.exe -m pytest -q tests`

## Risk / Rollback

- Risk is low-to-medium: this changes module ownership/import paths for registry confirmation views while preserving user-facing registration, modification, removal, cancel, ephemeral, and permission behavior.
- Rollback by reverting this PR and redeploying the previous bot version.
- No SQL deployment required.