### PR TITLE
[codex] Fix open-ended KVK state resolution

### DIFF
--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -16,7 +16,9 @@ promoted to production. Phase 2B PreKvK SQL compatibility cleanup was deployed a
 successfully. Phase 2C delivered the public read-only `/prekvk report` image report, was smoke
 tested successfully, and was pushed to production. Phase 2D refactored the scheduled PreKvK
 stats-alert path onto the Phase 2C report service architecture while preserving scheduled embed,
-guard/state, and upload-refresh behaviour; the remaining active backlog is listed below.
+guard/state, and upload-refresh behaviour; it was smoke tested successfully and pushed to
+production. Phase 3 local validation blockers are now the next upload-routing programme slice; the
+remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing and related test-environment blockers, not as a continuation of the

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md
@@ -122,9 +122,9 @@ Phase 2C starter and delivery notes:
 Goal: after Phase 2C is validated, refactor the scheduled PreKvK stats-alert helper/embed to use
 the new PreKvK report architecture where practical.
 
-Status: implemented in the current Phase 2D branch. The scheduled stats-alert path now uses a
-compact PreKvK scheduled-summary service shape backed by the Phase 2C report DAL/service
-architecture.
+Status: implemented in PR 103 (`codex/prekvk-phase-2d-scheduled-summary`), smoke tested
+successfully, and pushed to production. The scheduled stats-alert path now uses a compact PreKvK
+scheduled-summary service shape backed by the Phase 2C report DAL/service architecture.
 
 Starter packet:
 
@@ -138,7 +138,17 @@ In scope:
   behaviour
 - focused tests proving the scheduled stats-alert behaviour still works
 
-Phase 2D should be validated and reviewed before moving on from the PreKvK report phase.
+Phase 2D completed the PreKvK report follow-on. The next upload-routing programme slice is Phase 3
+local validation blockers.
+
+## Phase 3 - Local Validation Blockers
+
+Goal: fix or capability-gate DB/non-DB local validation blockers that affect confidence in the
+upload-routing work.
+
+Starter packet:
+
+- `docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md`
 
 ## Required Stop Points
 
@@ -146,5 +156,7 @@ Phase 2D should be validated and reviewed before moving on from the PreKvK repor
    before route extraction code changes.
 2. Phase 2B must produce a SQL dependency audit/design packet and stop before SQL changes.
 3. Phase 2C must produce a report/embed design packet and stop before implementation.
-4. Phase 2D must preserve scheduled stats-alert behaviour while adopting the new report
-   architecture.
+4. Phase 2D had to preserve scheduled stats-alert behaviour while adopting the new report
+   architecture; it is complete, smoke tested, and pushed to production.
+5. Phase 3 must begin with review/scope only, then stop before code changes unless explicitly
+   approved for one-pass implementation.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2C PreKvK Report Starter.md
@@ -29,9 +29,12 @@ Delivered production behaviour:
   handling, command-limit grouping, retry prompt naming, and governor-name glyph rendering.
 - No upload routing, importer, or production SQL behaviour was changed by Phase 2C.
 
-Next required follow-on:
+Follow-on status:
 
-- `docs/task_packs/DL_bot Upload Routing - Phase 2D PreKvK Stats-Alert Refactor Starter.md`
+- Phase 2D (`docs/task_packs/DL_bot Upload Routing - Phase 2D PreKvK Stats-Alert Refactor Starter.md`)
+  is complete, smoke tested successfully, and pushed to production.
+- The next upload-routing programme slice is Phase 3 local validation blockers:
+  `docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md`.
 
 ## Goal
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 2D PreKvK Stats-Alert Refactor Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 2D PreKvK Stats-Alert Refactor Starter.md
@@ -12,6 +12,27 @@ Phase 2D is the required follow-on to bring the scheduled PreKvK stats-alert hel
 new Phase 2C PreKvK report architecture where practical. It should not alter upload routing,
 PreKvK import behaviour, or SQL behaviour unless a separate approval explicitly expands scope.
 
+## Completion Status
+
+Phase 2D is complete. The scheduled PreKvK stats-alert path was refactored to use a compact
+PreKvK scheduled-summary service shape backed by the Phase 2C report DAL/service architecture.
+The change was smoke tested successfully and pushed to production.
+
+Delivered production behaviour:
+
+- `stats_alerts/prekvk_stats.py` no longer owns duplicated PreKvK ranking SQL; it remains only as a
+  compatibility wrapper over the PreKvK report service.
+- `stats_alerts/embeds/prekvk.py` keeps scheduled stats-alert responsibilities: metadata,
+  timeline, honor block, event block, guard/state handling, edit-vs-send behaviour, and upload
+  refresh compatibility.
+- Current Top 3 and previous-KVK target blocks are fed by the new PreKvK scheduled-summary service
+  shape.
+- Upload routing, PreKvK import behaviour, SQL behaviour, and `/prekvk report` UX were unchanged.
+
+Next required follow-on:
+
+- `docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md`
+
 ## Goal
 
 Refactor the scheduled PreKvK stats-alert path so it reuses the new PreKvK report architecture

