### PR TITLE
[codex] Migrate my registrations display loader

### DIFF
--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 import discord
 from discord.ext import commands as ext_commands
@@ -11,7 +11,6 @@ from discord.ext import commands as ext_commands
 from bot_config import GUILD_ID
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import is_admin_and_notify_channel, track_usage
-from registry.account_slots import ACCOUNT_ORDER
 from registry.registry_command_service import (
     apply_import_changes,
     build_import_preview,
@@ -29,9 +28,11 @@ from registry.registry_service import (
     remove_governor,
 )
 from services.governor_account_service import (
+    AccountResolutionSummary,
     filter_account_slots,
     get_account_summary_for_user,
     parse_discord_user_id,
+    summarize_accounts,
 )
 import target_utils
 from ui.views.admin_views import ConfirmImportView
@@ -44,6 +45,59 @@ from ui.views.registry_views import (
 from versioning import versioned
 
 logger = logging.getLogger(__name__)
+
+
+class _DisplayRequester(Protocol):
+    name: str
+
+
+async def _load_my_registrations_summary(discord_user_id: int) -> AccountResolutionSummary:
+    summary = await get_account_summary_for_user(discord_user_id)
+    if summary.ok:
+        return summary
+
+    if summary.error:
+        logger.warning("[my_registrations] account summary unavailable: %s", summary.error)
+
+    try:
+        registry: dict[str, Any] = (
+            await asyncio.to_thread(registry_service.load_registry_as_dict) or {}
+        )
+    except Exception:
+        logger.exception("[my_registrations] stale registry fallback failed")
+        return summary
+
+    user_data = registry.get(str(discord_user_id)) or registry.get(discord_user_id) or {}
+    return summarize_accounts(user_data.get("accounts", {}) or {})
+
+
+def _build_my_registrations_embed(
+    account_summary: AccountResolutionSummary,
+    *,
+    requested_by: _DisplayRequester,
+) -> tuple[discord.Embed, bool]:
+    lines: list[str] = []
+    for slot, info in account_summary.ordered_accounts.items():
+        gid = str(info.get("GovernorID", "")).strip()
+        gname = str(info.get("GovernorName", "")).strip()
+        label = f"**{gname}** (`{gid}`)" if (gname or gid) else "—"
+        lines.append(f"• **{slot}** — {label}")
+
+    has_regs = len(lines) > 0
+    desc = "\n".join(lines) if has_regs else "You don’t have any accounts registered yet."
+
+    if len(desc) > 4000:
+        logger.warning("[my_registrations] description too long (%d); truncating", len(desc))
+        desc = desc[:3970] + "\n… (truncated)"
+
+    embed = discord.Embed(
+        title="Your Registered Accounts",
+        description=desc,
+        colour=discord.Colour.green() if has_regs else discord.Colour.orange(),
+    )
+    requested_by_name = getattr(requested_by, "display_name", getattr(requested_by, "name", "?"))
+    embed.set_footer(text=f"Requested by {requested_by_name}")
+    return embed, has_regs
 
 
 def register_registry(bot: ext_commands.Bot) -> None:
@@ -445,11 +499,12 @@ def register_registry(bot: ext_commands.Bot) -> None:
         await ensure_deferred(ephemeral=True)
 
         try:
-            registry: dict[str, Any] = (
-                await asyncio.to_thread(registry_service.load_registry_as_dict) or {}
-            )
+            account_summary = await _load_my_registrations_summary(ctx.user.id)
         except Exception:
-            logger.exception("[my_registrations] load_registry_as_dict failed")
+            logger.exception("[my_registrations] account summary load failed")
+            account_summary = None
+
+        if not account_summary or not account_summary.ok:
             msg = "⚠️ Sorry, I couldn’t load your registrations. Please try again shortly."
             try:
                 await ctx.interaction.edit_original_response(content=msg, embed=None, view=None)
@@ -460,39 +515,7 @@ def register_registry(bot: ext_commands.Bot) -> None:
                     pass
             return
 
-        user_key_str = str(ctx.user.id)
-        user_data = registry.get(user_key_str) or registry.get(ctx.user.id) or {}
-        accounts = user_data.get("accounts", {}) or {}
-
-        # --- Build lines in a predictable order; fall back to sorted keys
-        try:
-            order = list(ACCOUNT_ORDER)
-        except NameError:
-            order = sorted(accounts.keys())
-
-        lines: list[str] = []
-        for slot in order:
-            info = accounts.get(slot)
-            if info:
-                gid = str(info.get("GovernorID", "")).strip()
-                gname = str(info.get("GovernorName", "")).strip()
-                label = f"**{gname}** (`{gid}`)" if (gname or gid) else "—"
-                lines.append(f"• **{slot}** — {label}")
-
-        has_regs = len(lines) > 0
-        desc = "\n".join(lines) if has_regs else "You don’t have any accounts registered yet."
-
-        # --- Guard Discord 4096-char embed description limit
-        if len(desc) > 4000:
-            logger.warning("[my_registrations] description too long (%d); truncating", len(desc))
-            desc = desc[:3970] + "\n… (truncated)"
-
-        embed = discord.Embed(
-            title="Your Registered Accounts",
-            description=desc,
-            colour=discord.Colour.green() if has_regs else discord.Colour.orange(),
-        )
-        embed.set_footer(text=f"Requested by {getattr(ctx.user, 'display_name', ctx.user.name)}")
+        embed, has_regs = _build_my_registrations_embed(account_summary, requested_by=ctx.user)
 
         # --- Build the action view defensively
         view = None

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,15 +51,6 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `commands/registry_cmds.py` `/my_registrations`, `services/governor_account_service.py`, `registry/registry_service.py`
-- Type: consistency
-- Description: `/my_registrations` still builds its display payload by loading the full registry through `registry_service.load_registry_as_dict()` and then selecting the invoking user's account dictionary locally. PR 89 intentionally preserved that path to avoid expanding a write-sensitive registry summary migration, but it leaves this one player-facing registry display flow outside the direct `AccountResolutionSummary` migration used by telemetry/KVK, registry action views, stats, inventory, and MGE adapters.
-- Suggested Fix: Audit `/my_registrations` and migrate its per-user display loading to `get_account_summary_for_user()` or a focused Discord-free registry display service that consumes `AccountResolutionSummary`, preserving embed title/copy, account slot ordering, empty-state copy, action buttons, truncation guard, ephemeral response behaviour, and stale/unavailable registry handling. Keep `load_registry_as_dict()` for audit/export/import flows that still need full-registry snapshots.
-- Impact: medium
-- Risk: low
-- Dependencies: PR 89 registry command/view direct migration complete; add focused `/my_registrations` regression coverage before changing the loader path.
-
-### Deferred Optimisation
 - Area: `ark/registration_flow.py` admin add fuzzy/name-cache lookup
 - Type: consistency
 - Description: Ark admin add still searches `target_utils._name_cache` directly for exact GovernorID, partial GovernorID, and substring fuzzy name matching. This is separate from the self-service linked-account migration because it supports admin roster search, cache refresh fallback, fuzzy selection, and admin slot prompts rather than selecting one of the actor's registered accounts.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -762,7 +762,7 @@ Important context:
 
 ## 33. PR 90 Ark Account-Resolution Direct Migration Completion Update
 
-Status: local validation complete; pending PR review and production smoke test.
+Status: smoke tested successfully and deployed to production.
 
 PR 90 delivered:
 
@@ -773,7 +773,7 @@ PR 90 delivered:
 - The Ark-local raw account loader and duplicate governor-name helper were removed from `ark/registration_flow.py`.
 - Admin add name-cache and fuzzy lookup behaviour was intentionally left unchanged because it is an admin roster-search flow, not a linked-account selection path; a structured deferred item now tracks that cleanup separately.
 - The active Ark deferred optimisation item was removed from `docs/reference/deferred_optimisations.md`.
-- Compatibility adapter cleanup remains deferred as the next dedicated cleanup slice, alongside the separate `/my_registrations` display-loader item.
+- Compatibility adapter cleanup remains deferred as a dedicated cleanup slice, alongside the separate `/my_registrations` display-loader item.
 
 Validation completed during PR 90:
 
@@ -794,3 +794,20 @@ Remaining follow-up slices intentionally left deferred:
 1. `/my_registrations` display-loader migration: audit and, if safe, move the player-facing display payload from full-registry local selection to `AccountResolutionSummary` or a focused display service.
 2. Ark admin fuzzy/name-cache lookup cleanup: move admin roster-search lookup out of the controller into a focused helper/service while preserving exact ID, partial ID, fuzzy name, refresh fallback, no-match responses, and admin slot prompts.
 3. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after preserving focused regression coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup.
+
+## 34. PR 91 My Registrations Display-Loader Completion Update
+
+Status: implementation and validation complete; pending PR review and production smoke test.
+
+PR 91 delivered:
+
+- `/my_registrations` now loads the invoking user's display accounts through `get_account_summary_for_user()` instead of loading a full-registry snapshot and selecting locally.
+- The command builds its display from `AccountResolutionSummary.ordered_accounts`, preserving embed title/copy, account slot ordering, empty-state copy, action buttons, truncation guard, and ephemeral response behaviour.
+- Registry audit, export, and import paths still use `registry_service.load_registry_as_dict()` because they require full-registry snapshots.
+- Focused regression coverage now checks the `/my_registrations` summary-backed display payload and empty-state copy.
+- The active `/my_registrations` display-loader deferred item was removed from `docs/reference/deferred_optimisations.md`.
+
+Remaining follow-up slices intentionally left deferred:
+
+1. Ark admin fuzzy/name-cache lookup cleanup: move admin roster-search lookup out of the controller into a focused helper/service while preserving exact ID, partial ID, fuzzy name, refresh fallback, no-match responses, slot prompts, ban enforcement, and admin/leadership permissions.
+2. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after preserving focused regression coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup.

--- a/tests/test_registry_cmds.py
+++ b/tests/test_registry_cmds.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import commands.registry_cmds as registry_cmds
+from commands.registry_cmds import _build_my_registrations_embed, _load_my_registrations_summary
+from services.governor_account_service import summarize_accounts
 
 
 def test_registry_cmds_uses_public_governor_lookup_helper() -> None:
@@ -37,11 +44,90 @@ def test_registry_autocomplete_falls_back_to_invoking_user_for_self_service() ->
     assert 'getattr(ctx, "user", None)' not in source
 
 
-def test_my_registrations_uses_service_loader_not_removed_facade_import() -> None:
+def test_my_registrations_uses_account_summary_display_loader() -> None:
     source = Path("commands/registry_cmds.py").read_text(encoding="utf-8")
 
     assert "asyncio.to_thread(load_registry)" not in source
-    assert "registry_service.load_registry_as_dict" in source
+    assert "await _load_my_registrations_summary(ctx.user.id)" in source
+
+
+@pytest.mark.asyncio
+async def test_my_registrations_summary_loader_uses_stale_registry_fallback(monkeypatch) -> None:
+    async def _failed_summary(_discord_user_id: int):
+        return summarize_accounts({}, ok=False, error="SQL down")
+
+    def _stale_registry():
+        return {
+            "123": {
+                "accounts": {
+                    "Main": {"GovernorID": "111", "GovernorName": "Stale Main"},
+                },
+            },
+        }
+
+    monkeypatch.setattr(registry_cmds, "get_account_summary_for_user", _failed_summary)
+    monkeypatch.setattr(registry_cmds.registry_service, "load_registry_as_dict", _stale_registry)
+
+    summary = await _load_my_registrations_summary(123)
+
+    assert summary.ok is True
+    assert summary.ordered_accounts == {"Main": {"GovernorID": "111", "GovernorName": "Stale Main"}}
+
+
+@pytest.mark.asyncio
+async def test_my_registrations_summary_loader_returns_primary_failure_when_no_fallback(
+    monkeypatch,
+) -> None:
+    async def _failed_summary(_discord_user_id: int):
+        return summarize_accounts({}, ok=False, error="SQL down")
+
+    def _failed_registry():
+        raise RuntimeError("cache unavailable")
+
+    monkeypatch.setattr(registry_cmds, "get_account_summary_for_user", _failed_summary)
+    monkeypatch.setattr(registry_cmds.registry_service, "load_registry_as_dict", _failed_registry)
+
+    summary = await _load_my_registrations_summary(123)
+
+    assert summary.ok is False
+    assert summary.error == "SQL down"
+
+
+def test_my_registrations_embed_uses_summary_order_and_copy() -> None:
+    summary = summarize_accounts(
+        {
+            "Farm 1": {"GovernorID": "333", "GovernorName": "Farmhand"},
+            "Main": {"GovernorID": "111", "GovernorName": "Main Gov"},
+            "Alt 1": {"GovernorID": "222", "GovernorName": "Alt Gov"},
+        }
+    )
+
+    embed, has_regs = _build_my_registrations_embed(
+        summary,
+        requested_by=SimpleNamespace(display_name="Tester", name="Fallback"),
+    )
+
+    assert has_regs is True
+    assert embed.title == "Your Registered Accounts"
+    assert embed.description.splitlines() == [
+        "• **Main** — **Main Gov** (`111`)",
+        "• **Alt 1** — **Alt Gov** (`222`)",
+        "• **Farm 1** — **Farmhand** (`333`)",
+    ]
+    assert embed.footer.text == "Requested by Tester"
+
+
+def test_my_registrations_embed_preserves_empty_state_copy() -> None:
+    summary = summarize_accounts({})
+
+    embed, has_regs = _build_my_registrations_embed(
+        summary,
+        requested_by=SimpleNamespace(name="No Display"),
+    )
+
+    assert has_regs is False
+    assert embed.title == "Your Registered Accounts"
+    assert embed.description == "You don’t have any accounts registered yet."
 
 
 def test_registration_audit_fetches_missing_registered_members_before_payload() -> None:


### PR DESCRIPTION
## Summary

- Migrates `/my_registrations` display loading to `get_account_summary_for_user()` and `AccountResolutionSummary.ordered_accounts`.
- Preserves stale-cache fallback behavior by using `registry_service.load_registry_as_dict()` as a degraded-mode fallback only when the primary per-user summary load fails.
- Preserves the existing embed title/copy, slot ordering, empty-state copy, action buttons, truncation guard, and ephemeral response behavior.
- Keeps full-registry `load_registry_as_dict()` usage for audit, export, and import paths that still need full snapshots.
- Updates the active deferred backlog and task pack to mark this slice complete while leaving Ark admin fuzzy lookup and compatibility cleanup deferred.

## Review Feedback Addressed

- Restored `/my_registrations` SQL-outage availability by falling back to the cached/stale full-registry snapshot when `get_account_summary_for_user()` returns `ok=False`.
- Tightened `_build_my_registrations_embed()` typing to accept `AccountResolutionSummary` and a small display requester protocol instead of broad `Any` annotations.
- Added focused regression tests for stale-cache fallback success and no-fallback failure behavior.

## Validation

- `\.\.venv\Scripts\python.exe -m py_compile commands\registry_cmds.py tests\test_registry_cmds.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py` (`28 passed`)
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `\.\.venv\Scripts\python.exe scripts\select_tests.py`
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests` (`1361 passed, 2 skipped`)
- `\.\.venv\Scripts\python.exe -m pre_commit run -a`

## SQL Changes

None.

## Risk / Rollback

Low risk: read-only player-facing display path now uses the same per-user account summary already used by other account-selection flows, while preserving the prior stale-cache degraded mode. Rollback by reverting this PR and redeploying the previous bot version.