### PR TITLE
feat: add PreKvK report command

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -12,6 +12,7 @@ from .inventory_cmds import register_inventory
 from .location_cmds import register_location
 from .mge_cmds import register_mge
 from .prekvk_admin_cmds import register_prekvk_admin
+from .prekvk_cmds import register_prekvk
 from .registry_cmds import register_registry
 from .stats_cmds import register_stats
 from .subscriptions_cmds import register_subscriptions
@@ -27,6 +28,7 @@ def register_all(bot: ext_commands.Bot) -> None:
     register_inventory(bot)
     register_location(bot)
     register_mge(bot)
+    register_prekvk(bot)
     register_prekvk_admin(bot)
     register_registry(bot)
     register_stats(bot)

--- a/commands/prekvk_cmds.py
+++ b/commands/prekvk_cmds.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands as ext_commands
+
+from bot_config import GUILD_ID
+from core.interaction_safety import safe_command, safe_defer
+from decoraters import track_usage
+from prekvk import report_service
+from ui.views.prekvk_report_views import send_prekvk_report
+from versioning import versioned
+
+logger = logging.getLogger(__name__)
+
+
+def register_prekvk(bot: ext_commands.Bot) -> None:
+    @bot.slash_command(
+        name="prekvk_report",
+        description="View the current PreKvK rankings report",
+        guild_ids=[GUILD_ID],
+    )
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def prekvk_report(
+        ctx: discord.ApplicationContext,
+        kvk_no: int | None = discord.Option(
+            int,
+            "Optional KVK number; defaults to the current KVK",
+            required=False,
+            default=None,
+            min_value=1,
+        ),
+        sort_by: str = discord.Option(
+            str,
+            "Initial report ordering",
+            choices=["Overall", "Stage 1", "Stage 2", "Stage 3"],
+            required=False,
+            default="Overall",
+        ),
+    ) -> None:
+        await safe_defer(ctx, ephemeral=True)
+        try:
+            parsed_sort = report_service.parse_report_sort(sort_by)
+            await send_prekvk_report(
+                ctx=ctx,
+                kvk_no=kvk_no,
+                sort_by=parsed_sort,
+                limit=10,
+            )
+        except ValueError as exc:
+            await ctx.followup.send(str(exc), ephemeral=True)
+        except Exception:
+            logger.exception(
+                "prekvk_report_command_failed actor_discord_id=%s kvk_no=%s sort_by=%s",
+                getattr(ctx.user, "id", None),
+                kvk_no,
+                sort_by,
+            )
+            await ctx.followup.send(
+                "PreKvK report generation failed. Please try again or contact an admin.",
+                ephemeral=True,
+            )

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,13 +5,15 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed during the DL_bot upload-routing Phase 2A work. PR 96
+Last reviewed after the DL_bot upload-routing Phase 2B production SQL cleanup. PR 96
 (`import-locations-command-orchestration-cleanup`) was smoke tested successfully and deployed to
 production. PR 97 (`dlbot-player-location-upload-route`) was smoke tested successfully and
 promoted to production. The governor fuzzy/name/partial-ID lookup standardisation item,
 profile/location profile-cache lookup item, `/import_locations` command orchestration item, DL_bot
 player location auto-import route/signal coupling item, and DL_bot PreKvK upload route extraction
-item are complete; the remaining active backlog is listed below.
+item from PR 98 (`dlbot-prekvk-upload-route`) are complete, smoke tested successfully, and
+promoted to production. Phase 2B PreKvK SQL compatibility cleanup was deployed and smoke tested
+successfully; the remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing and related test-environment blockers, not as a continuation of the
@@ -37,22 +39,31 @@ both this backlog and the current `K98-bot-mirror` GitHub issues list.
 - Dependencies: Local validation environment contract for venv naming and subprocess permissions.
 
 ### Deferred Optimisation
-- Area: SQL repo legacy PreKvK phase objects
+- Area: SQL repo legacy PreKvK phase object retirement
 - Type: cleanup
-- Description: `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and KVK-specific phase views still represent the old scan-window delta model even though Python reporting now uses direct stage columns.
-- Suggested Fix: Phase 2B should audit production SQL/report/manual workflow dependencies, then replace with direct-stage equivalents or retire the legacy objects only after an approved SQL cleanup design.
-- Impact: medium
+- Description: After Phase 2B compatibility wrappers remove active scan-window logic, `dbo.PreKvk_Phases` and any compatibility-only phase objects may remain as unused legacy SQL surface.
+- Suggested Fix: Run a later Option C retirement audit after at least one production cycle, re-check live SQL dependencies and manual/report usage, then prepare a SQL-repo-only drop plan with rollback scripts if no consumers remain.
+- Impact: low
 - Risk: medium
-- Dependencies: Confirm no production reports or manual SQL workflows still depend on scan-window phase objects.
+- Dependencies: Phase 2B compatibility wrapper deployment completed and smoke tested; live dependency checks confirm no references beyond the objects being retired; production owner approves destructive SQL cleanup.
 
 ### Deferred Optimisation
-- Area: PreKvK report/embed
-- Type: feature
-- Description: PreKvK stage-level import data is now available, but there is no dedicated PreKvK report command or embed outside the existing stats-alert panel.
-- Suggested Fix: Phase 2C should design and implement a dedicated PreKvK report/embed after the upload route boundary is stable, defining command/channel surface, permissions, limits, empty-data behaviour, and mobile-safe Discord output.
+- Area: `C:\K98-bot-SQL-Server` SQL development and deployment workflow
+- Type: architecture
+- Description: SQL schema changes can now be developed through Git PRs, but the existing production export routine can still overwrite Git-driven SQL changes because it syncs production schema back to the repository as the main routine.
+- Suggested Fix: After the current upload-routing phase set is complete, use `C:\Users\cwatt\Downloads\sql_deploy_route_task_pack.md` to create a PR-based SQL promotion workflow with guarded deploy scripts, migration history, a safe production schema export branch, `migrations/` conventions, and `docs/SQL_PROMOTION_GUIDE.md`.
+- Impact: high
+- Risk: medium
+- Dependencies: Complete the active DL_bot upload-routing phases first; preserve current production schema export as a drift/safety mechanism while preventing direct overwrite of `main`.
+
+### Deferred Optimisation
+- Area: `stats_alerts/prekvk_stats.py`, `stats_alerts/embeds/prekvk.py`
+- Type: refactor
+- Description: After the Phase 2C dedicated PreKvK report introduces the new report DAL/service/image-rendering architecture, the scheduled PreKvK stats-alert embed will still use its older helper/rendering path.
+- Suggested Fix: Phase 2D should refactor the scheduled PreKvK stats-alert helper/embed to reuse the new PreKvK architecture while preserving scheduled-post behaviour, guard/state handling, and existing upload-refresh behaviour.
 - Impact: medium
-- Risk: low
-- Dependencies: Complete Phase 2A route extraction first; reuse direct-stage PreKvK data path where practical.
+- Risk: medium
+- Dependencies: Complete and validate Phase 2C dedicated report first; do not move on from the PreKvK report phase until Phase 2D is complete.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py` KVK_ALL upload routing

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -312,7 +312,15 @@ Phase 2A delivery notes:
   listener/delegation responsibility.
 - Duplicate skips intentionally preserve the skipped embed but do not schedule background log
   backup or stats-embed refresh.
+- PR 98 (`dlbot-prekvk-upload-route`) was smoke tested successfully and pushed to production.
 - Phase 2B SQL cleanup and Phase 2C report/embed work remain separate approval-gated follow-ons.