--- a/docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md
@@ -1,0 +1,221 @@
+# DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter
+
+We are starting Phase 3 of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+
+Phase 3 is the required follow-on to improve local PR-validation confidence before the upload
+routing programme moves on to higher-blast-radius route extraction work.
+
+## Goal
+
+Fix or capability-gate DB and non-DB local validation blockers that affect confidence in the
+upload-routing work.
+
+The desired end state is:
+
+- Local test runs do not accidentally require live SQL Server or bot-machine-only ODBC setup unless
+  they are explicitly marked/gated as integration tests.
+- Full-suite or targeted validation failures caused by local environment capabilities are either
+  fixed or skipped behind clear capability gates.
+- Validation remains meaningful: real unit tests should still exercise DAL/service boundaries with
+  fakes or mocks where live infrastructure is unavailable.
+- The documented local environment command paths are aligned with the repository's actual `.venv`
+  workflow or made configurable where tests need a runtime interpreter path.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the blocker
+classification and first PR scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 2 PreKvK Initiation Statement.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any SQL-facing tests or DAL/service
+contracts reviewed during this phase.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+Use `k98-discord-command-feature` only if a selected validation blocker touches Discord command,
+view, modal, or listener behaviour.
+
+## Source Deferred Items
+
+### Deferred Optimisation
+- Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
+- Type: consistency
+- Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.
+- Suggested Fix: Add subsystem-specific DAL/service boundary patches or explicit integration markers, then gate live DB coverage behind RUN_DB_TESTS=1.
+- Impact: high
+- Risk: medium
+- Dependencies: Agreement on which non-Ark tests should remain live DB integration coverage.
+
+### Deferred Optimisation
+- Area: tests/test_dl_bot_mge_auto_import.py, tests/test_integration_end_to_end_fake_worker.py, tests/test_maintenance_suite.py
+- Type: consistency
+- Description: Full-suite validation in the Codex/local PR environment has non-DB environment blockers: DL_bot expects venv/Scripts/python.exe while the documented command uses .venv, and subprocess worker tests fail with WinError 5 in the sandbox.
+- Suggested Fix: Make startup interpreter validation configurable for tests and mark subprocess worker tests with an environment capability gate when process spawning is unavailable.
+- Impact: medium
+- Risk: medium
+- Dependencies: Local validation environment contract for venv naming and subprocess permissions.
+
+## Phase 3 Scope
+
+In scope:
+
+- Audit the listed DB and non-DB validation blockers.
+- Re-run or inspect the smallest reliable reproductions for each blocker.
+- Decide which tests should become true unit tests with faked DAL/service boundaries.
+- Decide which tests should remain live integration tests and be gated behind `RUN_DB_TESTS=1` or a
+  similarly explicit capability flag.
+- Decide whether interpreter path assumptions should be fixed in test setup, runtime config, or
+  helper code.
+- Decide whether subprocess-worker tests should be capability-gated in local/sandboxed
+  environments.
+- Update tests and validation documentation after implementation.
+- Keep each PR focused: DB gating and non-DB process/interpreter gating may be split if the audit
+  shows different risk profiles.
+
+Out of scope until separately approved:
+
+- Changing production import behaviour.
+- Changing upload route behaviour or Discord output.
+- Broad `DL_bot.py` lifecycle/startup refactor.
+- KVK_ALL route extraction.
+- Broad SQL schema changes.
+- Retiring legacy SQL objects.
+- Redesigning the validation framework beyond the blockers needed for PR confidence.
+
+## Current Files To Review
+
+Likely DB-facing blocker tests:
+
+- `tests/test_stats_service.py`
+- `tests/targets_sql_cache_subproc.py`
+- `tests/test_prekvk_stats.py`
+- `tests/test_proc_config_import_phase2.py`
+- `tests/test_sheets_sync_flow.py`
+
+Likely non-DB environment blocker tests:
+
+- `tests/test_dl_bot_mge_auto_import.py`
+- `tests/test_integration_end_to_end_fake_worker.py`
+- `tests/test_maintenance_suite.py`
+
+Likely implementation/helper files:
+
+- `file_utils.py`
+- `process_utils.py`
+- `worker.py`
+- `maintenance_suite.py`
+- `DL_bot.py`
+- `stats_service.py`
+- `targets_sql_cache.py`
+- `proc_config_import.py`
+- `sheets_sync.py` or the current sheets-sync modules discovered during audit
+- `scripts/select_tests.py`
+- `scripts/smoke_imports.py`
+- `scripts/validate_architecture_boundaries.py`
+- `scripts/validate_deferred_items.py`
+
+## Design Questions
+
+- Which listed blockers still reproduce after Phase 2D and current main?
+- Which tests are intended unit coverage and should never open real SQL connections?
+- Which tests are valuable live integration coverage and should be opt-in with `RUN_DB_TESTS=1`?
+- Should DB capability gating be implemented through pytest markers, environment checks, fixtures,
+  or local helper functions?
+- Which tests assume `venv/Scripts/python.exe`, and should that become `.venv` aware,
+  configurable, or injected by test fixtures?
+- Which subprocess tests fail only because the sandbox lacks process permissions, and what is the
+  cleanest capability signal?
+- How should `scripts/select_tests.py` recommend gated integration tests without making routine PR
+  validation noisy?
+- What documentation should tell future agents when to run live DB tests?
+
+## Step 1 Required Output
+
+Phase 3 Step 1 must produce:
+
+- Audit Summary
+- Current Validation Blocker Map
+- DB-Backed Test Classification
+- Non-DB Environment Blocker Classification
+- Recommended Gating Pattern
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the selected blocker slice:
+
+- focused tests for each fixed/gated blocker
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+
+If live SQL integration tests are intentionally retained, document and validate the opt-in path:
+
+```powershell
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected live DB tests>
+```
+
+## Acceptance Criteria
+
+- Every source deferred validation blocker is classified as fixed-now, gated-now, already resolved,
+  or deferred with a structured reason.
+- Routine local PR validation can run without accidental live SQL Server or bot-machine-only
+  dependencies.
+- Opt-in live DB coverage remains available where it is still valuable.
+- Subprocess or worker tests either run reliably in local validation or skip with a clear capability
+  reason.
+- `scripts/select_tests.py` output remains useful and not misleading.
+- Out-of-scope follow-ups are captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 3 audit/design packet.
+
+Do not implement fixes, alter SQL, change upload routing, or open a PR until the audit packet,
+blocker classification, and first implementation scope have each been approved.

--- a/kvk_state.py
+++ b/kvk_state.py
@@ -135,6 +135,7 @@ def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
                     PASS4_START_SCAN,
                     KVK_END_SCAN
                 FROM dbo.KVK_Details
+                WHERE KVK_NO IS NOT NULL
                 ORDER BY KVK_NO DESC
             """)
             row = fetch_one_dict(cur)
@@ -154,7 +155,10 @@ def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
         # positional fallback
         return vals[idx] if idx < len(vals) else None
 
-    kvk_no = int(by_name("KVK_NO", idx=0))
+    kvk_no = _as_int(by_name("KVK_NO", idx=0))
+    if not kvk_no:
+        log.warning("[kvk_state] Ignoring KVK_Details row with invalid KVK_NO=%r", kvk_no)
+        return None
     name = (by_name("KVK_NAME", idx=1) or f"KVK {kvk_no}").strip()
     registration = _as_date(by_name("KVK_REGISTRATION_DATE", idx=2))
     start_d = _as_date(by_name("KVK_START_DATE", idx=3))
@@ -162,7 +166,7 @@ def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
     mm_start = _as_date(by_name("MATCHMAKING_START_DATE", idx=5))
     fight_start = _as_date(by_name("FIGHTING_START_DATE", idx=6))
     next_no_raw = by_name("NEXT_KVK_NO", "NextKVKNo", idx=7)
-    next_no = int(next_no_raw) if next_no_raw is not None else None
+    next_no = _as_int(next_no_raw)
     matchmaking_scan = _as_int(by_name("MATCHMAKING_SCAN", idx=8))
     pass4_start_scan = _as_int(by_name("PASS4_START_SCAN", idx=9))
     kvk_end_scan = _as_int(by_name("KVK_END_SCAN", idx=10))

--- a/kvk_state.py
+++ b/kvk_state.py
@@ -5,8 +5,7 @@ import datetime as dt
 import logging
 from typing import Literal, TypedDict
 
-from constants import _conn
-from file_utils import fetch_one_dict
+from file_utils import fetch_one_dict, get_conn_with_retries
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +41,15 @@ class KVKDetails(TypedDict):
     max_scan_order: int | None
     state: State
     state_reason: str
+
+
+class KVKWindow(TypedDict):
+    kvk_no: int
+    matchmaking_scan: int | None
+    kvk_end_scan: int | None
+    pass4_start_scan: int | None
+    max_scan_order: int | None
+    source: str
 
 
 def _as_date(v) -> dt.date | None:
@@ -104,7 +112,7 @@ def resolve_kvk_scan_state(
 
 def _get_max_scan_order() -> int | None:
     try:
-        with _conn() as conn, conn.cursor() as cur:
+        with get_conn_with_retries() as conn, conn.cursor() as cur:
             cur.execute(
                 "SELECT MAX(ScanOrder) AS MaxScanOrder FROM ROK_TRACKER.dbo.kingdomscandata4"
             )
@@ -120,7 +128,7 @@ def _get_max_scan_order() -> int | None:
 def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
     today = today or dt.date.today()
     try:
-        with _conn() as conn, conn.cursor() as cur:
+        with get_conn_with_retries() as conn, conn.cursor() as cur:
             cur.execute("""
                 SELECT TOP 1
                     KVK_NO,
@@ -210,6 +218,87 @@ def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
         state=state,
         state_reason=reason,
     )
