### PR TITLE
[codex] Extract player location upload route

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -134,9 +134,12 @@ from Commands import register_commands
 from embed_utils import send_embed
 from honor_importer import ingest_honor_snapshot, parse_honor_xlsx
 from kvk_all_importer import _auto_export_kvk, ingest_kvk_all_excel
-from location_importer import load_staging_and_replace, parse_output_csv
 from log_health import LogHeadroomError, preflight_from_env_sync
 from prekvk_importer import import_prekvk_bytes
+from upload_routes.player_location_route import (
+    PlayerLocationRouteDeps,
+    handle_player_location_upload,
+)
 from utils import live_queue, update_live_queue_embed, utcnow
 from weekly_activity_importer import ingest_weekly_activity_excel
 
@@ -583,101 +586,18 @@ async def on_message(message: discord.Message):
             return
 
     # === Fast-path: Player Location CSV auto-import ===
-    if message.channel.id == PLAYER_LOCATION_CHANNEL_ID and message.attachments:
-        target = next(
-            (a for a in message.attachments if a.filename.lower() == "scan_1198.csv"), None
-        )
-        if target:
-            # Resolve target channel first so it's always defined
-            target_ch = message.channel
-            try:
-                notify_ch = await _get_notify_channel()
-                if notify_ch:
-                    target_ch = notify_ch
-            except Exception:
-                # keep fallback to message.channel
-                pass
-
-            try:
-                csv_bytes = await target.read()
-                rows = parse_output_csv(csv_bytes)
-
-                if not rows:
-                    await send_embed(
-                        target_ch,
-                        "Player Location Import",
-                        {
-                            "Status": "No valid rows found in CSV.",
-                            "Source Channel": f"#{message.channel.name} ({message.channel.id})",
-                            "Uploaded By": f"{message.author} ({message.author.id})",
-                        },
-                        0xE74C3C,
-                    )
-                    return
-
-                # NEW: preflight check before heavy DB work
-                ok = await ensure_sql_headroom_or_notify(target_ch)
-                if not ok:
-                    return
-
-                # Run blocking DB work off the event loop via offload helper
-                staging_rows, total_tracked = await _offload_callable(
-                    load_staging_and_replace,
-                    rows,
-                    name="load_staging_and_replace",
-                    prefer_process=True,
-                )
-
-                await send_embed(
-                    target_ch,
-                    "Player Location Import ✅",
-                    {
-                        "Imported Rows": str(staging_rows),
-                        "Total Tracked": str(total_tracked),
-                        "Source Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploaded By": f"{message.author} ({message.author.id})",
-                    },
-                    0x2ECC71,
-                )
-
-                # schedule a background log-backup trigger (best-effort)
-                try:
-                    asyncio.create_task(trigger_log_backup_background())
-                except Exception:
-                    logger.exception("Failed to schedule background log-backup trigger")
-
-                # 1) Ensure the profile cache reflects the newly merged data
-                try:
-                    from profile_cache import warm_cache as warm_profile_cache
-
-                    warm_profile_cache()
-                except Exception:
-                    pass
-
-                # 2) Signal any waiting tasks that the refresh is complete
-                try:
-                    from commands.location_cmds import (
-                        signal_location_refresh_complete,  # import where the globals live
-                    )
-
-                    signal_location_refresh_complete()
-                except Exception:
-                    pass
-
-            except Exception as e:
-                await send_embed(
-                    target_ch,
-                    "Player Location Import ❌",
-                    {
-                        "Error": f"{type(e).__name__}: {e}",
-                        "Source Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploaded By": f"{message.author} ({message.author.id})",
-                    },
-                    0xE74C3C,
-                    mention=None,
-                )
-            finally:
-                return  # don't enqueue into the heavy pipeline
+    if await handle_player_location_upload(
+        message,
+        PlayerLocationRouteDeps(
+            player_location_channel_id=PLAYER_LOCATION_CHANNEL_ID,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+        ),
+    ):
+        return
 
     # === Fast-path: MGE results auto-import ===
     if message.channel.id == MGE_DATA_CHANNEL_ID and message.attachments:

--- a/commands/location_cmds.py
+++ b/commands/location_cmds.py
@@ -1,7 +1,6 @@
 # commands/location_cmds.py
 from __future__ import annotations
 
-import asyncio
 from datetime import UTC, datetime
 import logging
 
@@ -25,6 +24,14 @@ from services.location_import_service import (
     import_location_csv_bytes,
     validate_location_csv_attachment,
 )
