### PR TITLE
[codex] migrate telemetry pickers to account summary

### DIFF
--- a/account_picker.py
+++ b/account_picker.py
@@ -39,13 +39,23 @@ def _slot_rank(slot_name: str) -> int:
         return len(_PREFERRED_ORDER)
 
 
+def _account_option_label_source(governor_name: Any, slot: Any) -> str:
+    slot_text = str(slot)
+    if governor_name is None:
+        return slot_text
+    name_text = str(governor_name).strip()
+    if not name_text or name_text.casefold() == "unknown":
+        return slot_text
+    return name_text
+
+
 def _iter_account_option_rows(accounts_or_summary: Any) -> list[tuple[str, str, str]]:
     if hasattr(accounts_or_summary, "resolved_accounts"):
         return [
             (
                 str(account.slot),
                 str(account.governor_id_str).strip(),
-                str(account.governor_name or account.slot),
+                _account_option_label_source(account.governor_name, account.slot),
             )
             for account in getattr(accounts_or_summary, "resolved_accounts", ())
         ]
@@ -65,8 +75,8 @@ def _iter_account_option_rows(accounts_or_summary: Any) -> list[tuple[str, str, 
         gid = str(gid).strip()
         if not gid:
             continue
-        name = acc.get("GovernorName") or acc.get("Governor") or slot
-        rows.append((str(slot), gid, str(name) if name is not None else str(slot)))
+        name = acc.get("GovernorName") or acc.get("Governor")
+        rows.append((str(slot), gid, _account_option_label_source(name, slot)))
     return rows
 
 

--- a/account_picker.py
+++ b/account_picker.py
@@ -6,7 +6,7 @@ Commands and UI modules. This decouples the account picker helper from Commands.
 so UI modules (kvk_ui, crystaltech UI, etc.) don't need to import Commands at runtime.
 
 Exports:
-- build_unique_gov_options(accounts: dict) -> list[discord.SelectOption]
+- build_unique_gov_options(accounts_or_summary) -> list[discord.SelectOption]
 - AccountPickerView(...) -> reusable discord.ui.View for account selection
 """
 
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
 import logging
+from typing import Any
 
 import discord
 
@@ -35,43 +36,62 @@ def _slot_rank(slot_name: str) -> int:
         return _PREFERRED_ORDER.index(slot_name)
     except ValueError:
         # push unknown slots after preferred list, but keep deterministic ordering
-        return len(_PREFERRED_ORDER) + hash(slot_name) % 10000
+        return len(_PREFERRED_ORDER)
 
 
-def build_unique_gov_options(accounts: dict[str, dict]) -> list[discord.SelectOption]:
-    """
-    Build a list of discord.SelectOption objects from a mapping of account slot -> account dict.
-    accounts: { slot_name: { "GovernorID": "...", "GovernorName": "..." }, ... }
+def _iter_account_option_rows(accounts_or_summary: Any) -> list[tuple[str, str, str]]:
+    if hasattr(accounts_or_summary, "resolved_accounts"):
+        return [
+            (
+                str(account.slot),
+                str(account.governor_id_str).strip(),
+                str(account.governor_name or account.slot),
+            )
+            for account in getattr(accounts_or_summary, "resolved_accounts", ())
+        ]
 
-    Behavior:
-    - Keeps one option per unique GovernorID (first seen by slot preference).
-    - Labels are GovernorName (if present) or slot fallback.
-    - Value is the governor id (string).
-    - Description is the slot name.
-    """
-    if not accounts:
+    accounts = accounts_or_summary or {}
+    if not isinstance(accounts, dict):
         return []
 
-    # Flatten and preserve order using preferred slot ranking
     items: list[tuple[str, dict]] = sorted(
         accounts.items(), key=lambda kv: (_slot_rank(kv[0]), kv[0])
     )
-
-    seen_gids: set[str] = set()
-    options: list[discord.SelectOption] = []
-
+    rows: list[tuple[str, str, str]] = []
     for slot, acc in items:
         if not acc or not isinstance(acc, dict):
             continue
         gid = acc.get("GovernorID") or acc.get("GovernorId") or acc.get("GovernorIdStr") or ""
         gid = str(gid).strip()
         if not gid:
-            # If there's no numeric id, skip this entry
             continue
+        name = acc.get("GovernorName") or acc.get("Governor") or slot
+        rows.append((str(slot), gid, str(name) if name is not None else str(slot)))
+    return rows
+
+
+def build_unique_gov_options(accounts_or_summary: Any) -> list[discord.SelectOption]:
+    """
+    Build a list of discord.SelectOption objects from AccountResolutionSummary
+    or a legacy mapping of account slot -> account dict.
+
+    Behavior:
+    - Keeps one option per unique GovernorID (first seen by canonical/slot preference).
+    - Labels are GovernorName (if present) or slot fallback.
+    - Value is the governor id (string).
+    - Description is the slot name.
+    """
+    rows = _iter_account_option_rows(accounts_or_summary)
+    if not rows:
+        return []
+
+    seen_gids: set[str] = set()
+    options: list[discord.SelectOption] = []
+
+    for slot, gid, name in rows:
         if gid in seen_gids:
             continue
         seen_gids.add(gid)
-        name = acc.get("GovernorName") or acc.get("Governor") or slot
         label = str(name)[:100] if name is not None else slot
         desc = str(slot) if slot else None
         opt = discord.SelectOption(label=label, value=gid, description=desc)
@@ -80,14 +100,14 @@ def build_unique_gov_options(accounts: dict[str, dict]) -> list[discord.SelectOp
     return options
 
 
-def safe_build_unique_gov_options(accounts: dict) -> list[discord.SelectOption]:
+def safe_build_unique_gov_options(accounts_or_summary: Any) -> list[discord.SelectOption]:
     """
     Error-handling wrapper around build_unique_gov_options.
     Logs and returns an empty list on any failure. Use this in command/view code
     where a crash from the options builder should never surface as an unhandled exception.
     """
     try:
-        opts = build_unique_gov_options(accounts)
+        opts = build_unique_gov_options(accounts_or_summary)
         if isinstance(opts, list):
             return opts
         logger.warning(
@@ -119,12 +139,11 @@ async def _rebuild_options_from_registry(
     behaviour used in kvk_ui._rebuild_options. Returns empty list on error.
     """
     try:
-        from services.governor_account_service import get_accounts_for_user
+        from services.governor_account_service import get_account_summary_for_user
 
-        lookup = await get_accounts_for_user(ctx.user.id)
-        accounts = lookup.accounts if lookup.ok else {}
+        summary = await get_account_summary_for_user(ctx.user.id)
         # Use the canonical builder in this module
-        return build_unique_gov_options(accounts)
+        return build_unique_gov_options(summary if summary.ok else {})
     except Exception:
         logger.exception("[AccountPicker] _rebuild_options_from_registry failed")
         return []

--- a/commands/telemetry_cmds.py
+++ b/commands/telemetry_cmds.py
@@ -51,7 +51,7 @@ from logging_setup import CRASH_LOG_PATH, ERROR_LOG_PATH, FULL_LOG_PATH
 from profile_cache import search_by_governor_name
 from registry.account_slots import ACCOUNT_ORDER
 from registry.registry_service import load_registry_as_dict
-from services.governor_account_service import free_account_slots, get_accounts_for_user
+from services.governor_account_service import get_account_summary_for_user
 from target_utils import (
     _name_cache,
     autocomplete_governor_names,
@@ -214,14 +214,14 @@ def register_commands(bot_instance):
                 pass
 
             try:
-                account_lookup = await get_accounts_for_user(interaction.user.id)
-                if not account_lookup.ok:
+                account_summary = await get_account_summary_for_user(interaction.user.id)
+                if not account_summary.ok:
                     await interaction.followup.send(
                         "Registry is temporarily unavailable. Please try again later.",
                         ephemeral=True,
                     )
                     return
-                free_slots = free_account_slots(account_lookup.accounts)
+                free_slots = account_summary.free_slots()
 
                 if not free_slots:
                     await interaction.followup.send(
@@ -379,10 +379,9 @@ def register_commands(bot_instance):
 
         # 2) Registered accounts path
         try:
-            account_lookup = await get_accounts_for_user(ctx.user.id)
-            if not account_lookup.ok:
-                raise RuntimeError(account_lookup.error or "registry unavailable")
-            accounts = account_lookup.accounts
+            account_summary = await get_account_summary_for_user(ctx.user.id)
+            if not account_summary.ok:
+                raise RuntimeError(account_summary.error or "registry unavailable")
         except Exception:
             logger.exception("[/mykvktargets] load_registry failed")
             await ctx.followup.send(
@@ -391,7 +390,7 @@ def register_commands(bot_instance):
             )
             return
 
-        options = safe_build_unique_gov_options(accounts)
+        options = safe_build_unique_gov_options(account_summary)
 
         # Single-account auto-open → use canonical helper
         if options and len(options) == 1:
@@ -679,10 +678,9 @@ def register_commands(bot_instance):
 
         # 2) Registered accounts path — reuse same registry logic & helpers as /mykvktargets
         try:
-            account_lookup = await get_accounts_for_user(ctx.user.id)
-            if not account_lookup.ok:
-                raise RuntimeError(account_lookup.error or "registry unavailable")
-            accounts = account_lookup.accounts
+            account_summary = await get_account_summary_for_user(ctx.user.id)
+            if not account_summary.ok:
+                raise RuntimeError(account_summary.error or "registry unavailable")
         except Exception:
             logger.exception("[/mykvkcrystaltech] load_registry failed")
             await ctx.followup.send(
@@ -692,7 +690,7 @@ def register_commands(bot_instance):
             return
 
         # Use canonical builder (safe fallback included)
-        options = safe_build_unique_gov_options(accounts)
+        options = safe_build_unique_gov_options(account_summary)
 
         if options:
             if len(options) == 1:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,10 +51,28 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `commands/mge_cmds.py`, `commands/stats_cmds.py`, `commands/telemetry_cmds.py`, `commands/inventory_cmds.py`, `inventory/inventory_service.py`
+- Area: `commands/registry_cmds.py`, `ui/views/registry_views.py`, `services/governor_account_service.py`
 - Type: consistency
-- Description: PR 84 centralised basic registry account slot helpers and Discord user-id parsing, PR 85A extracted registry audit/import/export orchestration, and PR 86 moved registry confirmation views into the UI layer. PR 87 introduced the shared richer account-resolution summary object in `services/governor_account_service.py` and migrated stats, inventory, and MGE service adapters while preserving their existing public shapes. Follow-up migration is still needed for direct command/view consumers and adjacent event flows that still build account picker or ownership shapes locally.
-- Suggested Fix: Complete the remaining slices incrementally: (1) migrate telemetry/KVK target/CrystalTech picker setup to consume `AccountResolutionSummary` directly while preserving autocomplete and public output behavior; (2) migrate registry command/view account selection helpers to the shared summary and retire old `AccountLookup`-only pathways once command tests cover them; (3) audit and migrate Ark registration account lookup helpers if its event signup flow can safely share the same summary; (4) remove compatibility adapters only after every command surface has focused regression coverage.
+- Description: After the telemetry/KVK target/CrystalTech picker slice, registry command and view account-selection flows still rely on `AccountLookup`-style account dictionaries and local option/free-slot shaping rather than consuming `AccountResolutionSummary` directly. This path is write-sensitive because it includes registration, modification, removal confirmation views, duplicate-claim checks, and player-facing error copy.
+- Suggested Fix: Migrate registry command autocomplete and `MyRegsActionView` registration/modify entry points to `AccountResolutionSummary`, preserving account slot ordering, command names, permissions, ephemeral/admin behaviour, registration confirmation/cancel behaviour, and SQL-backed duplicate ownership checks. Add focused command/view tests before retiring any registry-facing compatibility pathways.
 - Impact: medium
 - Risk: medium
-- Dependencies: Preserve current command output, autocomplete ordering, permission checks, ephemeral/admin behaviour, inventory permission checks, stats export behaviour, MGE self-service/admin behavior, and Ark signup behavior while migrating callers.
+- Dependencies: Telemetry/KVK picker migration complete; preserve `/my_registrations`, `/register_governor`, `/modify_registration`, `/remove_registration`, and admin registration behaviour.
+
+### Deferred Optimisation
+- Area: `ark/registration_flow.py`, `account_picker.py`, `services/governor_account_service.py`
+- Type: consistency
+- Description: Ark registration flows still load raw registry account dictionaries, build governor select options through the legacy account picker path, and resolve governor names from local account dictionaries. The flow also has Ark-specific signup, ban, roster, active-match, and persistent-message behaviour, so it should not be migrated opportunistically with registry command/view work.
+- Suggested Fix: Audit Ark self-service join/sub/leave/switch account lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`. Migrate only after confirming Ark signup behaviour, ban enforcement, roster filtering, active signup detection, and persistent registration-message refresh remain unchanged.
+- Impact: medium
+- Risk: medium
+- Dependencies: Registry command/view direct migration should land first or be explicitly skipped; preserve Ark signup behaviour and focused Ark regression coverage.
+
+### Deferred Optimisation
+- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `commands/registry_cmds.py`, `ui/views/registry_views.py`, `ark/registration_flow.py`
+- Type: cleanup
+- Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain necessary while direct command/view and Ark consumers are still being migrated. Removing them now would risk breaking public shapes used by stats, inventory, MGE, registry, telemetry, and Ark tests.
+- Suggested Fix: After telemetry/KVK, registry command/view, and Ark account-resolution migrations all have focused regression coverage, remove obsolete `AccountLookup`-only pathways and any duplicate local classification or option-shaping helpers that no longer have external callers.
+- Impact: medium
+- Risk: medium
+- Dependencies: All direct command/view surfaces migrated to `AccountResolutionSummary`; focused regression coverage exists for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, and Ark signup.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -543,17 +543,39 @@ Important context:
 
 ## 27. PR 87 Shared Account-Resolution First Slice
 
-Status: implementation slice approved after the PR 86 scope pass.
+Status: smoke tested successfully and deployed to production.
 
-PR 87 first slice scope:
+PR 87 delivered:
 
-- Introduce a shared richer account-resolution summary object in `services/governor_account_service.py`.
-- Preserve the existing `AccountLookup` public shape for registry, telemetry, and UI callers.
-- Preserve `StatsAccountSummary` for stats commands and personal stats export while backing it with the shared summary.
-- Preserve inventory `RegisteredGovernor` output, inventory permission behavior, and inventory report/export behavior while resolving accounts through the shared summary.
-- Preserve MGE linked-governor list output and self-service/admin signup behavior while resolving ownership through the shared summary.
-- Do not change command names, command output, autocomplete ordering, permission checks, ephemeral/admin behavior, inventory permission behavior, or stats export behavior.
-- Do not remove compatibility adapters until each command surface has focused regression coverage.
+- A shared richer account-resolution summary object in `services/governor_account_service.py`.
+- `ResolvedAccount` and `AccountResolutionSummary` with canonical account ordering, deduplicated GovernorIDs, GovernorID string/int access, account names, default choice, classification, free-slot, and ownership helpers.
+- Preservation of the existing `AccountLookup` public shape for registry, telemetry, and UI callers.
+- Preservation of `StatsAccountSummary` for stats commands and personal stats export while backing it with the shared summary.
+- Preservation of inventory `RegisteredGovernor` output, inventory permission behavior, stale registry fallback behavior, legacy inventory display-label fallback behavior, and inventory report/export behavior while resolving accounts through the shared summary.
+- Preservation of MGE linked-governor list output and self-service/admin signup behavior while resolving ownership through the shared summary.
+- Documentation of the remaining command/view and Ark follow-up slices without removing compatibility adapters prematurely.
+
+Smoke coverage completed after deployment:
+
+- `/my_stats`
+- `/mykvkstats`
+- inventory import/report/export account resolution and permission paths
+- MGE linked-governor signup behavior
+- inventory missing-name display fallback (`Governor` or GovernorID rather than `Unknown`)
+
+Validation completed during PR 87:
+
+- `.\.venv\Scripts\python.exe -m py_compile services\governor_account_service.py services\stats_account_service.py inventory\inventory_service.py mge\mge_signup_service.py tests\test_governor_account_service.py tests\test_stats_account_service.py tests\test_inventory_service.py tests\test_mge_signup_service.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_governor_account_service.py tests\test_stats_account_service.py tests\test_inventory_service.py tests\test_inventory_export_service.py tests\test_inventory_reporting_service.py tests\test_mge_signup_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "inventory"`
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "mge"`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
 
 Follow-up slices intentionally left deferred:
 
@@ -561,3 +583,30 @@ Follow-up slices intentionally left deferred:
 2. Registry command/view direct migration: update registry command and view account-selection flows to use the shared summary directly, then retire `AccountLookup` only after compatibility imports and smoke tests are updated.
 3. Ark account-resolution audit: inspect `ark/registration_flow.py` account lookup and governor-name helpers for safe reuse of `AccountResolutionSummary`; migrate only if Ark signup behavior and tests remain stable.
 4. Compatibility cleanup: after all command/view surfaces are migrated, remove duplicate local classification, linked-governor, and registered-governor adapter code that no longer has external callers.
+
+## 28. Next Phase Chat Starter
+
+Use this in a fresh Codex chat for the remaining shared account-resolution follow-up slices:
+
+```text
+Codex, start the next registry/account optimisation after PR 87 (`shared-account-resolution-slice`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: deliver the next PR-sized follow-up slice for the shared account-resolution migration. PR 87 introduced `ResolvedAccount` and `AccountResolutionSummary` in `services/governor_account_service.py` and migrated the stats, inventory, and MGE service adapters while preserving their public shapes. Now audit and begin direct command/view migration for the remaining consumers.
+
+Important context:
+- PR 84 centralised basic account slots, Discord user-id parsing, public GovernorID roster lookup, and `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- PR 85A extracted registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping into `registry/registry_command_service.py`.
+- PR 86 moved registry confirmation views into `ui/views/registry_views.py`, kept compatibility re-exports from `registry/governor_registry.py`, and removed the remaining inline registry-service import in `remove_registration_by_id`.
+- PR 87 introduced the shared richer account-resolution summary object and migrated stats, inventory, and MGE service adapters.
+- Remaining follow-up slices are:
+  1. migrate telemetry/KVK target/CrystalTech picker setup in `commands/telemetry_cmds.py`, `account_picker.py`, `kvk_ui.py`, and related views to consume `AccountResolutionSummary` directly;
+  2. migrate registry command/view account-selection flows in `commands/registry_cmds.py` and `ui/views/registry_views.py` to the shared summary;
+  3. audit `ark/registration_flow.py` account lookup and governor-name helpers for safe reuse of the shared summary;
+  4. remove compatibility adapters only after every direct command/view surface has focused regression coverage.
+- Keep the work PR-sized. Start with audit/scope and propose whether the first implementation slice should be telemetry/KVK target/CrystalTech or registry command/view direct migration.
+- Preserve current command output, autocomplete ordering, permission checks, ephemeral/admin behaviour, inventory permission behaviour, stats export behaviour, MGE signup behaviour, and Ark signup behaviour.
+- Validate any SQL-facing assumptions against `C:\K98-bot-SQL-Server` before implementation.
+- Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
+```

--- a/kvk_ui.py
+++ b/kvk_ui.py
@@ -181,13 +181,12 @@ def make_kvk_targets_view(
 
     async def _rebuild_options(ctx_inner: discord.ApplicationContext):
         try:
-            from services.governor_account_service import get_accounts_for_user
+            from services.governor_account_service import get_account_summary_for_user
 
-            lookup = await get_accounts_for_user(ctx_inner.user.id)
-            accounts = lookup.accounts if lookup.ok else {}
+            summary = await get_account_summary_for_user(ctx_inner.user.id)
             from account_picker import safe_build_unique_gov_options
 
-            return safe_build_unique_gov_options(accounts)
+            return safe_build_unique_gov_options(summary if summary.ok else {})
         except Exception:
             logger.exception("[KVK_UI] _rebuild_options failed")
             return []

--- a/tests/test_account_picker.py
+++ b/tests/test_account_picker.py
@@ -64,6 +64,22 @@ def test_build_unique_gov_options_accepts_account_resolution_summary():
     assert [o.description for o in opts] == ["Main", "Alt 1", "Farm 1"]
 
 
+def test_build_unique_gov_options_summary_falls_back_to_slot_for_unknown_names():
+    from services.governor_account_service import summarize_accounts
+
+    summary = summarize_accounts(
+        {
+            "Main": {"GovernorID": "100", "GovernorName": ""},
+            "Alt 1": {"GovernorID": "200"},
+            "Farm 1": {"GovernorID": "300", "GovernorName": "Unknown"},
+        }
+    )
+
+    opts = build_unique_gov_options(summary)
+
+    assert [o.label for o in opts] == ["Main", "Alt 1", "Farm 1"]
+
+
 @pytest.mark.asyncio
 async def test_account_picker_uses_generic_governor_placeholder():
     view = AccountPickerView(

--- a/tests/test_account_picker.py
+++ b/tests/test_account_picker.py
@@ -46,6 +46,24 @@ def test_build_unique_gov_options_labels_and_desc_limits():
     assert opts[0].description == "Main"
 
 
+def test_build_unique_gov_options_accepts_account_resolution_summary():
+    from services.governor_account_service import summarize_accounts
+
+    summary = summarize_accounts(
+        {
+            "Farm 1": {"GovernorID": "900", "GovernorName": "FarmOne"},
+            "Alt 1": {"GovernorID": "200", "GovernorName": "AltOne"},
+            "Main": {"GovernorID": "100", "GovernorName": "MainUser"},
+            "Alt 2": {"GovernorID": "200", "GovernorName": "AltDuplicate"},
+        }
+    )
+
+    opts = build_unique_gov_options(summary)
+
+    assert [o.value for o in opts] == ["100", "200", "900"]
+    assert [o.description for o in opts] == ["Main", "Alt 1", "Farm 1"]
+
+
 @pytest.mark.asyncio
 async def test_account_picker_uses_generic_governor_placeholder():
     view = AccountPickerView(

--- a/tests/test_mykvktargets.py
+++ b/tests/test_mykvktargets.py
@@ -134,14 +134,14 @@ async def test_manual_governorid_triggers_run_target_lookup(monkeypatch):
 
 async def test_single_registered_account_auto_opens(monkeypatch):
     import commands.telemetry_cmds as C
-    from services.governor_account_service import AccountLookup
+    from services.governor_account_service import summarize_accounts
 
     async def fake_load_last_kvk_map():
         return {}
 
-    async def fake_get_accounts_for_user(user_id):
+    async def fake_get_account_summary_for_user(user_id):
         assert user_id == 99
-        return AccountLookup(True, {"Main": {"GovernorID": "999", "GovernorName": "X"}})
+        return summarize_accounts({"Main": {"GovernorID": "999", "GovernorName": "X"}})
 
     called = {"run_target_lookup": 0}
 
@@ -158,7 +158,7 @@ async def test_single_registered_account_auto_opens(monkeypatch):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "get_accounts_for_user", fake_get_accounts_for_user)
+    monkeypatch.setattr(C, "get_account_summary_for_user", fake_get_account_summary_for_user)
     monkeypatch.setattr(C, "run_target_lookup", fake_run_target_lookup)
 
     ctx = DummyCtx(user_id=99)
@@ -172,15 +172,14 @@ async def test_single_registered_account_auto_opens(monkeypatch):
 
 async def test_multi_account_builds_selector(monkeypatch):
     import commands.telemetry_cmds as C
-    from services.governor_account_service import AccountLookup
+    from services.governor_account_service import summarize_accounts
 
     async def fake_load_last_kvk_map():
         return {}
 
-    async def fake_get_accounts_for_user(user_id):
+    async def fake_get_account_summary_for_user(user_id):
         assert user_id == 5
-        return AccountLookup(
-            True,
+        return summarize_accounts(
             {
                 "Main": {"GovernorID": "1", "GovernorName": "A"},
                 "Alt 1": {"GovernorID": "2", "GovernorName": "B"},
@@ -191,7 +190,7 @@ async def test_multi_account_builds_selector(monkeypatch):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "get_accounts_for_user", fake_get_accounts_for_user)
+    monkeypatch.setattr(C, "get_account_summary_for_user", fake_get_account_summary_for_user)
     monkeypatch.setattr(C, "load_last_kvk_map", fake_load_last_kvk_map)
     monkeypatch.setattr(
         C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False
@@ -219,20 +218,20 @@ async def test_multi_account_builds_selector(monkeypatch):
 
 async def test_no_registered_accounts_shows_hint_and_empty_picker(monkeypatch):
     import commands.telemetry_cmds as C
-    from services.governor_account_service import AccountLookup
+    from services.governor_account_service import summarize_accounts
 
     async def fake_load_last_kvk_map():
         return {}
 
-    async def fake_get_accounts_for_user(user_id):
+    async def fake_get_account_summary_for_user(user_id):
         assert user_id == 7
-        return AccountLookup(True, {})
+        return summarize_accounts({})
 
     async def fake_to_thread(fn, *a, **k):
         return fn(*a, **k)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(C, "get_accounts_for_user", fake_get_accounts_for_user)
+    monkeypatch.setattr(C, "get_account_summary_for_user", fake_get_account_summary_for_user)
     monkeypatch.setattr(C, "load_last_kvk_map", fake_load_last_kvk_map)
     monkeypatch.setattr(
         C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False
@@ -254,3 +253,73 @@ async def test_no_registered_accounts_shows_hint_and_empty_picker(monkeypatch):
 
     assert ctx.followup.sent, "Expected followup hint when no accounts"
     assert "options" in captured and captured["options"] == []
+
+
+async def test_crystaltech_single_registered_account_auto_opens(monkeypatch):
+    import commands.telemetry_cmds as C
+    from services.governor_account_service import summarize_accounts
+
+    async def fake_get_account_summary_for_user(user_id):
+        assert user_id == 33
+        return summarize_accounts({"Main": {"GovernorID": "333", "GovernorName": "Crystal"}})
+
+    called = {}
+
+    async def fake_run_crystaltech_flow(interaction, gid, ephemeral=False):
+        called["gid"] = gid
+        called["ephemeral"] = ephemeral
+
+    monkeypatch.setattr(
+        C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False
+    )
+    monkeypatch.setattr(C, "get_account_summary_for_user", fake_get_account_summary_for_user)
+    monkeypatch.setattr(C, "run_crystaltech_flow_service", fake_run_crystaltech_flow)
+
+    ctx = DummyCtx(user_id=33)
+    handler = _get_registered_command_impl(C, "mykvkcrystaltech")
+    assert handler is not None
+
+    await handler(ctx, governorid=None, only_me=True)
+
+    assert called == {"gid": "333", "ephemeral": True}
+
+
+async def test_crystaltech_multi_account_builds_summary_selector(monkeypatch):
+    import commands.telemetry_cmds as C
+    from services.governor_account_service import AccountResolutionSummary, summarize_accounts
+
+    async def fake_get_account_summary_for_user(user_id):
+        assert user_id == 44
+        return summarize_accounts(
+            {
+                "Main": {"GovernorID": "444", "GovernorName": "Main"},
+                "Alt 1": {"GovernorID": "445", "GovernorName": "Alt"},
+            }
+        )
+
+    captured = {}
+
+    def fake_picker_view(ctx, options, on_select_governor, **kwargs):
+        captured["options"] = options
+        captured["heading"] = kwargs.get("heading")
+        return types.SimpleNamespace(heading=kwargs.get("heading"))
+
+    def fake_options(summary):
+        assert isinstance(summary, AccountResolutionSummary)
+        return [types.SimpleNamespace(value="444"), types.SimpleNamespace(value="445")]
+
+    monkeypatch.setattr(
+        C, "safe_defer", lambda ctx, ephemeral=True: asyncio.sleep(0), raising=False
+    )
+    monkeypatch.setattr(C, "get_account_summary_for_user", fake_get_account_summary_for_user)
+    monkeypatch.setattr(C, "safe_build_unique_gov_options", fake_options)
+    monkeypatch.setattr(C, "AccountPickerView", fake_picker_view)
+
+    ctx = DummyCtx(user_id=44)
+    handler = _get_registered_command_impl(C, "mykvkcrystaltech")
+    assert handler is not None
+
+    await handler(ctx, governorid=None, only_me=True)
+
+    assert len(captured["options"]) == 2
+    assert captured["heading"] == "Select an account to manage its Crystal Tech:"


### PR DESCRIPTION
## Summary

- Migrates telemetry/KVK target/CrystalTech account picker setup to consume `AccountResolutionSummary` directly.
- Updates `account_picker` and `kvk_ui` refresh paths to rebuild options from the shared account summary while preserving legacy dict support for unmigrated callers.
- Splits the remaining account-resolution deferred backlog into registry command/view migration, Ark migration audit, and final compatibility cleanup.

## Behaviour Preserved

- `/mykvktargets` manual GovernorID, single-account auto-open, multi-account selector, and no-account hint flows.
- `/mykvkcrystaltech` manual GovernorID, single-account auto-open, multi-account selector, and no-account hint flows.
- Account selector label/value/description shape and GovernorID dedupe behaviour.
- Registry compatibility adapters remain in place for direct registry/view and Ark follow-up slices.

## Validation

- `.\.venv\Scripts\python.exe -m py_compile commands\telemetry_cmds.py account_picker.py kvk_ui.py tests\test_account_picker.py tests\test_mykvktargets.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_account_picker.py tests\test_mykvktargets.py tests\test_governor_account_service.py tests\test_crystaltech_service.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests -k "account_picker or mykvktargets or crystaltech or governor_account"`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1349 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`

## Smoke Test Focus

- `/mykvktargets` with a typed GovernorID, public and only-me variants.
- `/mykvktargets` with one linked governor to confirm it auto-opens the target embed.
- `/mykvktargets` with multiple linked governors to confirm selector ordering, refresh, lookup button, and register button still work.
- `/mykvktargets` with no linked governors to confirm the hint and empty picker still render.
- `/mykvkcrystaltech` with typed GovernorID, one linked governor, multiple linked governors, and no linked governors.
- From a KVK selector, click Refresh after changing/adding a registration to confirm the picker rebuilds from current registry state.

## Deferred Follow-up

- Registry command/view account-selection migration remains deferred and captured in `docs/reference/deferred_optimisations.md`.
- Ark account-resolution audit/migration remains deferred and captured separately.
- Compatibility adapter cleanup is deferred until all direct command/view and Ark consumers have focused coverage.