+
+
+def _is_valid_kvk_window(matchmaking_scan: int | None, kvk_end_scan: int | None) -> bool:
+    if not isinstance(matchmaking_scan, int) or matchmaking_scan <= 0:
+        return False
+    if kvk_end_scan is None:
+        return True
+    return isinstance(kvk_end_scan, int) and kvk_end_scan > 0 and kvk_end_scan >= matchmaking_scan
+
+
+def _get_proc_config_window(max_scan_order: int | None) -> KVKWindow | None:
+    try:
+        with get_conn_with_retries() as conn, conn.cursor() as cur:
+            cur.execute("""
+                SELECT MAX(TRY_CAST(ConfigValue AS int)) AS CurrentKVK
+                FROM dbo.ProcConfig
+                WHERE ConfigKey = 'CURRENTKVK3'
+            """)
+            row = fetch_one_dict(cur)
+            current_kvk = _as_int(row.get("CurrentKVK")) if row else None
+            if not current_kvk:
+                log.warning("[kvk_state] No CURRENTKVK3 found in ProcConfig.")
+                return None
+
+            cur.execute(
+                """
+                SELECT ConfigKey, ConfigValue
+                FROM dbo.ProcConfig
+                WHERE KVKVersion = ? AND ConfigKey IN ('MATCHMAKING_SCAN', 'KVK_END_SCAN')
+                """,
+                (current_kvk,),
+            )
+            kv_map = {x.ConfigKey: x.ConfigValue for x in cur.fetchall()}
+
+        matchmaking_scan = _as_int(kv_map.get("MATCHMAKING_SCAN"))
+        kvk_end_scan = _as_int(kv_map.get("KVK_END_SCAN"))
+        if not _is_valid_kvk_window(matchmaking_scan, kvk_end_scan):
+            log.warning(
+                "[kvk_state] Invalid ProcConfig KVK window. kvk_no=%s matchmaking_scan=%r kvk_end_scan=%r",
+                current_kvk,
+                matchmaking_scan,
+                kvk_end_scan,
+            )
+            return None
+        return KVKWindow(
+            kvk_no=current_kvk,
+            matchmaking_scan=matchmaking_scan,
+            kvk_end_scan=kvk_end_scan,
+            pass4_start_scan=None,
+            max_scan_order=max_scan_order,
+            source="ProcConfig",
+        )
+    except Exception as e:
+        log.warning("[kvk_state] Could not read ProcConfig KVK window: %s", e)
+        return None
+
+
+def get_kvk_window_with_fallback() -> KVKWindow | None:
+    details = get_latest_kvk_details()
+    max_scan_order = details["max_scan_order"] if details else _get_max_scan_order()
+    if details and _is_valid_kvk_window(details["matchmaking_scan"], details["kvk_end_scan"]):
+        return KVKWindow(
+            kvk_no=details["kvk_no"],
+            matchmaking_scan=details["matchmaking_scan"],
+            kvk_end_scan=details["kvk_end_scan"],
+            pass4_start_scan=details["pass4_start_scan"],
+            max_scan_order=max_scan_order,
+            source="KVK_Details",
+        )
+
+    fallback = _get_proc_config_window(max_scan_order)
+    if fallback:
+        log.info(
+            "[kvk_state] Using ProcConfig KVK window fallback. kvk_no=%s matchmaking_scan=%r "
+            "kvk_end_scan=%r max_scan_order=%r",
+            fallback["kvk_no"],
+            fallback["matchmaking_scan"],
+            fallback["kvk_end_scan"],
+            fallback["max_scan_order"],
+        )
+    return fallback
 
 
 def get_kvk_context_today(today: dt.date | None = None) -> KVKContext | None:

--- a/kvk_state.py
+++ b/kvk_state.py
@@ -20,6 +20,28 @@ class KVKContext(TypedDict):
     end_date: dt.date | None
     state: State
     next_kvk_no: int | None
+    matchmaking_scan: int | None
+    pass4_start_scan: int | None
+    kvk_end_scan: int | None
+    max_scan_order: int | None
+    state_reason: str
+
+
+class KVKDetails(TypedDict):
+    kvk_no: int
+    kvk_name: str
+    registration: dt.date | None
+    start_date: dt.date | None
+    end_date: dt.date | None
+    matchmaking_scan: int | None
+    kvk_end_scan: int | None
+    matchmaking_start_date: dt.date | None
+    fighting_start_date: dt.date | None
+    pass4_start_scan: int | None
+    next_kvk_no: int | None
+    max_scan_order: int | None
+    state: State
+    state_reason: str
 
 
 def _as_date(v) -> dt.date | None:
@@ -33,14 +55,85 @@ def _as_date(v) -> dt.date | None:
         return None
 
 
-def get_kvk_context_today(today: dt.date | None = None) -> KVKContext | None:
+def _as_int(v) -> int | None:
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_scan_within_open_window(
+    start_scan: int | None,
+    end_scan: int | None,
+    max_scan_order: int | None,
+) -> bool:
+    if not isinstance(start_scan, int) or start_scan <= 0:
+        return False
+    if not isinstance(max_scan_order, int) or max_scan_order < start_scan:
+        return False
+    if end_scan is not None:
+        if not isinstance(end_scan, int) or end_scan <= 0 or end_scan < start_scan:
+            return False
+        return max_scan_order <= end_scan
+    return True
+
+
+def resolve_kvk_scan_state(
+    *,
+    pass4_start_scan: int | None,
+    kvk_end_scan: int | None,
+    max_scan_order: int | None,
+) -> tuple[State, str]:
+    if not isinstance(pass4_start_scan, int) or pass4_start_scan <= 0:
+        return "DRAFT", "invalid_pass4_start_scan"
+    if not isinstance(max_scan_order, int):
+        return "DRAFT", "missing_max_scan_order"
+    if kvk_end_scan is not None:
+        if not isinstance(kvk_end_scan, int) or kvk_end_scan <= 0:
+            return "DRAFT", "invalid_kvk_end_scan"
+        if kvk_end_scan < pass4_start_scan:
+            return "DRAFT", "end_scan_before_pass4_start_scan"
+        if max_scan_order > kvk_end_scan:
+            return "ENDED", "max_scan_order_after_kvk_end_scan"
+    if max_scan_order < pass4_start_scan:
+        return "DRAFT", "max_scan_order_before_pass4_start_scan"
+    return "ACTIVE", "max_scan_order_within_fighting_window"
+
+
+def _get_max_scan_order() -> int | None:
+    try:
+        with _conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT MAX(ScanOrder) AS MaxScanOrder FROM ROK_TRACKER.dbo.kingdomscandata4"
+            )
+            row = fetch_one_dict(cur)
+            if not row:
+                return None
+            return _as_int(row.get("MaxScanOrder", next(iter(row.values()), None)))
+    except Exception as e:
+        log.warning("[kvk_state] Could not read max ScanOrder: %s", e)
+        return None
+
+
+def get_latest_kvk_details(today: dt.date | None = None) -> KVKDetails | None:
     today = today or dt.date.today()
     try:
         with _conn() as conn, conn.cursor() as cur:
             cur.execute("""
                 SELECT TOP 1
-                    KVK_NO, KVK_NAME, CAST(MATCHMAKING_START_DATE AS date), CAST(KVK_END_DATE AS date),
-                    NEXT_KVK_NO
+                    KVK_NO,
+                    KVK_NAME,
+                    KVK_REGISTRATION_DATE,
+                    KVK_START_DATE,
+                    KVK_END_DATE,
+                    CAST(MATCHMAKING_START_DATE AS date) AS MATCHMAKING_START_DATE,
+                    CAST(FIGHTING_START_DATE AS date) AS FIGHTING_START_DATE,
+                    NEXT_KVK_NO,
+                    MATCHMAKING_SCAN,
+                    PASS4_START_SCAN,
+                    KVK_END_SCAN
                 FROM dbo.KVK_Details
                 ORDER BY KVK_NO DESC
             """)
@@ -63,25 +156,73 @@ def get_kvk_context_today(today: dt.date | None = None) -> KVKContext | None:
 
     kvk_no = int(by_name("KVK_NO", idx=0))
     name = (by_name("KVK_NAME", idx=1) or f"KVK {kvk_no}").strip()
