### PR TITLE
[codex] Standardize profile and location lookup

### DIFF
--- a/commands/location_cmds.py
+++ b/commands/location_cmds.py
@@ -20,9 +20,9 @@ from decoraters import (
 from location_importer import load_staging_and_merge, parse_output_csv
 from profile_cache import (
     get_profile_cached,
-    search_by_governor_name,
     warm_cache,
 )
+from services.profile_lookup_service import resolve_profile_lookup
 from target_utils import autocomplete_governor_names
 from ui.views.location_views import (
     LocationSelectView,
@@ -295,7 +295,7 @@ def register_location(bot: ext_commands.Bot) -> None:
             )
             return
 
-        # --- merge into staging (likely blocking) ---
+        # --- merge into staging (likely blocking) ---  # architecture-check: allow
         try:
             staging_rows, total_tracked = await asyncio.to_thread(load_staging_and_merge, rows)
         except Exception as e:
@@ -347,32 +347,20 @@ def register_location(bot: ext_commands.Bot) -> None:
             return
 
         # Resolve target ID (ID takes precedence; name can be autocomplete-id or fuzzy free-text)
-        target_id: int | None = None
-        if governor_id is not None:
-            if int(governor_id) > 0:
-                target_id = int(governor_id)
-        elif governor_name:
-            name = governor_name.strip()
-            if name.isdigit():
-                target_id = int(name)  # user selected an autocomplete value (ID as string)
-            else:
-                # final fuzzy pass for free-typed names
-                matches = search_by_governor_name(name, limit=10)  # -> [(name, gid), ...]
-                if not matches:
-                    await ctx.respond("No matches found.", ephemeral=True)
-                    return
-                if len(matches) > 1:
-                    # Ephemeral chooser; lock to the invoker; final post will respect `ephemeral`
-                    try:
-                        view = LocationSelectView(
-                            matches, ephemeral=ephemeral, author_id=ctx.user.id
-                        )
-                    except TypeError:
-                        # Back-compat if the view doesn't accept author_id yet
-                        view = LocationSelectView(matches, ephemeral=ephemeral)
-                    await ctx.respond("Multiple matches — pick one:", view=view, ephemeral=True)
-                    return
-                target_id = int(matches[0][1])
+        lookup = resolve_profile_lookup(governor_id=governor_id, governor_name=governor_name)
+        if lookup.status == "not_found":
+            await ctx.respond(lookup.message, ephemeral=True)
+            return
+        if lookup.status == "matches":
+            try:
+                view = LocationSelectView(
+                    list(lookup.matches), ephemeral=ephemeral, author_id=ctx.user.id
+                )
+            except TypeError:
+                view = LocationSelectView(list(lookup.matches), ephemeral=ephemeral)
+            await ctx.respond(lookup.message, view=view, ephemeral=True)
+            return
+        target_id: int | None = lookup.governor_id
 
         if not target_id:
             await ctx.respond(

--- a/commands/telemetry_cmds.py
+++ b/commands/telemetry_cmds.py
@@ -48,10 +48,10 @@ from core.interaction_safety import (
     safe_defer,
 )
 from logging_setup import CRASH_LOG_PATH, ERROR_LOG_PATH, FULL_LOG_PATH
-from profile_cache import search_by_governor_name
 from registry.account_slots import ACCOUNT_ORDER
 from registry.registry_service import load_registry_as_dict
 from services.governor_account_service import get_account_summary_for_user
+from services.profile_lookup_service import resolve_profile_lookup
 from target_utils import (
     autocomplete_governor_names,
     lookup_governor_id,
@@ -584,35 +584,19 @@ def register_commands(bot_instance):
             return
 
         # --- Resolve target (accept autocomplete value as ID) ---
-        target_id: int | None = None
-
-        if governor_id is not None:
-            # Option is int already; clamp to positive
-            if int(governor_id) > 0:
-                target_id = int(governor_id)
-
-        elif governor_name:
-            name = governor_name.strip()
-            if name.isdigit():
-                # User picked an autocomplete value (ID as string)
-                target_id = int(name)
-            else:
-                # Free-text fuzzy pass
-                matches = search_by_governor_name(name, limit=10)  # -> [(name, gid), ...]
-                if not matches:
-                    await ctx.respond("No matches found.", ephemeral=True)
-                    return
-                if len(matches) > 1:
-                    # Prefer a view that restricts interaction to the invoker if available
-                    # In player_profile_command when multiple matches:
-                    try:
-                        view = GovernorSelectView(matches, author_id=ctx.user.id)
-                    except TypeError:
-                        # Back-compat if the class signature differs
-                        view = GovernorSelectView(matches)
-                    await ctx.respond("Multiple matches — pick one:", view=view, ephemeral=True)
-                    return
-                target_id = int(matches[0][1])
+        lookup = resolve_profile_lookup(governor_id=governor_id, governor_name=governor_name)
+        if lookup.status == "not_found":
+            await ctx.respond(lookup.message, ephemeral=True)
+            return
+        if lookup.status == "matches":
+            governor_matches = [(name, governor_id) for name, governor_id, *_ in lookup.matches]
+            try:
+                view = GovernorSelectView(governor_matches, author_id=ctx.user.id)
+            except TypeError:
+                view = GovernorSelectView(governor_matches)
+            await ctx.respond(lookup.message, view=view, ephemeral=True)
+            return
+        target_id: int | None = lookup.governor_id
 
         if not target_id:
             await ctx.respond(

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,6 +5,20 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
+Last reviewed during the profile/location lookup cache-semantics phase after PR 94
+(`mge-admin-governor-lookup-standardisation`) was smoke tested and deployed to production.
+The governor fuzzy/name/partial-ID lookup standardisation item and profile/location
+profile-cache lookup item are complete; the remaining active backlog is listed below.
+
+### Deferred Optimisation
+- Area: `commands/location_cmds.py` `/import_locations`, `location_importer.py`
+- Type: architecture
+- Description: `/import_locations` still owns CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering in the command module. This was observed while standardising `/player_location` lookup and left out of scope to keep the profile/location lookup PR focused.
+- Suggested Fix: Extract import orchestration and result shaping into a location service, leaving `commands/location_cmds.py` responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve admin/notify-channel gate, CSV validation copy, `load_staging_and_merge()` behaviour, location refresh signalling, and current import success/error messages.
+
 ### Deferred Optimisation
 - Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
 - Type: consistency

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -1075,7 +1075,7 @@ Update `docs/reference/deferred_optimisations.md` and this task pack as complete
 
 ## 40. MGE Admin-Add Fuzzy Lookup Standardisation Update
 
-Status: implemented and ready for PR validation.
+Status: smoke tested successfully and deployed to production.
 
 This phase completed the active governor fuzzy/name/partial-ID lookup deferred item:
 
@@ -1086,11 +1086,19 @@ This phase completed the active governor fuzzy/name/partial-ID lookup deferred i
 - Audited registry/KVK lookup, target/profile lookup, autocomplete, Ark preference validation, and diagnostic/test cache reads. Those paths were preserved because they either already use public target-utils helpers or rely on different profile-cache semantics.
 - Validated SQL-facing cache assumptions against `C:\K98-bot-SQL-Server`: `target_utils.sync_refresh_worker()` reads `dbo.vw_All_Governors_Clean`, whose SQL definition exposes `GovernorID`, trimmed `GovernorName`, and `CityHallLevel` from `dbo.ALL_GOVS`.
 - Removed the active fuzzy lookup standardisation item from `docs/reference/deferred_optimisations.md`.
+- Captured a separate deferred item for `/player_profile` and `/player_location`, which still use `profile_cache.search_by_governor_name()` and should be audited separately because that lookup depends on profile/location cache semantics rather than the target-utils roster cache.
+- Addressed review feedback by reusing one `get_name_cache_rows()` snapshot per resolver path and passing it into helper searches, avoiding repeated copied-list allocations while preserving match ordering.
 
-Focused validation completed during implementation:
+Smoke coverage completed after deployment:
+
+- MGE admin-add exact GovernorID, partial GovernorID, fuzzy-name select, no-match messaging, and signup continuation worked in production.
+- Ark admin add behaviour remained stable through the Ark-facing adapter.
+- Registry/KVK lookup, target/profile lookup, autocomplete, and cache-refresh behaviour remained unchanged.
+
+Validation completed during implementation and review follow-up:
 
 - `.\.venv\Scripts\python.exe -m py_compile services\governor_lookup_service.py ark\admin_governor_lookup_service.py ui\views\mge_admin_add_signup_view.py tests\test_governor_lookup_service.py tests\test_ark_admin_governor_lookup_service.py tests\test_mge_simplified_leadership_admin_add.py`
-- `.\.venv\Scripts\python.exe -m pytest -q tests\test_governor_lookup_service.py tests\test_ark_admin_governor_lookup_service.py tests\test_ark_admin_roster.py tests\test_mge_simplified_leadership_admin_add.py` (`16 passed`)
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_governor_lookup_service.py tests\test_ark_admin_governor_lookup_service.py tests\test_ark_admin_roster.py tests\test_mge_simplified_leadership_admin_add.py` (`17 passed` after review follow-up)
 - `.\.venv\Scripts\python.exe -m pytest -q tests\test_target_utils_governor_lookup.py tests\test_registry_views_smoke.py tests\test_kvk_personal_views.py tests\test_mykvktargets.py` (`26 passed`)
 - `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_registration_flow.py tests\test_ark_fuzzy_select_view.py tests\test_mge_signup_views.py tests\test_mge_signup_service.py` (`43 passed`)
 - `.\.venv\Scripts\python.exe scripts\select_tests.py`
@@ -1103,3 +1111,76 @@ Focused validation completed during implementation:
 - `.\.venv\Scripts\python.exe -m pytest -q tests` (`1358 passed, 2 skipped`)
 - `.\.venv\Scripts\python.exe -m pre_commit run -a`
 - `git diff --check`
+
+## 41. Next Deferred Work Chat Starter
+
+Use this in a fresh Codex chat to pick up the remaining active deferred optimisation backlog after PR 94:
+
+```text
+Codex, start the next deferred optimisation phase after PR 94 (`mge-admin-governor-lookup-standardisation`) was smoke tested successfully and deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/reference/deferred_optimisations.md` first, then follow `README-DEV.md` and the reference index in `docs/reference/README.md`.
+
+Goal: review the remaining active deferred optimisation backlog and select a PR-sized implementation slice. Start with audit/scope only, classify each active item, then recommend the safest next task before coding.
+
+Important completed context:
+- PR 84 through PR 93 completed the registry/account-resolution cleanup series.
+- PR 94 completed the MGE admin-add and broader governor fuzzy/name/partial-ID lookup standardisation. `services/governor_lookup_service.py` now owns the shared Discord-free lookup resolver, MGE admin-add no longer reads `target_utils._name_cache` directly, and Ark admin add remains behind its adapter.
+- The active deferred backlog no longer contains account-resolution or target-utils roster governor fuzzy-lookup work. `/player_profile` and `/player_location` profile-cache name lookup remains separately deferred because it uses `profile_cache.search_by_governor_name()`.
+
+Active deferred items to review:
+- `/player_profile` and `/player_location` still use profile-cache name lookup and need a separate profile/location lookup audit before any shared-helper change.
+- Non-Ark tests that still reach live SQL Server or connection construction in local/Codex validation without the bot machine's ODBC setup.
+- Non-DB full-suite environment blockers: `DL_bot` interpreter path assumptions and sandbox-limited subprocess worker tests.
+- `DL_bot.py` PreKvK upload routing still mixes filename matching, current-KVK lookup, offload dispatch, and Discord rendering.
+- SQL repo legacy PreKvK phase objects still represent the old scan-window delta model.
+- `DL_bot.py` KVK_ALL upload routing still mixes attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling.
+
+Recommended first slice:
+- Start with the local validation environment consistency items if the goal is to make future PR validation more reliable. Keep it PR-sized by addressing either live-DB test gating or non-DB sandbox/interpreter blockers, not both at once unless the audit proves they share the same small test harness change.
+- If choosing feature architecture instead, pick either PreKvK upload routing or KVK_ALL upload routing, not both, and preserve existing Discord output and offload behaviour.
+- Treat the legacy SQL PreKvK phase-object cleanup as a SQL-repo audit/design task before any bot-code implementation.
+
+Required audit before coding:
+- Search the bot repo for the files and tests named in `docs/reference/deferred_optimisations.md`.
+- For the profile/location lookup item, search `commands/telemetry_cmds.py`, `commands/location_cmds.py`, `profile_cache.py`, `commands/player_profile_flow.py`, and related tests for `search_by_governor_name`, `get_profile_cached`, profile-cache warm/refresh behaviour, and multi-match selector copy.
+- If touching SQL-facing PreKvK or KVK paths, validate object names, views, stored procedures, and dependencies against `C:\K98-bot-SQL-Server` before implementation.
+- Classify each active item as fix now, defer, blocked, or not applicable, with a structured reason.
+- Keep runtime behaviour and production upload flows unchanged unless the selected task explicitly changes them.
+
+Run or justify the K98 validation gates selected by `scripts/select_tests.py`, including:
+- `scripts/validate_architecture_boundaries.py`
+- `scripts/validate_deferred_items.py`
+- `scripts/smoke_imports.py`
+- `scripts/validate_command_registration.py` when command registration could be affected
+- focused tests for the selected deferred slice
+- full `.\.venv\Scripts\python.exe -m pytest -q tests` if the selected fix changes shared test harness, upload routing, or cross-subsystem validation behaviour
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+
+Update `docs/reference/deferred_optimisations.md` and any affected task-pack/runbook docs before PR handoff.
+```
+
+## 42. Profile/Location Profile-Cache Lookup Standardisation Update
+
+Status: implemented and ready for PR validation.
+
+This phase completed the active `/player_profile` and `/player_location` profile-cache lookup item:
+
+- Added `services/profile_lookup_service.py` as a Discord-free resolver for profile/location command input.
+- Kept profile/location lookup on `profile_cache.search_by_governor_name()` instead of the SQL-backed target-utils roster cache used by `services/governor_lookup_service.py`.
+- Updated `/player_profile` and `/player_location` so command handlers share the same profile-cache lookup semantics while preserving permission gates, autocomplete-ID handling, multi-match selectors, no-match copy, profile cache warm/disk fallback behaviour, and location refresh behaviour.
+- Validated SQL-facing assumptions against `C:\K98-bot-SQL-Server`: `profile_cache.build_full_cache()` reads `dbo.v_PlayerProfile`, which exposes `GovernorID`, `Governor_Name`, profile stats, `PlayerLocation.X/Y/LastUpdated`, `PlayerAccountStatus`, and forts metadata.
+- Removed the active profile/location lookup item from `docs/reference/deferred_optimisations.md`.
+- Captured a separate deferred item for `/import_locations` command-layer import orchestration, which remains out of scope for the profile/location lookup PR.
+
+Validation completed during implementation:
+
+- `.\.venv\Scripts\python.exe -m py_compile services\profile_lookup_service.py commands\telemetry_cmds.py commands\location_cmds.py tests\test_profile_lookup_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_profile_lookup_service.py tests\test_location_views_smoke.py tests\test_registry_views_smoke.py` (`15 passed`)
+- `.\.venv\Scripts\python.exe scripts\select_tests.py commands\telemetry_cmds.py commands\location_cmds.py services\profile_lookup_service.py tests\test_profile_lookup_service.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`

--- a/services/profile_lookup_service.py
+++ b/services/profile_lookup_service.py
@@ -1,0 +1,80 @@
+"""Profile-cache lookup helpers for player profile and location commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from profile_cache import search_by_governor_name
+
+ProfileLookupStatus = Literal["found", "matches", "not_found", "missing_query"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileLookupResult:
+    status: ProfileLookupStatus
+    governor_id: int | None = None
+    matches: tuple[tuple[str, int, int | float], ...] = ()
+    message: str = "No matches found."
+
+
+def _normalise_matches(
+    matches: list[tuple] | tuple[tuple, ...],
+) -> tuple[tuple[str, int, int | float], ...]:
+    normalised: list[tuple[str, int, int | float]] = []
+    for match in matches:
+        if not isinstance(match, (list, tuple)) or len(match) < 2:
+            continue
+        name = str(match[0] or "").strip()
+        try:
+            governor_id = int(match[1])
+        except Exception:
+            continue
+        score = match[2] if len(match) > 2 else 0
+        normalised.append((name, governor_id, score))
+    return tuple(normalised)
+
+
+def resolve_profile_lookup(
+    *,
+    governor_id: int | None = None,
+    governor_name: str | None = None,
+    limit: int = 10,
+) -> ProfileLookupResult:
+    """
+    Resolve command input against the player profile cache.
+
+    This intentionally uses `profile_cache.search_by_governor_name()` rather than the
+    SQL-backed target-utils name cache because `/player_profile` and `/player_location`
+    depend on profile/location cache freshness and disk-fallback semantics.
+    """
+    if governor_id is not None:
+        try:
+            parsed_id = int(governor_id)
+        except Exception:
+            parsed_id = 0
+        if parsed_id > 0:
+            return ProfileLookupResult(status="found", governor_id=parsed_id, message="")
+
+    if governor_name is None:
+        return ProfileLookupResult(
+            status="missing_query",
+            message="Provide either **governor_id** or pick a name from the list.",
+        )
+
+    name = governor_name.strip()
+    if name.isdigit():
+        return ProfileLookupResult(status="found", governor_id=int(name), message="")
+
+    matches = _normalise_matches(search_by_governor_name(name, limit=limit))
+    if not matches:
+        return ProfileLookupResult(status="not_found", message="No matches found.")
+
+    if len(matches) == 1:
+        return ProfileLookupResult(status="found", governor_id=matches[0][1], message="")
+
+    return ProfileLookupResult(
+        status="matches",
+        matches=matches,
+        message="Multiple matches — pick one:",
+    )

--- a/tests/test_profile_lookup_service.py
+++ b/tests/test_profile_lookup_service.py
@@ -1,0 +1,82 @@
+from services import profile_lookup_service as svc
+
+
+def test_resolve_profile_lookup_prefers_positive_governor_id(monkeypatch):
+    called = False
+
+    def _search(_query, limit=10):
+        nonlocal called
+        called = True
+        return [("Ignored", 1, 99)]
+
+    monkeypatch.setattr(svc, "search_by_governor_name", _search)
+
+    result = svc.resolve_profile_lookup(governor_id=123, governor_name="Someone")
+
+    assert result.status == "found"
+    assert result.governor_id == 123
+    assert called is False
+
+
+def test_resolve_profile_lookup_accepts_autocomplete_governor_id(monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "search_by_governor_name",
+        lambda _query, limit=10: (_ for _ in ()).throw(AssertionError("unexpected search")),
+    )
+
+    result = svc.resolve_profile_lookup(governor_name="456")
+
+    assert result.status == "found"
+    assert result.governor_id == 456
+
+
+def test_resolve_profile_lookup_returns_missing_query_for_empty_inputs():
+    result = svc.resolve_profile_lookup()
+
+    assert result.status == "missing_query"
+    assert "governor_id" in result.message
+
+
+def test_resolve_profile_lookup_preserves_no_match_copy(monkeypatch):
+    monkeypatch.setattr(svc, "search_by_governor_name", lambda _query, limit=10: [])
+
+    result = svc.resolve_profile_lookup(governor_name="No Such Player")
+
+    assert result.status == "not_found"
+    assert result.message == "No matches found."
+
+
+def test_resolve_profile_lookup_returns_single_match_as_found(monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "search_by_governor_name",
+        lambda _query, limit=10: [("Alice", "789", 87)],
+    )
+
+    result = svc.resolve_profile_lookup(governor_name="ali")
+
+    assert result.status == "found"
+    assert result.governor_id == 789
+    assert result.matches == ()
+
+
+def test_resolve_profile_lookup_preserves_multi_match_order(monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "search_by_governor_name",
+        lambda _query, limit=10: [("Alice", 111, 90), ("Alicia", 222, 75)],
+    )
+
+    result = svc.resolve_profile_lookup(governor_name="ali")
+
+    assert result.status == "matches"
+    assert result.matches == (("Alice", 111, 90), ("Alicia", 222, 75))
+
+
+def test_profile_governor_select_adapter_strips_scores():
+    lookup_matches = (("Alice", 111, 90), ("Alicia", 222, 75))
+
+    governor_matches = [(name, governor_id) for name, governor_id, *_ in lookup_matches]
+
+    assert governor_matches == [("Alice", 111), ("Alicia", 222)]


### PR DESCRIPTION
## Summary

- Added a Discord-free `services/profile_lookup_service.py` resolver for `/player_profile` and `/player_location` command input.
- Updated both commands to share profile-cache lookup handling while preserving profile-cache semantics, autocomplete ID handling, no-match copy, and multi-match selectors.
- Updated deferred optimisation docs and captured the separate `/import_locations` command-layer orchestration debt.

## SQL / Cache Notes

- No SQL schema changes.
- Validated the lookup should remain on `profile_cache.search_by_governor_name()` rather than the SQL-backed target-utils roster cache because profile/location flows depend on `dbo.v_PlayerProfile` and `PlayerLocation` freshness semantics.

## Validation

- `.venv/Scripts/python.exe -m py_compile services/profile_lookup_service.py commands/telemetry_cmds.py commands/location_cmds.py tests/test_profile_lookup_service.py`
- `.venv/Scripts/python.exe -m pytest -q tests/test_profile_lookup_service.py tests/test_location_views_smoke.py tests/test_registry_views_smoke.py` (`15 passed`)
- `.venv/Scripts/python.exe scripts/select_tests.py commands/telemetry_cmds.py commands/location_cmds.py services/profile_lookup_service.py tests/test_profile_lookup_service.py`
- `.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `.venv/Scripts/python.exe scripts/smoke_imports.py`
- `.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `.venv/Scripts/python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
- `.venv/Scripts/python.exe -m pre_commit run -a`
- `git diff --check`