+from services.location_refresh_signal import (
+    is_location_refresh_rate_limited,
+    is_location_refresh_running,
+    mark_location_refresh_started,
+    run_location_refresh_guarded,
+    signal_location_refresh_complete,
+    wait_for_location_refresh,
+)
 from services.profile_lookup_service import resolve_profile_lookup
 from target_utils import autocomplete_governor_names
 from ui.views.location_views import (
@@ -37,19 +44,6 @@ from versioning import versioned
 logger = logging.getLogger(__name__)
 UTC = UTC
 ALLOWED_CHANNEL_IDS = {int(cid) for cid in (NOTIFY_CHANNEL_ID, LEADERSHIP_CHANNEL_ID) if cid}
-
-# --- Location refresh coordination (global, in-process) ---
-_location_refresh_lock = asyncio.Lock()
-_location_refresh_event = asyncio.Event()
-_last_location_refresh_utc: datetime | None = None
-
-
-def signal_location_refresh_complete() -> None:
-    """Called by the CSV import flow when the location cache has been updated."""
-    try:
-        _location_refresh_event.set()
-    except Exception:
-        logger.exception("Failed to signal location refresh completion")
 
 
 async def _send_find_all_to_location_channel(
@@ -71,38 +65,6 @@ async def _send_find_all_to_location_channel(
 def _check_location_refresh_permission(interaction: discord.Interaction) -> bool:
     member = interaction.guild.get_member(interaction.user.id) if interaction.guild else None
     return bool(_is_admin(interaction.user) or _has_leadership_role(member))
-
-
-def _is_location_refresh_running() -> bool:
-    return _location_refresh_lock.locked()
-
-
-def _is_location_refresh_rate_limited() -> tuple[bool, int]:
-    if not _last_location_refresh_utc:
-        return False, 0
-    now = datetime.now(UTC)
-    delta = (now - _last_location_refresh_utc).total_seconds()
-    remain = 3600 - int(delta)
-    return (remain > 0), max(0, remain)
-
-
-def _mark_location_refresh_started() -> None:
-    global _last_location_refresh_utc
-    _last_location_refresh_utc = datetime.now(UTC)
-    _location_refresh_event.clear()
-
-
-async def _wait_for_location_refresh(timeout_seconds: float) -> bool:
-    try:
-        await asyncio.wait_for(_location_refresh_event.wait(), timeout=timeout_seconds)
-        return True
-    except TimeoutError:
-        return False
-
-
-async def _run_location_refresh_guarded(coro):
-    async with _location_refresh_lock:
-        await coro()
 
 
 async def _notify_location_refresh_timeout(
@@ -206,15 +168,15 @@ def register_location(bot: ext_commands.Bot) -> None:
         on_request_refresh=lambda interaction: _send_find_all_to_location_channel(
             bot, interaction=interaction
         ),
-        on_wait_for_refresh=_wait_for_location_refresh,
+        on_wait_for_refresh=wait_for_location_refresh,
         build_refreshed_location_embed=lambda target_id: _build_location_embed_for_target(
             target_id, refreshed=True
         ),
         check_refresh_permission=_check_location_refresh_permission,
-        is_refresh_running=_is_location_refresh_running,
-        is_refresh_rate_limited=_is_location_refresh_rate_limited,
-        mark_refresh_started=_mark_location_refresh_started,
-        run_refresh_guarded=_run_location_refresh_guarded,
+        is_refresh_running=is_location_refresh_running,
+        is_refresh_rate_limited=is_location_refresh_rate_limited,
+        mark_refresh_started=mark_location_refresh_started,
+        run_refresh_guarded=run_location_refresh_guarded,
         on_refresh_timeout=lambda interaction: _notify_location_refresh_timeout(bot, interaction),
     )
 

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,10 +5,17 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed during the profile/location lookup cache-semantics phase after PR 94
-(`mge-admin-governor-lookup-standardisation`) was smoke tested and deployed to production.
-The governor fuzzy/name/partial-ID lookup standardisation item and profile/location
-profile-cache lookup item are complete; the remaining active backlog is listed below.
+Last reviewed during the DL_bot upload-routing Phase 1 work. PR 96
+(`import-locations-command-orchestration-cleanup`) was smoke tested successfully and deployed to
+production. The governor fuzzy/name/partial-ID lookup standardisation item, profile/location
+profile-cache lookup item, `/import_locations` command orchestration item, and DL_bot player
+location auto-import route/signal coupling item are complete or being completed by the Phase 1
+upload-route PR; the remaining active backlog is listed below.
+
+The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
+upload routing and related test-environment blockers, not as a continuation of the
+`/import_locations` command cleanup. Start that task with a new audit/scope pass and review
+both this backlog and the current `K98-bot-mirror` GitHub issues list.
 
 ### Deferred Optimisation
 - Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
@@ -38,15 +45,6 @@ profile-cache lookup item are complete; the remaining active backlog is listed b
 - Dependencies: PreKvK diagnostics result model should remain stable after the import-history rollout.
 
 ### Deferred Optimisation
-- Area: `DL_bot.py` player location CSV auto-import, location refresh signalling
-- Type: architecture
-- Description: The player location auto-import flow in `DL_bot.py` now reaches directly into `commands/location_cmds.py` for `signal_location_refresh_complete`, so the legacy root bot listener depends on command-module internals for refresh-completion signalling. That coupling is fragile for the legacy auto-import path and should be addressed with the broader DL_bot routing cleanup.
-- Suggested Fix: When refactoring DL_bot upload routing, move player-location auto-import orchestration into a dedicated route/service boundary and centralise location refresh signalling behind a shared importable helper that both command handlers and legacy routing paths can call.
-- Impact: medium
-- Risk: medium
-- Dependencies: Coordinate with the existing deferred DL_bot upload-routing improvements; preserve current player location auto-import Discord output and scanner/import behaviour.
-
-### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase objects
 - Type: cleanup
 - Description: `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and KVK-specific phase views still represent the old scan-window delta model even though Python reporting now uses direct stage columns.
@@ -63,3 +61,21 @@ profile-cache lookup item are complete; the remaining active backlog is listed b
 - Impact: medium
 - Risk: medium
 - Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` remaining fast-path upload routes
+- Type: architecture
+- Description: After the first upload-route slices, `DL_bot.py` will still own MGE, honor, weekly activity, rally, inventory, and fallback queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
+- Suggested Fix: Phase 5 should consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering, and add route-level structured logging without changing importer contracts or Discord output.
+- Impact: medium
+- Risk: medium
+- Dependencies: Complete and validate the player-location, PreKvK, validation-blocker, and KVK_ALL phases first so the general router is based on proven route contracts.
+
+### Deferred Optimisation
+- Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
+- Type: architecture
+- Description: Startup and lifecycle responsibilities remain spread across DL_bot and bot_instance, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, and lifecycle coordination for the wider bot.
+- Suggested Fix: Phase 6 should audit DL_bot and bot_instance together, define the target lifecycle ownership model, and separate startup/runtime wiring from upload routing after the fast-path router consolidation is complete.
+- Impact: medium
+- Risk: medium
+- Dependencies: Defer until Phase 5 upload routing is complete so lifecycle changes are reviewed independently from upload-route behaviour.

--- a/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
+++ b/docs/task_packs/Codex Task Pack - Audit and Optimise registry_cmds.md
@@ -1186,207 +1186,74 @@ Validation completed during implementation and review follow-up:
 - `.\.venv\Scripts\python.exe -m pytest -q tests` (`1365 passed, 2 skipped`)
 - `.\.venv\Scripts\python.exe -m pre_commit run -a`
 
-## 43. Next Deferred Work Chat Starter
+## 43. Import Locations Orchestration Cleanup Update
 
-Use this in a fresh Codex chat for the `/import_locations` command-layer orchestration deferred item:
+Status: smoke tested successfully, deployed to production, and complete in PR 96.
 
-```text
-Codex, start the `/import_locations` command-layer orchestration cleanup after PR 95 (`profile-location-lookup-service`) was smoke tested successfully and completed.
+This phase completed the active `/import_locations` command orchestration deferred item:
 
-Use the K98 repo workflow and required docs. Read `docs/reference/deferred_optimisations.md` first, then follow `AGENTS.md`, `README-DEV.md`, and the reference index in `docs/reference/README.md`.
+- Added `services/location_import_service.py` as a Discord-free service for location CSV validation, parsing handoff, staging merge dispatch, result shaping, and success refresh signalling.
+- Thinned `commands/location_cmds.py` so `/import_locations` remains responsible for permission/defer/attachment IO/Discord response plumbing while SQL-facing import behaviour stays in `location_importer.py`.
+- Preserved the admin/notify-channel gate, command name, CSV validation copy, parser and merge behaviour, success/error copy, and `signal_location_refresh_complete()` behaviour after successful command import.
+- Updated `DL_bot.py` player-location auto-import signalling to import `signal_location_refresh_complete` from `commands.location_cmds`, matching the deployed command-module location.
+- Removed the completed `/import_locations` active deferred item from `docs/reference/deferred_optimisations.md`.
+- Reframed the remaining `DL_bot.py` player-location item as command-module coupling to resolve with the broader DL_bot upload-routing batch.
 
-## 1. Task Header
+Validation completed:
 
-- Task name: `import-locations-command-orchestration-cleanup`
-- Date: 2026-05-15
-- Owner/context: deferred optimisation captured during PR 95 profile/location lookup standardisation
-- Task type: refactor | deferred optimisation batch
-- One-pass approved: no
-
-## 2. Required Reading
-
-Before implementation, read:
-
-- `AGENTS.md`
-- `README-DEV.md`
-- `docs/reference/README.md`
-
-Then follow the required reading order and conditional references defined by `docs/reference/README.md`.
-
-For SQL-facing work, validate schema, procedure, view, index, staging/output table, and `ProcConfig` details against:
-
-`C:\K98-bot-SQL-Server`
-
-## 3. Objective
-
-Refactor `/import_locations` so command-layer code is thinner and orchestration/result shaping moves into a service/helper layer. Preserve existing Discord behaviour, admin/notify-channel gate, CSV validation messages, staging merge behaviour, location refresh signalling, and success/error copy.
-
-## 4. Background
-
-PR 95 completed `/player_profile` and `/player_location` profile-cache lookup standardisation. While touching `commands/location_cmds.py`, Codex found that `/import_locations` still mixes CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering inside the command module. The matching deferred item is active in `docs/reference/deferred_optimisations.md`.
-
-## 5. Scope
-
-### In Scope
-
-- Audit `commands/location_cmds.py` `/import_locations`.
-- Review `location_importer.py` and any tests around `parse_output_csv`, `load_staging_and_merge`, and location refresh signalling.
-- Extract import orchestration and result shaping into a small service/helper if the audit confirms a safe PR-sized slice.
-- Keep command code responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
-- Add or update focused tests for extracted logic and command-facing behaviour.
-- Update deferred docs/task-pack notes when complete.
-
-### Out of Scope
-
-- Changing `/player_location` lookup behaviour from PR 95.
-- Redesigning location scanner/import SQL.
-- Changing Discord command names, permissions, channel gates, or user-facing import copy unless required for correctness.
-- Touching `DL_bot.py` upload routing.
-- Broad location refresh lifecycle redesign.
-
-## 6. Source Deferred Items
-
-### Deferred Optimisation
-- Area: `commands/location_cmds.py` `/import_locations`, `location_importer.py`
-- Type: architecture
-- Description: `/import_locations` still owns CSV attachment validation, parsing handoff, staging merge dispatch, and Discord response rendering in the command module. This was observed while standardising `/player_location` lookup and left out of scope to keep the profile/location lookup PR focused.
-- Suggested Fix: Extract import orchestration and result shaping into a location service, leaving `commands/location_cmds.py` responsible for permission gates, safe defer/respond behaviour, attachment IO, and Discord rendering.
-- Impact: medium
-- Risk: medium
-- Dependencies: Preserve admin/notify-channel gate, CSV validation copy, `load_staging_and_merge()` behaviour, location refresh signalling, and current import success/error messages.
-
-## 7. Codex Skills To Use
-
-| Skill | Decision | Notes |
-|---|---|---|
-| `k98-architecture-scope` | use | Required before implementation to map command/service/DAL/cache boundaries. |
-| `k98-discord-command-feature` | use | `/import_locations` is a slash command with permissions, responses, and user-facing copy. |
-| `k98-sql-validation` | use | Location import depends on SQL-facing staging/merge behaviour through `location_importer.py`. |
-| `k98-test-selection` | use | Required to choose focused location/import tests and validation gates. |
-| `k98-deferred-optimisation-capture` | use | Required for closing/updating the deferred item and capturing any newly found debt. |
-| `k98-pr-review` | use | Use before PR handoff. |
-| `k98-promotion-check` | not applicable initially | Use only before production promotion/deployment, not during first audit. |
-
-## 8. Mandatory Workflow
-
-1. Audit / scope review, then stop for approval.
-2. Architecture validation, then stop for approval.
-3. Implementation plan, then stop for approval.
-4. Implementation after approval.
-5. Validation and final review.
-
-Do not proceed in one pass unless explicitly approved.
-
-## 9. Audit Requirements
-
-Review the touched area for:
-
-- direct SQL or SQL-facing work in command paths
-- business logic in the command layer
-- duplicate CSV validation, response shaping, or import result helpers
-- weak validation or logging
-- cache and location refresh safety
-- restart/persistence implications
-- test coverage gaps
-
-Map likely affected commands, services, DAL/import helpers, SQL objects/contracts, location cache behaviour, refresh signalling, docs, and tests.
-
-## 10. Architecture Targets
-
-| Concern | Target |
-|---|---|
-| Slash command | `commands/location_cmds.py` remains thin interaction plumbing |
-| Service / orchestration | `services/` or a focused location helper module |
-| Import/parser logic | `location_importer.py` unless audit finds a better existing location module |
-| Views / modals | no expected change |
-| SQL schema | SQL repo only, if schema changes are unexpectedly required |
-| Tests | `tests/` focused location/import coverage |
-
-## 11. Likely Files
-
-### Review
-
-- `commands/location_cmds.py`
-- `location_importer.py`
-- `tests/`
-- `docs/reference/deferred_optimisations.md`
-- SQL repo objects referenced by `location_importer.py`
-
-### Modify
-
-- `commands/location_cmds.py`
-- a focused service/helper module if justified
-- relevant tests
-- deferred/task-pack documentation
-
-### Create
-
-- Optional: `services/location_import_service.py`
-- Optional: focused tests for the extracted service/helper
-
-## 12. Implementation Requirements
-
-- Preserve `/import_locations` command name and admin/notify-channel restriction.
-- Preserve CSV file validation and existing user-facing success/error copy.
-- Preserve `parse_output_csv()` and `load_staging_and_merge()` behaviour unless the audit identifies a bug.
-- Preserve `signal_location_refresh_complete()` behaviour after successful import.
-- Keep SQL execution/data access outside the command layer.
-- Add tests for extracted result shaping/orchestration.
-- Do not mix in `/player_profile`, `/player_location`, or `DL_bot.py` work.
-
-## 13. Refactor Decisions
-
-Codex must populate this table after audit:
-
-| Issue | Decision | Reason |
-|---|---|---|
-| CSV attachment validation in command | fix now / defer / not applicable | |
-| Parsing handoff in command | fix now / defer / not applicable | |
-| Staging merge dispatch in command | fix now / defer / not applicable | |
-| Discord response/result shaping in command | fix now / defer / not applicable | |
-| Location refresh signalling ownership | fix now / defer / not applicable | |
-| SQL-facing ambiguity in `location_importer.py` | fix now / defer / blocked / not applicable | |
-| Test gaps | fix now / defer / not applicable | |
-
-## 14. Testing Requirements
-
-Run or justify:
-
-- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests\test_location_import_service.py` (`8 passed`)
 - `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
 - `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
 - `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
 - `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
-- focused pytest for location import/parser/service changes
-- `.\.venv\Scripts\python.exe -m pytest -q tests` if shared command/import behaviour changes
+- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1374 passed, 2 skipped`)
 - `.\.venv\Scripts\python.exe -m pre_commit run -a`
 
-Cover happy path, invalid/missing attachment, non-CSV attachment, empty parsed rows, parser failure, merge failure, success summary formatting, permission/channel boundaries where practical, and refresh signalling.
+## 44. Next Major Deferred Work Recommendation
 
-## 15. Acceptance Criteria
+Recommended next task: start a fresh DL_bot upload-routing deferred optimisation batch. This
+should be a new task, not a continuation of the `/import_locations` cleanup, because it has a
+broader legacy-entrypoint scope and should begin with a new audit/scope checkpoint.
 
-- [ ] Scope is complete and no unrelated location/DL_bot work was mixed in.
-- [ ] `/import_locations` command is thinner or a clear defer reason is documented.
-- [ ] No new direct SQL exists in commands or views.
-- [ ] SQL-facing assumptions are validated against `C:\K98-bot-SQL-Server`.
-- [ ] Existing Discord copy and permission boundaries are preserved.
-- [ ] Location refresh signalling remains correct.
-- [ ] Tests are added/updated or exceptions documented.
-- [ ] K98 validation gates are run or skipped with reasons.
-- [ ] Deferred item is updated or removed after completion.
+Current local deferred backlog items to consider together:
 
-## 16. Required Delivery Output
+- `DL_bot.py` PreKvK upload routing
+- `DL_bot.py` player location CSV auto-import and location refresh signalling coupling
+- `DL_bot.py` KVK_ALL upload routing
+- DL_bot-related local validation environment blockers where they affect the route-refactor test plan
 
-Return:
+Before choosing an implementation slice, review the current `K98-bot-mirror` GitHub issues list
+for DL_bot/upload-routing work. At the time of this documentation update, connected issue search
+for `DL_bot` in `cwatts6/K98-bot-mirror` returned no matching open issues, so the next task should
+not assume the GitHub issue set is empty without re-checking.
 
-1. Summary
-2. File Manifest
-3. New Files
-4. Modified Files
-5. SQL Changes
-6. Helpers Reused
-7. Refactor Findings
-8. Test Plan
-9. Deployment Steps
-10. Deferred Optimisations
+Use this in a fresh Codex chat for the next major batch:
+
+```text
+Codex, start a fresh DL_bot upload-routing deferred optimisation audit after PR 96
+(`import-locations-command-orchestration-cleanup`) was smoke tested successfully and
+deployed to production.
+
+Use the K98 repo workflow and required docs. Read `docs/reference/deferred_optimisations.md`
+first, then follow `AGENTS.md`, `README-DEV.md`, and the reference index in
+`docs/reference/README.md`.
+
+This is a new task, not a continuation of the `/import_locations` command cleanup.
+
+Objective:
+- Audit all active DL_bot-related deferred optimisation items and current K98-bot-mirror
+  GitHub issues for upload-routing, legacy listener, import orchestration, and local
+  validation environment blockers.
+- Recommend a safe PR-sized first implementation slice before coding.
+- Keep Step 1 audit/scope only unless explicitly approved otherwise.
+
+Initial backlog to review:
+- `DL_bot.py` PreKvK upload routing
+- `DL_bot.py` player location CSV auto-import and command-module refresh-signal coupling
+- `DL_bot.py` KVK_ALL upload routing
+- DL_bot-related local test-environment blockers where they affect validation of the batch
+
+Do not start implementation until the audit/scope packet, architecture direction, and
+implementation plan have each been approved.
 ```

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -1,0 +1,393 @@
+# Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit
+
+## 1. Task Header
+
+- Task name: `DL_bot upload-routing deferred optimisation audit`
+- Date: `2026-05-15`
+- Owner/context: `Post-PR 96 follow-up: import-locations-command-orchestration-cleanup deployed to production`
+- Task type: `deferred optimisation batch`
+- One-pass approved: `no`
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/deferred_optimisations.md`
+
+Then follow the required reading order and conditional references defined by `docs/reference/README.md`.
+
+For SQL-facing work or validation of SQL-backed imports, validate relevant schema, procedures, views, indexes, UDTs, and `ProcConfig` details against:
+
+`C:\K98-bot-SQL-Server`
+
+Also review current open GitHub issues in `K98-bot-mirror` that mention:
+
+- `DL_bot.py`
+- upload routing
+- legacy listener
+- import orchestration
+- PreKvK
+- KVK_ALL
+- player location import
+- local validation blockers
+
+## 3. Objective
+
+Audit all active DL_bot-related deferred optimisation items and current GitHub issues affecting upload routing, legacy listener behaviour, import orchestration, and local validation blockers.
+
+Produce a safe, PR-sized first implementation slice before coding.
+
+This is a defensive architecture polish task. Do not implement until the audit/scope packet, architecture direction, and implementation plan have each been approved.
+
+## 4. Background
+
+PR 96 (`import-locations-command-orchestration-cleanup`) was smoke tested successfully and deployed to production.
+
+The `/import_locations` command cleanup is complete. This task is fresh work around `DL_bot.py` upload routing and related validation blockers.
+
+Current `DL_bot.py` still contains multiple fast-path upload routes inside the root `on_message` listener, including player location CSV import, PreKvK snapshot ingest, KVK Honour ingest, weekly activity import, rally import, KVK_ALL import, and fallback monitored-channel queueing.
+
+The active deferred backlog identifies these DL_bot-specific architecture items:
+
+- PreKvK upload routing still mixes filename matching, KVK lookup, offload dispatch, and Discord rendering.
+- Player location CSV auto-import still couples `DL_bot.py` to `commands/location_cmds.py` refresh signalling.
+- KVK_ALL upload routing still mixes attachment filtering, import handling, Discord rendering, and export scheduling.
+- Local validation has DB and non-DB environment blockers that affect safe PR validation.
+
+## 5. Scope
+
+### In Scope
+
+- Audit `DL_bot.py` upload-routing responsibilities.
+- Audit active deferred optimisation items related to DL_bot upload routing.
+- Audit current `K98-bot-mirror` GitHub issues related to DL_bot, upload routing, import orchestration, and validation blockers.
+- Identify the safest first PR-sized slice.
+- Recommend target module boundaries for upload routes/services.
+- Classify each finding as:
+  - fix now
+  - defer
+  - not applicable
+- Produce an implementation plan only after audit/scope approval.
+- Preserve current production behaviour, Discord output, importer contracts, offload behaviour, and auto-export behaviour.
+
+### Out of Scope
+
+- No implementation during Step 1.
+- No broad rewrite of `DL_bot.py` in one PR.
+- No changes to production SQL without a separately approved SQL task.
+- No change to import file formats unless required to preserve current behaviour.
+- No changes to unrelated command modules except where required to remove fragile DL_bot coupling.
+- No continuation of `/import_locations` command cleanup.
+- No restart/performance hardening beyond what is necessary for the first DL_bot routing slice.
+
+## 6. Source Deferred Items
+
+```md
+### Deferred Optimisation
+- Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
+- Type: consistency
+- Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.
+- Suggested Fix: Add subsystem-specific DAL/service boundary patches or explicit integration markers, then gate live DB coverage behind RUN_DB_TESTS=1.
+- Impact: high
+- Risk: medium
+- Dependencies: Agreement on which non-Ark tests should remain live DB integration coverage.
+
+### Deferred Optimisation
+- Area: tests/test_dl_bot_mge_auto_import.py, tests/test_integration_end_to_end_fake_worker.py, tests/test_maintenance_suite.py
+- Type: consistency
+- Description: Full-suite validation in the Codex/local PR environment has non-DB environment blockers: DL_bot expects venv/Scripts/python.exe while the documented command uses .venv, and subprocess worker tests fail with WinError 5 in the sandbox.
+- Suggested Fix: Make startup interpreter validation configurable for tests and mark subprocess worker tests with an environment capability gate when process spawning is unavailable.
+- Impact: medium
+- Risk: medium
+- Dependencies: Local validation environment contract for venv naming and subprocess permissions.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` PreKvK upload routing
+- Type: architecture
+- Description: PreKvK upload routing still lives in the legacy root bot listener with filename matching, current-KVK lookup, offload dispatch, and Discord response rendering mixed together.
+- Suggested Fix: Move PreKvK upload routing into a dedicated route/service module and leave `DL_bot.py` responsible only for delegating the Discord event.
+- Impact: medium
+- Risk: medium
+- Dependencies: PreKvK diagnostics result model should remain stable after the import-history rollout.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` player location CSV auto-import, location refresh signalling
+- Type: architecture
+- Description: The player location auto-import flow in `DL_bot.py` now reaches directly into `commands/location_cmds.py` for `signal_location_refresh_complete`, so the legacy root bot listener depends on command-module internals for refresh-completion signalling.
+- Suggested Fix: Move player-location auto-import orchestration into a dedicated route/service boundary and centralise location refresh signalling behind a shared importable helper.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve current player location auto-import Discord output and scanner/import behaviour.
+
+### Deferred Optimisation
+- Area: `DL_bot.py` KVK_ALL upload routing
+- Type: architecture
+- Description: KVK_ALL upload routing still lives in the legacy root bot listener with attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling mixed together.
+- Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve existing Discord output and auto-export behaviour.
+```
+
+7. Codex Skills To Use
+Skill	Decision	Notes
+k98-architecture-scope	use	Mandatory before implementation. This is architecture-sensitive DL_bot routing work.
+k98-discord-command-feature	use	Upload handling affects Discord message/listener flows and user-facing embeds.
+k98-sql-validation	use	PreKvK, player locations, KVK_ALL, and validation blockers depend on SQL-backed import paths.
+k98-test-selection	use	Required before validation, especially because this task includes local test-environment blockers.
+k98-deferred-optimisation-capture	use	This task is explicitly a deferred optimisation audit and may discover further out-of-scope debt.
+k98-pr-review	use	Required before PR handoff because this touches critical bot startup/import routing.
+k98-promotion-check	use	Required before production promotion or bot-machine deployment.
+8. Mandatory Workflow
+Audit / scope review, then stop for approval.
+Architecture validation, then stop for approval.
+Implementation plan, then stop for approval.
+Implementation after approval.
+Validation and final review.
+
+Do not proceed in one pass.
+
+9. Audit Requirements
+
+Review:
+
+DL_bot.py root listener responsibilities.
+Upload-route branching order and fall-through behaviour.
+Importer contracts and result shapes.
+Discord embed/output parity.
+Offload behaviour and process/thread fallback.
+SQL preflight checks.
+Auto-export scheduling.
+Cache warming and refresh signalling.
+Startup interpreter validation.
+Subprocess/worker test blockers.
+GitHub issues related to this area.
+Existing tests that cover DL_bot upload routes.
+
+Map likely:
+
+commands
+services
+route modules
+repositories/DAL modules
+SQL objects/contracts
+caches
+persisted state
+restart implications
+conditional reference docs
+validation gates
+10. Architecture Targets
+Concern	Target
+Root listener	DL_bot.py delegates only
+Upload route detection	dedicated upload routing module
+PreKvK orchestration	dedicated route/service module
+Player location auto-import	dedicated route/service module
+Location refresh signalling	shared helper, not command internals
+KVK_ALL orchestration	later dedicated route/service module unless first slice proves safe
+Shared offload/preflight	reuse existing helpers where safe
+Discord rendering	route-level response helper or existing embed helper
+SQL validation	SQL repo contracts checked before implementation
+Tests	focused route/service tests plus selected regression tests
+11. Likely Files
+Review
+DL_bot.py
+commands/location_cmds.py
+location_importer.py
+prekvk_importer.py
+kvk_all_importer.py
+file_utils.py
+embed_utils.py
+stats_alerts/kvk_meta.py
+stats_alerts/interface.py
+tests/test_dl_bot_mge_auto_import.py
+tests/test_integration_end_to_end_fake_worker.py
+tests/test_maintenance_suite.py
+tests/prekvk_stats.py
+tests/sheets_sync_flow.py
+docs/reference/deferred_optimisations.md
+current relevant GitHub issues
+Modify
+
+To be decided after Step 1 approval.
+
+Likely first-slice candidates:
+
+DL_bot.py
+new or existing upload route/service module
+shared location refresh helper
+focused tests
+Create
+
+To be decided after Step 1 approval.
+
+Likely candidates:
+
+upload_routes/
+upload_routes/prekvk_route.py
+upload_routes/player_location_route.py
+services/location_refresh_signal.py
+focused route tests
+12. Implementation Requirements
+Keep DL_bot.py thin.
+Preserve upload route order and fall-through behaviour.
+Preserve existing Discord output unless intentionally approved.
+Preserve importer input/output contracts.
+Preserve SQL preflight behaviour.
+Preserve auto-export behaviour.
+Preserve cache warm/refresh behaviour.
+Avoid command-module internal coupling.
+Avoid direct SQL in Discord command/view/listener layers.
+Add tests before or alongside route extraction.
+Keep first implementation slice small enough for safe PR review.
+Capture all out-of-scope findings structurally.
+13. Refactor Decisions
+
+Initial classification before audit:
+
+Issue	Decision	Reason
+PreKvK route extraction	likely fix now	Medium-impact, clear boundary, contained route.
+Player location route extraction and refresh signal helper	likely fix now	Removes fragile command-module coupling.
+KVK_ALL route extraction	likely defer to phase 4	Higher blast radius due to multi-attachment import and auto-export scheduling.
+Local DB test blockers	likely partial fix now	Needed only where it blocks validating the selected first slice.
+Subprocess worker blockers	likely defer or capability-gate	Should not widen first routing PR unless validation is blocked.
+SQL legacy PreKvK phase objects	defer	Separate SQL cleanup task.
+
+Final decisions must be updated after Step 1 audit.
+
+## 13A. Approved Phase Direction
+
+The Step 1 audit, architecture direction, and Phase 1 implementation plan were approved after
+review. The approved end-state direction is an incremental `upload_routes` pattern rather than
+one-off route modules.
+
+Phase breakdown:
+
+1. **Phase 1 - Player location auto-import route**
+   - Introduce `upload_routes/`.
+   - Move the `scan_1198.csv` auto-import path out of the inline `DL_bot.py` listener branch.
+   - Move location refresh signalling out of `commands/location_cmds.py` into a shared service.
+   - Preserve current Discord output, SQL preflight, `load_staging_and_replace`, profile-cache
+     warm, background log backup scheduling, and handled/fall-through behaviour.
+2. **Phase 2 - PreKvK upload route**
+   - Extract filename detection, current-KVK lookup, offload dispatch, result rendering, duplicate
+     handling, and stats-embed refresh behind the same route contract.
+3. **Phase 3 - Local validation blockers**
+   - Fix or capability-gate DB/non-DB local validation blockers that affect confidence in the
+     routing work.
+4. **Phase 4 - KVK_ALL upload route**
+   - Extract the higher-risk multi-attachment KVK_ALL route after smaller routes prove the pattern.
+   - Preserve structured importer failures, health output, link button, and auto-export scheduling.
+5. **Phase 5 - Remaining upload fast-path consolidation**
+   - Consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing, shared
+     SQL-preflight/offload handling, shared import embed rendering, and route-level structured
+     logging into the general upload-routing layer.
+6. **Phase 6 - Startup/lifecycle separation**
+   - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
+     `bot_instance.py` review.
+   - Define the target ownership model for bot construction, startup checks, lifecycle wiring,
+     singleton/runtime concerns, and event registration separately from upload-route behaviour.
+
+14. Testing Requirements
+
+Consider and document:
+
+happy path
+negative path
+regression
+permission/channel boundary
+restart/persistence
+cache safety
+format/output shape
+local validation environment capability
+
+Baseline commands:
+
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+
+Focused tests to identify during Step 1:
+
+.\.venv\Scripts\python.exe -m pytest -q tests -k "dl_bot or prekvk or location"
+
+Broader checks where practical:
+
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+
+If live SQL tests are required, gate with:
+
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected-db-tests>
+15. Acceptance Criteria
+ Step 1 audit identifies all active DL_bot-related deferred items and relevant GitHub issues.
+ Affected routes and responsibilities in DL_bot.py are mapped.
+ First PR-sized slice is recommended and justified.
+ Architecture direction is approved before implementation planning.
+ Implementation plan is approved before coding.
+ DL_bot.py is made thinner only within approved scope.
+ Existing production behaviour is preserved.
+ No new direct SQL exists in commands, views, or listener layers.
+ Location refresh signalling no longer depends on command-module internals if included in first slice.
+ Tests are added/updated or exceptions documented.
+ Validation blockers are fixed, gated, or explicitly deferred.
+ Out-of-scope findings are captured structurally.
+16. Required Delivery Output
+
+Use this delivery shape:
+
+Summary
+File Manifest
+New Files
+Modified Files
+SQL Changes
+Helpers Reused
+Refactor Findings
+Test Plan
+Deployment Steps
+Deferred Optimisations
+
+For Step 1 audit only, include:
+
+Audit Summary
+Current Route Map
+Deferred Item Map
+GitHub Issue Map
+Risk / Blast Radius
+Recommended Phase Breakdown
+Recommended First PR Slice
+Approval Questions
+Explicit Stop Point
+17. PR Summary Template
+## Summary
+
+- <summary item>
+
+## Changes
+
+- <change item>
+
+## Tests
+
+- <test command or verification>
+
+## Deferred Optimisations
+
+- None, or structured deferred items.
+
+## Risk / Rollback
+
+- <risk and rollback note>
+18. Required Stop Point
+
+Stop after Step 1 with an audit/scope packet.
+
+Do not write code.
+
+Do not modify files.
+
+Do not create a branch implementation plan until the audit/scope packet is approved.

--- a/services/location_refresh_signal.py
+++ b/services/location_refresh_signal.py
@@ -1,0 +1,62 @@
+"""Shared coordination helpers for player-location refresh workflows."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+_location_refresh_lock = asyncio.Lock()
+_location_refresh_event = asyncio.Event()
+_last_location_refresh_utc: datetime | None = None
+
+
+def signal_location_refresh_complete() -> None:
+    """Signal waiters that the location import/cache refresh has completed."""
+    try:
+        _location_refresh_event.set()
+    except Exception:
+        logger.exception("Failed to signal location refresh completion")
+
+
+def is_location_refresh_running() -> bool:
+    return _location_refresh_lock.locked()
+
+
+def is_location_refresh_rate_limited() -> tuple[bool, int]:
+    if not _last_location_refresh_utc:
+        return False, 0
+    now = datetime.now(UTC)
+    delta = (now - _last_location_refresh_utc).total_seconds()
+    remain = 3600 - int(delta)
+    return (remain > 0), max(0, remain)
+
+
+def mark_location_refresh_started() -> None:
+    global _last_location_refresh_utc
+    _last_location_refresh_utc = datetime.now(UTC)
+    _location_refresh_event.clear()
+
+
+async def wait_for_location_refresh(timeout_seconds: float) -> bool:
+    try:
+        await asyncio.wait_for(_location_refresh_event.wait(), timeout=timeout_seconds)
+        return True
+    except TimeoutError:
+        return False
+
+
+async def run_location_refresh_guarded(coro: Callable[[], Awaitable[object]]) -> bool:
+    """Run one refresh at a time without queueing duplicate refresh requests."""
+    if _location_refresh_lock.locked():
+        return False
+
+    async with _location_refresh_lock:
+        limited, remain = is_location_refresh_rate_limited()
+        if limited and remain > 0:
+            return False
+        await coro()
+        return True

--- a/tests/test_location_refresh_signal.py
+++ b/tests/test_location_refresh_signal.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from services import location_refresh_signal as signal
+
+
+@pytest.fixture(autouse=True)
+def _reset_refresh_state(monkeypatch):
+    monkeypatch.setattr(signal, "_location_refresh_lock", asyncio.Lock())
+    monkeypatch.setattr(signal, "_location_refresh_event", asyncio.Event())
+    monkeypatch.setattr(signal, "_last_location_refresh_utc", None)
+
+
+@pytest.mark.asyncio
+async def test_signal_location_refresh_complete_releases_waiter():
+    waiter = asyncio.create_task(signal.wait_for_location_refresh(1.0))
+    await asyncio.sleep(0)
+
+    signal.signal_location_refresh_complete()
+
+    assert await waiter is True
+
+
+@pytest.mark.asyncio
+async def test_wait_for_location_refresh_times_out():
+    assert await signal.wait_for_location_refresh(0.01) is False
+
+
+def test_location_refresh_rate_limit_reports_remaining(monkeypatch):
+    monkeypatch.setattr(
+        signal,
+        "_last_location_refresh_utc",
+        datetime.now(UTC) - timedelta(minutes=10),
+    )
+
+    limited, remain = signal.is_location_refresh_rate_limited()
+
+    assert limited is True
+    assert 0 < remain <= 3000
+
+
+def test_mark_location_refresh_started_clears_existing_signal():
+    signal.signal_location_refresh_complete()
+
+    signal.mark_location_refresh_started()
+
+    assert signal.is_location_refresh_rate_limited()[0] is True
+    assert not signal._location_refresh_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_location_refresh_guarded_runs_and_reports_running_state():
+    states = []
+
+    async def refresh():
+        states.append(signal.is_location_refresh_running())
+
+    ran = await signal.run_location_refresh_guarded(refresh)
+
+    assert ran is True
+    assert states == [True]
+    assert signal.is_location_refresh_running() is False
+
+
+@pytest.mark.asyncio
+async def test_run_location_refresh_guarded_does_not_queue_concurrent_call():
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def first_refresh():
+        calls.append("first")
+        started.set()
+        await release.wait()
+
+    async def second_refresh():
+        calls.append("second")
+
+    first = asyncio.create_task(signal.run_location_refresh_guarded(first_refresh))
+    await started.wait()
+
+    second_ran = await signal.run_location_refresh_guarded(second_refresh)
+    release.set()
+
+    assert second_ran is False
+    assert await first is True
+    assert calls == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_run_location_refresh_guarded_rechecks_rate_limit_inside_guard(monkeypatch):
+    monkeypatch.setattr(signal, "_last_location_refresh_utc", datetime.now(UTC))
+    calls = []
+
+    async def refresh():
+        calls.append("ran")
+
+    ran = await signal.run_location_refresh_guarded(refresh)
+
+    assert ran is False
+    assert calls == []

--- a/tests/test_location_views_smoke.py
+++ b/tests/test_location_views_smoke.py
@@ -62,6 +62,7 @@ def test_location_views_instantiate_and_build_options():
 
         async def _guard(coro):
             await coro()
+            return True
 
         async def _timeout(_interaction):
             return None
@@ -91,5 +92,57 @@ def test_location_views_instantiate_and_build_options():
 
         v2 = lv.RefreshLocationView(target_id=123456, ephemeral=True)
         assert len(v2.children) == 1
+
+    asyncio.run(_run())
+
+
+def test_refresh_location_view_reports_rejected_guard():
+    lv = importlib.import_module("ui.views.location_views")
+
+    async def _run():
+        followups = []
+
+        async def _on_profile(_interaction, _gid, _ephemeral):
+            return None
+
+        async def _request_refresh(_interaction):
+            raise AssertionError("refresh request should not run when guard rejects")
+
+        async def _wait(_timeout):
+            raise AssertionError("wait should not run when guard rejects")
+
+        async def _guard(_coro):
+            return False
+
+        async def _timeout(_interaction):
+            raise AssertionError("timeout should not run when guard rejects")
+
+        class _RecordingFollow:
+            async def send(self, *args, **kwargs):
+                followups.append((args, kwargs))
+
+        interaction = _DummyInteraction()
+        interaction.followup = _RecordingFollow()
+
+        lv.configure_location_views(
+            on_profile_selected=_on_profile,
+            on_request_refresh=_request_refresh,
+            on_wait_for_refresh=_wait,
+            build_refreshed_location_embed=_embed_for,
+            check_refresh_permission=lambda _i: True,
+            is_refresh_running=lambda: False,
+            is_refresh_rate_limited=lambda: (False, 0),
+            mark_refresh_started=lambda: None,
+            run_refresh_guarded=_guard,
+            on_refresh_timeout=_timeout,
+        )
+
+        view = lv.RefreshLocationView(target_id=123456, ephemeral=True)
+        await view._on_refresh(interaction)
+
+        assert followups
+        args, kwargs = followups[-1]
+        assert "refresh is already running" in args[0]
+        assert kwargs["ephemeral"] is True
 
     asyncio.run(_run())

--- a/tests/test_player_location_upload_route.py
+++ b/tests/test_player_location_upload_route.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import pytest
+
+from upload_routes import player_location_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"csv"):
+        self.filename = filename
+        self._payload = payload
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "location-upload"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int, attachments):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = attachments
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    if attachments is None:
+        attachments = [_FakeAttachment("scan_1198.csv")]
+    return _FakeMessage(channel_id, attachments)
+
+
+def _deps(**overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+
+    async def get_notify_channel():
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+
+    async def ensure_sql_headroom_or_notify(ch):
+        return overrides.get("sql_ok", True)
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_result" in overrides:
+            return overrides["offload_result"]
+        return 3, 10
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    deps = route.PlayerLocationRouteDeps(
+        player_location_channel_id=10,
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        create_task=create_task,
+        warm_profile_cache=overrides.get("warm_profile_cache", lambda: None),
+    )
+    return deps, sent, offloads, created_tasks
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_ignores_other_channels():
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_player_location_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_ignores_other_filenames():
+    deps, sent, offloads, _created = _deps()
+    msg = _message(attachments=[_FakeAttachment("output.csv")])
+
+    handled = await route.handle_player_location_upload(msg, deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_ignores_empty_attachments():
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_player_location_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_empty_rows_sends_existing_warning(monkeypatch):
+    monkeypatch.setattr(route, "parse_output_csv", lambda _bytes: [])
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_player_location_upload(_message(), deps)
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Player Location Import"
+    assert fields["Status"] == "No valid rows found in CSV."
+    assert color == 0xE74C3C
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_sql_preflight_abort_skips_offload(monkeypatch):
+    monkeypatch.setattr(
+        route, "parse_output_csv", lambda _bytes: [(1, "A", 0, 0, 1, "TAG", 10, 20)]
+    )
+    deps, sent, offloads, _created = _deps(sql_ok=False)
+
+    handled = await route.handle_player_location_upload(_message(), deps)
+
+    assert handled is True
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_success_preserves_outputs_and_side_effects(monkeypatch):
+    rows = [(1, "A", 0, 0, 1, "TAG", 10, 20)]
+    warmed = []
+    signalled = []
+    monkeypatch.setattr(route, "parse_output_csv", lambda _bytes: rows)
+    monkeypatch.setattr(route, "signal_location_refresh_complete", lambda: signalled.append(True))
+    deps, sent, offloads, created = _deps(warm_profile_cache=lambda: warmed.append(True))
+
+    handled = await route.handle_player_location_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    assert func is route.load_staging_and_replace
+    assert args == (rows,)
+    assert kwargs["name"] == "load_staging_and_replace"
+    assert kwargs["prefer_process"] is True
+    assert warmed == [True]
+    assert signalled == [True]
+    assert len(created) == 1
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Player Location Import ✅"
+    assert fields["Imported Rows"] == "3"
+    assert fields["Total Tracked"] == "10"
+    assert fields["Uploaded By"] == "uploader (123)"
+    assert color == 0x2ECC71
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_sends_to_resolved_notify_channel(monkeypatch):
+    monkeypatch.setattr(
+        route, "parse_output_csv", lambda _bytes: [(1, "A", 0, 0, 1, "TAG", 10, 20)]
+    )
+    notify_channel = _FakeChannel(20, "notify")
+    deps, sent, _offloads, _created = _deps(notify_channel=notify_channel)
+
+    handled = await route.handle_player_location_upload(_message(), deps)
+
+    assert handled is True
+    ch, _title, _fields, _color, _mention = sent[-1]
+    assert ch is notify_channel
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_falls_back_when_notify_resolution_fails(monkeypatch):
+    monkeypatch.setattr(
+        route, "parse_output_csv", lambda _bytes: [(1, "A", 0, 0, 1, "TAG", 10, 20)]
+    )
+
+    async def get_notify_channel():
+        raise RuntimeError("notify unavailable")
+
+    deps, sent, _offloads, _created = _deps(get_notify_channel=get_notify_channel)
+    msg = _message()
+
+    handled = await route.handle_player_location_upload(msg, deps)
+
+    assert handled is True
+    ch, _title, _fields, _color, _mention = sent[-1]
+    assert ch is msg.channel
+
+
+@pytest.mark.asyncio
+async def test_player_location_route_importer_exception_sends_error(monkeypatch):
+    monkeypatch.setattr(
+        route, "parse_output_csv", lambda _bytes: [(1, "A", 0, 0, 1, "TAG", 10, 20)]
+    )
+
+    async def offload_raises(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    deps, sent, _offloads, _created = _deps()
+    deps = route.PlayerLocationRouteDeps(
+        player_location_channel_id=deps.player_location_channel_id,
+        get_notify_channel=deps.get_notify_channel,
+        send_embed=deps.send_embed,
+        ensure_sql_headroom_or_notify=deps.ensure_sql_headroom_or_notify,
+        offload_callable=offload_raises,
+        trigger_log_backup_background=deps.trigger_log_backup_background,
+        create_task=deps.create_task,
+        warm_profile_cache=deps.warm_profile_cache,
+    )
+
+    handled = await route.handle_player_location_upload(_message(), deps)
+
+    assert handled is True
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Player Location Import ❌"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert color == 0xE74C3C
+    assert mention is None

--- a/ui/views/location_views.py
+++ b/ui/views/location_views.py
@@ -33,6 +33,11 @@ class ProfileLinksView(discord.ui.View):
             )
 
 
+async def _default_run_refresh_guarded(coro: Callable[[], Awaitable[None]]) -> bool:
+    await coro()
+    return True
+
+
 # injected hooks from Commands.py
 _on_profile_selected: Callable[[discord.Interaction, int, bool], Awaitable[None]] = (
     lambda *_a, **_k: None
@@ -48,8 +53,8 @@ _check_refresh_permission: Callable[[discord.Interaction], bool] = lambda *_a, *
 _is_refresh_running: Callable[[], bool] = lambda: False
 _is_refresh_rate_limited: Callable[[], tuple[bool, int]] = lambda: (False, 0)
 _mark_refresh_started: Callable[[], None] = lambda: None
-_run_refresh_guarded: Callable[[Callable[[], Awaitable[None]]], Awaitable[None]] = (
-    lambda coro: coro()
+_run_refresh_guarded: Callable[[Callable[[], Awaitable[None]]], Awaitable[bool]] = (
+    _default_run_refresh_guarded
 )
 _on_refresh_timeout: Callable[[discord.Interaction], Awaitable[None]] = lambda *_a, **_k: None
 
@@ -64,7 +69,7 @@ def configure_location_views(
     is_refresh_running: Callable[[], bool],
     is_refresh_rate_limited: Callable[[], tuple[bool, int]],
     mark_refresh_started: Callable[[], None],
-    run_refresh_guarded: Callable[[Callable[[], Awaitable[None]]], Awaitable[None]],
+    run_refresh_guarded: Callable[[Callable[[], Awaitable[None]]], Awaitable[bool]],
     on_refresh_timeout: Callable[[discord.Interaction], Awaitable[None]],
 ) -> None:
     global _on_profile_selected
@@ -239,7 +244,12 @@ class RefreshLocationView(discord.ui.View):
             except (NotFound, HTTPException):
                 await interaction.followup.send(embed=embed, ephemeral=self.ephemeral)
 
-        await _run_refresh_guarded(_do_refresh)
+        ran = await _run_refresh_guarded(_do_refresh)
+        if not ran:
+            await interaction.followup.send(
+                "⏳ A refresh is already running or was just started. Please try again later.",
+                ephemeral=True,
+            )
 
 
 __all__ = [

--- a/upload_routes/__init__.py
+++ b/upload_routes/__init__.py
@@ -1,0 +1,1 @@
+"""Upload message route handlers for DL_bot."""

--- a/upload_routes/player_location_route.py
+++ b/upload_routes/player_location_route.py
@@ -111,5 +111,4 @@ async def handle_player_location_upload(message: Any, deps: PlayerLocationRouteD
             0xE74C3C,
             mention=None,
         )
-    finally:
-        return True
+    return True

--- a/upload_routes/player_location_route.py
+++ b/upload_routes/player_location_route.py
@@ -1,0 +1,115 @@
+"""Player-location CSV upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from location_importer import load_staging_and_replace, parse_output_csv
+from services.location_refresh_signal import signal_location_refresh_complete
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PlayerLocationRouteDeps:
+    player_location_channel_id: int
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+    warm_profile_cache: Callable[[], None] | None = None
+
+
+async def handle_player_location_upload(message: Any, deps: PlayerLocationRouteDeps) -> bool:
+    """Handle automatic `scan_1198.csv` imports from the location upload channel."""
+    if message.channel.id != deps.player_location_channel_id or not message.attachments:
+        return False
+
+    target = next((a for a in message.attachments if a.filename.lower() == "scan_1198.csv"), None)
+    if not target:
+        return False
+
+    target_ch = message.channel
+    try:
+        notify_ch = await deps.get_notify_channel()
+        if notify_ch:
+            target_ch = notify_ch
+    except Exception:
+        logger.debug("Failed to resolve notify channel for player location upload", exc_info=True)
+
+    try:
+        csv_bytes = await target.read()
+        rows = parse_output_csv(csv_bytes)
+
+        if not rows:
+            await deps.send_embed(
+                target_ch,
+                "Player Location Import",
+                {
+                    "Status": "No valid rows found in CSV.",
+                    "Source Channel": f"#{message.channel.name} ({message.channel.id})",
+                    "Uploaded By": f"{message.author} ({message.author.id})",
+                },
+                0xE74C3C,
+            )
+            return True
+
+        ok = await deps.ensure_sql_headroom_or_notify(target_ch)
+        if not ok:
+            return True
+
+        staging_rows, total_tracked = await deps.offload_callable(
+            load_staging_and_replace,
+            rows,
+            name="load_staging_and_replace",
+            prefer_process=True,
+        )
+
+        await deps.send_embed(
+            target_ch,
+            "Player Location Import ✅",
+            {
+                "Imported Rows": str(staging_rows),
+                "Total Tracked": str(total_tracked),
+                "Source Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploaded By": f"{message.author} ({message.author.id})",
+            },
+            0x2ECC71,
+        )
+
+        try:
+            deps.create_task(deps.trigger_log_backup_background())
+        except Exception:
+            logger.exception("Failed to schedule background log-backup trigger")
+
+        try:
+            if deps.warm_profile_cache is None:
+                from profile_cache import warm_cache as warm_profile_cache
+            else:
+                warm_profile_cache = deps.warm_profile_cache
+            warm_profile_cache()
+        except Exception:
+            logger.debug("Failed to warm profile cache after player location import", exc_info=True)
+
+        signal_location_refresh_complete()
+
+    except Exception as e:
+        await deps.send_embed(
+            target_ch,
+            "Player Location Import ❌",
+            {
+                "Error": f"{type(e).__name__}: {e}",
+                "Source Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploaded By": f"{message.author} ({message.author.id})",
+            },
+            0xE74C3C,
+            mention=None,
+        )
+    finally:
+        return True


### PR DESCRIPTION
## Summary

- Introduces the `upload_routes` package and moves the `scan_1198.csv` player-location auto-import path out of the inline `DL_bot.py` listener branch.
- Moves location refresh coordination into `services/location_refresh_signal.py` so `DL_bot.py` no longer imports command-module internals to signal refresh completion.
- Updates the DL_bot upload-routing task pack and deferred backlog, including the approved Phase 5 upload-route consolidation scope and Phase 6 DL_bot/bot_instance lifecycle audit split.

## Changes

- `DL_bot.py` now delegates the player-location fast path via `handle_player_location_upload(...)` and keeps the surrounding listener order unchanged.
- `upload_routes/player_location_route.py` preserves exact `scan_1198.csv` matching, notify-channel fallback, SQL preflight behavior, offload to `load_staging_and_replace`, success/error/no-row embeds, profile-cache warm, log-backup scheduling, and handled/fall-through behavior.
- `commands/location_cmds.py` now uses shared refresh coordination helpers from `services/location_refresh_signal.py`.
- Added focused route tests covering non-matches, empty rows, preflight abort, success side effects, and importer exceptions.

## Tests

- `./.venv/Scripts/python.exe -m py_compile DL_bot.py commands/location_cmds.py services/location_refresh_signal.py upload_routes/player_location_route.py tests/test_player_location_upload_route.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_player_location_upload_route.py tests/test_location_import_service.py tests/test_location_views_smoke.py tests/test_dl_bot_mge_auto_import.py` (`18 passed`)
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe -m pytest -q tests` (`1380 passed, 2 skipped`)

## SQL Changes

None. Existing player-location SQL contracts and `load_staging_and_replace` behavior are preserved.

## Deferred Optimisations

- Phase 2: PreKvK upload route extraction.
- Phase 3: Local validation blocker cleanup/capability gates.
- Phase 4: KVK_ALL upload route extraction.
- Phase 5: Remaining upload fast-path consolidation for MGE, honor, weekly activity, rally, inventory, fallback queueing, shared preflight/offload handling, shared import embed rendering, and route-level structured logging.
- Phase 6: DL_bot startup/lifecycle separation alongside full `bot_instance.py` audit.

## Risk / Rollback

Risk is limited to the player-location upload listener path and shared in-process location refresh signalling. Rollback is PR revert; no SQL or deployment sequencing change is required.