### PR TITLE
[codex] migrate Ark self-service account summary lookup

### DIFF
--- a/ark/registration_flow.py
+++ b/ark/registration_flow.py
@@ -33,7 +33,11 @@ from ark.registration_messages import upsert_registration_message
 from ark.state.ark_state import ArkJsonState, ArkMessageRef, ArkMessageState
 from decoraters import _has_leadership_role, _is_admin
 from profile_cache import get_profile_cached
-from registry.registry_service import get_discord_user_for_governor, get_user_accounts
+from registry.registry_service import get_discord_user_for_governor
+from services.governor_account_service import (
+    AccountResolutionSummary,
+    get_account_summary_for_user,
+)
 from target_utils import (
     _name_cache,
     get_name_cache_status,
@@ -170,22 +174,6 @@ async def _ensure_name_cache_ready() -> None:
             await asyncio.to_thread(sync_refresh_worker)
     except Exception:
         logger.exception("[ARK] Failed ensuring name cache is ready")
-
-
-async def _get_user_accounts(user_id: int) -> dict[str, dict]:
-    try:
-        return dict(await asyncio.to_thread(get_user_accounts, int(user_id)) or {})
-    except Exception:
-        logger.exception("ark_registration_user_accounts_lookup_failed user_id=%s", user_id)
-        return {}
-
-
-def _get_governor_name(accounts: dict[str, dict], governor_id: str) -> str:
-    gid = str(governor_id).strip()
-    for info in (accounts or {}).values():
-        if str(info.get("GovernorID", "")).strip() == gid:
-            return str(info.get("GovernorName") or "Unknown")
-    return "Unknown"
 
 
 def _find_user_signup(roster: list[dict], user_id: int) -> dict[str, Any] | None:
@@ -482,7 +470,7 @@ class ArkRegistrationController:
         self,
         interaction: discord.Interaction,
         *,
-        accounts: dict[str, dict],
+        accounts: AccountResolutionSummary,
         on_select,
         heading: str,
         only_governor_ids: set[str] | None = None,
@@ -584,7 +572,7 @@ class ArkRegistrationController:
 
         # NOTE: Removed user-level block. Governor-level duplicate check happens in _apply_join.
 
-        accounts = await _get_user_accounts(interaction.user.id)
+        accounts = await get_account_summary_for_user(interaction.user.id)
 
         async def _apply(inter: discord.Interaction, governor_id: str) -> None:
             await self._apply_join(inter, match, roster, accounts, governor_id, slot_type="Player")
@@ -617,7 +605,7 @@ class ArkRegistrationController:
             await interaction.followup.send("❌ Sub slots are full.", ephemeral=True)
             return
 
-        accounts = await _get_user_accounts(interaction.user.id)
+        accounts = await get_account_summary_for_user(interaction.user.id)
 
         async def _apply(inter: discord.Interaction, governor_id: str) -> None:
             await self._apply_join(inter, match, roster, accounts, governor_id, slot_type="Sub")
@@ -634,7 +622,7 @@ class ArkRegistrationController:
         interaction: discord.Interaction,
         match: dict[str, Any],
         roster: list[dict[str, Any]],
-        accounts: dict[str, dict],
+        accounts: AccountResolutionSummary,
         governor_id: str,
         *,
         slot_type: str,
@@ -703,7 +691,7 @@ class ArkRegistrationController:
         if not await self._validate_governor(interaction, governor_id):
             return
 
-        gov_name = _get_governor_name(accounts, governor_id)
+        gov_name = accounts.governor_name_for_id(governor_id)
         existing = await get_signup(self.match_id, int(governor_id))
         if existing and (existing.get("Status") or "").lower() != "active":
             ok = await reactivate_signup(
@@ -756,13 +744,8 @@ class ArkRegistrationController:
             return
 
         roster = await get_roster(self.match_id)
-        accounts = await _get_user_accounts(interaction.user.id)
-
-        account_gov_ids = {
-            str(info.get("GovernorID")).strip()
-            for info in (accounts or {}).values()
-            if info.get("GovernorID") is not None
-        }
+        accounts = await get_account_summary_for_user(interaction.user.id)
+        account_gov_ids = set(accounts.governor_id_strings)
 
         # Filter roster to governors linked to this Discord user
         roster_govs = [r for r in roster if str(r.get("GovernorId")).strip() in account_gov_ids]
@@ -823,14 +806,8 @@ class ArkRegistrationController:
             return
 
         roster = await get_roster(self.match_id)
-        accounts = await _get_user_accounts(interaction.user.id)
-
-        # Governor IDs linked to this Discord user
-        account_gov_ids = {
-            str(info.get("GovernorID")).strip()
-            for info in (accounts or {}).values()
-            if info.get("GovernorID") is not None
-        }
+        accounts = await get_account_summary_for_user(interaction.user.id)
+        account_gov_ids = set(accounts.governor_id_strings)
 
         # Active signups in this match that belong to this user
         active_govs = {
@@ -902,7 +879,7 @@ class ArkRegistrationController:
         interaction: discord.Interaction,
         match: dict[str, Any],
         roster: list[dict[str, Any]],
-        accounts: dict[str, dict],
+        accounts: AccountResolutionSummary,
         current_governor_id: str,
         governor_id: str,
     ) -> None:
@@ -936,7 +913,7 @@ class ArkRegistrationController:
         if not await self._validate_governor(interaction, governor_id):
             return
 
-        gov_name = _get_governor_name(accounts, governor_id)
+        gov_name = accounts.governor_name_for_id(governor_id)
 
         current_entry = next(
             (r for r in roster if str(r.get("GovernorId")) == str(current_governor_id)),

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,19 +51,28 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `ark/registration_flow.py`, `account_picker.py`, `services/governor_account_service.py`
+- Area: `commands/registry_cmds.py` `/my_registrations`, `services/governor_account_service.py`, `registry/registry_service.py`
 - Type: consistency
-- Description: Ark registration flows still load raw registry account dictionaries, build governor select options through the legacy account picker path, and resolve governor names from local account dictionaries. The flow also has Ark-specific signup, ban, roster, active-match, and persistent-message behaviour, so it should not be migrated opportunistically with registry command/view work even after the registry command/view summary migration.
-- Suggested Fix: Audit Ark self-service join/sub/leave/switch account lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`. Migrate only after confirming Ark signup behaviour, ban enforcement, roster filtering, active signup detection, and persistent registration-message refresh remain unchanged.
+- Description: `/my_registrations` still builds its display payload by loading the full registry through `registry_service.load_registry_as_dict()` and then selecting the invoking user's account dictionary locally. PR 89 intentionally preserved that path to avoid expanding a write-sensitive registry summary migration, but it leaves this one player-facing registry display flow outside the direct `AccountResolutionSummary` migration used by telemetry/KVK, registry action views, stats, inventory, and MGE adapters.
+- Suggested Fix: Audit `/my_registrations` and migrate its per-user display loading to `get_account_summary_for_user()` or a focused Discord-free registry display service that consumes `AccountResolutionSummary`, preserving embed title/copy, account slot ordering, empty-state copy, action buttons, truncation guard, ephemeral response behaviour, and stale/unavailable registry handling. Keep `load_registry_as_dict()` for audit/export/import flows that still need full-registry snapshots.
 - Impact: medium
-- Risk: medium
-- Dependencies: Registry command/view direct migration complete; preserve Ark signup behaviour and focused Ark regression coverage.
+- Risk: low
+- Dependencies: PR 89 registry command/view direct migration complete; add focused `/my_registrations` regression coverage before changing the loader path.
 
 ### Deferred Optimisation
-- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `ark/registration_flow.py`, `account_picker.py`
-- Type: cleanup
-- Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain necessary while Ark consumers are still pending migration. Removing them now would risk breaking public shapes used by stats, inventory, MGE, telemetry, registry compatibility imports, and Ark tests.
-- Suggested Fix: After Ark account-resolution migration has focused regression coverage, remove obsolete `AccountLookup`-only pathways and any duplicate local classification or option-shaping helpers that no longer have external callers.
+- Area: `ark/registration_flow.py` admin add fuzzy/name-cache lookup
+- Type: consistency
+- Description: Ark admin add still searches `target_utils._name_cache` directly for exact GovernorID, partial GovernorID, and substring fuzzy name matching. This is separate from the self-service linked-account migration because it supports admin roster search, cache refresh fallback, fuzzy selection, and admin slot prompts rather than selecting one of the actor's registered accounts.
+- Suggested Fix: Move Ark admin governor search into a focused Discord-free helper or service that uses public target/profile lookup helpers where available, preserves exact ID, partial ID, fuzzy name, cache refresh, and no-match messages, and leaves the view/controller responsible only for Discord response routing.
 - Impact: medium
 - Risk: medium
-- Dependencies: Telemetry/KVK and registry command/view surfaces migrated to `AccountResolutionSummary`; Ark migration and focused regression coverage still pending. Preserve coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, and Ark signup before cleanup.
+- Dependencies: Preserve Ark admin add behaviour, fuzzy result ordering, name-cache refresh fallback, ban enforcement, slot capacity checks, and admin/leadership permission tests.
+
+### Deferred Optimisation
+- Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `account_picker.py`, `ui/views/kvk_personal_views.py`
+- Type: cleanup
+- Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain after the stats, inventory, MGE, telemetry/KVK, registry, and Ark direct migrations. Removing them in the Ark PR would expand scope across legacy public shapes and KVK personal view compatibility paths.
+- Suggested Fix: In a dedicated cleanup PR, remove obsolete `AccountLookup`-only pathways and any duplicate local classification or option-shaping helpers that no longer have external callers.
+- Impact: medium
+- Risk: medium
+- Dependencies: Telemetry/KVK, registry command/view, and Ark surfaces migrated to `AccountResolutionSummary`; preserve coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup before cleanup.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -686,34 +686,111 @@ Important context:
 - Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
 ```
 
-## 31. PR 89 Registry Command/View Direct Migration Update
+## 31. PR 89 Registry Command/View Direct Migration Completion Update
 
-Status: local validation complete; pending PR review and production smoke test.
+Status: smoke tested successfully and deployed to production.
 
-PR 89 scope:
+PR 89 delivered:
 
 - `commands/registry_cmds.py` uses `get_account_summary_for_user()` directly for account-type autocomplete, `/modify_registration` slot existence checks, and admin remove pre-check display data.
 - `ui/views/registry_views.py` uses `get_account_summary_for_user()` directly from `MyRegsActionView` when opening modify/register entry points.
 - `ModifyStartView` now receives `AccountResolutionSummary` and builds options from `summary.ordered_accounts`.
 - `RegisterStartView` can receive `AccountResolutionSummary` for registry flows while retaining `free_slots` compatibility for telemetry/KVK callers that still open the same start view.
 - `AccountResolutionSummary.registered_slots()` was added so command autocomplete can preserve canonical registered-slot ordering without dropping back to `AccountLookup`.
+- `/modify_registration` autocomplete now falls back to the invoking user only when the autocomplete context belongs to the self-service modify command.
+- Admin remove autocomplete keeps the full slot list until a target Discord user or pasted user ID is present, avoiding accidental suggestions from the invoking admin's own registrations.
+- `MyRegsActionView` modify entry now reports temporary registry unavailability separately instead of treating summary load failure as no accounts registered.
 - Focused command/view/service tests cover summary-backed slot filtering, registry selection migration, view entry points, and registry-unavailable handling.
 - The active deferred item for registry command/view direct migration was removed from `docs/reference/deferred_optimisations.md`.
+
+Smoke coverage completed after deployment:
+
+- `/modify_registration` registered-slot autocomplete shows the invoking user's registered slots in canonical order.
+- `/modify_registration` valid modify path opens the existing confirmation prompt and preserves confirm/cancel behaviour.
+- `/modify_registration` `REMOVE` path opens the existing removal confirmation prompt and preserves confirm/cancel behaviour.
+- Admin `/remove_registration` autocomplete shows full slot suggestions before a target is entered, then target-specific registered slots once a Discord user or pasted ID is present.
+- Admin `/remove_registration_by_id` still handles valid removals, unregistered slots, and no-registration IDs with the existing user-facing responses.
+- `/my_registrations` action buttons open modify/register selectors from the shared account summary.
+- `/register_governor` confirmation flow still opens and preserves confirm/cancel behaviour.
+- Telemetry/KVK entry points that reuse `RegisterStartView` still open the slot picker through the preserved `free_slots` compatibility path.
 
 Validation completed during PR 89:
 
 - `.\.venv\Scripts\python.exe -m py_compile commands\registry_cmds.py ui\views\registry_views.py services\governor_account_service.py tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py`
-- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py` (`23 passed` after review fixes)
 - `.\.venv\Scripts\python.exe scripts\select_tests.py`
 - `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
 - `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
 - `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py tests\test_ui_imports.py`
 - `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
 - `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
-- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1353 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1355 passed, 2 skipped` after review fixes)
 - `.\.venv\Scripts\python.exe -m pre_commit run -a`
 
 Remaining follow-up slices intentionally left deferred:
 
 1. Ark account-resolution audit/migration: inspect `ark/registration_flow.py` self-service join/sub/leave/switch lookup and governor-name resolution for safe reuse of `AccountResolutionSummary`.
 2. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after Ark has focused regression coverage and the existing stats, inventory, MGE, telemetry/KVK, and registry regression surfaces remain green.
+
+## 32. Next Phase Chat Starter
+
+Use this in a fresh Codex chat for the next shared account-resolution deferred slice:
+
+```text
+Codex, start the next registry/account optimisation after PR 89 (`registry-account-summary-direct`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: deliver the next PR-sized follow-up slice for the shared account-resolution migration. PR 87 introduced `ResolvedAccount` and `AccountResolutionSummary` in `services/governor_account_service.py`; PR 88 migrated telemetry/KVK target/CrystalTech picker setup in `commands/telemetry_cmds.py`, `account_picker.py`, and `kvk_ui.py`; PR 89 migrated registry command/view account-selection flows in `commands/registry_cmds.py` and `ui/views/registry_views.py` to consume the shared summary directly. Now audit Ark and migrate only if the safe PR-sized shape is clear.
+
+Important context:
+- PR 84 centralised basic account slots, Discord user-id parsing, public GovernorID roster lookup, and `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- PR 85A extracted registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping into `registry/registry_command_service.py`.
+- PR 86 moved registry confirmation views into `ui/views/registry_views.py`, kept compatibility re-exports from `registry/governor_registry.py`, and removed the remaining inline registry-service import in `remove_registration_by_id`.
+- PR 87 introduced the shared richer account-resolution summary object and migrated stats, inventory, and MGE service adapters while preserving public shapes.
+- PR 88 migrated telemetry/KVK target/CrystalTech picker setup to `AccountResolutionSummary` and preserved selector labels, option ordering, refresh behaviour, lookup/register buttons, and slot fallback labels for blank or `Unknown` GovernorName values.
+- PR 89 migrated registry command/view account-selection flows to `AccountResolutionSummary`, preserved self-service/admin autocomplete behaviour, confirmation/cancel behaviour, duplicate ownership checks, and `RegisterStartView` compatibility for telemetry/KVK callers.
+- Remaining deferred slices are:
+  1. audit and, if safe, migrate `ark/registration_flow.py` account lookup and governor-name helpers to reuse `AccountResolutionSummary`;
+  2. remove compatibility adapters and duplicate local classification/option-shaping helpers only after Ark has focused regression coverage.
+- Recommended next slice: Ark account-resolution audit/migration. Start with audit/scope and stop for approval before implementation unless explicitly told otherwise.
+- Preserve current Ark signup behaviour, join/sub/leave/switch flows, ban enforcement, roster filtering, active signup detection, persistent registration-message refresh, account picker labels/ordering, telemetry/KVK picker behaviour, registry flows, inventory permission behaviour, stats export behaviour, and MGE signup behaviour.
+- Validate any SQL-facing assumptions against `C:\K98-bot-SQL-Server` before implementation.
+- Keep the work PR-sized. If Ark migration is not safely small, propose the split and leave compatibility cleanup deferred.
+- Update deferred docs as completed/deferred and run the K98 validation gates selected by `scripts/select_tests.py`.
+```
+
+## 33. PR 90 Ark Account-Resolution Direct Migration Completion Update
+
+Status: local validation complete; pending PR review and production smoke test.
+
+PR 90 delivered:
+
+- `ark/registration_flow.py` now uses `get_account_summary_for_user()` directly for self-service Ark join, sub, leave, and switch flows.
+- Ark self-service governor selectors now pass `AccountResolutionSummary` to the shared account picker option builder, preserving selector ordering, GovernorID de-dupe, and slot fallback labels.
+- Ark leave and switch roster filtering now derives linked GovernorIDs from `summary.governor_id_strings` instead of rebuilding local sets from raw account dictionaries.
+- Ark signup and switch GovernorName snapshots now resolve through `AccountResolutionSummary.governor_name_for_id()`.
+- The Ark-local raw account loader and duplicate governor-name helper were removed from `ark/registration_flow.py`.
+- Admin add name-cache and fuzzy lookup behaviour was intentionally left unchanged because it is an admin roster-search flow, not a linked-account selection path; a structured deferred item now tracks that cleanup separately.
+- The active Ark deferred optimisation item was removed from `docs/reference/deferred_optimisations.md`.
+- Compatibility adapter cleanup remains deferred as the next dedicated cleanup slice, alongside the separate `/my_registrations` display-loader item.
+
+Validation completed during PR 90:
+
+- `.\.venv\Scripts\python.exe -m py_compile ark\registration_flow.py services\governor_account_service.py tests\test_ark_registration_flow.py tests\test_governor_account_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_registration_flow.py tests\test_governor_account_service.py tests\test_account_picker.py` (`33 passed`)
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_bans_enforcement.py tests\test_ark_admin_roster.py` (`8 passed`)
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1356 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pytest -q <explicit test_ark_*.py file list>` (`165 passed`)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+
+Remaining follow-up slices intentionally left deferred:
+
+1. `/my_registrations` display-loader migration: audit and, if safe, move the player-facing display payload from full-registry local selection to `AccountResolutionSummary` or a focused display service.
+2. Ark admin fuzzy/name-cache lookup cleanup: move admin roster-search lookup out of the controller into a focused helper/service while preserving exact ID, partial ID, fuzzy name, refresh fallback, no-match responses, and admin slot prompts.
+3. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after preserving focused regression coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup.

--- a/services/governor_account_service.py
+++ b/services/governor_account_service.py
@@ -69,6 +69,16 @@ class AccountResolutionSummary:
     def registered_slots(self, prefix: str | None = None, *, limit: int = 25) -> list[str]:
         return registered_account_slots(self.ordered_accounts, prefix, limit=limit)
 
+    def governor_name_for_id(self, governor_id: str | int, fallback: str = "Unknown") -> str:
+        gid = _normalize_governor_id_str(governor_id)
+        if not gid:
+            return fallback
+        for account in self.resolved_accounts:
+            if account.governor_id_str == gid:
+                name = (account.governor_name or "").strip()
+                return fallback if not name or name.casefold() == "unknown" else name
+        return fallback
+
 
 def _normalize_governor_id_str(value: Any) -> str:
     try:

--- a/tests/test_ark_registration_flow.py
+++ b/tests/test_ark_registration_flow.py
@@ -6,6 +6,7 @@ import pytest
 
 from ark.registration_flow import ArkRegistrationController
 from ark.state.ark_state import ArkMessageRef, ArkMessageState
+from services.governor_account_service import summarize_accounts
 
 
 class DummyResponse:
@@ -50,6 +51,10 @@ class DummyInteraction:
 
 def _future_close() -> datetime:
     return datetime.now(UTC) + timedelta(hours=2)
+
+
+def _account_summary(accounts: dict[str, dict[str, str]]):
+    return summarize_accounts(accounts)
 
 
 @pytest.mark.asyncio
@@ -215,12 +220,12 @@ async def test_join_player_adds_signup(monkeypatch):
     monkeypatch.setattr("ark.registration_flow.insert_audit_log", _audit)
     monkeypatch.setattr(controller, "refresh_registration_message", _refresh)
 
-    async def _get_user_accounts_stub(_user_id):
-        return {"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}}
+    async def _get_account_summary_stub(_user_id):
+        return _account_summary({"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}})
 
     monkeypatch.setattr(
-        "ark.registration_flow._get_user_accounts",
-        _get_user_accounts_stub,
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
     )
 
     await controller.join_player(interaction)
@@ -241,12 +246,12 @@ async def test_leave_marks_withdrawn(monkeypatch):
 
     monkeypatch.setattr(controller, "_prompt_governor_selection", _prompt)
 
-    async def _get_user_accounts_stub(_user_id):
-        return {"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}}
+    async def _get_account_summary_stub(_user_id):
+        return _account_summary({"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}})
 
     monkeypatch.setattr(
-        "ark.registration_flow._get_user_accounts",
-        _get_user_accounts_stub,
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
     )
 
     async def _get_match(match_id):
@@ -368,15 +373,17 @@ async def test_switch_updates_governor(monkeypatch):
     monkeypatch.setattr("ark.registration_flow.insert_audit_log", _audit)
     monkeypatch.setattr(controller, "refresh_registration_message", _refresh)
 
-    async def _get_user_accounts_stub(_user_id):
-        return {
-            "Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"},
-            "Alt 2": {"GovernorID": "2510418", "GovernorName": "Scrooge M"},
-        }
+    async def _get_account_summary_stub(_user_id):
+        return _account_summary(
+            {
+                "Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"},
+                "Alt 2": {"GovernorID": "2510418", "GovernorName": "Scrooge M"},
+            }
+        )
 
     monkeypatch.setattr(
-        "ark.registration_flow._get_user_accounts",
-        _get_user_accounts_stub,
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
     )
 
     await controller.switch(interaction)
@@ -544,12 +551,12 @@ async def test_join_player_blocks_duplicate_weekend_governor(monkeypatch):
     monkeypatch.setattr("ark.registration_flow.find_active_signup_for_weekend", _conflict)
     monkeypatch.setattr("ark.registration_flow.add_signup", _add_signup)
 
-    async def _get_user_accounts_stub(_user_id):
-        return {"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}}
+    async def _get_account_summary_stub(_user_id):
+        return _account_summary({"Main": {"GovernorID": "2441482", "GovernorName": "Chrislos"}})
 
     monkeypatch.setattr(
-        "ark.registration_flow._get_user_accounts",
-        _get_user_accounts_stub,
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
     )
 
     await controller.join_player(interaction)
@@ -557,6 +564,42 @@ async def test_join_player_blocks_duplicate_weekend_governor(monkeypatch):
     assert called["add"] is False
     assert interaction.response.sent
     assert "another match this Ark weekend" in interaction.response.sent[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_join_player_uses_summary_failure_as_no_registered_governors(monkeypatch):
+    controller = ArkRegistrationController(match_id=20, config={"PlayersCap": 30, "SubsCap": 15})
+    interaction = DummyInteraction()
+
+    async def _get_match(match_id):
+        return {
+            "MatchId": 20,
+            "Alliance": "K98",
+            "ArkWeekendDate": datetime(2026, 3, 7, tzinfo=UTC).date(),
+            "MatchDay": "Sat",
+            "MatchTimeUtc": datetime(2026, 3, 7, 11, 0, tzinfo=UTC).time(),
+            "SignupCloseUtc": _future_close(),
+            "Status": "Scheduled",
+        }
+
+    async def _get_roster(match_id):
+        return []
+
+    async def _get_account_summary_stub(_user_id):
+        return summarize_accounts({}, ok=False, error="db down")
+
+    monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
+    monkeypatch.setattr("ark.registration_flow.get_roster", _get_roster)
+    monkeypatch.setattr(
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
+    )
+
+    await controller.join_player(interaction)
+
+    messages = interaction.response.sent + interaction.followup.sent
+    assert messages
+    assert "Use `/register_governor` first" in messages[-1]["content"]
 
 
 @pytest.mark.asyncio
@@ -634,7 +677,14 @@ async def test_switch_blocks_when_governor_already_signed(monkeypatch):
         "ark.registration_flow.find_active_signup_for_weekend", lambda *_a, **_k: None
     )
 
-    await controller._apply_switch(interaction, match, roster, {}, "2441482", "2510418")
+    await controller._apply_switch(
+        interaction,
+        match,
+        roster,
+        _account_summary({}),
+        "2441482",
+        "2510418",
+    )
 
     assert interaction.response.sent
     assert "already active in this match" in interaction.response.sent[-1]["content"]
@@ -666,7 +716,14 @@ async def test_switch_blocks_when_same_governor_selected(monkeypatch):
 
     monkeypatch.setattr(controller, "_validate_governor", lambda *_a, **_k: True)
 
-    await controller._apply_switch(interaction, match, roster, {}, "2441482", "2441482")
+    await controller._apply_switch(
+        interaction,
+        match,
+        roster,
+        _account_summary({}),
+        "2441482",
+        "2441482",
+    )
 
     assert interaction.response.sent
     assert "already signed up with that governor" in interaction.response.sent[-1]["content"]

--- a/tests/test_governor_account_service.py
+++ b/tests/test_governor_account_service.py
@@ -72,6 +72,9 @@ def test_account_resolution_summary_orders_deduplicates_and_defaults_to_main():
     assert summary.default_choice == "Main"
     assert summary.classification == ("multi", None)
     assert summary.contains_governor_id("100")
+    assert summary.governor_name_for_id("100") == "Main"
+    assert summary.governor_name_for_id(300) == "Farm"
+    assert summary.governor_name_for_id("999") == "Unknown"
     assert summary.registered_slots() == ["Main", "Alt 1", "Alt 2", "Farm 1"]
     assert summary.registered_slots("alt") == ["Alt 1", "Alt 2"]
 
@@ -85,6 +88,20 @@ def test_account_resolution_summary_single_classification_handles_unknown_slots(
     assert summary.classification == ("single", "987")
     assert summary.first_account is not None
     assert summary.first_account.slot == "Custom"
+
+
+def test_governor_name_for_id_treats_unknown_as_missing():
+    from services import governor_account_service as svc
+
+    summary = svc.summarize_accounts(
+        {
+            "Main": {"GovernorID": "987", "GovernorName": "Unknown"},
+            "Alt 1": {"GovernorID": "654", "GovernorName": "  "},
+        }
+    )
+
+    assert summary.governor_name_for_id("987", fallback="Governor 987") == "Governor 987"
+    assert summary.governor_name_for_id("654", fallback="Governor 654") == "Governor 654"
 
 
 def test_parse_discord_user_id_accepts_mentions_and_raw_ids():


### PR DESCRIPTION
## Summary

- Migrates Ark self-service join/sub/leave/switch account lookup to `AccountResolutionSummary` via `get_account_summary_for_user()`.
- Adds `AccountResolutionSummary.governor_name_for_id()` and removes Ark-local raw account loading/name lookup duplication.
- Updates deferred/task-pack docs: Ark self-service migration is complete, `/my_registrations`, compatibility cleanup, and Ark admin fuzzy/name-cache cleanup remain deferred.

## Changes

- Ark self-service governor selectors now pass `AccountResolutionSummary` to the shared account picker builder, preserving option ordering, GovernorID de-dupe, and slot fallback labels.
- Ark leave/switch roster filtering now uses `summary.governor_id_strings`.
- Ark signup/switch governor snapshots now resolve names through the shared summary helper.
- `governor_name_for_id()` now treats blank and case-insensitive `Unknown` names as missing so callers can use a meaningful fallback.
- Admin add fuzzy/name-cache lookup is intentionally unchanged because it is an admin roster-search path, not actor linked-account resolution; it is captured as a structured deferred optimisation.

## SQL / Persistence

- No SQL changes.
- SQL-facing assumptions were checked against `dbo.DiscordGovernorRegistry`, `dbo.sp_Registry_GetByDiscordID`, and `dbo.ArkSignups` in `C:\K98-bot-SQL-Server`.
- Ark signup persistence and registration-message refresh/rehydration behaviour are unchanged.

## Tests

- `.\.venv\Scripts\python.exe -m py_compile ark\registration_flow.py services\governor_account_service.py tests\test_ark_registration_flow.py tests\test_governor_account_service.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_registration_flow.py tests\test_governor_account_service.py tests\test_account_picker.py` (`33 passed`)
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_bans_enforcement.py tests\test_ark_admin_roster.py` (`8 passed`)
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1356 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe -m pytest -q <explicit test_ark_*.py file list>` (`165 passed`)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`

## Deferred Optimisations

- `/my_registrations` display-loader migration remains deferred.
- Ark admin fuzzy/name-cache lookup cleanup is now captured as deferred.
- Compatibility adapter cleanup remains deferred until a dedicated cleanup PR preserves all related regression surfaces.