### PR TITLE
[codex] thin import locations command orchestration

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -656,7 +656,7 @@ async def on_message(message: discord.Message):
 
                 # 2) Signal any waiting tasks that the refresh is complete
                 try:
-                    from Commands import (
+                    from commands.location_cmds import (
                         signal_location_refresh_complete,  # import where the globals live
                     )
 

--- a/commands/location_cmds.py
+++ b/commands/location_cmds.py
@@ -17,10 +17,13 @@ from decoraters import (
     is_admin_and_notify_channel,
     track_usage,
 )
-from location_importer import load_staging_and_merge, parse_output_csv
 from profile_cache import (
     get_profile_cached,
     warm_cache,
+)
+from services.location_import_service import (
+    import_location_csv_bytes,
+    validate_location_csv_attachment,
 )
 from services.profile_lookup_service import resolve_profile_lookup
 from target_utils import autocomplete_governor_names
@@ -251,26 +254,14 @@ def register_location(bot: ext_commands.Bot) -> None:
             )
             return
 
-        # --- basic validation ---
-        fname = (attach.filename or "").lower()
-        if not fname.endswith(".csv"):
-            await ctx.interaction.edit_original_response(
-                content=f"❌ `{attach.filename}` isn’t a CSV file. Please upload a `.csv` (e.g., `output.csv`)."
-            )
+        validation = validate_location_csv_attachment(
+            filename=getattr(attach, "filename", None),
+            size=getattr(attach, "size", None),
+        )
+        if not validation.ok:
+            await ctx.interaction.edit_original_response(content=validation.message)
             return
 
-        # Optional: size guard (e.g., 10 MB)
-        try:
-            fsize = getattr(attach, "size", None)
-            if isinstance(fsize, int) and fsize > 10 * 1024 * 1024:
-                await ctx.interaction.edit_original_response(
-                    content=f"❌ File too large ({fsize/1024/1024:.1f} MB). Please keep CSV under **10 MB**."
-                )
-                return
-        except Exception:
-            pass
-
-        # --- read + parse ---
         try:
             csv_bytes = await attach.read()
         except Exception as e:
@@ -280,39 +271,14 @@ def register_location(bot: ext_commands.Bot) -> None:
             )
             return
 
