### PR TITLE
[codex] migrate registry account summary flows

### DIFF
--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -26,14 +26,12 @@ import registry.registry_service as registry_service
 from registry.registry_service import (
     VALID_ACCOUNT_TYPES,
     admin_register_or_replace,
-    get_user_accounts,
     remove_governor,
 )
 from services.governor_account_service import (
     filter_account_slots,
-    get_accounts_for_user as get_user_accounts_async,
+    get_account_summary_for_user,
     parse_discord_user_id,
-    registered_account_slots,
 )
 import target_utils
 from ui.views.admin_views import ConfirmImportView
@@ -63,12 +61,18 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 target_id = parse_discord_user_id(ctx.options.get("user_id"))
 
             if not target_id:
-                return filter_account_slots(ctx.value)
+                command_name = getattr(getattr(ctx, "command", None), "name", None)
+                if command_name != "modify_registration":
+                    return filter_account_slots(ctx.value)
+                invoking_user = getattr(getattr(ctx, "interaction", None), "user", None)
+                target_id = getattr(invoking_user, "id", None)
+                if not target_id:
+                    return filter_account_slots(ctx.value)
 
-            lookup = await get_user_accounts_async(target_id)
-            if not lookup.ok:
+            summary = await get_account_summary_for_user(target_id)
+            if not summary.ok:
                 return []
-            return registered_account_slots(lookup.accounts, ctx.value)
+            return summary.registered_slots(ctx.value)
         except Exception:
             return filter_account_slots(ctx.value)
 
@@ -166,9 +170,9 @@ def register_registry(bot: ext_commands.Bot) -> None:
 
         # --- Load registry account state safely
         try:
