### PR TITLE
[codex] Extract Ark admin governor lookup

### DIFF
--- a/ark/admin_governor_lookup_service.py
+++ b/ark/admin_governor_lookup_service.py
@@ -1,0 +1,176 @@
+"""Discord-free governor lookup helpers for Ark admin add flows."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+from typing import Any, Literal
+
+from target_utils import (
+    get_name_cache_rows,
+    get_name_cache_status,
+    lookup_governor_id,
+    refresh_name_cache_from_sql,
+    sync_refresh_worker,
+)
+
+logger = logging.getLogger(__name__)
+
+LookupStatus = Literal["found", "matches", "not_found"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArkAdminGovernorLookupResult:
+    status: LookupStatus
+    query: str
+    governor_id: str | None = None
+    governor_name: str | None = None
+    matches: tuple[dict[str, str], ...] = ()
+    message: str = "No matches found."
+
+
+def _normalise_match(row: dict[str, Any]) -> dict[str, str]:
+    return {
+        "GovernorName": str(row.get("GovernorName") or "").strip(),
+        "GovernorID": str(row.get("GovernorID") or "").strip(),
+    }
+
+
+async def ensure_name_cache_ready() -> None:
+    """
+    Ensure the SQL-backed name cache is populated in this process.
+
+    The normal refresh helper may offload work, so keep the established same-process
+    fallback for admin lookup paths that immediately inspect the cache rows.
+    """
+    try:
+        status = get_name_cache_status()
+        if status.get("rows_count", 0) > 0:
+            return
+
+        await refresh_name_cache_from_sql()
+
+        status = get_name_cache_status()
+        if status.get("rows_count", 0) == 0:
+            await asyncio.to_thread(sync_refresh_worker)
+    except Exception:
+        logger.exception("[ARK] Failed ensuring name cache is ready")
+
+
+def find_partial_governor_id_matches(query: str, limit: int = 25) -> list[dict[str, str]]:
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    matches: list[dict[str, str]] = []
+    for row in get_name_cache_rows():
+        gid = str(row.get("GovernorID") or "").strip()
+        if not gid or q not in gid:
+            continue
+        matches.append(_normalise_match(row))
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def find_substring_name_matches(query: str, limit: int = 25) -> list[dict[str, str]]:
+    q = (query or "").strip().lower()
+    if not q:
+        return []
+
+    matches: list[dict[str, str]] = []
+    for row in get_name_cache_rows():
+        name = str(row.get("GovernorName") or "").strip()
+        if not name or q not in name.lower():
+            continue
+        matches.append(_normalise_match(row))
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+async def resolve_admin_governor_query(raw_query: str) -> ArkAdminGovernorLookupResult:
+    query = (raw_query or "").strip()
+    if not query:
+        return ArkAdminGovernorLookupResult(
+            status="not_found",
+            query=query,
+            message="Name is required.",
+        )
+
+    if query.isdigit():
+        await ensure_name_cache_ready()
+        for row in get_name_cache_rows():
+            if str(row.get("GovernorID") or "").strip() == query:
+                match = _normalise_match(row)
+                if match["GovernorName"]:
+                    return ArkAdminGovernorLookupResult(
+                        status="found",
+                        query=query,
+                        governor_id=match["GovernorID"],
+                        governor_name=match["GovernorName"],
+                    )
+
+        matches = find_partial_governor_id_matches(query)
+        if matches:
+            return ArkAdminGovernorLookupResult(
+                status="matches",
+                query=query,
+                matches=tuple(matches),
+            )
+
+        return ArkAdminGovernorLookupResult(
+            status="not_found",
+            query=query,
+            message="❌ GovernorID not found in name cache. Please verify the ID.",
+        )
+
+    result = await lookup_governor_id(query)
+    status = (result or {}).get("status")
+
+    if status == "not_found":
+        await ensure_name_cache_ready()
+        result = await lookup_governor_id(query)
+        status = (result or {}).get("status")
+
+    if status == "not_found":
+        matches = find_substring_name_matches(query)
+        if matches:
+            return ArkAdminGovernorLookupResult(
+                status="matches",
+                query=query,
+                matches=tuple(matches),
+            )
+
+    if status == "found":
+        data = result.get("data") or {}
+        return ArkAdminGovernorLookupResult(
+            status="found",
+            query=query,
+            governor_id=str(data.get("GovernorID") or ""),
+            governor_name=str(data.get("GovernorName") or "Unknown"),
+        )
+
+    if status == "fuzzy_matches":
+        matches = tuple(_normalise_match(m) for m in (result.get("matches") or []))
+        if not matches:
+            matches = tuple(find_substring_name_matches(query))
+        if matches:
+            return ArkAdminGovernorLookupResult(
+                status="matches",
+                query=query,
+                matches=matches,
+            )
+
+        return ArkAdminGovernorLookupResult(
+            status="not_found",
+            query=query,
+            message="No matches found.",
+        )
+
+    return ArkAdminGovernorLookupResult(
+        status="not_found",
+        query=query,
+        message=(result or {}).get("message", "No matches found."),
+    )

--- a/ark/registration_flow.py
+++ b/ark/registration_flow.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 import logging
-import math
 from typing import Any
 
 import discord
 
 from account_picker import build_unique_gov_options
+from ark.admin_governor_lookup_service import resolve_admin_governor_query
 from ark.ark_constants import ARK_MATCH_STATUS_CANCELLED, ARK_MATCH_STATUS_COMPLETED
 from ark.ban_utils import admin_override_ban_rule, format_ban_block_message
 from ark.dal.ark_dal import (
@@ -38,13 +38,6 @@ from services.governor_account_service import (
     AccountResolutionSummary,
     get_account_summary_for_user,
 )
-from target_utils import (
-    _name_cache,
-    get_name_cache_status,
-    lookup_governor_id,
-    refresh_name_cache_from_sql,
-    sync_refresh_worker,
-)
 from ui.views.ark_fuzzy_select_view import ArkFuzzySelectView
 from ui.views.ark_views import (
     ArkAdminAddNameModal,
@@ -57,29 +50,6 @@ from utils import ensure_aware_utc, utcnow
 logger = logging.getLogger(__name__)
 
 _SIGNUP_CLOSED_MESSAGE = "❌ Signups are closed. Contact leadership for changes."
-
-
-def _is_missing(val: Any) -> bool:
-    if val is None:
-        return True
-    try:
-        return math.isnan(float(val))
-    except Exception:
-        return False
-
-
-def _get_city_hall_level(governor_id: str) -> float | None:
-    rows = (_name_cache or {}).get("rows", []) if isinstance(_name_cache, dict) else []
-    for row in rows:
-        if str(row.get("GovernorID", "")).strip() == str(governor_id).strip():
-            ch = row.get("CityHallLevel")
-            if _is_missing(ch):
-                return None
-            try:
-                return float(ch)
-            except Exception:
-                return None
-    return None
 
 
 def _resolve_admin_add_discord_user_id(
@@ -117,29 +87,6 @@ def _resolve_admin_add_discord_user_id(
     return resolved_discord_id
 
 
-def _fallback_substring_matches(query: str, limit: int = 25) -> list[dict[str, str]]:
-    q = (query or "").strip().lower()
-    if not q:
-        return []
-
-    rows = _name_cache.get("rows") or []
-    matches: list[dict[str, str]] = []
-    for row in rows:
-        name = str(row.get("GovernorName") or "").strip()
-        if not name:
-            continue
-        if q in name.lower():
-            matches.append(
-                {
-                    "GovernorName": name,
-                    "GovernorID": str(row.get("GovernorID") or ""),
-                }
-            )
-            if len(matches) >= limit:
-                break
-    return matches
-
-
 def _build_fuzzy_embed(query: str, matches: list[dict]) -> discord.Embed:
     MAX_LINES = 15
     lines = [f"• **{m['GovernorName']}** — `{m['GovernorID']}`" for m in matches[:MAX_LINES]]
@@ -152,28 +99,6 @@ def _build_fuzzy_embed(query: str, matches: list[dict]) -> discord.Embed:
         description=desc,
         color=discord.Color.blue(),
     )
-
-
-async def _ensure_name_cache_ready() -> None:
-    """
-    Ensure the name cache is populated in THIS process.
-    refresh_name_cache_from_sql may run in a subprocess, so we
-    fallback to sync_refresh_worker in-thread if cache is still empty.
-    """
-    try:
-        status = get_name_cache_status()
-        if status.get("rows_count", 0) > 0:
-            return
-
-        # Try normal refresh first (may run in subprocess)
-        await refresh_name_cache_from_sql()
-
-        # If still empty, run worker in this process
-        status = get_name_cache_status()
-        if status.get("rows_count", 0) == 0:
-            await asyncio.to_thread(sync_refresh_worker)
-    except Exception:
-        logger.exception("[ARK] Failed ensuring name cache is ready")
 
 
 def _find_user_signup(roster: list[dict], user_id: int) -> dict[str, Any] | None:
@@ -1017,7 +942,6 @@ class ArkRegistrationController:
         )
 
     async def _handle_admin_add_name(self, interaction: discord.Interaction, raw_name: str) -> None:
-        # ✅ acknowledge immediately to prevent "Unknown interaction"
         responder = getattr(interaction, "response", None)
         is_done = False
         try:
@@ -1038,122 +962,17 @@ class ArkRegistrationController:
             await self._safe_send(interaction, "❌ Name is required.", ephemeral=True)
             return
 
-        def _fallback_governor_id_matches(query: str, limit: int = 25) -> list[dict[str, str]]:
-            q = (query or "").strip()
-            if not q:
-                return []
-
-            rows = _name_cache.get("rows") or []
-            matches: list[dict[str, str]] = []
-            for row in rows:
-                gid = str(row.get("GovernorID") or "").strip()
-                name = str(row.get("GovernorName") or "").strip()
-                if not gid:
-                    continue
-                if q in gid:
-                    matches.append(
-                        {
-                            "GovernorName": name,
-                            "GovernorID": gid,
-                        }
-                    )
-                    if len(matches) >= limit:
-                        break
-            return matches
-
-        # If numeric GovernorID provided, attempt exact ID lookup
-        if name.isdigit():
-            governor_id = str(name)
-
-            # Ensure cache is populated (this process)
-            await _ensure_name_cache_ready()
-
-            governor_name = None
-            for row in _name_cache.get("rows") or []:
-                if str(row.get("GovernorID")) == governor_id:
-                    governor_name = str(row.get("GovernorName") or "").strip()
-                    break
-
-            if governor_name:
-                await self._prompt_admin_slot_selection(
-                    interaction,
-                    governor_id=governor_id,
-                    governor_name=governor_name,
-                )
-                return
-
-            # Fallback: treat ID as search input (fuzzy)
-            matches = _fallback_governor_id_matches(governor_id)
-            if matches:
-
-                async def _apply_fuzzy_pick(inter: discord.Interaction, picked_id: str) -> None:
-                    id_to_name = {
-                        str(m.get("GovernorID")): str(m.get("GovernorName")) for m in matches
-                    }
-                    await self._prompt_admin_slot_selection(
-                        inter,
-                        governor_id=picked_id,
-                        governor_name=id_to_name.get(str(picked_id), "Unknown"),
-                    )
-
-                embed = _build_fuzzy_embed(governor_id, matches)
-                view = ArkFuzzySelectView(matches, interaction.user.id, _apply_fuzzy_pick)
-                await view.send_followup(interaction, embed)
-                return
-
-            await self._safe_send(
-                interaction,
-                "❌ GovernorID not found in name cache. Please verify the ID.",
-                ephemeral=True,
-            )
-            return
-
-        result = await lookup_governor_id(name)
-        status = (result or {}).get("status")
-
-        # If cache is stale/empty, refresh once and retry
-        if status == "not_found":
-            await _ensure_name_cache_ready()
-            result = await lookup_governor_id(name)
-            status = (result or {}).get("status")
-
-        # fallback substring matches even if lookup still not_found
-        if status == "not_found":
-            matches = _fallback_substring_matches(name)
-            if matches:
-
-                async def _apply(inter: discord.Interaction, governor_id: str) -> None:
-                    id_to_name = {
-                        str(m.get("GovernorID")): str(m.get("GovernorName")) for m in matches
-                    }
-                    await self._prompt_admin_slot_selection(
-                        inter,
-                        governor_id=governor_id,
-                        governor_name=id_to_name.get(str(governor_id), "Unknown"),
-                    )
-
-                embed = _build_fuzzy_embed(name, matches)
-                view = ArkFuzzySelectView(matches, interaction.user.id, _apply)
-                await view.send_followup(interaction, embed)
-                return
-
-        if status == "found":
-            data = result.get("data") or {}
+        result = await resolve_admin_governor_query(name)
+        if result.status == "found":
             await self._prompt_admin_slot_selection(
                 interaction,
-                governor_id=str(data.get("GovernorID")),
-                governor_name=str(data.get("GovernorName") or "Unknown"),
+                governor_id=str(result.governor_id or ""),
+                governor_name=str(result.governor_name or "Unknown"),
             )
             return
 
-        if status == "fuzzy_matches":
-            matches = result.get("matches") or []
-            if not matches:
-                matches = _fallback_substring_matches(name)
-
-            if not matches:
-                await self._safe_send(interaction, "No matches found.", ephemeral=True)
-                return
+        if result.status == "matches":
+            matches = list(result.matches)
 
             async def _apply(inter: discord.Interaction, governor_id: str) -> None:
                 id_to_name = {str(m.get("GovernorID")): str(m.get("GovernorName")) for m in matches}
@@ -1163,16 +982,12 @@ class ArkRegistrationController:
                     governor_name=id_to_name.get(str(governor_id), "Unknown"),
                 )
 
-            embed = _build_fuzzy_embed(name, matches)
+            embed = _build_fuzzy_embed(result.query, matches)
             view = ArkFuzzySelectView(matches, interaction.user.id, _apply)
             await view.send_followup(interaction, embed)
             return
 
-        await self._safe_send(
-            interaction,
-            (result or {}).get("message", "No matches found."),
-            ephemeral=True,
-        )
+        await self._safe_send(interaction, result.message, ephemeral=True)
 
     async def _prompt_admin_slot_selection(
         self,

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -51,15 +51,6 @@ Resolved historical notes were moved to `archive/deferred_optimisations_resolved
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
-- Area: `ark/registration_flow.py` admin add fuzzy/name-cache lookup
-- Type: consistency
-- Description: Ark admin add still searches `target_utils._name_cache` directly for exact GovernorID, partial GovernorID, and substring fuzzy name matching. This is separate from the self-service linked-account migration because it supports admin roster search, cache refresh fallback, fuzzy selection, and admin slot prompts rather than selecting one of the actor's registered accounts.
-- Suggested Fix: Move Ark admin governor search into a focused Discord-free helper or service that uses public target/profile lookup helpers where available, preserves exact ID, partial ID, fuzzy name, cache refresh, and no-match messages, and leaves the view/controller responsible only for Discord response routing.
-- Impact: medium
-- Risk: medium
-- Dependencies: Preserve Ark admin add behaviour, fuzzy result ordering, name-cache refresh fallback, ban enforcement, slot capacity checks, and admin/leadership permission tests.
-
-### Deferred Optimisation
 - Area: `services/governor_account_service.py`, `services/stats_account_service.py`, `inventory/inventory_service.py`, `mge/mge_signup_service.py`, `account_picker.py`, `ui/views/kvk_personal_views.py`
 - Type: cleanup
 - Description: Compatibility adapters and duplicate local account classification/linked-governor/registered-governor shaping remain after the stats, inventory, MGE, telemetry/KVK, registry, and Ark direct migrations. Removing them in the Ark PR would expand scope across legacy public shapes and KVK personal view compatibility paths.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -797,17 +797,109 @@ Remaining follow-up slices intentionally left deferred:
 
 ## 34. PR 91 My Registrations Display-Loader Completion Update
 
-Status: implementation and validation complete; pending PR review and production smoke test.
+Status: smoke tested successfully and deployed to production.
 
 PR 91 delivered:
 
-- `/my_registrations` now loads the invoking user's display accounts through `get_account_summary_for_user()` instead of loading a full-registry snapshot and selecting locally.
+- `/my_registrations` now loads the invoking user's display accounts through `get_account_summary_for_user()` instead of using the full-registry snapshot as the primary loader.
+- A review fix preserved the previous stale-cache degraded mode by falling back to `registry_service.load_registry_as_dict()` only when the primary per-user summary load fails.
 - The command builds its display from `AccountResolutionSummary.ordered_accounts`, preserving embed title/copy, account slot ordering, empty-state copy, action buttons, truncation guard, and ephemeral response behaviour.
 - Registry audit, export, and import paths still use `registry_service.load_registry_as_dict()` because they require full-registry snapshots.
-- Focused regression coverage now checks the `/my_registrations` summary-backed display payload and empty-state copy.
+- Focused regression coverage now checks the `/my_registrations` summary-backed display payload, empty-state copy, stale-cache fallback success, and no-fallback failure behaviour.
 - The active `/my_registrations` display-loader deferred item was removed from `docs/reference/deferred_optimisations.md`.
+
+Smoke coverage completed after deployment:
+
+- `/my_registrations` displays registered accounts in the expected canonical slot order.
+- `/my_registrations` preserves the existing title/copy, empty-state copy, action buttons, and ephemeral response behaviour.
+- `/my_registrations` action buttons still open the existing modify/register selectors.
+- Registry audit, export, and import full-snapshot flows were not changed by this PR.
+
+Validation completed during PR 91:
+
+- `.\.venv\Scripts\python.exe -m py_compile commands\registry_cmds.py tests\test_registry_cmds.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_views_smoke.py tests\test_governor_account_service.py` (`28 passed` after review fixes)
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1361 passed, 2 skipped` after review fixes)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
 
 Remaining follow-up slices intentionally left deferred:
 
 1. Ark admin fuzzy/name-cache lookup cleanup: move admin roster-search lookup out of the controller into a focused helper/service while preserving exact ID, partial ID, fuzzy name, refresh fallback, no-match responses, slot prompts, ban enforcement, and admin/leadership permissions.
 2. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local classification/option-shaping helpers only after preserving focused regression coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup.
+
+## 35. Next Phase Chat Starter
+
+Use this in a fresh Codex chat for the final shared account-resolution cleanup slices:
+
+```text
+Codex, start the final registry/account optimisation phase after PR 91 (`my-registrations-display-loader`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md` and `docs/reference/deferred_optimisations.md` first.
+
+Goal: deliver the remaining final PR-sized slices for the shared account-resolution migration. PR 87 introduced `ResolvedAccount` and `AccountResolutionSummary` in `services/governor_account_service.py`; PR 88 migrated telemetry/KVK target/CrystalTech picker setup in `commands/telemetry_cmds.py`, `account_picker.py`, and `kvk_ui.py`; PR 89 migrated registry command/view account-selection flows in `commands/registry_cmds.py` and `ui/views/registry_views.py`; PR 90 migrated Ark self-service join/sub/leave/switch account-selection flows in `ark/registration_flow.py`; PR 91 migrated `/my_registrations` display loading while preserving stale-cache fallback.
+
+Important context:
+- PR 84 centralised basic account slots, Discord user-id parsing, public GovernorID roster lookup, and initial `/my_registrations` loading through `registry_service.load_registry_as_dict`.
+- PR 85A extracted registration audit, bulk export, bulk import dry-run preview/error files, and bulk import apply summary shaping into `registry/registry_command_service.py`.
+- PR 86 moved registry confirmation views into `ui/views/registry_views.py`, kept compatibility re-exports from `registry/governor_registry.py`, and removed the remaining inline registry-service import in `remove_registration_by_id`.
+- PR 87 introduced the shared richer account-resolution summary object and migrated stats, inventory, and MGE service adapters while preserving public shapes.
+- PR 88 migrated telemetry/KVK target/CrystalTech picker setup to `AccountResolutionSummary` and preserved selector labels, option ordering, refresh behaviour, lookup/register buttons, and slot fallback labels for blank or `Unknown` GovernorName values.
+- PR 89 migrated registry command/view account-selection flows to `AccountResolutionSummary`, preserving self-service/admin autocomplete behaviour, confirmation/cancel behaviour, duplicate ownership checks, and `RegisterStartView` compatibility for telemetry/KVK callers.
+- PR 90 migrated Ark self-service join/sub/leave/switch flows to `AccountResolutionSummary`, preserving signup behaviour, ban enforcement, roster filtering, active signup detection, persistent registration-message refresh, and account picker labels/ordering.
+- PR 91 migrated `/my_registrations` display loading to `AccountResolutionSummary`, restored stale-cache degraded fallback after review, and preserved embed copy, slot ordering, action buttons, truncation guard, and ephemeral behaviour.
+
+Remaining active deferred slices:
+1. Ark admin fuzzy/name-cache lookup cleanup: move admin roster-search lookup out of `ark/registration_flow.py` into a focused Discord-free helper/service while preserving exact ID, partial ID, fuzzy name, cache refresh fallback, no-match responses, fuzzy result ordering, slot prompts, ban enforcement, slot capacity checks, and admin/leadership permissions.
+2. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local account classification, linked-governor, registered-governor, and option-shaping helpers after auditing external callers.
+
+Recommended approach:
+- Start with audit/scope only and decide whether Ark admin fuzzy/name-cache cleanup and compatibility cleanup should be one PR or two.
+- Prefer Ark admin fuzzy/name-cache cleanup first if compatibility cleanup still has uncertainty or broad caller risk.
+- Keep compatibility cleanup deferred unless the audit shows no remaining public callers and the regression surface is small.
+
+Preserve telemetry/KVK picker behaviour, registry flows, `/my_registrations` stale fallback, inventory permission behaviour, stats export behaviour, MGE signup behaviour, Ark self-service signup behaviour, and Ark admin add behaviour.
+
+Validate any SQL-facing assumptions against `C:\K98-bot-SQL-Server` before implementation.
+
+Run or justify the K98 validation gates selected by `scripts/select_tests.py`, including `scripts/validate_architecture_boundaries.py`, `scripts/validate_deferred_items.py`, `scripts/smoke_imports.py`, `scripts/validate_command_registration.py`, focused Ark/account tests, and full tests if selector/risk warrants it.
+
+Update `docs/reference/deferred_optimisations.md` and this task pack as completed/deferred before PR handoff.
+```
+
+## 36. PR 92 Ark Admin Governor Lookup Service Update
+
+Status: implementation and validation complete; pending PR review and production smoke test.
+
+PR 92 delivered the Ark admin fuzzy/name-cache lookup cleanup slice:
+
+- `ark/registration_flow.py` now delegates admin add governor query resolution to a Discord-free Ark lookup service.
+- `ark/admin_governor_lookup_service.py` owns exact numeric GovernorID lookup, partial GovernorID matching, fuzzy name lookup, stale/empty cache refresh fallback, substring fallback, and no-match result shaping.
+- `target_utils.get_name_cache_rows()` exposes a small public cache-row accessor so Ark admin lookup no longer reads `target_utils._name_cache` from the controller.
+- The Ark controller remains responsible for Discord modal/selector routing, fuzzy embed/view display, slot prompt wiring, and the existing admin add apply path.
+- Existing ban enforcement, player/sub capacity checks, duplicate signup checks, active-weekend conflict checks, admin/leadership permissions, audit logging, and registration-message refresh remain in `_apply_admin_add`.
+- Focused tests cover the lookup service exact ID path, partial ID ordering, substring fallback after refresh, numeric no-match copy, fuzzy selector routing, admin permissions, ban enforcement, and slot capacity behaviour.
+- The active Ark admin fuzzy/name-cache lookup deferred item was removed from `docs/reference/deferred_optimisations.md`.
+
+Validation completed during PR 92 implementation:
+
+- `.\.venv\Scripts\python.exe -m py_compile ark\registration_flow.py ark\admin_governor_lookup_service.py target_utils.py tests\test_ark_admin_governor_lookup_service.py tests\test_ark_admin_roster.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_admin_governor_lookup_service.py tests\test_ark_admin_roster.py tests\test_ark_bans_enforcement.py tests\test_ark_registration_flow.py tests\test_ark_fuzzy_select_view.py` (`32 passed`)
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_account_picker.py tests\test_governor_account_service.py` (`14 passed`)
+- `.\.venv\Scripts\python.exe -m pytest -q tests -k "ark"` (`453 passed, 2 skipped, 912 deselected`)
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `git diff --check`
+
+Remaining follow-up slice intentionally left deferred:
+
+1. Compatibility cleanup: remove obsolete `AccountLookup`-only pathways and duplicate local account classification, linked-governor, registered-governor, and option-shaping helpers after preserving focused regression coverage for stats export, inventory permissions, MGE signup, telemetry/KVK pickers, registry flows, KVK personal views, and Ark signup.

--- a/target_utils.py
+++ b/target_utils.py
@@ -245,6 +245,12 @@ def get_name_cache_status() -> dict[str, Any]:
     }
 
 
+def get_name_cache_rows() -> list[dict[str, Any]]:
+    """Return a copy of cached governor rows for service-layer search helpers."""
+    rows = _name_cache.get("rows", []) if isinstance(_name_cache, dict) else []
+    return [dict(row) for row in rows if isinstance(row, dict)]
+
+
 # ---------------- Targets: EXEMPT/NOT ACTIVE fallback (still via SQL) ----------------
 
 

--- a/tests/test_ark_admin_governor_lookup_service.py
+++ b/tests/test_ark_admin_governor_lookup_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from ark import admin_governor_lookup_service as svc
+
+
+@pytest.mark.asyncio
+async def test_resolve_admin_governor_query_exact_id(monkeypatch):
+    async def _ensure_ready():
+        return None
+
+    monkeypatch.setattr(svc, "ensure_name_cache_ready", _ensure_ready)
+    monkeypatch.setattr(
+        svc,
+        "get_name_cache_rows",
+        lambda: [
+            {"GovernorID": "12072972", "GovernorName": "Talita Tia"},
+            {"GovernorID": "99999999", "GovernorName": "Other"},
+        ],
+    )
+
+    result = await svc.resolve_admin_governor_query("12072972")
+
+    assert result.status == "found"
+    assert result.governor_id == "12072972"
+    assert result.governor_name == "Talita Tia"
+
+
+@pytest.mark.asyncio
+async def test_resolve_admin_governor_query_partial_id_preserves_cache_order(monkeypatch):
+    async def _ensure_ready():
+        return None
+
+    monkeypatch.setattr(svc, "ensure_name_cache_ready", _ensure_ready)
+    monkeypatch.setattr(
+        svc,
+        "get_name_cache_rows",
+        lambda: [
+            {"GovernorID": "12072972", "GovernorName": "Talita Tia"},
+            {"GovernorID": "12072999", "GovernorName": "Talita Two"},
+            {"GovernorID": "99999999", "GovernorName": "Other"},
+        ],
+    )
+
+    result = await svc.resolve_admin_governor_query("120729")
+
+    assert result.status == "matches"
+    assert [match["GovernorID"] for match in result.matches] == ["12072972", "12072999"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_admin_governor_query_refreshes_and_uses_substring_fallback(monkeypatch):
+    calls = {"lookup": 0, "ensure": 0}
+
+    async def _lookup(_query):
+        calls["lookup"] += 1
+        return {"status": "not_found", "message": "Governor not found in the database"}
+
+    async def _ensure_ready():
+        calls["ensure"] += 1
+
+    monkeypatch.setattr(svc, "lookup_governor_id", _lookup)
+    monkeypatch.setattr(svc, "ensure_name_cache_ready", _ensure_ready)
+    monkeypatch.setattr(
+        svc,
+        "get_name_cache_rows",
+        lambda: [
+            {"GovernorID": "12072972", "GovernorName": "Talita Tia"},
+            {"GovernorID": "99999999", "GovernorName": "Other"},
+        ],
+    )
+
+    result = await svc.resolve_admin_governor_query("tali")
+
+    assert calls == {"lookup": 2, "ensure": 1}
+    assert result.status == "matches"
+    assert result.matches == ({"GovernorName": "Talita Tia", "GovernorID": "12072972"},)
+
+
+@pytest.mark.asyncio
+async def test_resolve_admin_governor_query_preserves_numeric_no_match_message(monkeypatch):
+    async def _ensure_ready():
+        return None
+
+    monkeypatch.setattr(svc, "ensure_name_cache_ready", _ensure_ready)
+    monkeypatch.setattr(svc, "get_name_cache_rows", lambda: [])
+
+    result = await svc.resolve_admin_governor_query("123456")
+
+    assert result.status == "not_found"
+    assert result.message == "❌ GovernorID not found in name cache. Please verify the ID."

--- a/tests/test_ark_admin_roster.py
+++ b/tests/test_ark_admin_roster.py
@@ -240,24 +240,24 @@ async def test_admin_add_partial_governor_id_fuzzy_matches(monkeypatch):
         config={"PlayersCap": 30, "SubsCap": 15, "AdminOverrideSubRule": 0},
     )
 
-    # Dummy interaction (from existing helpers in this file)
     interaction = DummyInteraction()
 
-    # Seed name cache with a governor that should match a partial ID
-    monkeypatch.setattr(
-        "ark.registration_flow._name_cache",
-        {
-            "rows": [
+    from ark.admin_governor_lookup_service import ArkAdminGovernorLookupResult
+
+    async def _resolve_admin_governor_query(query):
+        return ArkAdminGovernorLookupResult(
+            status="matches",
+            query=query,
+            matches=(
                 {"GovernorID": "12072972", "GovernorName": "Talita Tia"},
                 {"GovernorID": "99999999", "GovernorName": "Other"},
-            ]
-        },
+            ),
+        )
+
+    monkeypatch.setattr(
+        "ark.registration_flow.resolve_admin_governor_query",
+        _resolve_admin_governor_query,
     )
-
-    async def _ensure_cache():
-        return None
-
-    monkeypatch.setattr("ark.registration_flow._ensure_name_cache_ready", _ensure_cache)
 
     created_views = []
 
@@ -278,7 +278,6 @@ async def test_admin_add_partial_governor_id_fuzzy_matches(monkeypatch):
 
     monkeypatch.setattr("ark.registration_flow.ArkFuzzySelectView", _view_factory)
 
-    # Run with partial GovernorID
     await controller._handle_admin_add_name(interaction, "120729")
 
     assert created_views, "Expected fuzzy view to be created for partial ID"


### PR DESCRIPTION
## Summary

- Extracted Ark admin add governor search into a Discord-free lookup service.
- Removed direct `target_utils._name_cache` access from `ark/registration_flow.py` by adding `target_utils.get_name_cache_rows()`.
- Preserved exact ID, partial ID, fuzzy name lookup, cache refresh fallback, no-match copy, fuzzy selector routing, slot prompts, ban enforcement, slot capacity checks, and admin/leadership permission behavior.
- Updated deferred docs and the registry/account optimisation task pack; compatibility cleanup remains deferred as the next PR-sized slice.

## Changes

- Added `ark/admin_governor_lookup_service.py` for admin lookup result shaping.
- Kept `ArkRegistrationController` responsible for Discord modal, selector, and slot-prompt routing only.
- Added focused lookup service tests and adjusted admin roster routing coverage.

## Tests

- `./.venv/Scripts/python.exe -m py_compile ark/registration_flow.py ark/admin_governor_lookup_service.py target_utils.py tests/test_ark_admin_governor_lookup_service.py tests/test_ark_admin_roster.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_ark_admin_governor_lookup_service.py tests/test_ark_admin_roster.py tests/test_ark_bans_enforcement.py tests/test_ark_registration_flow.py tests/test_ark_fuzzy_select_view.py` (`32 passed`)
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_account_picker.py tests/test_governor_account_service.py` (`14 passed`)
- `./.venv/Scripts/python.exe -m pytest -q tests -k "ark"` (`453 passed, 2 skipped, 912 deselected`)
- `./.venv/Scripts/python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `git diff --check`

## SQL Changes

None. Existing Ark SQL-facing assumptions were checked against `C:\K98-bot-SQL-Server` during implementation scope.

## Risk / Rollback

Medium-low risk: this is a controller/service extraction for Ark admin add lookup, with the persistence and rule-enforcement path left unchanged. Roll back by reverting this PR and redeploying the prior bot version.