+
+Phase 2B starter:
+
+- `docs/task_packs/DL_bot Upload Routing - Phase 2B PreKvK SQL Cleanup Audit Statement.md`
+- Phase 2B is audit/design only until explicitly approved for SQL changes.
+- It must validate dependencies on `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and
+  KVK-specific PreKvK phase views against `C:\K98-bot-SQL-Server` before proposing cleanup.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
@@ -10,8 +10,8 @@ This phase is split into three approval-gated slices:
 Goal: extract the PreKvK upload route from `DL_bot.py` into the existing `upload_routes` pattern
 introduced in Phase 1.
 
-Status: implemented as the Phase 2A route-extraction slice. Phase 2B and Phase 2C remain separate
-approval-gated follow-ons.
+Status: implemented in PR 98 (`dlbot-prekvk-upload-route`), smoke tested successfully, and pushed
+to production. Phase 2B and Phase 2C remain separate approval-gated follow-ons.
 
 In scope:
 
@@ -54,6 +54,14 @@ Out of scope for Phase 2A:
 
 Goal: audit whether legacy PreKvK SQL phase objects can be replaced or retired safely.
 
+Status: implemented in SQL PR 3 (`codex/prekvk-phase-sql-cleanup`), deployed to production,
+smoke tested successfully, and left `dbo.PreKvk_Phases` in place for a later Option C retirement
+audit.
+
+Starter packet:
+
+- `docs/task_packs/DL_bot Upload Routing - Phase 2B PreKvK SQL Cleanup Audit Statement.md`
+
 Minimum objects to review in `C:\K98-bot-SQL-Server`:
 
 - `dbo.PreKvk_Phases`
@@ -65,21 +73,47 @@ Minimum objects to review in `C:\K98-bot-SQL-Server`:
 This phase must stop for approval before any SQL object replacement, retirement, destructive
 cleanup, or production SQL migration.
 
+Delivered outcome:
+
+- `dbo.fn_PreKvkPhaseDelta` and `dbo.v_PreKvk13_Phase1/2/3` were preserved as compatibility
+  object names but now source direct stage values from `dbo.PreKvk_Scores`.
+- `dbo.sp_Build_Prekvk_And_Honor_Rankings` was aligned so PreKvK stage values and `ScanID` come
+  from the same deterministic best-score row.
+- Production deploy and rollback scripts were created in the SQL repo.
+- Later destructive retirement of `dbo.PreKvk_Phases` remains deferred until a separate Option C
+  audit and approval.
+
 ## Phase 2C - New PreKvK Report/Embed
 
 Goal: design and implement a dedicated PreKvK report/embed after the route boundary is stable.
 
-Design decisions required before implementation:
+Approved implementation direction:
 
-- Command, scheduled embed, admin-only, or channel-triggered surface.
-- Permission model and target channel.
-- Report limits and tie handling.
-- Empty-data and legacy total-only-row behaviour.
-- Whether to reuse `stats_alerts.prekvk_stats.load_prekvk_top3` directly or introduce a service
-  boundary for report orchestration.
-- Mobile-safe Discord output shape.
+- Add a public read-only `/prekvk_report` slash command.
+- Default to the current KVK when `kvk_no` is omitted.
+- Render a dedicated PNG leaderboard rather than a fixed-width embed table.
+- Include `Rank`, `GovernorName`, `Power`, `Stage 1`, `Stage 2`, `Stage 3`, and `Overall`.
+- Default sort is `Overall`; allow sorting by `Overall`, `Stage 1`, `Stage 2`, or `Stage 3`.
+- Default limit is Top 10; allow Top 10, Top 25, Top 50, and Top 100 buttons.
+- Use a new PreKvK report DAL/service/rendering architecture rather than extending upload routing
+  or import behaviour.
 
 Phase 2C should not change upload routing behaviour unless separately approved.
+
+## Phase 2D - PreKvK Stats-Alert Architecture Refactor
+
+Goal: after Phase 2C is validated, refactor the scheduled PreKvK stats-alert helper/embed to use
+the new PreKvK report architecture where practical.
+
+In scope:
+
+- `stats_alerts/prekvk_stats.py`
+- `stats_alerts/embeds/prekvk.py`
+- preservation of scheduled-post, guard/state, previous-KVK target, honor, event, and upload-refresh
+  behaviour
+- focused tests proving the scheduled stats-alert behaviour still works
+
+Phase 2D must be completed before moving on from the PreKvK report phase.
 
 ## Required Stop Points
 
@@ -87,3 +121,5 @@ Phase 2C should not change upload routing behaviour unless separately approved.
    before route extraction code changes.
 2. Phase 2B must produce a SQL dependency audit/design packet and stop before SQL changes.
 3. Phase 2C must produce a report/embed design packet and stop before implementation.
+4. Phase 2D must preserve scheduled stats-alert behaviour while adopting the new report
+   architecture.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2B PreKvK SQL Cleanup Audit Statement.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2B PreKvK SQL Cleanup Audit Statement.md
@@ -1,0 +1,177 @@
+# DL_bot Upload Routing - Phase 2B PreKvK SQL Cleanup Audit Statement
+
+We are starting Phase 2B after PR 98 (`dlbot-prekvk-upload-route`) was smoke tested successfully
+and pushed to production.
+
+Phase 2A delivered the PreKvK upload route extraction and left `DL_bot.py` as listener/delegation
+glue for the PreKvK path. Phase 2B is a SQL cleanup audit and design task for legacy PreKvK phase
+objects. It is not an implementation task unless the audit packet, cleanup direction, and
+implementation plan are each approved.
+
+## Goal
+
+Audit whether legacy PreKvK SQL phase objects can be replaced, retired, or left in place safely now
+that Python reporting uses direct stage columns from `dbo.PreKvk_Scores`.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/prekvk_schema_standardisation_task_pack.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Phase 2B Scope
+
+In scope:
+
+- Read-only SQL dependency audit in `C:\K98-bot-SQL-Server`.
+- Bot-code dependency audit for any references to legacy PreKvK phase objects.
+- Identify whether each legacy object is:
+  - still required
+  - replaceable with direct-stage equivalents
+  - safe to retire after dependency confirmation
+  - unsafe or ambiguous and should remain deferred
+- Recommend SQL cleanup direction and deployment order.
+- Produce a PR-sized implementation plan only after the audit/scope packet is approved.
+- Capture any out-of-scope findings using the Deferred Optimisation format.
+
+Out of scope until separately approved:
+
+- Dropping, renaming, or altering production SQL objects.
+- Adding or changing bot-side PreKvK reporting UI.
+- Changing `import_prekvk_bytes`, `upload_routes/prekvk_route.py`, or `DL_bot.py` upload behavior.
+- Reworking `dbo.PreKvk_Scan`, `dbo.PreKvk_Scores`, `dbo.PreKvk_ImportHistory`, or
+  `dbo.PreKvk_Scores_Ranked` except where the audit proves a cleanup dependency.
+- Production deployment or bot-machine restart.
+
+## Minimum SQL Objects To Audit
+
+Legacy cleanup candidates:
+
+- `dbo.PreKvk_Phases`
+- `dbo.fn_PreKvkPhaseDelta`
+- KVK-specific phase views such as `dbo.v_PreKvk13_Phase1`,
+  `dbo.v_PreKvk13_Phase2`, and `dbo.v_PreKvk13_Phase3`
+- Any other `v_PreKvk*_Phase*` view found in the SQL repo or live schema export
+
+Direct-stage/current objects to cross-check:
+
+- `dbo.PreKvk_Scan`
+- `dbo.PreKvk_Scores`
+- `dbo.PreKvk_ImportHistory`
+- `dbo.PreKvk_Scores_Ranked`
+- `dbo.fn_PreKvkLatestOverall`
+- `dbo.sp_Build_Prekvk_And_Honor_Rankings`
+- `dbo.sp_ExcelOutput_ByKVK`
+- any `v_PreKvk*_All` or `v_PreKvk*_Overall` object referenced by legacy phase views
+
+## Required Searches
+
+Run or adapt these searches in the SQL repo:
+
+```powershell
+rg "PreKvk_Phases|fn_PreKvkPhaseDelta|v_PreKvk.*Phase" C:\K98-bot-SQL-Server
+rg "CREATE.*PreKvk_Phases|CREATE.*fn_PreKvkPhaseDelta|CREATE.*v_PreKvk" C:\K98-bot-SQL-Server
+rg "PreKvk_Scan|PreKvk_Scores|PreKvk_Scores_Ranked" C:\K98-bot-SQL-Server
+rg "sp_Build_Prekvk_And_Honor_Rankings|sp_ExcelOutput_ByKVK|fn_PreKvkLatestOverall" C:\K98-bot-SQL-Server
+rg "PreKvk_Phases|fn_PreKvkPhaseDelta|v_PreKvk.*Phase" C:\discord_file_downloader
+```
+
+If live production dependency checks are needed, propose the exact read-only SQL statements first
+and stop for approval before running them.
+
+## Step 1 Required Output
+
+Phase 2B Step 1 must produce:
+
+- Audit Summary
+- Legacy Object Inventory
+- Current Direct-Stage SQL Map
+- Bot-Code Dependency Review
+- SQL Dependency / Blast-Radius Review
+- Cleanup Options
+- Recommended Architecture / SQL Direction
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write SQL or bot code during Step 1.
+
+## Cleanup Options To Evaluate
+
+Option A - leave legacy objects in place:
+
+- Use when dependencies are ambiguous or still active.
+- Update docs/deferred items with evidence and next check point.
+
+Option B - replace with compatibility wrappers:
+
+- Preserve object names but rewrite internals to use direct-stage columns.
+- Lower immediate breakage risk for manual/report consumers, but still requires SQL review and
+  deployment ordering.
+
+Option C - retire/drop legacy objects:
+
+- Only after proving no bot, SQL procedure, view, report, export, or manual workflow still depends
+  on them.
+- Requires rollback plan and production deployment approval.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the selected cleanup option:
+
+- SQL repo object-definition review.
+- Read-only SQL dependency checks where approved.
+- Focused tests covering PreKvK stats/reporting assumptions.
+- Existing PreKvK importer and diagnostics tests where touched.
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- Full pytest if selector/risk warrants it.
+
+## Acceptance Criteria
+
+- Legacy phase-object dependencies are mapped with file/object evidence.
+- SQL cleanup recommendation is evidence-based and separated from Phase 2A route work.
+- No destructive SQL changes are made without approval.
+- Any proposed SQL implementation includes deployment order and rollback notes.
+- Bot behavior and PreKvK upload routing remain unchanged.
+- Out-of-scope follow-ups are captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 2B audit/scope packet.
+
+Do not implement SQL cleanup, alter SQL files, change bot code, or open a PR until the audit packet,
+cleanup direction, and implementation plan have each been approved.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
@@ -1,0 +1,196 @@
+# DL_bot Upload Routing - Phase 2C PreKvK Report Starter
+
+We are starting Phase 2C after:
+
+- Phase 2A (`dlbot-prekvk-upload-route`) was smoke tested successfully and pushed to production.
+- Phase 2B (`codex/prekvk-phase-sql-cleanup` in `K98-bot-SQL-Server`) was deployed to production
+  and smoke tested successfully.
+
+Phase 2C is the dedicated PreKvK report/embed design task. It should not alter upload routing or
+PreKvK import behaviour unless a separate approval explicitly expands scope.
+
+## Goal
+
+Design a dedicated PreKvK report surface that uses the now-stable direct-stage PreKvK data path:
+
+- overall total points
+- Stage I points
+- Stage II points
+- Stage III points
+
+The first step is an audit/design packet, not implementation. Stop before code changes until the
+report surface, architecture direction, and implementation plan are each approved.
+
+## Approved Phase 2C Direction
+
+The audit/design packet was reviewed and implementation was approved with these decisions:
+
+- Build a public read-only `/prekvk_report` slash command rather than an admin-only command.
+- Keep the command unannounced initially; it remains low risk because it only reads existing
+  PreKvK data.
+- Default to the current `kvk_no` from metadata, with an optional `kvk_no` override.
+- Default ordering is `Overall`; users can switch to `Stage 1`, `Stage 2`, or `Stage 3`.
+- Default limit is Top 10; buttons support Top 10, Top 25, Top 50, and Top 100.
+- Output should be a mobile-safe image report, improving on the older `/kvk_rankings` fixed-width
+  embed table style and borrowing the image-rendering pattern used by the inventory reports.
+- Report columns are `Rank`, `GovernorName`, `Power`, `Stage 1`, `Stage 2`, `Stage 3`, and
+  `Overall`.
+- `Power` should be enriched from the existing player/KVK stats SQL source when available and show
+  `N/A` when unavailable.
+- Use the approved architecture: PreKvK DAL, service, image renderer, and Discord view layers.
+- Add Phase 2D as a required follow-on to refactor `stats_alerts/prekvk_stats.py` and
+  `stats_alerts/embeds/prekvk.py` to reuse the new architecture before moving on from the PreKvK
+  report phase.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/prekvk_schema_standardisation_task_pack.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for PreKvK tables, views, functions, and
+stored procedures.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Phase 2C Scope
+
+In scope:
+
+- Audit current PreKvK reporting helpers and embeds.
+- Decide whether the report surface should be command-based, scheduled, admin-only, or channel
+  triggered.
+- Define permission model and target channel behaviour.
+- Define report limits, tie handling, empty-data behaviour, and legacy total-only-row behaviour.
+- Decide whether to reuse `stats_alerts.prekvk_stats.load_prekvk_top3` directly or introduce a
+  small service layer.
+- Design mobile-safe Discord output for overall and stage blocks.
+- Recommend a PR-sized implementation plan after the audit packet is approved.
+
+Out of scope until separately approved:
+
+- Changing `import_prekvk_bytes`.
+- Changing `upload_routes/prekvk_route.py` or `DL_bot.py` upload behaviour.
+- Retiring `dbo.PreKvk_Phases` or any legacy SQL object.
+- Reworking PreKvK storage, import history, or ranking procedures.
+- Broad stats-alert panel redesign.
+- Production deployment or bot-machine restart.
+
+## Current Objects And Files To Review
+
+Python/reporting:
+
+- `stats_alerts/prekvk_stats.py`
+- `stats_alerts/embeds/prekvk.py`
+- `stats_alerts/interface.py`
+- `kvk/dal/kvk_stats_dal.py`
+- `commands/prekvk_admin_cmds.py`
+- `upload_routes/prekvk_route.py`
+- `DL_bot.py`
+
+Tests:
+
+- `tests/test_prekvk_stats.py`
+- `tests/test_prekvk_diagnostics.py`
+- `tests/test_prekvk_importer.py`
+- `tests/test_prekvk_upload_route.py`
+- any command/embed tests discovered during audit
+
+SQL source of truth:
+
+- `dbo.PreKvk_Scan`
+- `dbo.PreKvk_Scores`
+- `dbo.PreKvk_ImportHistory`
+- `dbo.PreKvk_Scores_Ranked`
+- `dbo.fn_PreKvkLatestOverall`
+- `dbo.fn_PreKvkPhaseDelta`
+- `dbo.sp_Build_Prekvk_And_Honor_Rankings`
+
+## Design Questions
+
+- Should the first report be an admin slash command, public slash command, scheduled embed, or
+  channel-triggered action?
+- Which roles/users can run or refresh the report?
+- Should output default to the current KVK from config, or require a `kvk_no` argument?
+- What Top N should be used by default, and should it be configurable?
+- How should ties be displayed when more than N players share a boundary score?
+- How should old total-only rows behave for stage blocks?
+- Should the implementation call `load_prekvk_top3` directly, extend it, or introduce
+  `prekvk/report_service.py`?
+- Should report rendering reuse the existing stats-alert embed style or create a dedicated embed?
+- What should the command/report say when no PreKvK import exists for the selected KVK?
+
+## Step 1 Required Output
+
+Phase 2C Step 1 must produce:
+
+- Audit Summary
+- Current PreKvK Reporting Map
+- Proposed Report Surface Options
+- Permission And Channel Model
+- Data Access / SQL Review
+- Discord Output Design
+- Recommended Architecture Direction
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the selected report surface:
+
+- focused PreKvK report/service tests
+- focused image rendering tests
+- command registration validation if a slash command is added
+- interaction/permission tests if a command or button/view is added
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+
+## Acceptance Criteria
+
+- Report design is separated from upload routing and SQL cleanup work.
+- PreKvK report dependencies are mapped with file/object evidence.
+- Proposed output is mobile-safe and handles empty/legacy data clearly.
+- No upload route, importer, or production SQL behaviour changes are made without separate
+  approval.
+- Out-of-scope follow-ups are captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 2C audit/design packet.
+
+Do not implement the report, alter SQL, change upload routing, or open a PR until the audit packet,
+report surface, architecture direction, and implementation plan have each been approved.

--- a/prekvk/dal/report_dal.py
+++ b/prekvk/dal/report_dal.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from file_utils import cursor_row_to_dict, get_conn_with_retries
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_all(cursor: Any) -> list[dict[str, Any]]:
+    return [cursor_row_to_dict(cursor, row) for row in cursor.fetchall()]
+
+
+def fetch_latest_prekvk_report_rows(kvk_no: int) -> list[dict[str, Any]]:
+    """Return latest direct-stage PreKvK rows enriched with player power when available."""
+    conn = get_conn_with_retries()
+    with conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            WITH Latest AS (
+                SELECT TOP (1)
+                    ScanID,
+                    ScanTimestampUTC,
+                    SourceFileName
+                FROM dbo.PreKvk_Scan
+                WHERE KVK_NO = ?
+                ORDER BY ScanID DESC
+            ),
+            PowerRows AS (
+                SELECT
+                    CAST(Gov_ID AS bigint) AS GovernorID,
+                    MAX(CAST([Starting Power] AS bigint)) AS Power
+                FROM dbo.ALL_STATS_FOR_DASHBAORD
+                WHERE KVK_NO = ?
+                  AND Gov_ID IS NOT NULL
+                GROUP BY CAST(Gov_ID AS bigint)
+            )
+            SELECT
+                sc.GovernorID,
+                COALESCE(NULLIF(LTRIM(RTRIM(sc.GovernorName)), ''), CONVERT(varchar(20), sc.GovernorID)) AS GovernorName,
+                pr.Power,
+                sc.Stage1Points,
+                sc.Stage2Points,
+                sc.Stage3Points,
+                COALESCE(sc.TotalPoints, sc.Points, 0) AS OverallPoints,
+                l.ScanID,
+                l.ScanTimestampUTC,
+                l.SourceFileName
+            FROM dbo.PreKvk_Scores sc
+            JOIN Latest l
+              ON l.ScanID = sc.ScanID
+            LEFT JOIN PowerRows pr
+              ON pr.GovernorID = sc.GovernorID
+            WHERE sc.KVK_NO = ?
+            ORDER BY COALESCE(sc.TotalPoints, sc.Points, 0) DESC, sc.GovernorID ASC;
+            """,
+            (int(kvk_no), int(kvk_no), int(kvk_no)),
+        )
+        return _fetch_all(cursor)

--- a/prekvk/models.py
+++ b/prekvk/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from io import BytesIO
+from typing import Any
+
+
+class PreKvkReportSort(StrEnum):
+    OVERALL = "overall"
+    STAGE1 = "stage1"
+    STAGE2 = "stage2"
+    STAGE3 = "stage3"
+
+
+PREKVK_REPORT_LIMITS = (10, 25, 50, 100)
+
+
+@dataclass(frozen=True)
+class PreKvkReportRow:
+    rank: int
+    governor_id: int
+    governor_name: str
+    power: int | None
+    stage1_points: int | None
+    stage2_points: int | None
+    stage3_points: int | None
+    overall_points: int
+
+
+@dataclass(frozen=True)
+class PreKvkReportPayload:
+    kvk_no: int
+    sort_by: PreKvkReportSort
+    limit: int
+    rows: list[PreKvkReportRow] = field(default_factory=list)
+    scan_id: int | None = None
+    scan_timestamp_utc: Any | None = None
+    source_filename: str | None = None
+    generated_at_utc: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def has_stage_data(self) -> bool:
+        return any(
+            row.stage1_points is not None
+            or row.stage2_points is not None
+            or row.stage3_points is not None
+            for row in self.rows
+        )
+
+
+@dataclass(frozen=True)
+class RenderedPreKvkReportImage:
+    filename: str
+    image_bytes: BytesIO

--- a/prekvk/report_image_renderer.py
+++ b/prekvk/report_image_renderer.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from io import BytesIO
+import unicodedata
+
+from PIL import Image, ImageDraw, ImageFont
+
+from prekvk.models import PreKvkReportPayload, RenderedPreKvkReportImage
+from prekvk.report_service import SORT_LABELS
+
+WIDTH = 1680
+HEADER_H = 172
+ROW_H = 38
+FOOTER_H = 70
+BG = (12, 31, 55)
+PANEL = (19, 48, 83)
+HEADER = (30, 76, 126)
+TEXT = (245, 250, 255)
+MUTED = (166, 196, 225)
+LINE = (54, 108, 164)
+GOLD = (250, 204, 21)
+BLUE = (96, 165, 250)
+
+
+@lru_cache(maxsize=32)
+def _font(size: int, *, bold: bool = False) -> ImageFont.ImageFont:
+    candidates = [
+        "C:/Windows/Fonts/segoeuib.ttf" if bold else "C:/Windows/Fonts/segoeui.ttf",
+        "C:/Windows/Fonts/arialbd.ttf" if bold else "C:/Windows/Fonts/arial.ttf",
+    ]
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(candidate, size=size)
+        except Exception:
+            continue
+    return ImageFont.load_default()
+
+
+def _compact(value: int | None) -> str:
+    if value is None:
+        return "N/A"
+    abs_val = abs(float(value))
+    for threshold, unit in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        if abs_val >= threshold:
+            out = f"{float(value) / threshold:.1f}".rstrip("0").rstrip(".")
+            return f"{out}{unit}"
+    return f"{int(value):,}"
+
+
+def _clean_text(value: str, max_chars: int) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    cleaned = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    cleaned = cleaned.replace("\r", " ").replace("\n", " ")
+    cleaned = " ".join(cleaned.split()) or "Unknown"
+    return cleaned if len(cleaned) <= max_chars else cleaned[: max_chars - 1].rstrip() + "."
+
+
+def _cell(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int],
+    text: str,
+    *,
+    width: int,
+    align: str = "left",
+    font: ImageFont.ImageFont | None = None,
+    fill: tuple[int, int, int] = TEXT,
+) -> None:
+    font = font or _font(20)
+    x, y = xy
+    if align == "right":
+        box = draw.textbbox((0, 0), text, font=font)
+        x = x + width - int(box[2] - box[0])
+    elif align == "center":
+        box = draw.textbbox((0, 0), text, font=font)
+        x = x + max(0, (width - int(box[2] - box[0])) // 2)
+    draw.text((x, y), text, fill=fill, font=font)
+
+
+def render_prekvk_report(payload: PreKvkReportPayload) -> RenderedPreKvkReportImage | None:
+    if not payload.rows:
+        return None
+    height = HEADER_H + ROW_H * (len(payload.rows) + 1) + FOOTER_H
+    canvas = Image.new("RGBA", (WIDTH, height), BG)
+    draw = ImageDraw.Draw(canvas, "RGBA")
+    draw.rounded_rectangle(
+        (28, 28, WIDTH - 28, height - 28), radius=18, fill=PANEL, outline=LINE, width=2
+    )
+    draw.text(
+        (58, 48), f"PreKvK Report - KVK {payload.kvk_no}", fill=TEXT, font=_font(36, bold=True)
+    )
+    draw.text(
+        (58, 94),
+        f"Sorted by {SORT_LABELS[payload.sort_by]} | Top {payload.limit}",
+        fill=MUTED,
+        font=_font(22),
+    )
+    if payload.scan_id is not None:
+        draw.text((1180, 54), f"Scan {payload.scan_id}", fill=BLUE, font=_font(22, bold=True))
+    if payload.source_filename:
+        draw.text((1180, 90), _clean_text(payload.source_filename, 34), fill=MUTED, font=_font(18))
+
+    cols = [
+        ("Rank", 58, 78, "left"),
+        ("GovernorName", 150, 360, "left"),
+        ("Power", 540, 150, "right"),
+        ("Stage 1", 730, 150, "right"),
+        ("Stage 2", 910, 150, "right"),
+        ("Stage 3", 1090, 150, "right"),
+        ("Overall", 1288, 180, "right"),
+    ]
+    y = HEADER_H
+    draw.rounded_rectangle((48, y, WIDTH - 48, y + ROW_H), radius=8, fill=HEADER)
+    for title, x, w, align in cols:
+        _cell(draw, (x, y + 8), title, width=w, align=align, font=_font(18, bold=True), fill=TEXT)
+
+    for idx, row in enumerate(payload.rows):
+        y = HEADER_H + ROW_H * (idx + 1)
+        if idx % 2 == 0:
+            draw.rectangle((48, y, WIDTH - 48, y + ROW_H), fill=(15, 41, 72))
+        rank_fill = GOLD if row.rank <= 3 else TEXT
+        values = [
+            (str(row.rank), 58, 78, "left", rank_fill),
+            (_clean_text(row.governor_name, 28), 150, 360, "left", TEXT),
+            (_compact(row.power), 540, 150, "right", MUTED if row.power is None else TEXT),
+            (
+                _compact(row.stage1_points),
+                730,
+                150,
+                "right",
+                MUTED if row.stage1_points is None else TEXT,
+            ),
+            (
+                _compact(row.stage2_points),
+                910,
+                150,
+                "right",
+                MUTED if row.stage2_points is None else TEXT,
+            ),
+            (
+                _compact(row.stage3_points),
+                1090,
+                150,
+                "right",
+                MUTED if row.stage3_points is None else TEXT,
+            ),
+            (_compact(row.overall_points), 1288, 180, "right", TEXT),
+        ]
+        for value, x, w, align, fill in values:
+            _cell(draw, (x, y + 8), value, width=w, align=align, font=_font(18), fill=fill)
+
+    footer = (
+        "Legacy total-only imports show N/A for stage columns."
+        if not payload.has_stage_data
+        else "Direct-stage PreKvK data path"
+    )
+    draw.text((58, height - 52), footer, fill=MUTED, font=_font(17))
+    draw.text(
+        (1280, height - 52),
+        f"Generated {payload.generated_at_utc:%Y-%m-%d %H:%M UTC}",
+        fill=MUTED,
+        font=_font(17),
+    )
+    buf = BytesIO()
+    canvas.convert("RGB").save(buf, format="PNG", optimize=True)
+    buf.seek(0)
+    return RenderedPreKvkReportImage(
+        filename=f"prekvk_report_kvk{payload.kvk_no}_{payload.sort_by.value}_top{payload.limit}.png",
+        image_bytes=buf,
+    )

--- a/prekvk/report_service.py
+++ b/prekvk/report_service.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from prekvk.dal import report_dal
+from prekvk.models import (
+    PREKVK_REPORT_LIMITS,
+    PreKvkReportPayload,
+    PreKvkReportRow,
+    PreKvkReportSort,
+)
+
+SORT_LABELS = {
+    PreKvkReportSort.OVERALL: "Overall",
+    PreKvkReportSort.STAGE1: "Stage 1",
+    PreKvkReportSort.STAGE2: "Stage 2",
+    PreKvkReportSort.STAGE3: "Stage 3",
+}
+
+
+def parse_report_sort(value: str | None) -> PreKvkReportSort:
+    normalized = (value or PreKvkReportSort.OVERALL.value).strip().lower().replace(" ", "")
+    aliases = {
+        "overall": PreKvkReportSort.OVERALL,
+        "total": PreKvkReportSort.OVERALL,
+        "stage1": PreKvkReportSort.STAGE1,
+        "stagei": PreKvkReportSort.STAGE1,
+        "p1": PreKvkReportSort.STAGE1,
+        "stage2": PreKvkReportSort.STAGE2,
+        "stageii": PreKvkReportSort.STAGE2,
+        "p2": PreKvkReportSort.STAGE2,
+        "stage3": PreKvkReportSort.STAGE3,
+        "stageiii": PreKvkReportSort.STAGE3,
+        "p3": PreKvkReportSort.STAGE3,
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise ValueError("Sort must be Overall, Stage 1, Stage 2, or Stage 3.") from exc
+
+
+def normalize_report_limit(value: int | None) -> int:
+    try:
+        requested = int(value or PREKVK_REPORT_LIMITS[0])
+    except Exception:
+        requested = PREKVK_REPORT_LIMITS[0]
+    return requested if requested in PREKVK_REPORT_LIMITS else PREKVK_REPORT_LIMITS[0]
+
+
+def _to_int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(float(value))
+    except Exception:
+        return None
+
+
+def _sort_value(row: PreKvkReportRow, sort_by: PreKvkReportSort) -> int:
+    if sort_by == PreKvkReportSort.STAGE1:
+        return int(row.stage1_points or 0)
+    if sort_by == PreKvkReportSort.STAGE2:
+        return int(row.stage2_points or 0)
+    if sort_by == PreKvkReportSort.STAGE3:
+        return int(row.stage3_points or 0)
+    return int(row.overall_points or 0)
+
+
+def _rank_rows(rows: list[PreKvkReportRow], sort_by: PreKvkReportSort) -> list[PreKvkReportRow]:
+    sorted_rows = sorted(
+        rows,
+        key=lambda row: (-_sort_value(row, sort_by), -(row.power or 0), row.governor_id),
+    )
+    ranked: list[PreKvkReportRow] = []
+    previous_value: int | None = None
+    current_rank = 0
+    for index, row in enumerate(sorted_rows, start=1):
+        value = _sort_value(row, sort_by)
+        if previous_value is None or value != previous_value:
+            current_rank = index
+            previous_value = value
+        ranked.append(
+            PreKvkReportRow(
+                rank=current_rank,
+                governor_id=row.governor_id,
+                governor_name=row.governor_name,
+                power=row.power,
+                stage1_points=row.stage1_points,
+                stage2_points=row.stage2_points,
+                stage3_points=row.stage3_points,
+                overall_points=row.overall_points,
+            )
+        )
+    return ranked
+
+
+def build_report_payload_from_rows(
+    kvk_no: int,
+    raw_rows: list[dict[str, Any]],
+    *,
+    sort_by: PreKvkReportSort = PreKvkReportSort.OVERALL,
+    limit: int = 10,
+) -> PreKvkReportPayload:
+    normalized_limit = normalize_report_limit(limit)
+    rows: list[PreKvkReportRow] = []
+    scan_id = None
+    scan_timestamp_utc = None
+    source_filename = None
+    for raw in raw_rows:
+        if scan_id is None:
+            scan_id = _to_int_or_none(raw.get("ScanID"))
+            scan_timestamp_utc = raw.get("ScanTimestampUTC")
+            source_filename = raw.get("SourceFileName")
+        governor_id = _to_int_or_none(raw.get("GovernorID"))
+        if governor_id is None:
+            continue
+        rows.append(
+            PreKvkReportRow(
+                rank=0,
+                governor_id=governor_id,
+                governor_name=str(raw.get("GovernorName") or governor_id).strip()
+                or str(governor_id),
+                power=_to_int_or_none(raw.get("Power")),
+                stage1_points=_to_int_or_none(raw.get("Stage1Points")),
+                stage2_points=_to_int_or_none(raw.get("Stage2Points")),
+                stage3_points=_to_int_or_none(raw.get("Stage3Points")),
+                overall_points=int(_to_int_or_none(raw.get("OverallPoints")) or 0),
+            )
+        )
+    ranked = _rank_rows(rows, sort_by)[:normalized_limit]
+    return PreKvkReportPayload(
+        kvk_no=int(kvk_no),
+        sort_by=sort_by,
+        limit=normalized_limit,
+        rows=ranked,
+        scan_id=scan_id,
+        scan_timestamp_utc=scan_timestamp_utc,
+        source_filename=source_filename,
+    )
+
+
+def resolve_current_kvk_no() -> int | None:
+    from stats_alerts.kvk_meta import get_latest_kvk_metadata_sql
+
+    meta = get_latest_kvk_metadata_sql()
+    if not meta or meta.get("kvk_no") is None:
+        return None
+    return int(meta["kvk_no"])
+
+
+async def build_prekvk_report_payload(
+    *,
+    kvk_no: int | None = None,
+    sort_by: PreKvkReportSort = PreKvkReportSort.OVERALL,
+    limit: int = 10,
+) -> PreKvkReportPayload:
+    resolved_kvk_no = (
+        int(kvk_no) if kvk_no is not None else await asyncio.to_thread(resolve_current_kvk_no)
+    )
+    if not resolved_kvk_no:
+        raise ValueError("Could not determine the current KVK number.")
+    raw_rows = await asyncio.to_thread(
+        report_dal.fetch_latest_prekvk_report_rows, int(resolved_kvk_no)
+    )
+    return build_report_payload_from_rows(
+        int(resolved_kvk_no),
+        raw_rows,
+        sort_by=sort_by,
+        limit=limit,
+    )

--- a/tests/test_prekvk_report_command.py
+++ b/tests/test_prekvk_report_command.py
@@ -1,0 +1,16 @@
+import inspect
+
+from commands.prekvk_cmds import register_prekvk
+
+
+def test_prekvk_report_command_is_public_read_only_surface():
+    source = inspect.getsource(register_prekvk)
+
+    assert 'name="prekvk_report"' in source
+    assert "@safe_command" in source
+    assert "@track_usage()" in source
+    assert "safe_defer(ctx, ephemeral=True)" in source
+    assert "safe_defer(ctx, ephemeral=False)" not in source
+    assert "@is_admin_and_notify_channel()" not in source
+    assert "import_prekvk_bytes" not in source
+    assert "handle_prekvk_upload" not in source

--- a/tests/test_prekvk_report_dal.py
+++ b/tests/test_prekvk_report_dal.py
@@ -1,0 +1,49 @@
+from prekvk.dal import report_dal
+
+
+def test_fetch_latest_report_rows_uses_direct_stage_columns_and_power(monkeypatch):
+    captured = {}
+
+    class Cursor:
+        def __init__(self):
+            self.description = [
+                ("GovernorID",),
+                ("GovernorName",),
+                ("Power",),
+                ("Stage1Points",),
+                ("Stage2Points",),
+                ("Stage3Points",),
+                ("OverallPoints",),
+                ("ScanID",),
+                ("ScanTimestampUTC",),
+                ("SourceFileName",),
+            ]
+
+        def execute(self, sql, params):
+            captured["sql"] = sql
+            captured["params"] = params
+
+        def fetchall(self):
+            return [(1, "Alpha", 100, 10, 20, 30, 60, 7, "now", "file.xlsx")]
+
+    class Conn:
+        def cursor(self):
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(report_dal, "get_conn_with_retries", lambda: Conn())
+
+    rows = report_dal.fetch_latest_prekvk_report_rows(15)
+
+    assert rows[0]["GovernorName"] == "Alpha"
+    assert "Stage1Points" in captured["sql"]
+    assert "Stage2Points" in captured["sql"]
+    assert "Stage3Points" in captured["sql"]
+    assert "ALL_STATS_FOR_DASHBAORD" in captured["sql"]
+    assert "PreKvk_Phases" not in captured["sql"]
+    assert captured["params"] == (15, 15, 15)

--- a/tests/test_prekvk_report_image_renderer.py
+++ b/tests/test_prekvk_report_image_renderer.py
@@ -1,0 +1,41 @@
+from prekvk.models import PreKvkReportPayload, PreKvkReportRow, PreKvkReportSort
+from prekvk.report_image_renderer import render_prekvk_report
+
+
+def test_render_prekvk_report_returns_png():
+    payload = PreKvkReportPayload(
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+        rows=[
+            PreKvkReportRow(
+                rank=1,
+                governor_id=1,
+                governor_name="Alpha",
+                power=100_000_000,
+                stage1_points=10,
+                stage2_points=20,
+                stage3_points=30,
+                overall_points=60,
+            )
+        ],
+        scan_id=7,
+        source_filename="PreKvK_Rankings.xlsx",
+    )
+
+    rendered = render_prekvk_report(payload)
+
+    assert rendered is not None
+    assert rendered.filename == "prekvk_report_kvk15_overall_top10.png"
+    assert rendered.image_bytes.getvalue().startswith(b"\x89PNG")
+
+
+def test_render_prekvk_report_empty_payload_returns_none():
+    payload = PreKvkReportPayload(
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+        rows=[],
+    )
+
+    assert render_prekvk_report(payload) is None

--- a/tests/test_prekvk_report_service.py
+++ b/tests/test_prekvk_report_service.py
@@ -1,0 +1,85 @@
+from prekvk import report_service
+from prekvk.models import PreKvkReportSort
+
+
+def _rows():
+    return [
+        {
+            "GovernorID": 1,
+            "GovernorName": "Alpha",
+            "Power": 100_000_000,
+            "Stage1Points": 10,
+            "Stage2Points": 30,
+            "Stage3Points": 20,
+            "OverallPoints": 60,
+            "ScanID": 7,
+            "SourceFileName": "PreKvK.xlsx",
+        },
+        {
+            "GovernorID": 2,
+            "GovernorName": "Bravo",
+            "Power": 120_000_000,
+            "Stage1Points": 40,
+            "Stage2Points": 10,
+            "Stage3Points": 20,
+            "OverallPoints": 70,
+            "ScanID": 7,
+            "SourceFileName": "PreKvK.xlsx",
+        },
+    ]
+
+
+def test_parse_report_sort_accepts_stage_aliases():
+    assert report_service.parse_report_sort("Overall") == PreKvkReportSort.OVERALL
+    assert report_service.parse_report_sort("Stage 1") == PreKvkReportSort.STAGE1
+    assert report_service.parse_report_sort("stage iii") == PreKvkReportSort.STAGE3
+
+
+def test_normalize_report_limit_only_allows_buttons():
+    assert report_service.normalize_report_limit(25) == 25
+    assert report_service.normalize_report_limit(99) == 10
+
+
+def test_build_report_payload_defaults_overall_and_keeps_scan_metadata():
+    payload = report_service.build_report_payload_from_rows(
+        15,
+        _rows(),
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+    )
+
+    assert payload.kvk_no == 15
+    assert payload.scan_id == 7
+    assert payload.source_filename == "PreKvK.xlsx"
+    assert [row.governor_name for row in payload.rows] == ["Bravo", "Alpha"]
+    assert [row.rank for row in payload.rows] == [1, 2]
+
+
+def test_build_report_payload_sorts_by_stage_and_uses_power_tiebreaker():
+    payload = report_service.build_report_payload_from_rows(
+        15,
+        _rows(),
+        sort_by=PreKvkReportSort.STAGE3,
+        limit=10,
+    )
+
+    assert [row.governor_name for row in payload.rows] == ["Bravo", "Alpha"]
+    assert [row.rank for row in payload.rows] == [1, 1]
+
+
+def test_build_report_payload_handles_legacy_total_only_rows():
+    payload = report_service.build_report_payload_from_rows(
+        15,
+        [
+            {
+                "GovernorID": 1,
+                "GovernorName": "Legacy",
+                "Power": None,
+                "OverallPoints": 50,
+            }
+        ],
+    )
+
+    assert payload.has_stage_data is False
+    assert payload.rows[0].stage1_points is None
+    assert payload.rows[0].overall_points == 50

--- a/tests/test_prekvk_report_views.py
+++ b/tests/test_prekvk_report_views.py
@@ -1,0 +1,218 @@
+import pytest
+
+from prekvk.models import PreKvkReportSort
+from ui.views import prekvk_report_views
+from ui.views.prekvk_report_views import PreKvkReportView, send_prekvk_report
+
+
+@pytest.mark.asyncio
+async def test_prekvk_report_view_exposes_sort_and_limit_controls():
+    view = PreKvkReportView(
+        requester_id=42,
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+    )
+
+    custom_ids = [getattr(item, "custom_id", None) for item in view.children]
+
+    assert "prekvk_report_top_10" in custom_ids
+    assert "prekvk_report_top_100" in custom_ids
+    assert view.sort_select.placeholder == "Sort by"
+
+
+@pytest.mark.asyncio
+async def test_prekvk_report_view_rejects_wrong_user():
+    view = PreKvkReportView(
+        requester_id=42,
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+    )
+    response = {}
+
+    class Response:
+        async def send_message(self, content=None, **kwargs):
+            response["content"] = content
+            response.update(kwargs)
+
+    interaction = type(
+        "Interaction",
+        (),
+        {
+            "user": type("User", (), {"id": 99})(),
+            "response": Response(),
+        },
+    )()
+
+    await view._refresh(interaction)
+
+    assert "not yours" in response["content"]
+    assert response["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_prekvk_report_view_refresh_failure_sends_private_feedback(monkeypatch):
+    view = PreKvkReportView(
+        requester_id=42,
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+    )
+    followups = []
+
+    async def _fail_build(**_kwargs):
+        raise RuntimeError("database unavailable")
+
+    class Response:
+        async def defer(self):
+            return None
+
+    class Followup:
+        async def send(self, content=None, **kwargs):
+            followups.append((content, kwargs))
+
+    interaction = type(
+        "Interaction",
+        (),
+        {
+            "user": type("User", (), {"id": 42})(),
+            "response": Response(),
+            "followup": Followup(),
+        },
+    )()
+    monkeypatch.setattr(
+        prekvk_report_views.report_service, "build_prekvk_report_payload", _fail_build
+    )
+
+    await view._refresh(interaction)
+
+    assert followups
+    assert "refresh failed" in followups[0][0]
+    assert followups[0][1]["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_prekvk_report_view_refresh_edits_component_message(monkeypatch):
+    payload = type(
+        "Payload",
+        (),
+        {
+            "kvk_no": 15,
+            "sort_by": PreKvkReportSort.STAGE1,
+            "limit": 25,
+            "rows": [object()],
+        },
+    )()
+    view = PreKvkReportView(
+        requester_id=42,
+        kvk_no=15,
+        sort_by=PreKvkReportSort.STAGE1,
+        limit=25,
+    )
+
+    async def _build_payload(**_kwargs):
+        return payload
+
+    async def _no_file(_payload):
+        return None
+
+    class Response:
+        async def defer(self):
+            return None
+
+    class Message:
+        def __init__(self):
+            self.kwargs = None
+
+        async def edit(self, **kwargs):
+            self.kwargs = kwargs
+
+    message = Message()
+
+    async def _wrong_target(**_kwargs):
+        raise AssertionError("refresh should edit the component host message first")
+
+    interaction = type(
+        "Interaction",
+        (),
+        {
+            "user": type("User", (), {"id": 42})(),
+            "response": Response(),
+            "message": message,
+            "edit_original_response": _wrong_target,
+        },
+    )()
+    monkeypatch.setattr(
+        prekvk_report_views.report_service, "build_prekvk_report_payload", _build_payload
+    )
+    monkeypatch.setattr(prekvk_report_views, "_discord_file", _no_file)
+
+    await view._refresh(interaction)
+
+    assert view.message is message
+    assert "sorted by **Stage 1**" in message.kwargs["content"]
+    assert message.kwargs["view"] is view
+
+
+@pytest.mark.asyncio
+async def test_send_prekvk_report_stores_public_channel_message(monkeypatch):
+    payload = type(
+        "Payload",
+        (),
+        {
+            "kvk_no": 15,
+            "sort_by": PreKvkReportSort.OVERALL,
+            "limit": 10,
+            "rows": [object()],
+        },
+    )()
+    public_message = object()
+
+    async def _build_payload(**_kwargs):
+        return payload
+
+    async def _no_file(_payload):
+        return None
+
+    class Channel:
+        def __init__(self):
+            self.kwargs = None
+
+        async def send(self, **kwargs):
+            self.kwargs = kwargs
+            return public_message
+
+    class Followup:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, content=None, **kwargs):
+            self.sent.append((content, kwargs))
+
+    channel = Channel()
+    followup = Followup()
+    ctx = type(
+        "Ctx",
+        (),
+        {
+            "user": type("User", (), {"id": 42})(),
+            "channel": channel,
+            "followup": followup,
+        },
+    )()
+    monkeypatch.setattr(
+        prekvk_report_views.report_service, "build_prekvk_report_payload", _build_payload
+    )
+    monkeypatch.setattr(prekvk_report_views, "_discord_file", _no_file)
+
+    await send_prekvk_report(
+        ctx=ctx,
+        kvk_no=15,
+        sort_by=PreKvkReportSort.OVERALL,
+        limit=10,
+    )
+
+    view = channel.kwargs["view"]
+    assert view.message is public_message
+    assert followup.sent == [("PreKvK report posted.", {"ephemeral": True})]

--- a/ui/views/prekvk_report_views.py
+++ b/ui/views/prekvk_report_views.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import discord
+
+from prekvk import report_service
+from prekvk.models import PREKVK_REPORT_LIMITS, PreKvkReportPayload, PreKvkReportSort
+from prekvk.report_image_renderer import render_prekvk_report
+
+logger = logging.getLogger(__name__)
+
+
+async def _discord_file(payload: PreKvkReportPayload) -> discord.File | None:
+    rendered = await asyncio.to_thread(render_prekvk_report, payload)
+    if rendered is None:
+        return None
+    return discord.File(rendered.image_bytes, filename=rendered.filename)
+
+
+def _content(payload: PreKvkReportPayload) -> str:
+    if not payload.rows:
+        return f"No PreKvK import found for KVK `{payload.kvk_no}`."
+    return (
+        f"PreKvK report for KVK `{payload.kvk_no}` - "
+        f"sorted by **{report_service.SORT_LABELS[payload.sort_by]}**, Top `{payload.limit}`."
+    )
+
+
+class PreKvkReportView(discord.ui.View):
+    def __init__(
+        self,
+        *,
+        requester_id: int,
+        kvk_no: int,
+        sort_by: PreKvkReportSort,
+        limit: int,
+        timeout: float = 300.0,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self.requester_id = int(requester_id)
+        self.kvk_no = int(kvk_no)
+        self.sort_by = sort_by
+        self.limit = int(limit)
+        self.message: discord.Message | None = None
+        self.sort_select = discord.ui.Select(
+            placeholder="Sort by",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(label="Overall", value=PreKvkReportSort.OVERALL.value),
+                discord.SelectOption(label="Stage 1", value=PreKvkReportSort.STAGE1.value),
+                discord.SelectOption(label="Stage 2", value=PreKvkReportSort.STAGE2.value),
+                discord.SelectOption(label="Stage 3", value=PreKvkReportSort.STAGE3.value),
+            ],
+            row=0,
+        )
+        self.sort_select.callback = self.on_sort_change
+        self.add_item(self.sort_select)
+        for option_limit in PREKVK_REPORT_LIMITS:
+            button = discord.ui.Button(
+                label=f"Top {option_limit}",
+                style=discord.ButtonStyle.secondary,
+                custom_id=f"prekvk_report_top_{option_limit}",
+                row=1,
+            )
+            button.callback = self._make_limit_handler(option_limit)
+            self.add_item(button)
+        self._sync_controls()
+
+    def _sync_controls(self) -> None:
+        for option in self.sort_select.options:
+            option.default = option.value == self.sort_by.value
+        for item in self.children:
+            if isinstance(item, discord.ui.Button) and item.label and item.label.startswith("Top "):
+                item.style = (
+                    discord.ButtonStyle.primary
+                    if item.label == f"Top {self.limit}"
+                    else discord.ButtonStyle.secondary
+                )
+
+    async def _refresh(self, interaction: discord.Interaction) -> None:
+        if int(interaction.user.id) != self.requester_id:
+            await interaction.response.send_message(
+                "This PreKvK report control is not yours. Run `/prekvk_report` to open a fresh report.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await interaction.response.defer()
+        except Exception:
+            pass
+        try:
+            payload = await report_service.build_prekvk_report_payload(
+                kvk_no=self.kvk_no,
+                sort_by=self.sort_by,
+                limit=self.limit,
+            )
+            self._sync_controls()
+            file = await _discord_file(payload)
+            kwargs: dict[str, Any] = {
+                "content": _content(payload),
+                "attachments": [],
+                "view": self,
+            }
+            if file is not None:
+                kwargs["files"] = [file]
+            message = getattr(interaction, "message", None)
+            if message is not None:
+                self.message = message
+                try:
+                    await message.edit(**kwargs)
+                    return
+                except Exception:
+                    logger.debug("prekvk_report_host_message_edit_failed", exc_info=True)
+            await interaction.edit_original_response(**kwargs)
+        except Exception:
+            logger.exception(
+                "prekvk_report_refresh_failed actor_discord_id=%s kvk_no=%s sort_by=%s limit=%s",
+                getattr(interaction.user, "id", None),
+                self.kvk_no,
+                self.sort_by.value,
+                self.limit,
+            )
+            try:
+                await interaction.followup.send(
+                    "PreKvK report refresh failed. Please try again or run `/prekvk_report` for a fresh report.",
+                    ephemeral=True,
+                )
+            except Exception:
+                logger.debug("prekvk_report_refresh_error_response_failed", exc_info=True)
+
+    async def on_sort_change(self, interaction: discord.Interaction) -> None:
+        self.sort_by = report_service.parse_report_sort(self.sort_select.values[0])
+        await self._refresh(interaction)
+
+    def _make_limit_handler(self, limit: int):
+        async def _handler(interaction: discord.Interaction) -> None:
+            self.limit = report_service.normalize_report_limit(limit)
+            await self._refresh(interaction)
+
+        return _handler
+
+    async def on_timeout(self) -> None:
+        for item in self.children:
+            item.disabled = True
+        try:
+            if self.message:
+                await self.message.edit(view=self)
+        except Exception:
+            logger.debug("prekvk_report_view_timeout_edit_failed", exc_info=True)
+
+
+async def send_prekvk_report(
+    *,
+    ctx: discord.ApplicationContext,
+    kvk_no: int | None,
+    sort_by: PreKvkReportSort,
+    limit: int,
+) -> None:
+    payload = await report_service.build_prekvk_report_payload(
+        kvk_no=kvk_no,
+        sort_by=sort_by,
+        limit=limit,
+    )
+    view = PreKvkReportView(
+        requester_id=int(ctx.user.id),
+        kvk_no=payload.kvk_no,
+        sort_by=payload.sort_by,
+        limit=payload.limit,
+    )
+    file = await _discord_file(payload)
+    kwargs: dict[str, Any] = {"content": _content(payload), "view": view}
+    if file is not None:
+        kwargs["file"] = file
+    try:
+        channel = getattr(ctx, "channel", None)
+        if channel is not None:
+            view.message = await channel.send(**kwargs)
+            try:
+                await ctx.followup.send("PreKvK report posted.", ephemeral=True)
+            except Exception:
+                logger.debug("prekvk_report_post_ack_failed", exc_info=True)
+            return
+        view.message = await ctx.followup.send(wait=True, ephemeral=False, **kwargs)
+    except TypeError:
+        await ctx.followup.send(ephemeral=False, **kwargs)
+        view.message = None
+    except Exception:
+        logger.debug("prekvk_report_send_failed", exc_info=True)
+        view.message = None
+        raise


### PR DESCRIPTION
## Summary
- Add public `/prekvk_report` command with current-KVK defaulting, sort controls, and Top 10/25/50/100 refresh buttons.
- Add PreKvK report DAL/service/model/image-renderer stack using direct-stage PreKvK data and player power enrichment.
- Add Phase 2C/2D docs, including the required Phase 2D stats-alert refactor before moving on.
- Address code review feedback so the view stores the actual report message, component refresh edits the clicked report message, refresh interactions fail gracefully, and command errors stay private while the report posts publicly.

## Changes
- New `prekvk` report architecture: DAL query, payload/ranking service, and PIL PNG renderer.
- New requester-scoped Discord view for changing sort and limit.
- Public command registration in `commands/prekvk_cmds.py` and `commands/__init__.py`.
- Focused report command/service/DAL/renderer/view tests, including followup-message capture, component-message refresh, and refresh-error coverage.

## Tests
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py` (6 passed)
- `./.venv/Scripts/python.exe -m ruff check ui/views/prekvk_report_views.py tests/test_prekvk_report_views.py`
- `./.venv/Scripts/python.exe -m black --check ui/views/prekvk_report_views.py tests/test_prekvk_report_views.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_service.py tests/test_prekvk_report_dal.py tests/test_prekvk_report_image_renderer.py tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py tests/test_prekvk_stats.py tests/test_prekvk_diagnostics.py tests/test_ui_imports.py tests/test_command_registration_smoke.py` (32 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests` (1416 passed, 2 skipped)
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe -m pyright` (0 errors; existing optional/script missing-import warnings)
- `git diff --check`

## Deferred Optimisations
- Phase 2D: refactor `stats_alerts/prekvk_stats.py` and `stats_alerts/embeds/prekvk.py` to reuse the new PreKvK report architecture before moving on from the PreKvK report phase.

## Risk / Rollback
- Read-only report command; no upload route, importer, or SQL object changes.
- Rollback is reverting the bot PR; no database rollback required.