-            accounts_lookup = await get_user_accounts_async(ctx.user.id)
-            if not accounts_lookup.ok:
-                raise RuntimeError(accounts_lookup.error or "registry unavailable")
+            account_summary = await get_account_summary_for_user(ctx.user.id)
+            if not account_summary.ok:
+                raise RuntimeError(account_summary.error or "registry unavailable")
         except Exception as e:
             logger.exception("[modify_registration] get_user_accounts failed")
             await ctx.interaction.edit_original_response(
@@ -178,10 +182,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        user_accounts = accounts_lookup.accounts
-
         # Ensure this slot exists
-        if account_type not in user_accounts:
+        if account_type not in account_summary.ordered_accounts:
             await ctx.interaction.edit_original_response(
                 content=f"❌ You haven't registered `{account_type}` yet. Use `/register_governor` instead.",
                 embed=None,
@@ -293,15 +295,21 @@ def register_registry(bot: ext_commands.Bot) -> None:
         )
 
         # Pre-check: confirm slot exists so we can give a clear message before acting
-        accounts = await asyncio.to_thread(get_user_accounts, target_user_id)
-        if account_type not in accounts:
+        account_summary = await get_account_summary_for_user(target_user_id)
+        if not account_summary.ok:
+            await ctx.interaction.edit_original_response(
+                content=f"❌ Could not load registrations for {target_display}."
+            )
+            return
+        if account_type not in account_summary.ordered_accounts:
             await ctx.interaction.edit_original_response(
                 content=f"⚠️ `{account_type}` is not registered for {target_display}."
             )
             return
 
-        gov_name = accounts[account_type].get("GovernorName", "Unknown")
-        gov_id = accounts[account_type].get("GovernorID", "Unknown")
+        account_info = account_summary.ordered_accounts[account_type]
+        gov_name = account_info.get("GovernorName", "Unknown")
+        gov_id = account_info.get("GovernorID", "Unknown")
 
         ok, err = remove_governor(
             discord_user_id=target_user_id,
@@ -355,21 +363,27 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
             return
 
-        accounts = await asyncio.to_thread(get_user_accounts, target_id)
-        if not accounts:
+        account_summary = await get_account_summary_for_user(target_id)
+        if not account_summary.ok:
+            await ctx.interaction.edit_original_response(
+                content=f"❌ Could not load registrations for ID `{target_id}`."
+            )
+            return
+        if not account_summary.ordered_accounts:
             await ctx.interaction.edit_original_response(
                 content=f"⚠️ No registry entry found for ID `{target_id}`."
             )
             return
 
-        if account_type not in accounts:
+        if account_type not in account_summary.ordered_accounts:
             await ctx.interaction.edit_original_response(
                 content=f"⚠️ `{account_type}` is not registered for ID `{target_id}`."
             )
             return
 
-        gov_name = accounts[account_type].get("GovernorName", "Unknown")
-        gov_id = accounts[account_type].get("GovernorID", "Unknown")
+        account_info = account_summary.ordered_accounts[account_type]
+        gov_name = account_info.get("GovernorName", "Unknown")
+        gov_id = account_info.get("GovernorID", "Unknown")
 
         ok, err = remove_governor(
             discord_user_id=target_id,

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,28 +51,19 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `commands/registry_cmds.py`, `ui/views/registry_views.py`, `services/governor_account_service.py`
-- Type: consistency
-- Description: After the telemetry/KVK target/CrystalTech picker slice, registry command and view account-selection flows still rely on `AccountLookup`-style account dictionaries and local option/free-slot shaping rather than consuming `AccountResolutionSummary` directly. This path is write-sensitive because it includes registration, modification, removal confirmation views, duplicate-claim checks, and player-facing error copy.
-- Suggested Fix: Migrate registry command autocomplete and `MyRegsActionView` registration/modify entry points to `AccountResolutionSummary`, preserving account slot ordering, command names, permissions, ephemeral/admin behaviour, registration confirmation/cancel behaviour, and SQL-backed duplicate ownership checks. Add focused command/view tests before retiring any registry-facing compatibility pathways.
-- Impact: medium
-- Risk: medium
-- Dependencies: Telemetry/KVK picker migration complete; preserve `/my_registrations`, `/register_governor`, `/modify_registration`, `/remove_registration`, and admin registration behaviour.
-
-### Deferred Optimisation
 - Area: `ark/registration_flow.py`, `account_picker.py`, `services/governor_account_service.py`
 - Type: consistency
-- Description: Ark registration flows still load raw registry account dictionaries, build governor select options through the legacy account picker path, and resolve governor names from local account dictionaries. The flow also has Ark-specific signup, ban, roster, active-match, and persistent-message behaviour, so it should not be migrated opportunistically with registry command/view work.
+- Description: Ark registration flows still load raw registry account dictionaries, build governor select options through the legacy account picker path, and resolve governor names from local account dictionaries. The flow also has Ark-specific signup, ban, roster, active-match, and persistent-message behaviour, so it should not be migrated opportunistically with registry command/view work even after the registry command/view summary migration.
 - Suggested Fix: Audit Ark self-service join/sub/leave/switch account lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`. Migrate only after confirming Ark signup behaviour, ban enforcement, roster filtering, active signup detection, and persistent registration-message refresh remain unchanged.
 - Impact: medium
 - Risk: medium
-- Dependencies: Registry command/view direct migration should land first or be explicitly skipped; preserve Ark signup behaviour and focused Ark regression coverage.
+- Dependencies: Registry command/view direct migration complete; preserve Ark signup behaviour and focused Ark regression coverage.
 
 ### Deferred Optimisation
-- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `commands/registry_cmds.py`, `ui/views/registry_views.py`, `ark/registration_flow.py`
+- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `ark/registration_flow.py`, `account_picker.py`
 - Type: cleanup
-- Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain necessary while direct command/view and Ark consumers are still being migrated. Removing them now would risk breaking public shapes used by stats, inventory, MGE, registry, telemetry, and Ark tests.
-- Suggested Fix: After telemetry/KVK, registry command/view, and Ark account-resolution migrations all have focused regression coverage, remove obsolete `AccountLookup`-only pathways and any duplicate local classification or option-shaping helpers that no longer have external callers.
+- Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain necessary while Ark consumers are still pending migration. Removing them now would risk breaking public shapes used by stats, inventory, MGE, telemetry, registry compatibility imports, and Ark tests.
+- Suggested Fix: After Ark account-resolution migration has focused regression coverage, remove obsolete `AccountLookup`-only pathways and any duplicate local classification or option-shaping helpers that no longer have external callers.
 - Impact: medium
 - Risk: medium
-- Dependencies: All direct command/view surfaces migrated to `AccountResolutionSummary`; focused regression coverage exists for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, and Ark signup.
+- Dependencies: Telemetry/KVK and registry command/view surfaces migrated to `AccountResolutionSummary`; Ark migration and focused regression coverage still pending. Preserve coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, and Ark signup before cleanup.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -610,3 +610,110 @@ Important context:
 - Validate any SQL-facing assumptions against `C:\K98-bot-SQL-Server` before implementation.
 - Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
 ```
+
+## 29. PR 88 Telemetry/KVK Picker Direct Migration Completion Update
+
+Status: smoke tested successfully and deployed to production.
+
+PR 88 delivered:
+
+- `commands/telemetry_cmds.py` now uses `get_account_summary_for_user()` directly for `/mykvktargets`, `/mykvkcrystaltech`, and the KVK registration callback.
+- `account_picker.py` now accepts `AccountResolutionSummary` directly when building unique governor select options, while preserving legacy dict support for remaining unmigrated callers.
+- `kvk_ui.py` selector refresh now rebuilds options from `AccountResolutionSummary`.
+- Account selector label/value/description shape and GovernorID dedupe behaviour were preserved.
+- Review feedback was addressed so blank, missing, or `Unknown` GovernorName values fall back to the slot label instead of rendering repeated `Unknown` picker labels.
+- Registry command/view and Ark direct migrations remained deferred and were captured as separate active backlog items.
+- Compatibility adapter cleanup remained deferred until all direct command/view and Ark consumers have focused regression coverage.
+
+Smoke coverage completed after deployment:
+
+- `/mykvktargets` typed GovernorID path.
+- `/mykvktargets` one-linked-governor auto-open path.
+- `/mykvktargets` multi-governor selector path.
+- `/mykvktargets` no-linked-governor hint and picker path.
+- KVK selector refresh, lookup, and register buttons.
+- `/mykvkcrystaltech` typed GovernorID path.
+- `/mykvkcrystaltech` one-linked-governor auto-open path.
+- `/mykvkcrystaltech` multi-governor selector path.
+- `/mykvkcrystaltech` no-linked-governor hint and picker path.
+- `/my_registrations` spot check to confirm intentionally deferred registry flows still open normally.
+
+Validation completed during PR 88:
+
+- `.\.venv\Scripts\python.exe -m py_compile commands\telemetry_cmds.py account_picker.py kvk_ui.py tests\test_account_picker.py tests\test_mykvktargets.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_account_picker.py tests\test_mykvktargets.py tests\test_governor_account_service.py tests\test_crystaltech_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "account_picker or mykvktargets or crystaltech or governor_account"`
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1349 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- Review-fix validation: `.\.venv\Scripts\python.exe -m pytest -q tests\test_account_picker.py tests\test_mykvktargets.py tests\test_governor_account_service.py tests\test_crystaltech_service.py` (`22 passed`)
+
+Remaining follow-up slices intentionally left deferred:
+
+1. Registry command/view direct migration: update registry command autocomplete and `MyRegsActionView` registration/modify entry points in `commands/registry_cmds.py` and `ui/views/registry_views.py` to consume `AccountResolutionSummary` directly while preserving write-sensitive behaviour.
+2. Ark account-resolution audit/migration: inspect `ark/registration_flow.py` self-service join/sub/leave/switch lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`.
+3. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after telemetry/KVK, registry command/view, and Ark surfaces all have focused regression coverage.
+
+## 30. Next Phase Chat Starter
+
+Use this in a fresh Codex chat for the remaining shared account-resolution deferred elements:
+
+```text
+Codex, start the next registry/account optimisation after PR 88 (`account-summary-telemetry-picker`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: deliver the next PR-sized follow-up slice for the shared account-resolution migration. PR 87 introduced `ResolvedAccount` and `AccountResolutionSummary` in `services/governor_account_service.py`; PR 88 migrated telemetry/KVK target/CrystalTech picker setup in `commands/telemetry_cmds.py`, `account_picker.py`, and `kvk_ui.py` to consume the shared summary directly. Now deliver the remaining deferred elements incrementally.
+
+Important context:
+- PR 84 centralised basic account slots, Discord user-id parsing, public GovernorID roster lookup, and `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- PR 85A extracted registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping into `registry/registry_command_service.py`.
+- PR 86 moved registry confirmation views into `ui/views/registry_views.py`, kept compatibility re-exports from `registry/governor_registry.py`, and removed the remaining inline registry-service import in `remove_registration_by_id`.
+- PR 87 introduced the shared richer account-resolution summary object and migrated stats, inventory, and MGE service adapters while preserving public shapes.
+- PR 88 migrated telemetry/KVK target/CrystalTech picker setup to `AccountResolutionSummary` and preserved selector labels, option ordering, refresh behaviour, lookup/register buttons, and slot fallback labels for blank or `Unknown` GovernorName values.
+- Remaining deferred slices are:
+  1. migrate registry command/view account-selection flows in `commands/registry_cmds.py` and `ui/views/registry_views.py` to consume `AccountResolutionSummary` directly;
+  2. audit and, if safe, migrate `ark/registration_flow.py` account lookup and governor-name helpers to reuse the shared summary;
+  3. remove compatibility adapters and duplicate local classification/option-shaping helpers only after every direct command/view and Ark surface has focused regression coverage.
+- Recommended next slice: registry command/view direct migration, because it is the next consumer in the account-registration workflow and should land before Ark or adapter cleanup.
+- Preserve current command output, autocomplete ordering, permission checks, ephemeral/admin behaviour, registration confirmation/cancel behaviour, SQL-backed duplicate ownership checks, inventory permission behaviour, stats export behaviour, MGE signup behaviour, telemetry/KVK picker behaviour, and Ark signup behaviour.
+- Validate any SQL-facing assumptions against `C:\K98-bot-SQL-Server` before implementation.
+- Keep the work PR-sized. Start with audit/scope and stop for approval before implementation unless explicitly told otherwise.
+- Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
+```
+
+## 31. PR 89 Registry Command/View Direct Migration Update
+
+Status: local validation complete; pending PR review and production smoke test.
+
+PR 89 scope:
+
+- `commands/registry_cmds.py` uses `get_account_summary_for_user()` directly for account-type autocomplete, `/modify_registration` slot existence checks, and admin remove pre-check display data.
+- `ui/views/registry_views.py` uses `get_account_summary_for_user()` directly from `MyRegsActionView` when opening modify/register entry points.
+- `ModifyStartView` now receives `AccountResolutionSummary` and builds options from `summary.ordered_accounts`.
+- `RegisterStartView` can receive `AccountResolutionSummary` for registry flows while retaining `free_slots` compatibility for telemetry/KVK callers that still open the same start view.
+- `AccountResolutionSummary.registered_slots()` was added so command autocomplete can preserve canonical registered-slot ordering without dropping back to `AccountLookup`.
+- Focused command/view/service tests cover summary-backed slot filtering, registry selection migration, view entry points, and registry-unavailable handling.
+- The active deferred item for registry command/view direct migration was removed from `docs/reference/deferred_optimisations.md`.
+
+Validation completed during PR 89:
+
+- `.\.venv\Scripts\python.exe -m py_compile commands\registry_cmds.py ui\views\registry_views.py services\governor_account_service.py tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py tests\test_ui_imports.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1353 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+
+Remaining follow-up slices intentionally left deferred:
+
+1. Ark account-resolution audit/migration: inspect `ark/registration_flow.py` self-service join/sub/leave/switch lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`.
+2. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after Ark has focused regression coverage and the existing stats, inventory, MGE, telemetry/KVK, and registry regression surfaces remain green.

--- a/services/governor_account_service.py
+++ b/services/governor_account_service.py
@@ -66,6 +66,9 @@ class AccountResolutionSummary:
     def free_slots(self) -> list[str]:
         return free_account_slots(self.accounts)
 
+    def registered_slots(self, prefix: str | None = None, *, limit: int = 25) -> list[str]:
+        return registered_account_slots(self.ordered_accounts, prefix, limit=limit)
+
 
 def _normalize_governor_id_str(value: Any) -> str:
     try:

--- a/tests/test_governor_account_service.py
+++ b/tests/test_governor_account_service.py
@@ -72,6 +72,8 @@ def test_account_resolution_summary_orders_deduplicates_and_defaults_to_main():
     assert summary.default_choice == "Main"
     assert summary.classification == ("multi", None)
     assert summary.contains_governor_id("100")
+    assert summary.registered_slots() == ["Main", "Alt 1", "Alt 2", "Farm 1"]
+    assert summary.registered_slots("alt") == ["Alt 1", "Alt 2"]
 
 
 def test_account_resolution_summary_single_classification_handles_unknown_slots():

--- a/tests/test_registry_cmds.py
+++ b/tests/test_registry_cmds.py
@@ -16,8 +16,25 @@ def test_registry_cmds_uses_shared_account_helpers() -> None:
 
     assert "parse_discord_user_id" in source
     assert "filter_account_slots" in source
-    assert "registered_account_slots" in source
+    assert "get_account_summary_for_user" in source
+    assert "summary.registered_slots" in source
     assert "def _parse_user_id" not in source
+
+
+def test_registry_cmds_uses_account_summary_directly_for_registry_selection() -> None:
+    source = Path("commands/registry_cmds.py").read_text(encoding="utf-8")
+
+    assert "get_accounts_for_user as get_user_accounts_async" not in source
+    assert "await asyncio.to_thread(get_user_accounts" not in source
+    assert "account_summary.ordered_accounts" in source
+
+
+def test_registry_autocomplete_falls_back_to_invoking_user_for_self_service() -> None:
+    source = Path("commands/registry_cmds.py").read_text(encoding="utf-8")
+
+    assert 'command_name != "modify_registration"' in source
+    assert 'getattr(getattr(ctx, "interaction", None), "user", None)' in source
+    assert 'getattr(ctx, "user", None)' not in source
 
 
 def test_my_registrations_uses_service_loader_not_removed_facade_import() -> None:

--- a/tests/test_registry_views_smoke.py
+++ b/tests/test_registry_views_smoke.py
@@ -62,9 +62,32 @@ def test_registry_views_instantiate(monkeypatch):
         )
         v1 = rv.MyRegsActionView(author_id=1, has_regs=True)
         m1 = rv.GovNameModal(author_id=1)
-        v2 = rv.RegisterStartView(author_id=1, free_slots=["Main"])
+        summary = rv.AccountResolutionSummary(
+            ok=True,
+            accounts={"Main": {"GovernorID": "1", "GovernorName": "A"}},
+            ordered_accounts={"Main": {"GovernorID": "1", "GovernorName": "A"}},
+            resolved_accounts=(),
+            governor_ids=(),
+            governor_id_strings=(),
+            account_names=(),
+            name_to_id={},
+            default_choice="ALL",
+        )
+        empty_summary = rv.AccountResolutionSummary(
+            ok=True,
+            accounts={},
+            ordered_accounts={},
+            resolved_accounts=(),
+            governor_ids=(),
+            governor_id_strings=(),
+            account_names=(),
+            name_to_id={},
+            default_choice="ALL",
+        )
+        v2 = rv.RegisterStartView(author_id=1, account_summary=empty_summary)
         v3 = rv.ModifyStartView(
-            author_id=1, accounts={"Main": {"GovernorID": "1", "GovernorName": "A"}}
+            author_id=1,
+            account_summary=summary,
         )
         m2 = rv.EnterGovernorIDModal(author_id=1, mode="register", account_type="Main")
         v4 = rv.GovernorSelectView([("A", 1)], author_id=1)
@@ -80,6 +103,110 @@ def test_registry_views_instantiate(monkeypatch):
         assert v5.governor_id == "1"
         assert v6.new_gov_id == "2"
         assert v7.account_type == "Main"
+
+    asyncio.run(_run())
+
+
+def test_my_regs_action_view_register_and_modify_use_account_summary(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+    calls = []
+
+    async def _get_account_summary_for_user(user_id):
+        calls.append(user_id)
+        return rv.AccountResolutionSummary(
+            ok=True,
+            accounts={
+                "Main": {"GovernorID": "1", "GovernorName": "A"},
+                "Alt 1": {"GovernorID": "2", "GovernorName": "B"},
+            },
+            ordered_accounts={
+                "Main": {"GovernorID": "1", "GovernorName": "A"},
+                "Alt 1": {"GovernorID": "2", "GovernorName": "B"},
+            },
+            resolved_accounts=(),
+            governor_ids=(),
+            governor_id_strings=(),
+            account_names=(),
+            name_to_id={},
+            default_choice="ALL",
+        )
+
+    monkeypatch.setattr(rv, "get_account_summary_for_user", _get_account_summary_for_user)
+
+    async def _run():
+        view = rv.MyRegsActionView(author_id=1, has_regs=True)
+
+        modify_interaction = _FakeInteraction(_User(1))
+        await _button_contains(view, "Modify Registration").callback(modify_interaction)
+
+        register_interaction = _FakeInteraction(_User(1))
+        await _button_contains(view, "Register New Account").callback(register_interaction)
+
+        assert calls == [1, 1]
+        modify_view = modify_interaction.followup.messages[-1]["view"]
+        register_view = register_interaction.followup.messages[-1]["view"]
+        assert isinstance(modify_view, rv.ModifyStartView)
+        assert isinstance(register_view, rv.RegisterStartView)
+
+    asyncio.run(_run())
+
+
+def test_my_regs_action_view_register_reports_summary_failure(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+
+    async def _get_account_summary_for_user(_user_id):
+        return rv.AccountResolutionSummary(
+            ok=False,
+            accounts={},
+            ordered_accounts={},
+            resolved_accounts=(),
+            governor_ids=(),
+            governor_id_strings=(),
+            account_names=(),
+            name_to_id={},
+            default_choice="ALL",
+            error="db down",
+        )
+
+    monkeypatch.setattr(rv, "get_account_summary_for_user", _get_account_summary_for_user)
+
+    async def _run():
+        view = rv.MyRegsActionView(author_id=1, has_regs=False)
+        interaction = _FakeInteraction(_User(1))
+
+        await _button_contains(view, "Register New Account").callback(interaction)
+
+        assert "Registry temporarily unavailable" in interaction.followup.messages[-1]["content"]
+
+    asyncio.run(_run())
+
+
+def test_my_regs_action_view_modify_reports_summary_failure(monkeypatch):
+    rv = _load_registry_views(monkeypatch)
+
+    async def _get_account_summary_for_user(_user_id):
+        return rv.AccountResolutionSummary(
+            ok=False,
+            accounts={},
+            ordered_accounts={},
+            resolved_accounts=(),
+            governor_ids=(),
+            governor_id_strings=(),
+            account_names=(),
+            name_to_id={},
+            default_choice="ALL",
+            error="db down",
+        )
+
+    monkeypatch.setattr(rv, "get_account_summary_for_user", _get_account_summary_for_user)
+
+    async def _run():
+        view = rv.MyRegsActionView(author_id=1, has_regs=True)
+        interaction = _FakeInteraction(_User(1))
+
+        await _button_contains(view, "Modify Registration").callback(interaction)
+
+        assert "Registry temporarily unavailable" in interaction.followup.messages[-1]["content"]
 
     asyncio.run(_run())
 
@@ -195,6 +322,10 @@ def test_confirmation_cancel_callbacks_clear_prompt(monkeypatch):
 
 def _button(view, label: str):
     return next(child for child in view.children if getattr(child, "label", "") == label)
+
+
+def _button_contains(view, label: str):
+    return next(child for child in view.children if label in getattr(child, "label", ""))
 
 
 class _User:

--- a/ui/views/registry_views.py
+++ b/ui/views/registry_views.py
@@ -11,6 +11,7 @@ from discord import Embed
 
 from registry.governor_registry import register_account
 from registry.registry_service import check_governor_claimed_by_other, remove_governor
+from services.governor_account_service import AccountResolutionSummary, get_account_summary_for_user
 from utils import normalize_governor_id
 
 logger = logging.getLogger(__name__)
@@ -288,10 +289,14 @@ class MyRegsActionView(discord.ui.View):
         except Exception:
             pass
         try:
-            from services.governor_account_service import get_accounts_for_user
-
-            lookup = await get_accounts_for_user(self.author_id)
-            accounts = lookup.accounts if lookup.ok else {}
+            summary = await get_account_summary_for_user(self.author_id)
+            if not summary.ok:
+                await interaction.followup.send(
+                    "⚠️ Registry temporarily unavailable. Please try again in a moment.",
+                    ephemeral=True,
+                )
+                return
+            accounts = summary.ordered_accounts
             if not accounts:
                 await interaction.followup.send(
                     "You don’t have any accounts to modify. Use **Register New Account** instead.",
@@ -300,7 +305,7 @@ class MyRegsActionView(discord.ui.View):
                 return
             await interaction.followup.send(
                 "Select which registered account you want to modify:",
-                view=ModifyStartView(author_id=self.author_id, accounts=accounts),
+                view=ModifyStartView(author_id=self.author_id, account_summary=summary),
                 ephemeral=True,
             )
         except Exception as e:
@@ -323,17 +328,14 @@ class MyRegsActionView(discord.ui.View):
         except Exception:
             pass
         try:
-            from services.governor_account_service import free_account_slots, get_accounts_for_user
-
-            lookup = await get_accounts_for_user(self.author_id)
-            if not lookup.ok:
+            summary = await get_account_summary_for_user(self.author_id)
+            if not summary.ok:
                 await interaction.followup.send(
                     "⚠️ Registry temporarily unavailable. Please try again in a moment.",
                     ephemeral=True,
                 )
                 return
-            accounts = lookup.accounts
-            free_slots = free_account_slots(accounts)
+            free_slots = summary.free_slots()
             if not free_slots:
                 await interaction.followup.send(
                     "All account slots are registered already. Use **Modify Registration** to change one.",
@@ -342,7 +344,7 @@ class MyRegsActionView(discord.ui.View):
                 return
             await interaction.followup.send(
                 "Pick an account slot to register:",
-                view=RegisterStartView(author_id=self.author_id, free_slots=free_slots),
+                view=RegisterStartView(author_id=self.author_id, account_summary=summary),
                 ephemeral=True,
             )
         except Exception as e:
@@ -427,17 +429,21 @@ class GovNameModal(discord.ui.Modal):
 
 
 class ModifyStartView(discord.ui.View):
-    def __init__(self, *, author_id: int, accounts: dict, timeout: float = 180):
+    def __init__(
+        self,
+        *,
+        author_id: int,
+        account_summary: AccountResolutionSummary,
+        timeout: float = 180,
+    ):
         super().__init__(timeout=timeout)
         self.author_id = author_id
         options = []
-        for slot in _account_order_getter():
-            if slot in accounts:
-                info = accounts.get(slot) or {}
-                gid = str(info.get("GovernorID", "")).strip()
-                gname = str(info.get("GovernorName", "")).strip()
-                label = f"{slot} — {gname} ({gid})" if (gname or gid) else f"{slot}"
-                options.append(discord.SelectOption(label=label[:100], value=slot))
+        for slot, info in account_summary.ordered_accounts.items():
+            gid = str(info.get("GovernorID", "")).strip()
+            gname = str(info.get("GovernorName", "")).strip()
+            label = f"{slot} — {gname} ({gid})" if (gname or gid) else f"{slot}"
+            options.append(discord.SelectOption(label=label[:100], value=slot))
         select = discord.ui.Select(
             placeholder="Choose an account to modify",
             options=options[:25],
@@ -484,13 +490,17 @@ class RegisterStartView(discord.ui.View):
         self,
         *,
         author_id: int,
-        free_slots: list,
+        account_summary: AccountResolutionSummary | None = None,
+        free_slots: list | None = None,
         timeout: float = 180,
         prefill_id: str | None = None,
     ):
         super().__init__(timeout=timeout)
         self.author_id = author_id
         self.prefill_id = prefill_id
+        if account_summary is not None:
+            free_slots = account_summary.free_slots()
+        free_slots = free_slots or []
         options = [discord.SelectOption(label=slot, value=slot) for slot in free_slots[:25]]
         select = discord.ui.Select(
             placeholder="Choose a slot to register", options=options, min_values=1, max_values=1


### PR DESCRIPTION
## Summary

- Migrates registry command account-selection paths to consume `AccountResolutionSummary` directly.
- Updates `MyRegsActionView`, `ModifyStartView`, and registry `RegisterStartView` to use the shared account summary while preserving `free_slots` compatibility for telemetry/KVK callers.
- Updates deferred optimisation docs and the registry task pack so Ark migration and compatibility cleanup remain separate follow-up slices.

## Changes

- Adds `AccountResolutionSummary.registered_slots()` for canonical registered-slot autocomplete ordering.
- Replaces registry command `AccountLookup`/raw account dict use in autocomplete, `/modify_registration`, and admin remove pre-checks.
- Uses command metadata so only self-service `/modify_registration` falls back to the invoking user for autocomplete; admin remove autocomplete keeps the full slot list until a target user/ID is present.
- Returns a temporary-unavailable response when the My Registrations modify action cannot load the registry summary.
- Adds focused command/view/service tests for summary-backed registry selection, view entry points, unavailable-registry handling, and registered-slot filtering.

## SQL Changes

- None. Existing registry SQL contract was checked against `C:\K98-bot-SQL-Server` for `dbo.DiscordGovernorRegistry` and registry stored procedures.

## Validation

- `.\.venv\Scripts\python.exe -m py_compile commands\registry_cmds.py ui\views\registry_views.py services\governor_account_service.py tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py` (`23 passed` after review fixes)
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py tests\test_ui_imports.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1355 passed, 2 skipped` after review fixes)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`

## Follow-up

- Ark account-resolution audit/migration remains deferred.
- Compatibility adapter cleanup remains deferred until Ark migration has focused regression coverage.