### PR TITLE
[codex] Extract PreKvK upload route

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -135,11 +135,11 @@ from embed_utils import send_embed
 from honor_importer import ingest_honor_snapshot, parse_honor_xlsx
 from kvk_all_importer import _auto_export_kvk, ingest_kvk_all_excel
 from log_health import LogHeadroomError, preflight_from_env_sync
-from prekvk_importer import import_prekvk_bytes
 from upload_routes.player_location_route import (
     PlayerLocationRouteDeps,
     handle_player_location_upload,
 )
+from upload_routes.prekvk_route import PreKvkRouteDeps, handle_prekvk_upload
 from utils import live_queue, update_live_queue_embed, utcnow
 from weekly_activity_importer import ingest_weekly_activity_excel
 
@@ -679,176 +679,19 @@ async def on_message(message: discord.Message):
             return
 
     # === Fast-path: Pre-KVK snapshot ingest (dynamic KVK lookup) ===
-    if message.channel.id == PREKVK_CHANNEL_ID and message.attachments:
-        notify_ch = await _get_notify_channel() or message.channel
-
-        prekvk_name_rx = re.compile(
-            r"^(?:1198_prekvk|PreKvK_Rankings_[^\\/:*?\"<>|]+)\.xlsx$",
-            re.IGNORECASE,
-        )
-        target = next(
-            (a for a in message.attachments if prekvk_name_rx.match(a.filename.strip())),
-            None,
-        )
-
-        if not target:
-            await send_embed(
-                notify_ch,
-                "Pre-KVK Import ⚠️",
-                {
-                    "Info": "No matching file found.",
-                    "Expected": "1198_prekvk.xlsx or PreKvK_Rankings_*.xlsx",
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE67E22,
-            )
-            return
-
-        try:
-            file_bytes = await target.read()
-
-            # NEW: preflight check
-            ok = await ensure_sql_headroom_or_notify(notify_ch)
-            if not ok:
-                return
-
-            # Resolve current KVK number dynamically (offload when available)
-            try:
-                from file_utils import run_blocking_in_thread
-            except Exception:
-                run_blocking_in_thread = None
-
-            meta = None
-            try:
-                import stats_alerts.kvk_meta as kvk_meta
-
-                if run_blocking_in_thread is not None:
-                    meta = await run_blocking_in_thread(
-                        kvk_meta.get_latest_kvk_metadata_sql,
-                        name="get_latest_kvk_metadata_sql_dlbot",
-                    )
-                else:
-                    # fallback to asyncio.to_thread
-                    meta = await asyncio.to_thread(kvk_meta.get_latest_kvk_metadata_sql)
-            except Exception:
-                logger.exception("[DL_BOT] Failed to determine current KVK metadata")
-
-            # Hard-fail if we cannot determine a valid kvk_no
-            detected_kvk_no = None
-            try:
-                if meta and meta.get("kvk_no") is not None:
-                    detected_kvk_no = int(meta.get("kvk_no"))
-            except Exception:
-                detected_kvk_no = None
-
-            if detected_kvk_no is None:
-                logger.error(
-                    "[DL_BOT] Could not determine current KVK number; aborting Pre-KVK import"
-                )
-                await send_embed(
-                    notify_ch,
-                    "Pre-KVK Import ❌",
-                    {
-                        "Error": "Could not determine current KVK number (kvk_no). Import aborted.",
-                        "Filename": target.filename,
-                        "Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploader": f"{message.author} ({message.author.id})",
-                    },
-                    0xE74C3C,
-                )
-                return
-
-            # Run importer offload (prefer process) with detected kvk_no
-            ok, note, rows = await _offload_callable(
-                import_prekvk_bytes,
-                file_bytes,
-                target.filename,
-                kvk_no=detected_kvk_no,
-                uploader_discord_id=(
-                    int(message.author.id)
-                    if getattr(message.author, "id", None) is not None
-                    else None
-                ),
-                channel_id=(
-                    int(message.channel.id)
-                    if getattr(message.channel, "id", None) is not None
-                    else None
-                ),
-                message_id=int(message.id) if getattr(message, "id", None) is not None else None,
-                name="import_prekvk_bytes",
-                prefer_process=True,
-                meta={"filename": target.filename, "kvk_no": detected_kvk_no},
-            )
-
-            if ok:
-                duplicate_skip = "duplicate file skipped" in (note or "").lower()
-                await send_embed(
-                    notify_ch,
-                    (
-                        "Pre-KVK Snapshot Skipped"
-                        if duplicate_skip
-                        else "Pre-KVK Snapshot Imported ✅"
-                    ),
-                    {
-                        "KVK": str(detected_kvk_no),
-                        "Rows": str(rows),
-                        "Filename": target.filename,
-                        "Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploader": f"{message.author} ({message.author.id})",
-                        "Note": note,
-                    },
-                    0xF1C40F if duplicate_skip else 0x2ECC71,
-                )
-
-                # schedule a background log-backup trigger (best-effort)
-                try:
-                    asyncio.create_task(trigger_log_backup_background())
-                except Exception:
-                    logger.exception("Failed to schedule background log-backup trigger")
-
-                # Optional: refresh your daily/pinned stats embed which includes the Pre-KVK panel.
-                # Guarded so it never crashes this path if debug is enabled
-                try:
-                    from stats_alerts.interface import send_stats_update_embed
-
-                    ts = utcnow().strftime("%Y-%m-%d %H:%M UTC")
-
-                    # ✅ IMPORTANT: is_kvk=True to trigger Pre-KVK path (before Pass 4)
-                    await send_stats_update_embed(bot, ts, True, is_test=False)
-                except Exception:
-                    # Silent: embed refresh is a bonus; import success is what matters
-                    pass
-            else:
-                await send_embed(
-                    notify_ch,
-                    (
-                        "Pre-KVK Import (Skipped/Duplicate) ℹ️"
-                        if "Duplicate" in (note or "")
-                        else "Pre-KVK Import ❌"
-                    ),
-                    {
-                        "Filename": target.filename,
-                        "Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploader": f"{message.author} ({message.author.id})",
-                        "Info" if "Duplicate" in (note or "") else "Error": note or "Unknown",
-                    },
-                    0xF1C40F if "Duplicate" in (note or "") else 0xE74C3C,
-                )
-        except Exception as e:
-            await send_embed(
-                notify_ch,
-                "Pre-KVK Import ❌",
-                {
-                    "Error": f"{type(e).__name__}: {e}",
-                    "Filename": target.filename,
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE74C3C,
-            )
-        finally:
-            return  # do not fall through to other pipelines
+    if await handle_prekvk_upload(
+        message,
+        PreKvkRouteDeps(
+            prekvk_channel_id=PREKVK_CHANNEL_ID,
+            bot=bot,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+        ),
+    ):
+        return
 
     # === Fast-path: KVK Honour ingest (full snapshots, multiple/day) ===
     if message.channel.id == HONOR_CHANNEL_ID and message.attachments:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,12 +5,13 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed during the DL_bot upload-routing Phase 1 work. PR 96
+Last reviewed during the DL_bot upload-routing Phase 2A work. PR 96
 (`import-locations-command-orchestration-cleanup`) was smoke tested successfully and deployed to
-production. The governor fuzzy/name/partial-ID lookup standardisation item, profile/location
-profile-cache lookup item, `/import_locations` command orchestration item, and DL_bot player
-location auto-import route/signal coupling item are complete or being completed by the Phase 1
-upload-route PR; the remaining active backlog is listed below.
+production. PR 97 (`dlbot-player-location-upload-route`) was smoke tested successfully and
+promoted to production. The governor fuzzy/name/partial-ID lookup standardisation item,
+profile/location profile-cache lookup item, `/import_locations` command orchestration item, DL_bot
+player location auto-import route/signal coupling item, and DL_bot PreKvK upload route extraction
+item are complete; the remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing and related test-environment blockers, not as a continuation of the
@@ -36,22 +37,22 @@ both this backlog and the current `K98-bot-mirror` GitHub issues list.
 - Dependencies: Local validation environment contract for venv naming and subprocess permissions.
 
 ### Deferred Optimisation
-- Area: `DL_bot.py` PreKvK upload routing
-- Type: architecture
-- Description: PreKvK upload routing still lives in the legacy root bot listener with filename matching, current-KVK lookup, offload dispatch, and Discord response rendering mixed together.
-- Suggested Fix: Move PreKvK upload routing into a dedicated route/service module and leave `DL_bot.py` responsible only for delegating the Discord event.
-- Impact: medium
-- Risk: medium
-- Dependencies: PreKvK diagnostics result model should remain stable after the import-history rollout.
-
-### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase objects
 - Type: cleanup
 - Description: `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and KVK-specific phase views still represent the old scan-window delta model even though Python reporting now uses direct stage columns.
-- Suggested Fix: Audit production SQL/report dependencies, then replace with direct-stage equivalents or retire the legacy objects in a separate SQL cleanup task.
+- Suggested Fix: Phase 2B should audit production SQL/report/manual workflow dependencies, then replace with direct-stage equivalents or retire the legacy objects only after an approved SQL cleanup design.
 - Impact: medium
 - Risk: medium
 - Dependencies: Confirm no production reports or manual SQL workflows still depend on scan-window phase objects.
+
+### Deferred Optimisation
+- Area: PreKvK report/embed
+- Type: feature
+- Description: PreKvK stage-level import data is now available, but there is no dedicated PreKvK report command or embed outside the existing stats-alert panel.
+- Suggested Fix: Phase 2C should design and implement a dedicated PreKvK report/embed after the upload route boundary is stable, defining command/channel surface, permissions, limits, empty-data behaviour, and mobile-safe Discord output.
+- Impact: medium
+- Risk: low
+- Dependencies: Complete Phase 2A route extraction first; reuse direct-stage PreKvK data path where practical.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py` KVK_ALL upload routing

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -253,7 +253,8 @@ Player location route extraction and refresh signal helper	likely fix now	Remove
 KVK_ALL route extraction	likely defer to phase 4	Higher blast radius due to multi-attachment import and auto-export scheduling.
 Local DB test blockers	likely partial fix now	Needed only where it blocks validating the selected first slice.
 Subprocess worker blockers	likely defer or capability-gate	Should not widen first routing PR unless validation is blocked.
-SQL legacy PreKvK phase objects	defer	Separate SQL cleanup task.
+SQL legacy PreKvK phase objects	defer to Phase 2B	Separate SQL cleanup audit/design task; do not mix destructive SQL cleanup into the route-extraction PR.
+New PreKvK report/embed	defer to Phase 2C	Separate user-facing reporting task after the route boundary is stable.
 
 Final decisions must be updated after Step 1 audit.
 
@@ -271,24 +272,47 @@ Phase breakdown:
    - Move location refresh signalling out of `commands/location_cmds.py` into a shared service.
    - Preserve current Discord output, SQL preflight, `load_staging_and_replace`, profile-cache
      warm, background log backup scheduling, and handled/fall-through behaviour.
-2. **Phase 2 - PreKvK upload route**
+2. **Phase 2A - PreKvK upload route extraction**
    - Extract filename detection, current-KVK lookup, offload dispatch, result rendering, duplicate
      handling, and stats-embed refresh behind the same route contract.
-3. **Phase 3 - Local validation blockers**
+   - Preserve the existing Discord output and importer metadata contract except for the approved
+     duplicate-skip side-effect change: duplicate skips should send the skipped embed but should
+     not schedule a background log backup or refresh the stats embed.
+   - Keep SQL schema cleanup and new PreKvK report/embed work out of this PR.
+3. **Phase 2B - PreKvK SQL cleanup audit and design**
+   - Audit dependencies on legacy SQL phase objects before proposing any SQL cleanup:
+     `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and KVK-specific PreKvK phase views.
+   - Validate production SQL/report/manual workflow dependencies in `C:\K98-bot-SQL-Server`.
+   - Stop for approval before any SQL object replacement, retirement, or destructive cleanup.
+4. **Phase 2C - New PreKvK report/embed**
+   - Design and implement a dedicated PreKvK report/embed after the route extraction is stable.
+   - Reuse the direct-stage PreKvK data path where possible and avoid changing upload routing
+     behaviour in the reporting PR.
+   - Define command/channel surface, permissions, limits, empty-data behaviour, and mobile-safe
+     Discord output before implementation.
+5. **Phase 3 - Local validation blockers**
    - Fix or capability-gate DB/non-DB local validation blockers that affect confidence in the
      routing work.
-4. **Phase 4 - KVK_ALL upload route**
+6. **Phase 4 - KVK_ALL upload route**
    - Extract the higher-risk multi-attachment KVK_ALL route after smaller routes prove the pattern.
    - Preserve structured importer failures, health output, link button, and auto-export scheduling.
-5. **Phase 5 - Remaining upload fast-path consolidation**
+7. **Phase 5 - Remaining upload fast-path consolidation**
    - Consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing, shared
      SQL-preflight/offload handling, shared import embed rendering, and route-level structured
      logging into the general upload-routing layer.
-6. **Phase 6 - Startup/lifecycle separation**
+8. **Phase 6 - Startup/lifecycle separation**
    - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
      `bot_instance.py` review.
    - Define the target ownership model for bot construction, startup checks, lifecycle wiring,
      singleton/runtime concerns, and event registration separately from upload-route behaviour.
+
+Phase 2A delivery notes:
+
+- PreKvK upload routing is extracted into the `upload_routes` pattern with `DL_bot.py` retaining
+  listener/delegation responsibility.
+- Duplicate skips intentionally preserve the skipped embed but do not schedule background log
+  backup or stats-embed refresh.
+- Phase 2B SQL cleanup and Phase 2C report/embed work remain separate approval-gated follow-ons.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
@@ -1,0 +1,89 @@
+# DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement
+
+We are starting Phase 2 of the DL_bot upload-routing optimisation programme after PR 97
+(`dlbot-player-location-upload-route`) was smoke tested successfully and promoted to production.
+
+This phase is split into three approval-gated slices:
+
+## Phase 2A - PreKvK Upload Route Extraction
+
+Goal: extract the PreKvK upload route from `DL_bot.py` into the existing `upload_routes` pattern
+introduced in Phase 1.
+
+Status: implemented as the Phase 2A route-extraction slice. Phase 2B and Phase 2C remain separate
+approval-gated follow-ons.
+
+In scope:
+
+- `DL_bot.py` PreKvK route delegation.
+- Dedicated `upload_routes/prekvk_route.py` or equivalent route module.
+- Focused route-level tests for matching, non-matching, KVK lookup failure, duplicate skip,
+  import success, import failure, and stats-refresh best-effort behaviour.
+- Documentation updates that mark Phase 2A delivered or re-defer any remaining findings after
+  implementation.
+
+Preserve:
+
+- Channel and attachment gating.
+- Accepted filenames: `1198_prekvk.xlsx` and `PreKvK_Rankings_*.xlsx`.
+- No-matching-file warning embed.
+- SQL headroom preflight.
+- Current KVK metadata lookup.
+- `import_prekvk_bytes` offload contract.
+- Uploader/channel/message metadata passed to the importer.
+- Duplicate skip handling and embed title/colour.
+- Success and failure embed fields.
+- Background log-backup scheduling for successful imports.
+- Stats embed refresh after successful imports.
+- No fall-through after the PreKvK route handles a message.
+
+Approved behaviour change:
+
+- Duplicate skips should send the skipped embed but should not schedule a background log backup or
+  refresh the stats embed.
+
+Out of scope for Phase 2A:
+
+- Legacy PreKvK SQL phase-object cleanup.
+- New PreKvK report command or embed.
+- KVK_ALL route extraction.
+- Broad upload-router consolidation for MGE, honor, weekly, rally, inventory, or fallback queueing.
+- `DL_bot.py` startup/lifecycle or `bot_instance.py` audit.
+
+## Phase 2B - PreKvK SQL Cleanup Audit And Design
+
+Goal: audit whether legacy PreKvK SQL phase objects can be replaced or retired safely.
+
+Minimum objects to review in `C:\K98-bot-SQL-Server`:
+
+- `dbo.PreKvk_Phases`
+- `dbo.fn_PreKvkPhaseDelta`
+- KVK-specific PreKvK phase views, including `v_PreKvk*_Phase*`
+- Any production reports, manual workflows, views, stored procedures, or functions that still
+  depend on the scan-window delta model
+
+This phase must stop for approval before any SQL object replacement, retirement, destructive
+cleanup, or production SQL migration.
+
+## Phase 2C - New PreKvK Report/Embed
+
+Goal: design and implement a dedicated PreKvK report/embed after the route boundary is stable.
+
+Design decisions required before implementation:
+
+- Command, scheduled embed, admin-only, or channel-triggered surface.
+- Permission model and target channel.
+- Report limits and tie handling.
+- Empty-data and legacy total-only-row behaviour.
+- Whether to reuse `stats_alerts.prekvk_stats.load_prekvk_top3` directly or introduce a service
+  boundary for report orchestration.
+- Mobile-safe Discord output shape.
+
+Phase 2C should not change upload routing behaviour unless separately approved.
+
+## Required Stop Points
+
+1. Phase 2A audit/scope, architecture direction, and implementation plan must each be approved
+   before route extraction code changes.
+2. Phase 2B must produce a SQL dependency audit/design packet and stop before SQL changes.
+3. Phase 2C must produce a report/embed design packet and stop before implementation.

--- a/tests/test_prekvk_upload_route.py
+++ b/tests/test_prekvk_upload_route.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from upload_routes import prekvk_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"xlsx"):
+        self.filename = filename
+        self._payload = payload
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "pre-kvk"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeBot:
+    pass
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments if attachments is not None else [_FakeAttachment("1198_prekvk.xlsx")]
+        )
+        self.id = 987654321
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _deps(**overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+    stats_refreshes = []
+
+    async def get_notify_channel():
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+
+    async def ensure_sql_headroom_or_notify(ch):
+        return overrides.get("sql_ok", True)
+
+    async def run_blocking_in_thread(func, *args, **kwargs):
+        return func(*args)
+
+    def current_kvk_metadata():
+        if "metadata" in overrides:
+            return overrides["metadata"]
+        return {"kvk_no": 15}
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_exception" in overrides:
+            raise overrides["offload_exception"]
+        return overrides.get("offload_result", (True, "Imported 3 rows as scan 9.", 3))
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    async def send_stats_update_embed(*args, **kwargs):
+        stats_refreshes.append((args, kwargs))
+        if "stats_exception" in overrides:
+            raise overrides["stats_exception"]
+
+    deps = route.PreKvkRouteDeps(
+        prekvk_channel_id=10,
+        bot=overrides.get("bot", _FakeBot()),
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        create_task=create_task,
+        current_kvk_metadata=overrides.get("current_kvk_metadata", current_kvk_metadata),
+        run_blocking_in_thread=overrides.get("run_blocking_in_thread", run_blocking_in_thread),
+        send_stats_update_embed=overrides.get("send_stats_update_embed", send_stats_update_embed),
+        now_utc=lambda: datetime(2026, 5, 16, 12, 30, tzinfo=UTC),
+    )
+    return deps, sent, offloads, created_tasks, stats_refreshes
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_ignores_other_channels():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_prekvk_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_ignores_empty_attachments():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_prekvk_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_no_matching_file_warns_and_handles():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_prekvk_upload(
+        _message(attachments=[_FakeAttachment("unrelated.xlsx")]), deps
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Pre-KVK Import ⚠️"
+    assert fields["Info"] == "No matching file found."
+    assert fields["Expected"] == "1198_prekvk.xlsx or PreKvK_Rankings_*.xlsx"
+    assert color == 0xE67E22
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_sql_preflight_abort_skips_import():
+    deps, sent, offloads, _created, _stats = _deps(sql_ok=False)
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_kvk_lookup_failure_sends_existing_error():
+    deps, sent, offloads, _created, _stats = _deps(metadata=None)
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Import ❌"
+    assert fields["Error"] == "Could not determine current KVK number (kvk_no). Import aborted."
+    assert fields["Filename"] == "1198_prekvk.xlsx"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_success_preserves_import_contract_and_side_effects():
+    deps, sent, offloads, created, stats = _deps()
+    msg = _message(
+        attachments=[_FakeAttachment("PreKvK_Rankings_C13164_2026-05-08.xlsx", b"xlsx-bytes")]
+    )
+
+    handled = await route.handle_prekvk_upload(msg, deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    assert func is route.import_prekvk_bytes
+    assert args == (b"xlsx-bytes", "PreKvK_Rankings_C13164_2026-05-08.xlsx")
+    assert kwargs["kvk_no"] == 15
+    assert kwargs["uploader_discord_id"] == 123456789
+    assert kwargs["channel_id"] == 10
+    assert kwargs["message_id"] == 987654321
+    assert kwargs["name"] == "import_prekvk_bytes"
+    assert kwargs["prefer_process"] is True
+    assert kwargs["meta"] == {
+        "filename": "PreKvK_Rankings_C13164_2026-05-08.xlsx",
+        "kvk_no": 15,
+    }
+    assert len(created) == 1
+    assert len(stats) == 1
+    stats_args, stats_kwargs = stats[0]
+    assert stats_args[1] == "2026-05-16 12:30 UTC"
+    assert stats_args[2] is True
+    assert stats_kwargs == {"is_test": False}
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Snapshot Imported ✅"
+    assert fields["KVK"] == "15"
+    assert fields["Rows"] == "3"
+    assert fields["Note"] == "Imported 3 rows as scan 9."
+    assert color == 0x2ECC71
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_duplicate_skip_preserves_embed_without_refresh_side_effects():
+    deps, sent, offloads, created, stats = _deps(
+        offload_result=(True, "Duplicate file skipped (hash match).", 0)
+    )
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    assert created == []
+    assert stats == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Snapshot Skipped"
+    assert fields["Rows"] == "0"
+    assert fields["Note"] == "Duplicate file skipped (hash match)."
+    assert color == 0xF1C40F
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_importer_failure_sends_existing_error():
+    deps, sent, _offloads, created, stats = _deps(offload_result=(False, "bad workbook", 0))
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    assert stats == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Import ❌"
+    assert fields["Error"] == "bad workbook"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_importer_exception_sends_existing_error():
+    deps, sent, _offloads, created, stats = _deps(offload_exception=RuntimeError("boom"))
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    assert stats == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Import ❌"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_prekvk_route_stats_refresh_failure_is_best_effort():
+    deps, sent, _offloads, created, stats = _deps(stats_exception=RuntimeError("stats down"))
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert len(created) == 1
+    assert len(stats) == 1
+    _ch, title, _fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Snapshot Imported ✅"
+    assert color == 0x2ECC71

--- a/tests/test_prekvk_upload_route.py
+++ b/tests/test_prekvk_upload_route.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import logging
 
 import pytest
 
@@ -245,6 +246,24 @@ async def test_prekvk_route_importer_failure_sends_existing_error():
 
 
 @pytest.mark.asyncio
+async def test_prekvk_route_duplicate_governor_rejection_is_error():
+    deps, sent, _offloads, created, stats = _deps(
+        offload_result=(False, "Duplicate GovernorID(s) detected in file: 123.", 0)
+    )
+
+    handled = await route.handle_prekvk_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    assert stats == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Pre-KVK Import ❌"
+    assert fields["Error"] == "Duplicate GovernorID(s) detected in file: 123."
+    assert "Info" not in fields
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
 async def test_prekvk_route_importer_exception_sends_existing_error():
     deps, sent, _offloads, created, stats = _deps(offload_exception=RuntimeError("boom"))
 
@@ -260,8 +279,10 @@ async def test_prekvk_route_importer_exception_sends_existing_error():
 
 
 @pytest.mark.asyncio
-async def test_prekvk_route_stats_refresh_failure_is_best_effort():
+async def test_prekvk_route_stats_refresh_failure_is_best_effort(caplog):
     deps, sent, _offloads, created, stats = _deps(stats_exception=RuntimeError("stats down"))
+
+    caplog.set_level(logging.DEBUG, logger=route.__name__)
 
     handled = await route.handle_prekvk_upload(_message(), deps)
 
@@ -271,3 +292,4 @@ async def test_prekvk_route_stats_refresh_failure_is_best_effort():
     _ch, title, _fields, color, _mention = sent[-1]
     assert title == "Pre-KVK Snapshot Imported ✅"
     assert color == 0x2ECC71
+    assert "Failed to refresh stats embed after Pre-KVK import" in caplog.text

--- a/upload_routes/prekvk_route.py
+++ b/upload_routes/prekvk_route.py
@@ -174,22 +174,20 @@ async def handle_prekvk_upload(message: Any, deps: PreKvkRouteDeps) -> bool:
                 try:
                     await _refresh_stats_embed(deps)
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Failed to refresh stats embed after Pre-KVK import", exc_info=True
+                    )
         else:
             await deps.send_embed(
                 notify_ch,
-                (
-                    "Pre-KVK Import (Skipped/Duplicate) ℹ️"
-                    if "Duplicate" in (note or "")
-                    else "Pre-KVK Import ❌"
-                ),
+                "Pre-KVK Import ❌",
                 {
                     "Filename": target.filename,
                     "Channel": f"#{message.channel.name} ({message.channel.id})",
                     "Uploader": f"{message.author} ({message.author.id})",
-                    "Info" if "Duplicate" in (note or "") else "Error": note or "Unknown",
+                    "Error": note or "Unknown",
                 },
-                0xF1C40F if "Duplicate" in (note or "") else 0xE74C3C,
+                0xE74C3C,
             )
     except Exception as e:
         await deps.send_embed(

--- a/upload_routes/prekvk_route.py
+++ b/upload_routes/prekvk_route.py
@@ -1,0 +1,206 @@
+"""PreKvK workbook upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+import re
+from typing import Any
+
+from prekvk_importer import import_prekvk_bytes
+from utils import utcnow
+
+logger = logging.getLogger(__name__)
+
+PREKVK_NAME_RX = re.compile(
+    r"^(?:1198_prekvk|PreKvK_Rankings_[^\\/:*?\"<>|]+)\.xlsx$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class PreKvkRouteDeps:
+    prekvk_channel_id: int
+    bot: Any
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+    current_kvk_metadata: Callable[[], Any] | None = None
+    run_blocking_in_thread: Callable[..., Awaitable[Any]] | None = None
+    send_stats_update_embed: Callable[..., Awaitable[Any]] | None = None
+    now_utc: Callable[[], Any] = utcnow
+
+
+async def _load_current_kvk_metadata(deps: PreKvkRouteDeps) -> dict[str, Any] | None:
+    metadata_func = deps.current_kvk_metadata
+    if metadata_func is None:
+        import stats_alerts.kvk_meta as kvk_meta
+
+        metadata_func = kvk_meta.get_latest_kvk_metadata_sql
+
+    run_blocking_in_thread = deps.run_blocking_in_thread
+    if run_blocking_in_thread is None:
+        try:
+            from file_utils import run_blocking_in_thread as imported_runner
+
+            run_blocking_in_thread = imported_runner
+        except Exception:
+            run_blocking_in_thread = None
+
+    if run_blocking_in_thread is not None:
+        return await run_blocking_in_thread(
+            metadata_func,
+            name="get_latest_kvk_metadata_sql_dlbot",
+        )
+    return await asyncio.to_thread(metadata_func)
+
+
+async def _refresh_stats_embed(deps: PreKvkRouteDeps) -> None:
+    stats_refresh = deps.send_stats_update_embed
+    if stats_refresh is None:
+        from stats_alerts.interface import send_stats_update_embed as stats_refresh
+
+    ts = deps.now_utc().strftime("%Y-%m-%d %H:%M UTC")
+    await stats_refresh(deps.bot, ts, True, is_test=False)
+
+
+async def handle_prekvk_upload(message: Any, deps: PreKvkRouteDeps) -> bool:
+    """Handle PreKvK workbook imports from the configured upload channel."""
+    if message.channel.id != deps.prekvk_channel_id or not message.attachments:
+        return False
+
+    notify_ch = await deps.get_notify_channel() or message.channel
+
+    target = next(
+        (a for a in message.attachments if PREKVK_NAME_RX.match(a.filename.strip())),
+        None,
+    )
+
+    if not target:
+        await deps.send_embed(
+            notify_ch,
+            "Pre-KVK Import ⚠️",
+            {
+                "Info": "No matching file found.",
+                "Expected": "1198_prekvk.xlsx or PreKvK_Rankings_*.xlsx",
+                "Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploader": f"{message.author} ({message.author.id})",
+            },
+            0xE67E22,
+        )
+        return True
+
+    try:
+        file_bytes = await target.read()
+
+        ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+        if not ok:
+            return True
+
+        meta = None
+        try:
+            meta = await _load_current_kvk_metadata(deps)
+        except Exception:
+            logger.exception("[DL_BOT] Failed to determine current KVK metadata")
+
+        detected_kvk_no = None
+        try:
+            if meta and meta.get("kvk_no") is not None:
+                detected_kvk_no = int(meta.get("kvk_no"))
+        except Exception:
+            detected_kvk_no = None
+
+        if detected_kvk_no is None:
+            logger.error("[DL_BOT] Could not determine current KVK number; aborting Pre-KVK import")
+            await deps.send_embed(
+                notify_ch,
+                "Pre-KVK Import ❌",
+                {
+                    "Error": "Could not determine current KVK number (kvk_no). Import aborted.",
+                    "Filename": target.filename,
+                    "Channel": f"#{message.channel.name} ({message.channel.id})",
+                    "Uploader": f"{message.author} ({message.author.id})",
+                },
+                0xE74C3C,
+            )
+            return True
+
+        ok, note, rows = await deps.offload_callable(
+            import_prekvk_bytes,
+            file_bytes,
+            target.filename,
+            kvk_no=detected_kvk_no,
+            uploader_discord_id=(
+                int(message.author.id) if getattr(message.author, "id", None) is not None else None
+            ),
+            channel_id=(
+                int(message.channel.id)
+                if getattr(message.channel, "id", None) is not None
+                else None
+            ),
+            message_id=int(message.id) if getattr(message, "id", None) is not None else None,
+            name="import_prekvk_bytes",
+            prefer_process=True,
+            meta={"filename": target.filename, "kvk_no": detected_kvk_no},
+        )
+
+        if ok:
+            duplicate_skip = "duplicate file skipped" in (note or "").lower()
+            await deps.send_embed(
+                notify_ch,
+                ("Pre-KVK Snapshot Skipped" if duplicate_skip else "Pre-KVK Snapshot Imported ✅"),
+                {
+                    "KVK": str(detected_kvk_no),
+                    "Rows": str(rows),
+                    "Filename": target.filename,
+                    "Channel": f"#{message.channel.name} ({message.channel.id})",
+                    "Uploader": f"{message.author} ({message.author.id})",
+                    "Note": note,
+                },
+                0xF1C40F if duplicate_skip else 0x2ECC71,
+            )
+
+            if not duplicate_skip:
+                try:
+                    deps.create_task(deps.trigger_log_backup_background())
+                except Exception:
+                    logger.exception("Failed to schedule background log-backup trigger")
+
+                try:
+                    await _refresh_stats_embed(deps)
+                except Exception:
+                    pass
+        else:
+            await deps.send_embed(
+                notify_ch,
+                (
+                    "Pre-KVK Import (Skipped/Duplicate) ℹ️"
+                    if "Duplicate" in (note or "")
+                    else "Pre-KVK Import ❌"
+                ),
+                {
+                    "Filename": target.filename,
+                    "Channel": f"#{message.channel.name} ({message.channel.id})",
+                    "Uploader": f"{message.author} ({message.author.id})",
+                    "Info" if "Duplicate" in (note or "") else "Error": note or "Unknown",
+                },
+                0xF1C40F if "Duplicate" in (note or "") else 0xE74C3C,
+            )
+    except Exception as e:
+        await deps.send_embed(
+            notify_ch,
+            "Pre-KVK Import ❌",
+            {
+                "Error": f"{type(e).__name__}: {e}",
+                "Filename": target.filename,
+                "Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploader": f"{message.author} ({message.author.id})",
+            },
+            0xE74C3C,
+        )
+    return True


### PR DESCRIPTION
﻿## Summary

- Extracts the PreKvK upload branch from `DL_bot.py` into `upload_routes/prekvk_route.py` using the Phase 1 route/dependency-injection pattern.
- Preserves PreKvK channel/file gating, SQL headroom preflight, KVK metadata lookup, importer offload contract, uploader/channel/message metadata, embed output, and no-fall-through behavior.
- Applies the approved duplicate-skip behavior change: duplicate skips still send the skipped embed but no longer schedule log backup or stats-embed refresh.
- Adds focused route-level tests and includes the Phase 2A/2B/2C documentation updates.

## Changes

- `DL_bot.py` now delegates PreKvK uploads to the route layer.
- New `upload_routes/prekvk_route.py` owns PreKvK filename matching, KVK lookup, offload dispatch, response rendering, and best-effort side effects.
- New `tests/test_prekvk_upload_route.py` covers non-match, KVK lookup failure, SQL preflight abort, duplicate skip, success, importer failure, exception handling, and stats refresh best-effort behavior.
- Docs now mark Phase 2A delivered and keep Phase 2B SQL cleanup plus Phase 2C PreKvK report/embed as separate approval-gated follow-ons.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_upload_route.py tests/test_player_location_upload_route.py tests/test_dl_bot_mge_auto_import.py`
- `./.venv/Scripts/python.exe -m pytest -q tests`
- `./.venv/Scripts/python.exe -m pre_commit run --files DL_bot.py upload_routes/prekvk_route.py tests/test_prekvk_upload_route.py "docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md" "docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md" docs/reference/deferred_optimisations.md`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`

Full suite result: `1401 passed, 2 skipped`.

## Risk / Rollback

Risk is mainly Discord output/side-effect parity around the moved PreKvK listener branch. Rollback is straightforward by reverting this commit; no SQL schema or production config changes are included.