-    start_d = _as_date(by_name("MATCHMAKING_START_DATE", "KVK_START_DATE", idx=2))
-    end_d = _as_date(by_name("KVK_END_DATE", "MATCHMAKING_END_DATE", idx=3))
-    next_no_raw = by_name("NEXT_KVK_NO", "NextKVKNo", idx=4)
+    registration = _as_date(by_name("KVK_REGISTRATION_DATE", idx=2))
+    start_d = _as_date(by_name("KVK_START_DATE", idx=3))
+    end_d = _as_date(by_name("KVK_END_DATE", idx=4))
+    mm_start = _as_date(by_name("MATCHMAKING_START_DATE", idx=5))
+    fight_start = _as_date(by_name("FIGHTING_START_DATE", idx=6))
+    next_no_raw = by_name("NEXT_KVK_NO", "NextKVKNo", idx=7)
     next_no = int(next_no_raw) if next_no_raw is not None else None
+    matchmaking_scan = _as_int(by_name("MATCHMAKING_SCAN", idx=8))
+    pass4_start_scan = _as_int(by_name("PASS4_START_SCAN", idx=9))
+    kvk_end_scan = _as_int(by_name("KVK_END_SCAN", idx=10))
+    max_scan_order = _get_max_scan_order()
 
-    if start_d and today < start_d:
+    if mm_start and today < mm_start:
         state: State = "DRAFT"
-    elif start_d and end_d and start_d <= today <= end_d:
-        state = "ACTIVE"
-    elif end_d and today > end_d:
-        state = "ENDED"
+        reason = "today_before_matchmaking_start_date"
     else:
-        state = "DRAFT"
+        state, reason = resolve_kvk_scan_state(
+            pass4_start_scan=pass4_start_scan,
+            kvk_end_scan=kvk_end_scan,
+            max_scan_order=max_scan_order,
+        )
 