-        try:
-            rows = parse_output_csv(csv_bytes)
-        except Exception as e:
-            logger.exception("[/import_locations] parse_output_csv crashed")
-            await ctx.interaction.edit_original_response(
-                content=f"❌ Failed to parse CSV: `{type(e).__name__}: {e}`"
-            )
-            return
-
-        if not rows:
-            await ctx.interaction.edit_original_response(
-                content="⚠️ No valid rows found in the CSV."
-            )
-            return
-
-        # --- merge into staging (likely blocking) ---  # architecture-check: allow
-        try:
-            staging_rows, total_tracked = await asyncio.to_thread(load_staging_and_merge, rows)
-        except Exception as e:
-            logger.exception("[/import_locations] load_staging_and_merge failed")
-            await ctx.interaction.edit_original_response(
-                content=f"❌ Failed to import rows: `{type(e).__name__}: {e}`"
-            )
-            return
-
-        dur = (datetime.now(UTC) - started).total_seconds()
-        count_part = f"Imported **{staging_rows}** row{'s' if staging_rows != 1 else ''}."
-        tracked_part = (
-            f" Total tracked now **{total_tracked}**." if total_tracked is not None else ""
+        result = await import_location_csv_bytes(
+            csv_bytes,
+            filename=getattr(attach, "filename", None),
+            size=getattr(attach, "size", None),
+            on_success=signal_location_refresh_complete,
+            started_at_utc=started,
         )
-        msg = f"✅ {count_part}{tracked_part} ⏱ {dur:.1f}s"
-
-        await ctx.interaction.edit_original_response(content=msg)
+        await ctx.interaction.edit_original_response(content=result.message)
 
     @bot.slash_command(
         name="player_location",

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -11,15 +11,6 @@ The governor fuzzy/name/partial-ID lookup standardisation item and profile/locat
 profile-cache lookup item are complete; the remaining active backlog is listed below.
 
 ### Deferred Optimisation
-- Area: `commands/location_cmds.py` `/import_locations`, `location_importer.py`
-- Type: architecture
-- Description: `/import_locations` still owns CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering in the command module. This was observed while standardising `/player_location` lookup and left out of scope to keep the profile/location lookup PR focused.
-- Suggested Fix: Extract import orchestration and result shaping into a location service, leaving `commands/location_cmds.py` responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
-- Impact: medium
-- Risk: medium
-- Dependencies: Preserve admin/notify-channel gate, CSV validation copy, `load_staging_and_merge()` behaviour, location refresh signalling, and current import success/error messages.
-
-### Deferred Optimisation
 - Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
 - Type: consistency
 - Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.
@@ -45,6 +36,15 @@ profile-cache lookup item are complete; the remaining active backlog is listed b
 - Impact: medium
 - Risk: medium
 - Dependencies: PreKvK diagnostics result model should remain stable after the import-history rollout.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` player location CSV auto-import, `Commands.py` compatibility shim
+- Type: architecture
+- Description: The player location auto-import flow in `DL_bot.py` attempts to import `signal_location_refresh_complete` from the legacy `Commands.py` shim, but the signal currently lives in `commands/location_cmds.py` and is not exposed by `Commands.py`. This makes refresh-completion signalling fragile for the legacy auto-import path and should be handled with the broader DL_bot routing cleanup.
+- Suggested Fix: When refactoring DL_bot upload routing, move player-location auto-import orchestration into a dedicated route/service boundary and centralise location refresh signalling behind an importable helper that both command and legacy routing paths can call.
+- Impact: medium
+- Risk: medium
+- Dependencies: Coordinate with the existing deferred DL_bot upload-routing improvements; preserve current player location auto-import Discord output and scanner/import behaviour.
 
 ### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase objects

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -1162,7 +1162,7 @@ Update `docs/reference/deferred_optimisations.md` and any affected task-pack/run
 
 ## 42. Profile/Location Profile-Cache Lookup Standardisation Update
 
-Status: implemented and ready for PR validation.
+Status: smoke tested successfully and PR complete.
 
 This phase completed the active `/player_profile` and `/player_location` profile-cache lookup item:
 
@@ -1173,10 +1173,11 @@ This phase completed the active `/player_profile` and `/player_location` profile
 - Removed the active profile/location lookup item from `docs/reference/deferred_optimisations.md`.
 - Captured a separate deferred item for `/import_locations` command-layer import orchestration, which remains out of scope for the profile/location lookup PR.
 
-Validation completed during implementation:
+Validation completed during implementation and review follow-up:
 
 - `.\.venv\Scripts\python.exe -m py_compile services\profile_lookup_service.py commands\telemetry_cmds.py commands\location_cmds.py tests\test_profile_lookup_service.py`
 - `.\.venv\Scripts\python.exe -m pytest -q tests\test_profile_lookup_service.py tests\test_location_views_smoke.py tests\test_registry_views_smoke.py` (`15 passed`)
+- Review follow-up for PR feedback: `/player_profile` now strips the score field before constructing `GovernorSelectView`; focused regression coverage passed with `16 passed`.
 - `.\.venv\Scripts\python.exe scripts\select_tests.py commands\telemetry_cmds.py commands\location_cmds.py services\profile_lookup_service.py tests\test_profile_lookup_service.py`
 - `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
 - `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
@@ -1184,3 +1185,208 @@ Validation completed during implementation:
 - `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
 - `.\.venv\Scripts\python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
 - `.\.venv\Scripts\python.exe -m pre_commit run -a`
+
+## 43. Next Deferred Work Chat Starter
+
+Use this in a fresh Codex chat for the `/import_locations` command-layer orchestration deferred item:
+
+```text
+Codex, start the `/import_locations` command-layer orchestration cleanup after PR 95 (`profile-location-lookup-service`) was smoke tested successfully and completed.
+
+Use the K98 repo workflow and required docs. Read `docs/reference/deferred_optimisations.md` first, then follow `AGENTS.md`, `README-DEV.md`, and the reference index in `docs/reference/README.md`.
+
+## 1. Task Header
+
+- Task name: `import-locations-command-orchestration-cleanup`
+- Date: 2026-05-15
+- Owner/context: deferred optimisation captured during PR 95 profile/location lookup standardisation
+- Task type: refactor | deferred optimisation batch
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+
+Then follow the required reading order and conditional references defined by `docs/reference/README.md`.
+
+For SQL-facing work, validate schema, procedure, view, index, staging/output table, and `ProcConfig` details against:
+
+`C:\K98-bot-SQL-Server`
+
+## 3. Objective
+
+Refactor `/import_locations` so command-layer code is thinner and orchestration/result shaping moves into a service/helper layer. Preserve existing Discord behaviour, admin/notify-channel gate, CSV validation messages, staging merge behaviour, location refresh signalling, and success/error copy.
+
+## 4. Background
+
+PR 95 completed `/player_profile` and `/player_location` profile-cache lookup standardisation. While touching `commands/location_cmds.py`, Codex found that `/import_locations` still mixes CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering inside the command module. The matching deferred item is active in `docs/reference/deferred_optimisations.md`.
+
+## 5. Scope
+
+### In Scope
+
+- Audit `commands/location_cmds.py` `/import_locations`.
+- Review `location_importer.py` and any tests around `parse_output_csv`, `load_staging_and_merge`, and location refresh signalling.
+- Extract import orchestration and result shaping into a small service/helper if the audit confirms a safe PR-sized slice.
+- Keep command code responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
+- Add or update focused tests for extracted logic and command-facing behaviour.
+- Update deferred docs/task-pack notes when complete.
+
+### Out of Scope
+
+- Changing `/player_location` lookup behaviour from PR 95.
+- Redesigning location scanner/import SQL.
+- Changing Discord command names, permissions, channel gates, or user-facing import copy unless required for correctness.
+- Touching `DL_bot.py` upload routing.
+- Broad location refresh lifecycle redesign.
+
+## 6. Source Deferred Items
+
+### Deferred Optimisation
+- Area: `commands/location_cmds.py` `/import_locations`, `location_importer.py`
+- Type: architecture
+- Description: `/import_locations` still owns CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering in the command module. This was observed while standardising `/player_location` lookup and left out of scope to keep the profile/location lookup PR focused.
+- Suggested Fix: Extract import orchestration and result shaping into a location service, leaving `commands/location_cmds.py` responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve admin/notify-channel gate, CSV validation copy, `load_staging_and_merge()` behaviour, location refresh signalling, and current import success/error messages.
+
+## 7. Codex Skills To Use
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | use | Required before implementation to map command/service/DAL/cache boundaries. |
+| `k98-discord-command-feature` | use | `/import_locations` is a slash command with permissions, responses, and user-facing copy. |
+| `k98-sql-validation` | use | Location import depends on SQL-facing staging/merge behaviour through `location_importer.py`. |
+| `k98-test-selection` | use | Required to choose focused location/import tests and validation gates. |
+| `k98-deferred-optimisation-capture` | use | Required for closing/updating the deferred item and capturing any newly found debt. |
+| `k98-pr-review` | use | Use before PR handoff. |
+| `k98-promotion-check` | not applicable initially | Use only before production promotion/deployment, not during first audit. |
+
+## 8. Mandatory Workflow
+
+1. Audit / scope review, then stop for approval.
+2. Architecture validation, then stop for approval.
+3. Implementation plan, then stop for approval.
+4. Implementation after approval.
+5. Validation and final review.
+
+Do not proceed in one pass unless explicitly approved.
+
+## 9. Audit Requirements
+
+Review the touched area for:
+
+- direct SQL or SQL-facing work in command paths
+- business logic in the command layer
+- duplicate CSV validation, response shaping, or import result helpers
+- weak validation or logging
+- cache and location refresh safety
+- restart/persistence implications
+- test coverage gaps
+
+Map likely affected commands, services, DAL/import helpers, SQL objects/contracts, location cache behaviour, refresh signalling, docs, and tests.
+
+## 10. Architecture Targets
+
+| Concern | Target |
+|---|---|
+| Slash command | `commands/location_cmds.py` remains thin interaction plumbing |
+| Service / orchestration | `services/` or a focused location helper module |
+| Import/parser logic | `location_importer.py` unless audit finds a better existing location module |
+| Views / modals | no expected change |
+| SQL schema | SQL repo only, if schema changes are unexpectedly required |
+| Tests | `tests/` focused location/import coverage |
+
+## 11. Likely Files
+
+### Review
+
+- `commands/location_cmds.py`
+- `location_importer.py`
+- `tests/`
+- `docs/reference/deferred_optimisations.md`
+- SQL repo objects referenced by `location_importer.py`
+
+### Modify
+
+- `commands/location_cmds.py`
+- a focused service/helper module if justified
+- relevant tests
+- deferred/task-pack documentation
+
+### Create
+
+- Optional: `services/location_import_service.py`
+- Optional: focused tests for the extracted service/helper
+
+## 12. Implementation Requirements
+
+- Preserve `/import_locations` command name and admin/notify-channel restriction.
+- Preserve CSV file validation and existing user-facing success/error copy.
+- Preserve `parse_output_csv()` and `load_staging_and_merge()` behaviour unless the audit identifies a bug.
+- Preserve `signal_location_refresh_complete()` behaviour after successful import.
+- Keep SQL execution/data access outside the command layer.
+- Add tests for extracted result shaping/orchestration.
+- Do not mix in `/player_profile`, `/player_location`, or `DL_bot.py` work.
+
+## 13. Refactor Decisions
+
+Codex must populate this table after audit:
+
+| Issue | Decision | Reason |
+|---|---|---|
+| CSV attachment validation in command | fix now / defer / not applicable | |
+| Parsing handoff in command | fix now / defer / not applicable | |
+| Staging merge dispatch in command | fix now / defer / not applicable | |
+| Discord response/result shaping in command | fix now / defer / not applicable | |
+| Location refresh signalling ownership | fix now / defer / not applicable | |
+| SQL-facing ambiguity in `location_importer.py` | fix now / defer / blocked / not applicable | |
+| Test gaps | fix now / defer / not applicable | |
+
+## 14. Testing Requirements
+
+Run or justify:
+
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- focused pytest for location import/parser/service changes
+- `.\.venv\Scripts\python.exe -m pytest -q tests` if shared command/import behaviour changes
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+
+Cover happy path, invalid/missing attachment, non-CSV attachment, empty parsed rows, parser failure, merge failure, success summary formatting, permission/channel boundaries where practical, and refresh signalling.
+
+## 15. Acceptance Criteria
+
+- [ ] Scope is complete and no unrelated location/DL_bot work was mixed in.
+- [ ] `/import_locations` command is thinner or a clear defer reason is documented.
+- [ ] No new direct SQL exists in commands or views.
+- [ ] SQL-facing assumptions are validated against `C:\K98-bot-SQL-Server`.
+- [ ] Existing Discord copy and permission boundaries are preserved.
+- [ ] Location refresh signalling remains correct.
+- [ ] Tests are added/updated or exceptions documented.
+- [ ] K98 validation gates are run or skipped with reasons.
+- [ ] Deferred item is updated or removed after completion.
+
+## 16. Required Delivery Output
+
+Return:
+
+1. Summary
+2. File Manifest
+3. New Files
+4. Modified Files
+5. SQL Changes
+6. Helpers Reused
+7. Refactor Findings
+8. Test Plan
+9. Deployment Steps
+10. Deferred Optimisations
+```

--- a/services/location_import_service.py
+++ b/services/location_import_service.py
@@ -1,0 +1,114 @@
+"""Service helpers for player location CSV imports."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import logging
+
+from location_importer import load_staging_and_merge, parse_output_csv
+
+logger = logging.getLogger(__name__)
+
+MAX_LOCATION_CSV_BYTES = 10 * 1024 * 1024
+
+CsvParser = Callable[[bytes], list[tuple]]
+LocationMerge = Callable[[list[tuple]], tuple[int, int]]
+SuccessCallback = Callable[[], None]
+AsyncThreadRunner = Callable[..., Awaitable[tuple[int, int]]]
+
+
+@dataclass(frozen=True, slots=True)
+class LocationCsvValidation:
+    ok: bool
+    message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LocationImportResult:
+    ok: bool
+    message: str
+    rows_parsed: int = 0
+    staging_rows: int = 0
+    total_tracked: int | None = None
+
+
+def validate_location_csv_attachment(
+    *, filename: str | None, size: int | None
+) -> LocationCsvValidation:
+    display_name = str(filename)
+    lowered = (filename or "").lower()
+    if not lowered.endswith(".csv"):
+        return LocationCsvValidation(
+            ok=False,
+            message=f"❌ `{display_name}` isn’t a CSV file. Please upload a `.csv` (e.g., `output.csv`).",
+        )
+
+    if isinstance(size, int) and size > MAX_LOCATION_CSV_BYTES:
+        return LocationCsvValidation(
+            ok=False,
+            message=f"❌ File too large ({size/1024/1024:.1f} MB). Please keep CSV under **10 MB**.",
+        )
+
+    return LocationCsvValidation(ok=True)
+
+
+async def import_location_csv_bytes(
+    csv_bytes: bytes,
+    *,
+    filename: str | None = None,
+    size: int | None = None,
+    parser: CsvParser = parse_output_csv,
+    merge_rows: LocationMerge = load_staging_and_merge,
+    on_success: SuccessCallback | None = None,
+    thread_runner: AsyncThreadRunner = asyncio.to_thread,
+    started_at_utc: datetime | None = None,
+) -> LocationImportResult:
+    validation = validate_location_csv_attachment(filename=filename, size=size)
+    if not validation.ok:
+        return LocationImportResult(ok=False, message=validation.message or "❌ Invalid CSV file.")
+
+    started = started_at_utc or datetime.now(UTC)
+
+    try:
+        rows = parser(csv_bytes)
+    except Exception as exc:
+        logger.exception("[/import_locations] parse_output_csv crashed")
+        return LocationImportResult(
+            ok=False,
+            message=f"❌ Failed to parse CSV: `{type(exc).__name__}: {exc}`",
+        )
+
+    if not rows:
+        return LocationImportResult(ok=False, message="⚠️ No valid rows found in the CSV.")
+
+    try:
+        staging_rows, total_tracked = await thread_runner(merge_rows, rows)
+    except Exception as exc:
+        logger.exception("[/import_locations] load_staging_and_merge failed")
+        return LocationImportResult(
+            ok=False,
+            rows_parsed=len(rows),
+            message=f"❌ Failed to import rows: `{type(exc).__name__}: {exc}`",
+        )
+
+    if on_success is not None:
+        try:
+            on_success()
+        except Exception:
+            logger.exception("[/import_locations] refresh success callback failed")
+
+    duration = (datetime.now(UTC) - started).total_seconds()
+    count_part = f"Imported **{staging_rows}** row{'s' if staging_rows != 1 else ''}."
+    tracked_part = f" Total tracked now **{total_tracked}**." if total_tracked is not None else ""
+    message = f"✅ {count_part}{tracked_part} ⏱ {duration:.1f}s"
+
+    return LocationImportResult(
+        ok=True,
+        message=message,
+        rows_parsed=len(rows),
+        staging_rows=staging_rows,
+        total_tracked=total_tracked,
+    )

--- a/tests/test_location_import_service.py
+++ b/tests/test_location_import_service.py
@@ -1,0 +1,128 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from services import location_import_service as svc
+
+
+def test_validate_location_csv_attachment_rejects_non_csv():
+    result = svc.validate_location_csv_attachment(filename="output.txt", size=10)
+
+    assert result.ok is False
+    assert result.message == "❌ `output.txt` isn’t a CSV file. Please upload a `.csv` (e.g., `output.csv`)."
+
+
+def test_validate_location_csv_attachment_rejects_oversize_csv():
+    result = svc.validate_location_csv_attachment(
+        filename="output.csv", size=svc.MAX_LOCATION_CSV_BYTES + 1
+    )
+
+    assert result.ok is False
+    assert result.message == "❌ File too large (10.0 MB). Please keep CSV under **10 MB**."
+
+
+@pytest.mark.asyncio
+async def test_import_location_csv_bytes_returns_parse_failure():
+    def _parser(_csv_bytes):
+        raise ValueError("bad csv")
+
+    result = await svc.import_location_csv_bytes(
+        b"bad",
+        filename="output.csv",
+        parser=_parser,
+    )
+
+    assert result.ok is False
+    assert result.message == "❌ Failed to parse CSV: `ValueError: bad csv`"
+
+
+@pytest.mark.asyncio
+async def test_import_location_csv_bytes_returns_empty_rows_message():
+    result = await svc.import_location_csv_bytes(
+        b"header",
+        filename="output.csv",
+        parser=lambda _csv_bytes: [],
+    )
+
+    assert result.ok is False
+    assert result.message == "⚠️ No valid rows found in the CSV."
+
+
+@pytest.mark.asyncio
+async def test_import_location_csv_bytes_returns_merge_failure():
+    async def _thread_runner(func, rows):
+        return func(rows)
+
+    def _merge(_rows):
+        raise RuntimeError("db unavailable")
+
+    result = await svc.import_location_csv_bytes(
+        b"csv",
+        filename="output.csv",
+        parser=lambda _csv_bytes: [(1, "A", 2, 3, 4, "K98", 10, 20)],
+        merge_rows=_merge,
+        thread_runner=_thread_runner,
+    )
+
+    assert result.ok is False
+    assert result.rows_parsed == 1
+    assert result.message == "❌ Failed to import rows: `RuntimeError: db unavailable`"
+
+
+@pytest.mark.asyncio
+async def test_import_location_csv_bytes_formats_success_and_signals_refresh(monkeypatch):
+    started = datetime.now(UTC) - timedelta(seconds=1.24)
+    signal_calls = []
+
+    async def _thread_runner(func, rows):
+        return func(rows)
+
+    result = await svc.import_location_csv_bytes(
+        b"csv",
+        filename="output.csv",
+        parser=lambda _csv_bytes: [(1, "A", 2, 3, 4, "K98", 10, 20)],
+        merge_rows=lambda _rows: (1, 42),
+        thread_runner=_thread_runner,
+        on_success=lambda: signal_calls.append("called"),
+        started_at_utc=started,
+    )
+
+    assert result.ok is True
+    assert result.rows_parsed == 1
+    assert result.staging_rows == 1
+    assert result.total_tracked == 42
+    assert result.message.startswith("✅ Imported **1** row. Total tracked now **42**. ⏱ ")
+    assert signal_calls == ["called"]
+
+
+@pytest.mark.asyncio
+async def test_import_location_csv_bytes_preserves_success_when_refresh_signal_fails(caplog):
+    async def _thread_runner(func, rows):
+        return func(rows)
+
+    def _signal():
+        raise RuntimeError("signal failed")
+
+    result = await svc.import_location_csv_bytes(
+        b"csv",
+        filename="output.csv",
+        parser=lambda _csv_bytes: [(1, "A", 2, 3, 4, "K98", 10, 20)],
+        merge_rows=lambda _rows: (2, 50),
+        thread_runner=_thread_runner,
+        on_success=_signal,
+    )
+
+    assert result.ok is True
+    assert "Imported **2** rows." in result.message
+
+
+def test_parse_output_csv_skips_bad_rows_and_keeps_valid_rows():
+    csv_bytes = (
+        "player_id,player_name,player_power,player_kills,player_ch,player_alliance,x,y\n"
+        "123,Alice,1000,20,25,K98,10,20\n"
+        "bad,Broken,1000,20,25,K98,10,20\n"
+    ).encode()
+
+    rows = svc.parse_output_csv(csv_bytes)
+
+    assert rows == [(123, "Alice", 1000, 20, 25, "K98", 10, 20)]

--- a/tests/test_location_import_service.py
+++ b/tests/test_location_import_service.py
@@ -9,7 +9,10 @@ def test_validate_location_csv_attachment_rejects_non_csv():
     result = svc.validate_location_csv_attachment(filename="output.txt", size=10)
 
     assert result.ok is False
-    assert result.message == "❌ `output.txt` isn’t a CSV file. Please upload a `.csv` (e.g., `output.csv`)."
+    assert (
+        result.message
+        == "❌ `output.txt` isn’t a CSV file. Please upload a `.csv` (e.g., `output.csv`)."
+    )
 
 
 def test_validate_location_csv_attachment_rejects_oversize_csv():
@@ -118,10 +121,10 @@ async def test_import_location_csv_bytes_preserves_success_when_refresh_signal_f
 
 def test_parse_output_csv_skips_bad_rows_and_keeps_valid_rows():
     csv_bytes = (
-        "player_id,player_name,player_power,player_kills,player_ch,player_alliance,x,y\n"
-        "123,Alice,1000,20,25,K98,10,20\n"
-        "bad,Broken,1000,20,25,K98,10,20\n"
-    ).encode()
+        b"player_id,player_name,player_power,player_kills,player_ch,player_alliance,x,y\n"
+        b"123,Alice,1000,20,25,K98,10,20\n"
+        b"bad,Broken,1000,20,25,K98,10,20\n"
+    )
 
     rows = svc.parse_output_csv(csv_bytes)
 


### PR DESCRIPTION
## Summary
- Extract `/import_locations` CSV validation, parse/merge orchestration, result shaping, and refresh signalling into a Discord-free location import service.
- Keep the command layer focused on permission/defer/attachment IO/response plumbing.
- Retire the completed `/import_locations` deferred item and capture the separate `DL_bot.py` signal shim issue for the broader DL_bot cleanup batch.

## Validation
- `./.venv/Scripts/python.exe -m pytest -q tests/test_location_import_service.py` — 8 passed
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py` — passed
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py` — passed
- `./.venv/Scripts/python.exe scripts/select_tests.py` — reviewed recommendations
- `./.venv/Scripts/python.exe scripts/smoke_imports.py` — passed
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` — passed
- `./.venv/Scripts/python.exe -m pytest -q tests` — 1374 passed, 2 skipped
- `./.venv/Scripts/python.exe -m pre_commit run -a` — passed

## SQL
No SQL changes. Existing `location_importer.py` merge behavior and SQL object contracts are preserved.