### PR TITLE
fix: improve PreKvK name glyph coverage

### DIFF
--- a/prekvk/report_image_renderer.py
+++ b/prekvk/report_image_renderer.py
@@ -171,16 +171,13 @@ def _coverage_codepoints(text: str) -> list[int]:
 
 
 @lru_cache(maxsize=512)
-def _font_supports_text(font_path: str, text: str) -> bool:
+def _font_coverage(font_path: str) -> frozenset[int] | None:
     if not Path(font_path).exists():
-        return False
-    codepoints = _coverage_codepoints(text)
-    if not codepoints:
-        return True
+        return frozenset()
     try:
         from fontTools.ttLib import TTCollection, TTFont
     except Exception:
-        return True
+        return None
     try:
         font_obj = (
             TTCollection(font_path).fonts[0]
@@ -190,10 +187,20 @@ def _font_supports_text(font_path: str, text: str) -> bool:
         coverage: set[int] = set()
         for table in font_obj["cmap"].tables:
             coverage.update(table.cmap.keys())
-        return all(codepoint in coverage for codepoint in codepoints)
+        return frozenset(coverage)
     except Exception:
+        return None
+
+
+@lru_cache(maxsize=512)
+def _font_supports_text(font_path: str, text: str) -> bool:
+    codepoints = _coverage_codepoints(text)
+    if not codepoints:
         return True
-    return False
+    coverage = _font_coverage(font_path)
+    if coverage is None:
+        return True
+    return all(codepoint in coverage for codepoint in codepoints)
 
 
 def _compact(value: int | None) -> str:
@@ -212,6 +219,26 @@ def _clean_text(value: str, max_chars: int) -> str:
     cleaned = cleaned.replace("\r", " ").replace("\n", " ")
     cleaned = " ".join(cleaned.split()) or "Unknown"
     return cleaned if len(cleaned) <= max_chars else cleaned[: max_chars - 1].rstrip() + "."
+
+
+def _fit_text_to_width(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    *,
+    width: int,
+    font: ImageFont.ImageFont,
+    bold: bool = False,
+) -> str:
+    if _text_width(draw, text, font=font, bold=bold) <= width:
+        return text
+    out = ""
+    suffix = "."
+    for cluster in _text_clusters(text):
+        candidate = f"{out}{cluster}{suffix}"
+        if _text_width(draw, candidate, font=font, bold=bold) > width:
+            break
+        out += cluster
+    return (out.rstrip() + suffix) if out.strip() else suffix
 
 
 def _text_width(
@@ -315,9 +342,16 @@ def render_prekvk_report(payload: PreKvkReportPayload) -> RenderedPreKvkReportIm
         if idx % 2 == 0:
             draw.rectangle((48, y, WIDTH - 48, y + ROW_H), fill=(15, 41, 72))
         rank_fill = GOLD if row.rank <= 3 else TEXT
+        name_font = _font(18)
+        governor_name = _fit_text_to_width(
+            draw,
+            _clean_text(row.governor_name, 40),
+            width=360,
+            font=name_font,
+        )
         values = [
             (str(row.rank), 58, 78, "left", rank_fill),
-            (_clean_text(row.governor_name, 28), 150, 360, "left", TEXT),
+            (governor_name, 150, 360, "left", TEXT),
             (_compact(row.power), 540, 150, "right", MUTED if row.power is None else TEXT),
             (
                 _compact(row.stage1_points),
@@ -343,7 +377,7 @@ def render_prekvk_report(payload: PreKvkReportPayload) -> RenderedPreKvkReportIm
             (_compact(row.overall_points), 1288, 180, "right", TEXT),
         ]
         for value, x, w, align, fill in values:
-            _cell(draw, (x, y + 8), value, width=w, align=align, font=_font(18), fill=fill)
+            _cell(draw, (x, y + 8), value, width=w, align=align, font=name_font, fill=fill)
 
     footer = (
         "Legacy total-only imports show N/A for stage columns."

--- a/prekvk/report_image_renderer.py
+++ b/prekvk/report_image_renderer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from io import BytesIO
+from pathlib import Path
 import unicodedata
 
 from PIL import Image, ImageDraw, ImageFont
@@ -96,12 +97,23 @@ def _font_candidates_for_text(text: str, *, bold: bool = False) -> list[str]:
             "C:/Windows/Fonts/seguiemj.ttf",
             "C:/Windows/Fonts/seguisym.ttf",
         ]
-    if (
-        any(0x3000 <= codepoint <= 0x30FF for codepoint in codepoints)
-        or any(0x3400 <= codepoint <= 0x9FFF for codepoint in codepoints)
-        or any(0xAC00 <= codepoint <= 0xD7AF for codepoint in codepoints)
+    if any(0x0E00 <= codepoint <= 0x0E7F for codepoint in codepoints):
+        return [
+            "C:/Windows/Fonts/LeelaUIb.ttf" if bold else "C:/Windows/Fonts/LeelawUI.ttf",
+            "C:/Windows/Fonts/LEELAWAD.TTF",
+        ]
+    if any(0x3400 <= codepoint <= 0x9FFF for codepoint in codepoints):
+        return [
+            "C:/Windows/Fonts/msyhbd.ttc" if bold else "C:/Windows/Fonts/msyh.ttc",
+            "C:/Windows/Fonts/simsun.ttc",
+            "C:/Windows/Fonts/YuGothB.ttc" if bold else "C:/Windows/Fonts/YuGothM.ttc",
+            "C:/Windows/Fonts/msgothic.ttc",
+        ]
+    if any(0x3000 <= codepoint <= 0x30FF for codepoint in codepoints) or any(
+        0xAC00 <= codepoint <= 0xD7AF for codepoint in codepoints
     ):
         return [
+            "C:/Windows/Fonts/msyhbd.ttc" if bold else "C:/Windows/Fonts/msyh.ttc",
             "C:/Windows/Fonts/YuGothB.ttc" if bold else "C:/Windows/Fonts/YuGothM.ttc",
             "C:/Windows/Fonts/msgothic.ttc",
             "C:/Windows/Fonts/simsun.ttc",
@@ -132,11 +144,56 @@ def _font_for_char(ch: str, size: int, *, bold: bool = False) -> ImageFont.Image
 @lru_cache(maxsize=512)
 def _font_for_text(text: str, size: int, *, bold: bool = False) -> ImageFont.ImageFont:
     for candidate in _font_candidates_for_text(text, bold=bold):
+        if not _font_supports_text(candidate, text):
+            continue
         try:
             return ImageFont.truetype(candidate, size=size)
         except Exception:
             continue
     return _font(size, bold=bold)
+
+
+def _cluster_font_size(text: str, base_size: int) -> int:
+    codepoints = [ord(ch) for ch in text]
+    if any(0x0E00 <= codepoint <= 0x0E7F for codepoint in codepoints) or any(
+        0x3000 <= codepoint <= 0x9FFF or 0xAC00 <= codepoint <= 0xD7AF for codepoint in codepoints
+    ):
+        return base_size + 4
+    return base_size
+
+
+def _coverage_codepoints(text: str) -> list[int]:
+    return [
+        ord(ch)
+        for ch in text
+        if ord(ch) != 0x200D and not _is_variation_selector(ord(ch)) and not _is_tag_char(ord(ch))
+    ]
+
+
+@lru_cache(maxsize=512)
+def _font_supports_text(font_path: str, text: str) -> bool:
+    if not Path(font_path).exists():
+        return False
+    codepoints = _coverage_codepoints(text)
+    if not codepoints:
+        return True
+    try:
+        from fontTools.ttLib import TTCollection, TTFont
+    except Exception:
+        return True
+    try:
+        font_obj = (
+            TTCollection(font_path).fonts[0]
+            if font_path.lower().endswith(".ttc")
+            else TTFont(font_path, lazy=True)
+        )
+        coverage: set[int] = set()
+        for table in font_obj["cmap"].tables:
+            coverage.update(table.cmap.keys())
+        return all(codepoint in coverage for codepoint in codepoints)
+    except Exception:
+        return True
+    return False
 
 
 def _compact(value: int | None) -> str:
@@ -151,8 +208,7 @@ def _compact(value: int | None) -> str:
 
 
 def _clean_text(value: str, max_chars: int) -> str:
-    normalized = unicodedata.normalize("NFKD", str(value or ""))
-    cleaned = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    cleaned = unicodedata.normalize("NFC", str(value or ""))
     cleaned = cleaned.replace("\r", " ").replace("\n", " ")
     cleaned = " ".join(cleaned.split()) or "Unknown"
     return cleaned if len(cleaned) <= max_chars else cleaned[: max_chars - 1].rstrip() + "."
@@ -163,7 +219,8 @@ def _text_width(
 ) -> int:
     width = 0
     for cluster in _text_clusters(text):
-        cluster_font = _font_for_text(cluster, getattr(font, "size", 20), bold=bold)
+        base_size = getattr(font, "size", 20)
+        cluster_font = _font_for_text(cluster, _cluster_font_size(cluster, base_size), bold=bold)
         box = draw.textbbox((0, 0), cluster, font=cluster_font)
         width += int(box[2] - box[0])
     return width
@@ -180,7 +237,8 @@ def _draw_text(
 ) -> None:
     x, y = xy
     for cluster in _text_clusters(text):
-        cluster_font = _font_for_text(cluster, getattr(font, "size", 20), bold=bold)
+        base_size = getattr(font, "size", 20)
+        cluster_font = _font_for_text(cluster, _cluster_font_size(cluster, base_size), bold=bold)
         draw.text((x, y), cluster, fill=fill, font=cluster_font)
         box = draw.textbbox((0, 0), cluster, font=cluster_font)
         x += int(box[2] - box[0])

--- a/tests/test_prekvk_report_image_renderer.py
+++ b/tests/test_prekvk_report_image_renderer.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from prekvk import report_image_renderer
 from prekvk.models import PreKvkReportPayload, PreKvkReportRow, PreKvkReportSort
 from prekvk.report_image_renderer import render_prekvk_report
@@ -37,6 +39,10 @@ def test_render_prekvk_report_handles_symbol_names():
     astronaut = "Orbit\U0001f469\u200d\U0001f680"
     flag = "Flag\U0001f1ec\U0001f1e7"
     thumbs_up = "Boost\U0001f44d\U0001f3fd"
+    laki = "\u30c5 Laki \u0e5b"
+    fox_yi = "Fox\u4e49"
+    viper = "\u4e49V\u00ecper\u4e49"
+    fart = "\u30c5 Fart \u0e5b"
     payload = PreKvkReportPayload(
         kvk_no=15,
         sort_by=PreKvkReportSort.STAGE3,
@@ -92,6 +98,46 @@ def test_render_prekvk_report_handles_symbol_names():
                 stage3_points=26,
                 overall_points=48,
             ),
+            PreKvkReportRow(
+                rank=6,
+                governor_id=6,
+                governor_name=laki,
+                power=50_000_000,
+                stage1_points=5,
+                stage2_points=15,
+                stage3_points=25,
+                overall_points=45,
+            ),
+            PreKvkReportRow(
+                rank=7,
+                governor_id=7,
+                governor_name=fox_yi,
+                power=40_000_000,
+                stage1_points=4,
+                stage2_points=14,
+                stage3_points=24,
+                overall_points=42,
+            ),
+            PreKvkReportRow(
+                rank=8,
+                governor_id=8,
+                governor_name=viper,
+                power=30_000_000,
+                stage1_points=3,
+                stage2_points=13,
+                stage3_points=23,
+                overall_points=39,
+            ),
+            PreKvkReportRow(
+                rank=9,
+                governor_id=9,
+                governor_name=fart,
+                power=20_000_000,
+                stage1_points=2,
+                stage2_points=12,
+                stage3_points=22,
+                overall_points=36,
+            ),
         ],
     )
 
@@ -100,6 +146,7 @@ def test_render_prekvk_report_handles_symbol_names():
     assert rendered is not None
     assert rendered.image_bytes.getvalue().startswith(b"\x89PNG")
     assert report_image_renderer._clean_text(fox, 28) == fox
+    assert report_image_renderer._clean_text(viper, 28) == viper
     assert report_image_renderer._text_clusters(astronaut)[5:] == ["\U0001f469\u200d\U0001f680"]
     assert report_image_renderer._text_clusters(flag)[4:] == ["\U0001f1ec\U0001f1e7"]
     assert report_image_renderer._text_clusters(thumbs_up)[5:] == ["\U0001f44d\U0001f3fd"]
@@ -108,9 +155,29 @@ def test_render_prekvk_report_handles_symbol_names():
         for candidate in report_image_renderer._font_candidates_for_char("\U0001f98a")
     )
     assert any(
-        candidate.endswith("YuGothM.ttc")
+        candidate.endswith("msyh.ttc")
         for candidate in report_image_renderer._font_candidates_for_char("\u3010")
     )
+    assert any(
+        candidate.endswith("LeelawUI.ttf")
+        for candidate in report_image_renderer._font_candidates_for_char("\u0e5b")
+    )
+    assert any(
+        candidate.endswith("msyh.ttc")
+        for candidate in report_image_renderer._font_candidates_for_char("\u4e49")
+    )
+    assert any(
+        candidate.endswith("msyh.ttc")
+        for candidate in report_image_renderer._font_candidates_for_char("\u3400")
+    )
+    msyh = Path("C:/Windows/Fonts/msyh.ttc")
+    if msyh.exists():
+        assert report_image_renderer._font_supports_text(str(msyh), "\u4e49")
+    leelaw = Path("C:/Windows/Fonts/LeelawUI.ttf")
+    if leelaw.exists():
+        assert report_image_renderer._font_supports_text(str(leelaw), "\u0e5b")
+    assert report_image_renderer._cluster_font_size("\u30c5", 18) == 22
+    assert report_image_renderer._cluster_font_size("\u0e5b", 18) == 22
 
 
 def test_render_prekvk_report_empty_payload_returns_none():

--- a/tests/test_prekvk_report_image_renderer.py
+++ b/tests/test_prekvk_report_image_renderer.py
@@ -180,6 +180,56 @@ def test_render_prekvk_report_handles_symbol_names():
     assert report_image_renderer._cluster_font_size("\u0e5b", 18) == 22
 
 
+def test_font_for_text_skips_unsupported_candidate(monkeypatch):
+    report_image_renderer._font_for_text.cache_clear()
+    used_paths = []
+
+    monkeypatch.setattr(
+        report_image_renderer,
+        "_font_candidates_for_text",
+        lambda text, *, bold=False: ["unsupported.ttf", "supported.ttf"],
+    )
+    monkeypatch.setattr(
+        report_image_renderer,
+        "_font_supports_text",
+        lambda path, text: path == "supported.ttf",
+    )
+
+    def _fake_truetype(path, *, size):
+        used_paths.append(path)
+        return object()
+
+    monkeypatch.setattr(report_image_renderer.ImageFont, "truetype", _fake_truetype)
+
+    assert report_image_renderer._font_for_text("\u4e49", 18) is not None
+    assert used_paths == ["supported.ttf"]
+    report_image_renderer._font_for_text.cache_clear()
+
+
+def test_font_supports_text_reuses_cached_coverage():
+    report_image_renderer._font_coverage.cache_clear()
+    report_image_renderer._font_supports_text.cache_clear()
+
+    path = "C:/Windows/Fonts/definitely_missing_test_font.ttf"
+
+    assert report_image_renderer._font_supports_text(path, "A") is False
+    assert report_image_renderer._font_supports_text(path, "B") is False
+    assert report_image_renderer._font_coverage.cache_info().misses == 1
+    assert report_image_renderer._font_coverage.cache_info().hits == 1
+
+
+def test_fit_text_to_width_truncates_by_rendered_width():
+    image = report_image_renderer.Image.new("RGBA", (420, 80))
+    draw = report_image_renderer.ImageDraw.Draw(image)
+    font = report_image_renderer._font(18)
+    text = "\u30c5" * 80
+
+    fitted = report_image_renderer._fit_text_to_width(draw, text, width=120, font=font)
+
+    assert fitted.endswith(".")
+    assert report_image_renderer._text_width(draw, fitted, font=font) <= 120
+
+
 def test_render_prekvk_report_empty_payload_returns_none():
     payload = PreKvkReportPayload(
         kvk_no=15,


### PR DESCRIPTION
## Summary
- Improve PreKvK report name rendering for the latest examples: `ヅ Laki ๛`, `Fox义`, `义Vìper义`, and `ヅ Fart ๛`.
- Preserve accented characters during report text cleaning instead of decomposing/removing diacritics.
- Choose fallback fonts by actual glyph coverage using cached font cmap checks, so `义` routes to Microsoft YaHei/SimSun and `๛` routes to Leelawadee UI.
- Restore CJK Extension A fallback coverage (`U+3400..U+4DBF`) and keep `.ttc` coverage checks aligned with the default face Pillow renders.
- Fit governor names by measured rendered width so enlarged CJK/Thai fallback glyphs cannot overlap numeric columns.

## Validation
- Visual sample generated locally with the supplied names; characters render without tofu/square replacement boxes.
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_image_renderer.py` (6 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests/test_prekvk_report_image_renderer.py tests/test_prekvk_report_service.py tests/test_prekvk_report_dal.py tests/test_prekvk_report_views.py tests/test_prekvk_report_command.py` (18 passed)
- `./.venv/Scripts/python.exe -m pytest -q tests` (1420 passed, 2 skipped)
- `./.venv/Scripts/python.exe -m ruff check prekvk/report_image_renderer.py tests/test_prekvk_report_image_renderer.py`
- `./.venv/Scripts/python.exe -m black --check prekvk/report_image_renderer.py tests/test_prekvk_report_image_renderer.py`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pyright` (0 errors; existing optional/script missing-import warnings)
- `git diff --check`

## Risk / Rollback
- Renderer-only change; no SQL, import, upload route, command registration, or report data changes.
- Runtime gracefully falls back to the existing range-based font behavior if fontTools is unavailable.