-    return KVKContext(
+    log.info(
+        "[kvk_state] resolved KVK state kvk_no=%s matchmaking_scan=%r pass4_start_scan=%r "
+        "kvk_end_scan=%r max_scan_order=%r resolved_state=%s reason=%s",
+        kvk_no,
+        matchmaking_scan,
+        pass4_start_scan,
+        kvk_end_scan,
+        max_scan_order,
+        state,
+        reason,
+    )
+
+    return KVKDetails(
         kvk_no=kvk_no,
         kvk_name=name,
+        registration=registration,
         start_date=start_d,
         end_date=end_d,
-        state=state,
+        matchmaking_scan=matchmaking_scan,
+        kvk_end_scan=kvk_end_scan,
+        matchmaking_start_date=mm_start,
+        fighting_start_date=fight_start,
+        pass4_start_scan=pass4_start_scan,
         next_kvk_no=next_no,
+        max_scan_order=max_scan_order,
+        state=state,
+        state_reason=reason,
+    )
+
+
+def get_kvk_context_today(today: dt.date | None = None) -> KVKContext | None:
+    details = get_latest_kvk_details(today=today)
+    if not details:
+        return None
+
+    return KVKContext(
+        kvk_no=details["kvk_no"],
+        kvk_name=details["kvk_name"],
+        start_date=details["matchmaking_start_date"],
+        end_date=details["end_date"],
+        state=details["state"],
+        next_kvk_no=details["next_kvk_no"],
+        matchmaking_scan=details["matchmaking_scan"],
+        pass4_start_scan=details["pass4_start_scan"],
+        kvk_end_scan=details["kvk_end_scan"],
+        max_scan_order=details["max_scan_order"],
+        state_reason=details["state_reason"],
     )

--- a/stats_alerts/kvk_meta.py
+++ b/stats_alerts/kvk_meta.py
@@ -8,8 +8,8 @@ import pandas as pd
 from constants import (
     KVK_SHEET_ID,
 )
-from file_utils import fetch_one_dict, get_conn_with_retries
 import gsheet_module as gm
+from kvk_state import get_kvk_context_today, get_latest_kvk_details, is_scan_within_open_window
 
 # Fixed import: parse_mixed_dates exists as that name in formatters.py
 from stats_alerts.formatters import parse_mixed_dates as _parse_mixed_dates
@@ -20,75 +20,10 @@ logger = logging.getLogger(__name__)
 
 def get_latest_kvk_metadata_sql() -> dict[str, Any] | None:
     try:
-        conn = get_conn_with_retries()
-        with conn:
-            cur = conn.cursor()
-            cur.execute("""
-                SELECT TOP (1)
-                       KVK_NO, KVK_NAME,
-                       KVK_REGISTRATION_DATE, KVK_START_DATE, KVK_END_DATE,
-                       MATCHMAKING_SCAN, KVK_END_SCAN, NEXT_KVK_NO,
-                       MATCHMAKING_START_DATE, FIGHTING_START_DATE, PASS4_START_SCAN
-                FROM dbo.KVK_Details
-                WHERE KVK_NO IS NOT NULL
-                ORDER BY KVK_NO DESC
-            """)
-            row = cur.fetchone()
-            if not row:
-                return None
-
-            kvk_no = int(row.KVK_NO)
-            kvk_name = row.KVK_NAME or "KVK"
-            registration = row.KVK_REGISTRATION_DATE
-            start_date = row.KVK_START_DATE
-            end_date = row.KVK_END_DATE
-            match_scan = int(row.MATCHMAKING_SCAN) if row.MATCHMAKING_SCAN is not None else None
-            end_scan = int(row.KVK_END_SCAN) if row.KVK_END_SCAN is not None else None
-            next_kvk_no = int(row.NEXT_KVK_NO) if row.NEXT_KVK_NO is not None else None
-            mm_start = row.MATCHMAKING_START_DATE
-            fight_start = row.FIGHTING_START_DATE
-            pass4_scan = int(row.PASS4_START_SCAN) if row.PASS4_START_SCAN is not None else None
-
-            if (
-                (not isinstance(match_scan, int))
-                or (not isinstance(end_scan, int))
-                or match_scan <= 0
-                or end_scan <= 0
-                or end_scan < match_scan
-            ):
-                logger.warning(
-                    "[KVK SQL META] Invalid scan window in KVK_Details: KVK=%s, MM=%r, END=%r",
-                    kvk_no,
-                    match_scan,
-                    end_scan,
-                )
-                return {
-                    "kvk_no": kvk_no,
-                    "kvk_name": kvk_name,
-                    "registration": registration,
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "matchmaking_scan": None,
-                    "kvk_end_scan": None,
-                    "matchmaking_start_date": mm_start,
-                    "fighting_start_date": fight_start,
-                    "pass4_start_scan": pass4_scan,
-                    "next_kvk_no": next_kvk_no,
-                }
-
-            return {
-                "kvk_no": kvk_no,
-                "kvk_name": kvk_name,
-                "registration": registration,
-                "start_date": start_date,
-                "end_date": end_date,
-                "matchmaking_scan": match_scan,
-                "kvk_end_scan": end_scan,
-                "matchmaking_start_date": mm_start,
-                "fighting_start_date": fight_start,
-                "pass4_start_scan": pass4_scan,
-                "next_kvk_no": next_kvk_no,
-            }
+        details = get_latest_kvk_details()
+        if not details:
+            return None
+        return dict(details)
     except Exception:
         logger.exception("[KVK SQL META] Failed to read KVK_Details")
         return None
@@ -145,120 +80,32 @@ def get_latest_kvk_metadata() -> dict[str, Any] | None:
         return None
 
 
-def get_kvk_window_from_sql() -> dict[str, int] | None:
+def get_kvk_window_from_sql() -> dict[str, int | None] | None:
     try:
-        conn = get_conn_with_retries()
-        with conn:
-            cur = conn.cursor()
-            # Prefer dbo.KVK_Details (latest)
-            cur.execute("""
-                SELECT TOP (1) KVK_NO, MATCHMAKING_SCAN, KVK_END_SCAN, PASS4_START_SCAN
-                FROM dbo.KVK_Details
-                WHERE KVK_NO IS NOT NULL
-                ORDER BY KVK_NO DESC
-                """)
-            r = fetch_one_dict(cur)
-            if r:
-                # prefer explicit column names; otherwise fall back to first returned value
-                def _val(dct, *names):
-                    for n in names:
-                        if n in dct:
-                            return dct[n]
-                    return next(iter(dct.values())) if dct else None
-
-                kvk_no = int(_val(r, "KVK_NO"))
-                mm_raw = _val(r, "MATCHMAKING_SCAN")
-                ke_raw = _val(r, "KVK_END_SCAN")
-                p4_raw = _val(r, "PASS4_START_SCAN")
-                mm = int(mm_raw) if mm_raw is not None else None
-                ke = int(ke_raw) if ke_raw is not None else None
-                p4 = int(p4_raw) if p4_raw is not None else None
-                if isinstance(mm, int) and isinstance(ke, int) and mm > 0 and ke > 0 and ke >= mm:
-                    return {
-                        "kvk_no": kvk_no,
-                        "matchmaking_scan": mm,
-                        "kvk_end_scan": ke,
-                        "pass4_start_scan": p4,
-                    }
-                else:
-                    logger.warning(
-                        "[KVK SQL] KVK_Details has invalid window for KVK=%s (MM=%r, END=%r)",
-                        kvk_no,
-                        mm,
-                        ke,
-                    )
-
-            # ProcConfig fallback
-            cur.execute("""
-                SELECT MAX(TRY_CAST(ConfigValue AS int)) AS CurrentKVK
-                FROM dbo.ProcConfig
-                WHERE ConfigKey = 'CURRENTKVK3'
-                """)
-            rowd = fetch_one_dict(cur)
-            if not rowd or rowd.get("CurrentKVK") is None:
-                logger.warning("[KVK SQL] No CURRENTKVK3 found in ProcConfig.")
-                return None
-            current_kvk = int(rowd["CurrentKVK"])
-
-            cur.execute(
-                """
-                SELECT ConfigKey, ConfigValue
-                FROM dbo.ProcConfig
-                WHERE KVKVersion = ? AND ConfigKey IN ('MATCHMAKING_SCAN','KVK_END_SCAN')
-                """,
-                (current_kvk,),
-            )
-            kv_map = {x.ConfigKey: x.ConfigValue for x in cur.fetchall()}
-            mm = kv_map.get("MATCHMAKING_SCAN")
-            ke = kv_map.get("KVK_END_SCAN")
-            try:
-                match_scan = int(mm) if mm is not None else None
-                end_scan = int(ke) if ke is not None else None
-            except Exception:
-                match_scan, end_scan = None, None
-
-            if (
-                not match_scan
-                or not end_scan
-                or match_scan <= 0
-                or end_scan <= 0
-                or end_scan < match_scan
-            ):
-                logger.warning(
-                    "[KVK SQL] Invalid window. MATCHMAKING_SCAN=%r, KVK_END_SCAN=%r for KVK=%s",
-                    mm,
-                    ke,
-                    current_kvk,
-                )
-                return None
-
-            return {"kvk_no": current_kvk, "matchmaking_scan": match_scan, "kvk_end_scan": end_scan}
+        details = get_latest_kvk_details()
+        if not details:
+            return None
+        return {
+            "kvk_no": details["kvk_no"],
+            "matchmaking_scan": details["matchmaking_scan"],
+            "kvk_end_scan": details["kvk_end_scan"],
+            "pass4_start_scan": details["pass4_start_scan"],
+        }
     except Exception:
         logger.exception("[KVK SQL] Failed to read KVK window")
         return None
 
 
-def is_currently_kvk() -> bool:
+def is_currently_kvk(*_args: Any, **_kwargs: Any) -> bool:
     try:
-        win = get_kvk_window_from_sql()
-        if not win:
+        ctx = get_kvk_context_today()
+        if not ctx:
             return False
-        match_scan = win["matchmaking_scan"]
-        end_scan = win["kvk_end_scan"]
-
-        conn = get_conn_with_retries()
-        cursor = conn.cursor()
-        cursor.execute("SELECT MAX(ScanOrder) FROM ROK_TRACKER.dbo.kingdomscandata4")
-        r = fetch_one_dict(cursor)
-        # extract first (and only) column value using next(iter(...))
-        max_scan_order = next(iter(r.values())) if r else None
-        conn.close()
-
-        if max_scan_order is None:
-            logger.warning("[KVK CHECK] No ScanOrder found \u2014 treating as off-season.")
-            return False
-
-        return match_scan <= max_scan_order <= end_scan
+        return is_scan_within_open_window(
+            ctx.get("matchmaking_scan"),
+            ctx.get("kvk_end_scan"),
+            ctx.get("max_scan_order"),
+        )
     except Exception:
         logger.exception("[KVK CHECK] Unexpected failure in KVK detection logic")
         return False
@@ -266,27 +113,8 @@ def is_currently_kvk() -> bool:
 
 def is_kvk_fighting_open() -> bool:
     try:
-        win = get_kvk_window_from_sql()
-        if not win:
-            return False
-        end_scan = win.get("kvk_end_scan")
-        pass4_scan = win.get("pass4_start_scan")
-        if not isinstance(end_scan, int) or not isinstance(pass4_scan, int):
-            return False
-        if end_scan <= 0 or pass4_scan <= 0 or end_scan < pass4_scan:
-            return False
-
-        conn = get_conn_with_retries()
-        cursor = conn.cursor()
-        cursor.execute("SELECT MAX(ScanOrder) FROM ROK_TRACKER.dbo.kingdomscandata4")
-        max_scan_order = cursor.fetchone()[0]
-        conn.close()
-
-        if max_scan_order is None:
-            logger.warning("[KVK CHECK] No ScanOrder found \u2014 treating as not fighting.")
-            return False
-
-        return pass4_scan <= max_scan_order <= end_scan
+        ctx = get_kvk_context_today()
+        return bool(ctx and ctx.get("state") == "ACTIVE")
     except Exception:
         logger.exception("[KVK CHECK] Unexpected failure in Pass4 gate")
         return False

--- a/stats_alerts/kvk_meta.py
+++ b/stats_alerts/kvk_meta.py
@@ -9,7 +9,12 @@ from constants import (
     KVK_SHEET_ID,
 )
 import gsheet_module as gm
-from kvk_state import get_kvk_context_today, get_latest_kvk_details, is_scan_within_open_window
+from kvk_state import (
+    get_kvk_context_today,
+    get_kvk_window_with_fallback,
+    get_latest_kvk_details,
+    is_scan_within_open_window,
+)
 
 # Fixed import: parse_mixed_dates exists as that name in formatters.py
 from stats_alerts.formatters import parse_mixed_dates as _parse_mixed_dates
@@ -82,14 +87,14 @@ def get_latest_kvk_metadata() -> dict[str, Any] | None:
 
 def get_kvk_window_from_sql() -> dict[str, int | None] | None:
     try:
-        details = get_latest_kvk_details()
-        if not details:
+        window = get_kvk_window_with_fallback()
+        if not window:
             return None
         return {
-            "kvk_no": details["kvk_no"],
-            "matchmaking_scan": details["matchmaking_scan"],
-            "kvk_end_scan": details["kvk_end_scan"],
-            "pass4_start_scan": details["pass4_start_scan"],
+            "kvk_no": window["kvk_no"],
+            "matchmaking_scan": window["matchmaking_scan"],
+            "kvk_end_scan": window["kvk_end_scan"],
+            "pass4_start_scan": window["pass4_start_scan"],
         }
     except Exception:
         logger.exception("[KVK SQL] Failed to read KVK window")
@@ -98,13 +103,13 @@ def get_kvk_window_from_sql() -> dict[str, int | None] | None:
 
 def is_currently_kvk(*_args: Any, **_kwargs: Any) -> bool:
     try:
-        ctx = get_kvk_context_today()
-        if not ctx:
+        window = get_kvk_window_with_fallback()
+        if not window:
             return False
         return is_scan_within_open_window(
-            ctx.get("matchmaking_scan"),
-            ctx.get("kvk_end_scan"),
-            ctx.get("max_scan_order"),
+            window.get("matchmaking_scan"),
+            window.get("kvk_end_scan"),
+            window.get("max_scan_order"),
         )
     except Exception:
         logger.exception("[KVK CHECK] Unexpected failure in KVK detection logic")

--- a/targets_sql_cache.py
+++ b/targets_sql_cache.py
@@ -52,11 +52,8 @@ def _cache_matches_context(cache: dict[str, Any], ctx: dict[str, Any] | None) ->
     return meta.get("kvk_no") == ctx.get("kvk_no") and meta.get("state") == ctx.get("state")
 
 
-def _cache_might_be_stale(cache: dict[str, Any], key: str) -> bool:
+def _cache_might_be_stale(cache: dict[str, Any]) -> bool:
     if not cache:
-        return True
-    by_gov = cache.get("by_gov") or {}
-    if key not in by_gov:
         return True
     meta = cache.get("_meta") if isinstance(cache, dict) else None
     if not isinstance(meta, dict):
@@ -214,7 +211,7 @@ def get_targets_for_governor(governor_id: int) -> dict[str, Any] | None:
         key = str(governor_id)
 
     cache = _read_json(PLAYER_TARGETS_CACHE)
-    if _cache_might_be_stale(cache, key):
+    if _cache_might_be_stale(cache):
         ctx = get_kvk_context_today()
         if ctx and not _cache_matches_context(cache, ctx):
             if cache:

--- a/targets_sql_cache.py
+++ b/targets_sql_cache.py
@@ -43,6 +43,15 @@ def _write_json(path: str, data: dict[str, Any]) -> None:
         raise
 
 
+def _cache_matches_context(cache: dict[str, Any], ctx: dict[str, Any] | None) -> bool:
+    if not cache or not ctx:
+        return False
+    meta = cache.get("_meta") if isinstance(cache, dict) else None
+    if not isinstance(meta, dict):
+        return False
+    return meta.get("kvk_no") == ctx.get("kvk_no") and meta.get("state") == ctx.get("state")
+
+
 def _fetch_targets_from_view(cur) -> list[dict[str, Any]]:
     """
     Reads from dbo.v_TARGETS_FOR_UPLOAD and normalizes columns to:
@@ -120,6 +129,11 @@ def refresh_targets_cache() -> dict[str, Any]:
             "generated_at": utcnow().isoformat(),
             "kvk_no": ctx.get("kvk_no"),
             "state": ctx.get("state"),
+            "state_reason": ctx.get("state_reason"),
+            "matchmaking_scan": ctx.get("matchmaking_scan"),
+            "pass4_start_scan": ctx.get("pass4_start_scan"),
+            "kvk_end_scan": ctx.get("kvk_end_scan"),
+            "max_scan_order": ctx.get("max_scan_order"),
         },
         "by_gov": {},
     }
@@ -183,7 +197,18 @@ def refresh_targets_cache() -> dict[str, Any]:
 
 def get_targets_for_governor(governor_id: int) -> dict[str, Any] | None:
     cache = _read_json(PLAYER_TARGETS_CACHE)
-    if not cache:
+    ctx = get_kvk_context_today()
+    if not cache or not _cache_matches_context(cache, ctx):
+        if cache:
+            logger.info(
+                "[targets_sql_cache] Refreshing stale targets cache. cached_kvk=%r cached_state=%r "
+                "resolved_kvk=%r resolved_state=%r reason=%r",
+                (cache.get("_meta") or {}).get("kvk_no"),
+                (cache.get("_meta") or {}).get("state"),
+                (ctx or {}).get("kvk_no"),
+                (ctx or {}).get("state"),
+                (ctx or {}).get("state_reason"),
+            )
         cache = refresh_targets_cache()
     try:
         key = normalize_governor_id(governor_id)

--- a/targets_sql_cache.py
+++ b/targets_sql_cache.py
@@ -52,6 +52,18 @@ def _cache_matches_context(cache: dict[str, Any], ctx: dict[str, Any] | None) ->
     return meta.get("kvk_no") == ctx.get("kvk_no") and meta.get("state") == ctx.get("state")
 
 
+def _cache_might_be_stale(cache: dict[str, Any], key: str) -> bool:
+    if not cache:
+        return True
+    by_gov = cache.get("by_gov") or {}
+    if key not in by_gov:
+        return True
+    meta = cache.get("_meta") if isinstance(cache, dict) else None
+    if not isinstance(meta, dict):
+        return True
+    return meta.get("state") == "DRAFT"
+
+
 def _fetch_targets_from_view(cur) -> list[dict[str, Any]]:
     """
     Reads from dbo.v_TARGETS_FOR_UPLOAD and normalizes columns to:
@@ -196,22 +208,29 @@ def refresh_targets_cache() -> dict[str, Any]:
 
 
 def get_targets_for_governor(governor_id: int) -> dict[str, Any] | None:
-    cache = _read_json(PLAYER_TARGETS_CACHE)
-    ctx = get_kvk_context_today()
-    if not cache or not _cache_matches_context(cache, ctx):
-        if cache:
-            logger.info(
-                "[targets_sql_cache] Refreshing stale targets cache. cached_kvk=%r cached_state=%r "
-                "resolved_kvk=%r resolved_state=%r reason=%r",
-                (cache.get("_meta") or {}).get("kvk_no"),
-                (cache.get("_meta") or {}).get("state"),
-                (ctx or {}).get("kvk_no"),
-                (ctx or {}).get("state"),
-                (ctx or {}).get("state_reason"),
-            )
-        cache = refresh_targets_cache()
     try:
         key = normalize_governor_id(governor_id)
     except Exception:
         key = str(governor_id)
+
+    cache = _read_json(PLAYER_TARGETS_CACHE)
+    if _cache_might_be_stale(cache, key):
+        ctx = get_kvk_context_today()
+        if ctx and not _cache_matches_context(cache, ctx):
+            if cache:
+                logger.info(
+                    "[targets_sql_cache] Refreshing stale targets cache. cached_kvk=%r cached_state=%r "
+                    "resolved_kvk=%r resolved_state=%r reason=%r",
+                    (cache.get("_meta") or {}).get("kvk_no"),
+                    (cache.get("_meta") or {}).get("state"),
+                    ctx.get("kvk_no"),
+                    ctx.get("state"),
+                    ctx.get("state_reason"),
+                )
+            cache = refresh_targets_cache()
+        elif not ctx and cache:
+            logger.info(
+                "[targets_sql_cache] Keeping existing targets cache because KVK context could not be resolved."
+            )
+
     return (cache.get("by_gov") or {}).get(str(key))

--- a/tests/test_kvk_state_open_window.py
+++ b/tests/test_kvk_state_open_window.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import kvk_state
 from kvk_state import is_scan_within_open_window, resolve_kvk_scan_state
 import stats_alerts.kvk_meta as kvk_meta
@@ -91,7 +93,7 @@ class _KvkCursor:
     def __exit__(self, *_args):
         return None
 
-    def execute(self, sql):
+    def execute(self, sql, *_params):
         self.sql = sql
 
 
@@ -110,7 +112,7 @@ class _KvkConn:
 
 def test_latest_kvk_details_filters_null_kvk_no(monkeypatch) -> None:
     conn = _KvkConn()
-    monkeypatch.setattr(kvk_state, "_conn", lambda: conn)
+    monkeypatch.setattr(kvk_state, "get_conn_with_retries", lambda: conn)
     monkeypatch.setattr(kvk_state, "fetch_one_dict", lambda _cur: None)
 
     assert kvk_state.get_latest_kvk_details() is None
@@ -118,7 +120,59 @@ def test_latest_kvk_details_filters_null_kvk_no(monkeypatch) -> None:
 
 
 def test_latest_kvk_details_returns_none_for_invalid_kvk_no(monkeypatch) -> None:
-    monkeypatch.setattr(kvk_state, "_conn", lambda: _KvkConn())
+    monkeypatch.setattr(kvk_state, "get_conn_with_retries", lambda: _KvkConn())
     monkeypatch.setattr(kvk_state, "fetch_one_dict", lambda _cur: {"KVK_NO": None})
 
     assert kvk_state.get_latest_kvk_details() is None
+
+
+def test_kvk_window_uses_proc_config_fallback_for_missing_detail_scans(monkeypatch) -> None:
+    class _ProcConfigCursor(_KvkCursor):
+        def fetchall(self):
+            return [
+                SimpleNamespace(ConfigKey="MATCHMAKING_SCAN", ConfigValue="837"),
+                SimpleNamespace(ConfigKey="KVK_END_SCAN", ConfigValue="900"),
+            ]
+
+    class _ProcConfigConn(_KvkConn):
+        cursor_obj = _ProcConfigCursor()
+
+    monkeypatch.setattr(
+        kvk_state,
+        "get_latest_kvk_details",
+        lambda: {
+            "kvk_no": 15,
+            "matchmaking_scan": None,
+            "kvk_end_scan": None,
+            "pass4_start_scan": None,
+            "max_scan_order": 875,
+        },
+    )
+    monkeypatch.setattr(kvk_state, "get_conn_with_retries", lambda: _ProcConfigConn())
+    monkeypatch.setattr(kvk_state, "fetch_one_dict", lambda _cur: {"CurrentKVK": 15})
+
+    window = kvk_state.get_kvk_window_with_fallback()
+
+    assert window is not None
+    assert window["source"] == "ProcConfig"
+    assert window["kvk_no"] == 15
+    assert window["matchmaking_scan"] == 837
+    assert window["kvk_end_scan"] == 900
+    assert window["max_scan_order"] == 875
+
+
+def test_stats_alerts_currently_kvk_uses_fallback_window(monkeypatch) -> None:
+    monkeypatch.setattr(
+        kvk_meta,
+        "get_kvk_window_with_fallback",
+        lambda: {
+            "kvk_no": 15,
+            "matchmaking_scan": 837,
+            "kvk_end_scan": 900,
+            "pass4_start_scan": None,
+            "max_scan_order": 875,
+            "source": "ProcConfig",
+        },
+    )
+
+    assert kvk_meta.is_currently_kvk() is True

--- a/tests/test_kvk_state_open_window.py
+++ b/tests/test_kvk_state_open_window.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from kvk_state import is_scan_within_open_window, resolve_kvk_scan_state
+import stats_alerts.kvk_meta as kvk_meta
+
+
+def test_open_ended_fighting_window_is_active() -> None:
+    state, reason = resolve_kvk_scan_state(
+        pass4_start_scan=866,
+        kvk_end_scan=None,
+        max_scan_order=875,
+    )
+
+    assert state == "ACTIVE"
+    assert reason == "max_scan_order_within_fighting_window"
+    assert is_scan_within_open_window(866, None, 875) is True
+
+
+def test_known_end_fighting_window_is_active() -> None:
+    state, _reason = resolve_kvk_scan_state(
+        pass4_start_scan=866,
+        kvk_end_scan=900,
+        max_scan_order=875,
+    )
+
+    assert state == "ACTIVE"
+    assert is_scan_within_open_window(866, 900, 875) is True
+
+
+def test_before_pass4_is_draft() -> None:
+    state, reason = resolve_kvk_scan_state(
+        pass4_start_scan=866,
+        kvk_end_scan=None,
+        max_scan_order=850,
+    )
+
+    assert state == "DRAFT"
+    assert reason == "max_scan_order_before_pass4_start_scan"
+    assert is_scan_within_open_window(866, None, 850) is False
+
+
+def test_after_known_end_is_ended() -> None:
+    state, reason = resolve_kvk_scan_state(
+        pass4_start_scan=866,
+        kvk_end_scan=900,
+        max_scan_order=901,
+    )
+
+    assert state == "ENDED"
+    assert reason == "max_scan_order_after_kvk_end_scan"
+    assert is_scan_within_open_window(866, 900, 901) is False
+
+
+def test_missing_pass4_is_draft() -> None:
+    state, reason = resolve_kvk_scan_state(
+        pass4_start_scan=None,
+        kvk_end_scan=None,
+        max_scan_order=875,
+    )
+
+    assert state == "DRAFT"
+    assert reason == "invalid_pass4_start_scan"
+    assert is_scan_within_open_window(None, None, 875) is False
+
+
+def test_stats_alerts_fighting_gate_allows_null_end_scan(monkeypatch) -> None:
+    monkeypatch.setattr(
+        kvk_meta,
+        "get_kvk_context_today",
+        lambda: {
+            "kvk_no": 15,
+            "matchmaking_scan": 837,
+            "pass4_start_scan": 866,
+            "kvk_end_scan": None,
+            "max_scan_order": 875,
+            "state": "ACTIVE",
+            "state_reason": "max_scan_order_within_fighting_window",
+        },
+    )
+
+    assert kvk_meta.is_kvk_fighting_open() is True

--- a/tests/test_kvk_state_open_window.py
+++ b/tests/test_kvk_state_open_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import kvk_state
 from kvk_state import is_scan_within_open_window, resolve_kvk_scan_state
 import stats_alerts.kvk_meta as kvk_meta
 
@@ -79,3 +80,45 @@ def test_stats_alerts_fighting_gate_allows_null_end_scan(monkeypatch) -> None:
     )
 
     assert kvk_meta.is_kvk_fighting_open() is True
