### PR TITLE
fix: keep PreKvK report under command cap

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -11,7 +11,6 @@ from .events_cmds import register_events
 from .inventory_cmds import register_inventory
 from .location_cmds import register_location
 from .mge_cmds import register_mge
-from .prekvk_admin_cmds import register_prekvk_admin
 from .prekvk_cmds import register_prekvk
 from .registry_cmds import register_registry
 from .stats_cmds import register_stats
@@ -29,7 +28,6 @@ def register_all(bot: ext_commands.Bot) -> None:
     register_location(bot)
     register_mge(bot)
     register_prekvk(bot)
-    register_prekvk_admin(bot)
     register_registry(bot)
     register_stats(bot)
     register_subscriptions(bot)

--- a/commands/prekvk_admin_cmds.py
+++ b/commands/prekvk_admin_cmds.py
@@ -15,11 +15,10 @@ from versioning import versioned
 logger = logging.getLogger(__name__)
 
 
-def register_prekvk_admin(bot: ext_commands.Bot) -> None:
-    @bot.slash_command(
-        name="prekvk_import_history",
+def attach_prekvk_import_history(command_group: discord.SlashCommandGroup) -> None:
+    @command_group.command(
+        name="import_history",
         description="Show recent PreKvK import diagnostics",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.00")
     @safe_command
@@ -91,3 +90,13 @@ def register_prekvk_admin(bot: ext_commands.Bot) -> None:
         embed.add_field(name="Rows", value=str(len(rows)), inline=True)
 
         await ctx.followup.send(embed=embed, ephemeral=True)
+
+
+def register_prekvk_admin(bot: ext_commands.Bot) -> None:
+    group = discord.SlashCommandGroup(
+        "prekvk",
+        "PreKvK reports and diagnostics",
+        guild_ids=[GUILD_ID],
+    )
+    attach_prekvk_import_history(group)
+    bot.add_application_command(group)

--- a/commands/prekvk_cmds.py
+++ b/commands/prekvk_cmds.py
@@ -12,14 +12,21 @@ from prekvk import report_service
 from ui.views.prekvk_report_views import send_prekvk_report
 from versioning import versioned
 
+from .prekvk_admin_cmds import attach_prekvk_import_history
+
 logger = logging.getLogger(__name__)
 
 
 def register_prekvk(bot: ext_commands.Bot) -> None:
-    @bot.slash_command(
-        name="prekvk_report",
-        description="View the current PreKvK rankings report",
+    group = discord.SlashCommandGroup(
+        "prekvk",
+        "PreKvK reports and diagnostics",
         guild_ids=[GUILD_ID],
+    )
+
+    @group.command(
+        name="report",
+        description="View the current PreKvK rankings report",
     )
     @versioned("v1.00")
     @safe_command
@@ -63,3 +70,6 @@ def register_prekvk(bot: ext_commands.Bot) -> None:
                 "PreKvK report generation failed. Please try again or contact an admin.",
                 ephemeral=True,
             )
+
+    attach_prekvk_import_history(group)
+    bot.add_application_command(group)

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -21,6 +21,15 @@ upload routing and related test-environment blockers, not as a continuation of t
 both this backlog and the current `K98-bot-mirror` GitHub issues list.
 
 ### Deferred Optimisation
+- Area: `commands/`, `scripts/validate_command_registration.py`
+- Type: architecture
+- Description: The primary Discord application-command set is currently at the 100 top-level command limit. Phase 2C avoided the limit by grouping PreKvK commands under `/prekvk`, but future standalone slash commands can still break startup sync with Discord error 30032 unless command surface consolidation is planned before new command work.
+- Suggested Fix: Run a command-surface balancing audit before the next command-heavy feature. Group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling in PR validation.
+- Impact: high
+- Risk: medium
+- Dependencies: Coordinate with bot operators before renaming public command paths; preserve admin-only permission checks when commands move into groups.
+
+### Deferred Optimisation
 - Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
 - Type: consistency
 - Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
@@ -89,7 +89,8 @@ Goal: design and implement a dedicated PreKvK report/embed after the route bound
 
 Approved implementation direction:
 
-- Add a public read-only `/prekvk_report` slash command.
+- Add a public read-only `/prekvk report` subcommand under a shared PreKvK command group so
+  the report does not increase the Discord top-level command count.
 - Default to the current KVK when `kvk_no` is omitted.
 - Render a dedicated PNG leaderboard rather than a fixed-width embed table.
 - Include `Rank`, `GovernorName`, `Power`, `Stage 1`, `Stage 2`, `Stage 3`, and `Overall`.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
@@ -25,7 +25,9 @@ report surface, architecture direction, and implementation plan are each approve
 
 The audit/design packet was reviewed and implementation was approved with these decisions:
 
-- Build a public read-only `/prekvk_report` slash command rather than an admin-only command.
+- Build a public read-only `/prekvk report` subcommand rather than an admin-only command. Use the
+  shared `/prekvk` top-level group to avoid exceeding Discord's 100 top-level application-command
+  limit.
 - Keep the command unannounced initially; it remains low risk because it only reads existing
   PreKvK data.
 - Default to the current `kvk_no` from metadata, with an optional `kvk_no` override.

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -12,11 +12,27 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-MODULES = [
-    ("Commands.py (authoritative)", ROOT / "Commands.py"),
+PRIMARY_COMMAND_LIMIT = 100
+
+SECONDARY_MODULES = [
     ("cogs/commands.py (secondary)", ROOT / "cogs" / "commands.py"),
     ("subscribe.py (secondary)", ROOT / "subscribe.py"),
 ]
+
+
+def _literal_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value:
+        return str(node.value)
+    return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
 
 
 def collect_names(path: Path) -> set[str]:
@@ -40,36 +56,95 @@ def collect_names(path: Path) -> set[str]:
             if not (is_slash or is_app):
                 continue
             for kw in deco.keywords:
-                if kw.arg == "name" and isinstance(kw.value, ast.Constant) and kw.value.value:
-                    names.add(str(kw.value.value))
+                name = _literal_string(kw.value) if kw.arg == "name" else None
+                if name:
+                    names.add(name)
                     break
     return names
 
 
+def collect_primary_names() -> set[str]:
+    names: set[str] = set()
+    for path in sorted((ROOT / "commands").glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        source = path.read_text(encoding="utf-8-sig")
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for deco in node.decorator_list:
+                    if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
+                        continue
+                    attr = deco.func.attr
+                    owner = deco.func.value
+                    is_bot_slash = (
+                        attr == "slash_command"
+                        and isinstance(owner, ast.Name)
+                        and owner.id in {"bot", "bot_instance"}
+                    )
+                    is_app_command = (
+                        attr == "command"
+                        and isinstance(owner, ast.Name)
+                        and owner.id == "app_commands"
+                    )
+                    if not (is_bot_slash or is_app_command):
+                        continue
+                    for kw in deco.keywords:
+                        name = _literal_string(kw.value) if kw.arg == "name" else None
+                        if name:
+                            names.add(name)
+                            break
+
+            if isinstance(node, ast.Call) and _call_name(node) == "SlashCommandGroup":
+                if node.args:
+                    name = _literal_string(node.args[0])
+                    if name:
+                        names.add(name)
+                        continue
+                for kw in node.keywords:
+                    name = _literal_string(kw.value) if kw.arg == "name" else None
+                    if name:
+                        names.add(name)
+                        break
+
+    return names
+
+
 def main() -> int:
-    paths = {label: collect_names(path) for label, path in MODULES}
+    paths = {"commands package (authoritative)": collect_primary_names()}
+    paths.update({label: collect_names(path) for label, path in SECONDARY_MODULES})
     owners: dict[str, list[str]] = {}
     for label, names in paths.items():
         for name in names:
             owners.setdefault(name, []).append(label)
     duplicates = {k: sorted(v) for k, v in owners.items() if len(v) > 1}
 
+    primary_count = len(paths["commands package (authoritative)"])
     total_unique = len(set().union(*paths.values()))
     print(
-        f"registration summary: primary={len(paths['Commands.py (authoritative)'])} "
+        f"registration summary: primary={primary_count} "
         f"secondary_cogs={len(paths['cogs/commands.py (secondary)'])} "
         f"secondary_subscribe={len(paths['subscribe.py (secondary)'])} "
         f"total_unique={total_unique}"
     )
 
+    failed = False
+    if primary_count > PRIMARY_COMMAND_LIMIT:
+        print(
+            f"primary command limit exceeded: {primary_count}/{PRIMARY_COMMAND_LIMIT} "
+            "top-level application commands"
+        )
+        failed = True
+
     if not duplicates:
         print("no duplicates detected")
-        return 0
+    else:
+        print("duplicates detected:")
+        for name in sorted(duplicates):
+            print(f"  /{name}: {', '.join(duplicates[name])}")
 
-    print("duplicates detected:")
-    for name in sorted(duplicates):
-        print(f"  /{name}: {', '.join(duplicates[name])}")
-    return 0
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -22,12 +22,15 @@ def test_register_commands_smoke(monkeypatch):
 
     import Commands
 
+    registered_top_level = []
     fake_bot = types.SimpleNamespace()
     fake_bot.tree = types.SimpleNamespace(command=lambda **kw: (lambda fn: fn))
     fake_bot.add_listener = lambda *args, **kwargs: None
+    fake_bot.add_application_command = lambda command: registered_top_level.append(command.name)
 
     def slash_command(**kwargs):
         def deco(fn):
+            registered_top_level.append(kwargs.get("name"))
             return fn
 
         return deco
@@ -35,3 +38,8 @@ def test_register_commands_smoke(monkeypatch):
     fake_bot.slash_command = slash_command
 
     Commands.register_commands(fake_bot)
+
+    assert len([name for name in registered_top_level if name]) <= 100
+    assert "prekvk" in registered_top_level
+    assert "prekvk_report" not in registered_top_level
+    assert "prekvk_import_history" not in registered_top_level

--- a/tests/test_prekvk_diagnostics.py
+++ b/tests/test_prekvk_diagnostics.py
@@ -5,7 +5,7 @@ import inspect
 
 import pandas as pd
 
-from commands.prekvk_admin_cmds import register_prekvk_admin
+from commands.prekvk_admin_cmds import attach_prekvk_import_history
 from kvk.dal import kvk_stats_dal
 from prekvk import diagnostics_service
 from prekvk.dal import import_history_dal
@@ -328,8 +328,9 @@ def test_format_history_rows_sanitizes_markdown_and_mentions():
 
 
 def test_prekvk_import_history_command_has_admin_gate():
-    source = inspect.getsource(register_prekvk_admin)
+    source = inspect.getsource(attach_prekvk_import_history)
 
+    assert 'name="import_history"' in source
     assert "@is_admin_and_notify_channel()" in source
     assert "@safe_command" in source
     assert "@track_usage()" in source

--- a/tests/test_prekvk_report_command.py
+++ b/tests/test_prekvk_report_command.py
@@ -6,7 +6,9 @@ from commands.prekvk_cmds import register_prekvk
 def test_prekvk_report_command_is_public_read_only_surface():
     source = inspect.getsource(register_prekvk)
 
-    assert 'name="prekvk_report"' in source
+    assert "SlashCommandGroup" in source
+    assert '"prekvk"' in source
+    assert 'name="report"' in source
     assert "@safe_command" in source
     assert "@track_usage()" in source
     assert "safe_defer(ctx, ephemeral=True)" in source

--- a/tests/test_prekvk_report_views.py
+++ b/tests/test_prekvk_report_views.py
@@ -48,6 +48,7 @@ async def test_prekvk_report_view_rejects_wrong_user():
     await view._refresh(interaction)
 
     assert "not yours" in response["content"]
+    assert "/prekvk report" in response["content"]
     assert response["ephemeral"] is True
 
 
@@ -89,6 +90,7 @@ async def test_prekvk_report_view_refresh_failure_sends_private_feedback(monkeyp
 
     assert followups
     assert "refresh failed" in followups[0][0]
+    assert "/prekvk report" in followups[0][0]
     assert followups[0][1]["ephemeral"] is True
 
 

--- a/ui/views/prekvk_report_views.py
+++ b/ui/views/prekvk_report_views.py
@@ -84,7 +84,7 @@ class PreKvkReportView(discord.ui.View):
     async def _refresh(self, interaction: discord.Interaction) -> None:
         if int(interaction.user.id) != self.requester_id:
             await interaction.response.send_message(
-                "This PreKvK report control is not yours. Run `/prekvk_report` to open a fresh report.",
+                "This PreKvK report control is not yours. Run `/prekvk report` to open a fresh report.",
                 ephemeral=True,
             )
             return
@@ -126,7 +126,7 @@ class PreKvkReportView(discord.ui.View):
             )
             try:
                 await interaction.followup.send(
-                    "PreKvK report refresh failed. Please try again or run `/prekvk_report` for a fresh report.",
+                    "PreKvK report refresh failed. Please try again or run `/prekvk report` for a fresh report.",
                     ephemeral=True,
                 )
             except Exception:


### PR DESCRIPTION
## Summary
- Fix smoke-test failure `Maximum number of application commands reached (100)` by moving the PreKvK report and import-history diagnostics under one top-level `/prekvk` command group.
- Public report surface is now `/prekvk report`; admin diagnostics are now `/prekvk import_history`.
- Update view retry prompts to point users at `/prekvk report` after the command rename.
- Update command registration validation so it counts package-based top-level commands and fails if the primary command count exceeds Discord's 100-command limit.
- Update Phase 2 docs to record the grouped command surface.
- Add a deferred optimisation for command-surface balancing because the bot is now exactly at the 100 top-level command ceiling.

## Tests
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py tests/test_command_registration_smoke.py` (7 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests/test_command_registration_smoke.py tests/test_prekvk_report_command.py tests/test_prekvk_diagnostics.py tests/test_prekvk_report_views.py` (19 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_service.py tests/test_prekvk_report_dal.py tests/test_prekvk_report_image_renderer.py tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py tests/test_prekvk_stats.py tests/test_prekvk_diagnostics.py tests/test_ui_imports.py tests/test_command_registration_smoke.py` (32 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests` (1416 passed, 2 skipped)
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` (primary=100, total_unique=100; known disabled secondary duplicates listed)
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe -m ruff check ui/views/prekvk_report_views.py tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py tests/test_command_registration_smoke.py`
- `./.venv/Scripts/python.exe -m black --check ui/views/prekvk_report_views.py tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py tests/test_command_registration_smoke.py`
- `./.venv/Scripts/python.exe -m pyright` (0 errors; existing optional/script missing-import warnings)
- `git diff --check`
- After adding the deferred optimisation: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`; `./.venv/Scripts/python.exe scripts/validate_command_registration.py`

## Risk / Rollback
- No SQL, import, upload route, or report rendering behavior changes.
- Command invocation changes from `/prekvk_report` to `/prekvk report` to avoid exceeding Discord's top-level application-command cap.