+
+
+class _KvkCursor:
+    sql = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def execute(self, sql):
+        self.sql = sql
+
+
+class _KvkConn:
+    cursor_obj = _KvkCursor()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+def test_latest_kvk_details_filters_null_kvk_no(monkeypatch) -> None:
+    conn = _KvkConn()
+    monkeypatch.setattr(kvk_state, "_conn", lambda: conn)
+    monkeypatch.setattr(kvk_state, "fetch_one_dict", lambda _cur: None)
+
+    assert kvk_state.get_latest_kvk_details() is None
+    assert "WHERE KVK_NO IS NOT NULL" in conn.cursor_obj.sql
+
+
+def test_latest_kvk_details_returns_none_for_invalid_kvk_no(monkeypatch) -> None:
+    monkeypatch.setattr(kvk_state, "_conn", lambda: _KvkConn())
+    monkeypatch.setattr(kvk_state, "fetch_one_dict", lambda _cur: {"KVK_NO": None})
+
+    assert kvk_state.get_latest_kvk_details() is None

--- a/tests/test_targets_sql_cache_subproc.py
+++ b/tests/test_targets_sql_cache_subproc.py
@@ -152,6 +152,29 @@ def test_get_targets_for_governor_uses_active_cache_without_context_lookup(monke
     assert res["TargetState"] == "ACTIVE"
 
 
+def test_get_targets_for_governor_uses_active_cache_miss_without_context_lookup(monkeypatch):
+    def fail_context_lookup():
+        raise AssertionError("context lookup should not be called for active cache misses")
+
+    monkeypatch.setattr("targets_sql_cache.get_kvk_context_today", fail_context_lookup)
+    monkeypatch.setattr(
+        "targets_sql_cache._read_json",
+        lambda _path: {
+            "_meta": {"kvk_no": 15, "state": "ACTIVE"},
+            "by_gov": {
+                "123": {
+                    "GovernorID": "123",
+                    "GovernorName": "Alice",
+                    "TargetState": "ACTIVE",
+                    "KVK_NO": 15,
+                }
+            },
+        },
+    )
+
+    assert tsc.get_targets_for_governor(999) is None
+
+
 def test_get_targets_for_governor_keeps_cache_when_context_missing(monkeypatch):
     monkeypatch.setattr("targets_sql_cache.get_kvk_context_today", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_targets_sql_cache_subproc.py
+++ b/tests/test_targets_sql_cache_subproc.py
@@ -124,3 +124,56 @@ def test_get_targets_for_governor_refreshes_stale_state(monkeypatch):
 
     assert res is not None
     assert res["TargetState"] == "ACTIVE"
+
+
+def test_get_targets_for_governor_uses_active_cache_without_context_lookup(monkeypatch):
+    def fail_context_lookup():
+        raise AssertionError("context lookup should not be called for active cache hits")
+
+    monkeypatch.setattr("targets_sql_cache.get_kvk_context_today", fail_context_lookup)
+    monkeypatch.setattr(
+        "targets_sql_cache._read_json",
+        lambda _path: {
+            "_meta": {"kvk_no": 15, "state": "ACTIVE"},
+            "by_gov": {
+                "123": {
+                    "GovernorID": "123",
+                    "GovernorName": "Alice",
+                    "TargetState": "ACTIVE",
+                    "KVK_NO": 15,
+                }
+            },
+        },
+    )
+
+    res = tsc.get_targets_for_governor(123)
+
+    assert res is not None
+    assert res["TargetState"] == "ACTIVE"
+
+
+def test_get_targets_for_governor_keeps_cache_when_context_missing(monkeypatch):
+    monkeypatch.setattr("targets_sql_cache.get_kvk_context_today", lambda: None)
+    monkeypatch.setattr(
+        "targets_sql_cache.refresh_targets_cache",
+        lambda: (_ for _ in ()).throw(AssertionError("refresh should not run without context")),
+    )
+    monkeypatch.setattr(
+        "targets_sql_cache._read_json",
+        lambda _path: {
+            "_meta": {"kvk_no": 15, "state": "DRAFT"},
+            "by_gov": {
+                "123": {
+                    "GovernorID": "123",
+                    "GovernorName": "Alice",
+                    "TargetState": "DRAFT",
+                    "KVK_NO": 15,
+                }
+            },
+        },
+    )
+
+    res = tsc.get_targets_for_governor(123)
+
+    assert res is not None
+    assert res["TargetState"] == "DRAFT"

--- a/tests/test_targets_sql_cache_subproc.py
+++ b/tests/test_targets_sql_cache_subproc.py
@@ -84,3 +84,43 @@ def test_refresh_targets_cache_returns_full_when_not_subprocess(monkeypatch, tmp
     assert "_meta" in res
     assert "by_gov" in res
     assert len(res["by_gov"]) == 2
+
+
+def test_get_targets_for_governor_refreshes_stale_state(monkeypatch):
+    monkeypatch.setattr(
+        "targets_sql_cache.get_kvk_context_today",
+        lambda: {"kvk_no": 15, "state": "ACTIVE", "state_reason": "test_active"},
+    )
+    monkeypatch.setattr(
+        "targets_sql_cache._read_json",
+        lambda _path: {
+            "_meta": {"kvk_no": 15, "state": "DRAFT"},
+            "by_gov": {
+                "123": {
+                    "GovernorID": "123",
+                    "GovernorName": "Alice",
+                    "TargetState": "DRAFT",
+                    "KVK_NO": 15,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "targets_sql_cache.refresh_targets_cache",
+        lambda: {
+            "_meta": {"kvk_no": 15, "state": "ACTIVE"},
+            "by_gov": {
+                "123": {
+                    "GovernorID": "123",
+                    "GovernorName": "Alice",
+                    "TargetState": "ACTIVE",
+                    "KVK_NO": 15,
+                }
+            },
+        },
+    )
+
+    res = tsc.get_targets_for_governor(123)
+
+    assert res is not None
+    assert res["TargetState"] == "ACTIVE"


### PR DESCRIPTION
## Summary

- Fix KVK fighting-state detection when `KVK_END_SCAN` is not yet populated.
- Centralize active KVK state resolution in `kvk_state.py` so stats alerts and target cache use the same scan-window logic.
- Include upload-routing task-pack/deferred-backlog doc sync updates so the branch keeps current planning docs aligned.

## Changes

- Allow fighting/open KVK state when `MaxScanOrder >= PASS4_START_SCAN` and `KVK_END_SCAN` is `NULL`.
- Preserve completed-KVK handling when `KVK_END_SCAN` is populated and `MaxScanOrder > KVK_END_SCAN`.
- Convert `stats_alerts/kvk_meta.py` to compatibility wrappers over shared KVK state helpers.
- Route KVK state/window SQL reads through `get_conn_with_retries()` to preserve retry/backoff behavior.
- Restore ProcConfig window fallback for incomplete `KVK_Details` scan fields.
- Add target-cache state metadata and stale-state refresh so old `DRAFT` cache entries rebuild as `ACTIVE`.
- Avoid live KVK context SQL reads on normal active target-cache hits and active target-cache misses; if context cannot be resolved, keep serving the existing cache instead of forcing refresh.
- Harden `kvk_state.get_latest_kvk_details()` against null or invalid `KVK_NO` rows.
- Add regression coverage for open-ended KVK scan windows, invalid KVK detail rows, ProcConfig fallback, stale target-cache state, cache-hit behavior, and unknown-governor cache misses.
- Sync PreKvK upload-routing task-pack status docs and include the Phase 3 local validation blockers starter doc.

## Tests

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_state_open_window.py tests\test_targets_sql_cache_subproc.py` — 16 passed
- `.\.venv\Scripts\python.exe -m pytest -q tests -k "kvk or target or stats_alert"` — 285 passed, 1158 deselected
- `.\.venv\Scripts\python.exe -m pytest -q tests` — 1441 passed, 2 skipped
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py` — passed
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py` — passed
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py` — passed after doc sync
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py` — exit 0 with existing duplicate summary
- `.\.venv\Scripts\python.exe -m pre_commit run --files kvk_state.py stats_alerts/kvk_meta.py tests/test_kvk_state_open_window.py` — passed for latest review-fix files
- `git diff --check` — passed

## SQL / Cache Notes

- No SQL changes.
- Validated `dbo.KVK_Details` in `C:\K98-bot-SQL-Server`: `KVK_END_SCAN` is nullable and `PASS4_START_SCAN` exists.
- Validated `dbo.v_TARGETS_FOR_UPLOAD` currently points at `dbo.EXCEL_EXPORT_KVK_TARGETS_15`.
- Deployment should delete or refresh `C:\discord_file_downloader\data\player_targets_cache.json` after stopping the bot so target embeds rebuild with the corrected active state.

## Risk / Rollback

- Risk is medium because KVK-state resolution affects stats alerts and target embeds.
- Rollback by reverting this PR. If needed operationally, clear `player_targets_cache.json` again after rollback so cached state matches deployed code.