### PR TITLE
[codex] Fix target lookup maintenance result unwrapping

### DIFF
--- a/target_utils.py
+++ b/target_utils.py
@@ -259,9 +259,13 @@ def _unwrap_targets_result(result: Any) -> dict[str, Any] | None:
 
     first, second = result[0], result[1]
     if isinstance(first, bool):
-        return second if first and isinstance(second, dict) else None
+        if not first:
+            raise RuntimeError(f"Target maintenance failed: {second}")
+        return second if isinstance(second, dict) else None
     if isinstance(second, bool):
-        return first if second and isinstance(first, dict) else None
+        if not second:
+            raise RuntimeError(f"Target maintenance failed: {first}")
+        return first if isinstance(first, dict) else None
     if isinstance(first, dict):
         return first
     if isinstance(second, dict) and isinstance(second.get("result"), dict):

--- a/target_utils.py
+++ b/target_utils.py
@@ -251,6 +251,24 @@ def get_name_cache_rows() -> list[dict[str, Any]]:
     return [dict(row) for row in rows if isinstance(row, dict)]
 
 
+def _unwrap_targets_result(result: Any) -> dict[str, Any] | None:
+    if isinstance(result, dict):
+        return result
+    if not isinstance(result, tuple) or len(result) < 2:
+        return None
+
+    first, second = result[0], result[1]
+    if isinstance(first, bool):
+        return second if first and isinstance(second, dict) else None
+    if isinstance(second, bool):
+        return first if second and isinstance(first, dict) else None
+    if isinstance(first, dict):
+        return first
+    if isinstance(second, dict) and isinstance(second.get("result"), dict):
+        return second["result"]
+    return None
+
+
 # ---------------- Targets: EXEMPT/NOT ACTIVE fallback (still via SQL) ----------------
 
 
@@ -623,17 +641,14 @@ async def run_target_lookup(*args, **kwargs) -> dict[str, Any] | None:
                     run_blocking_in_thread = None
 
                 if run_maintenance_with_isolation is not None:
-                    res = await run_maintenance_with_isolation(
-                        get_targets_for_governor,
-                        gid,
-                        name="get_targets_for_governor",
-                        prefer_process=True,
-                        meta={"governor_id": gid},
-                    )
-                    targets = (
-                        res[0]
-                        if isinstance(res, tuple) and len(res) == 2 and isinstance(res[1], dict)
-                        else res
+                    targets = _unwrap_targets_result(
+                        await run_maintenance_with_isolation(
+                            get_targets_for_governor,
+                            gid,
+                            name="get_targets_for_governor",
+                            prefer_process=True,
+                            meta={"governor_id": gid},
+                        )
                     )
                 elif run_blocking_in_thread is not None:
                     targets = await run_blocking_in_thread(
@@ -758,17 +773,14 @@ async def run_target_lookup(*args, **kwargs) -> dict[str, Any] | None:
                     run_blocking_in_thread = None
 
                 if run_maintenance_with_isolation is not None:
-                    res = await run_maintenance_with_isolation(
-                        get_targets_for_governor,
-                        gid,
-                        name="get_targets_for_governor",
-                        prefer_process=True,
-                        meta={"governor_id": gid},
-                    )
-                    targets = (
-                        res[0]
-                        if isinstance(res, tuple) and len(res) == 2 and isinstance(res[1], dict)
-                        else res
+                    targets = _unwrap_targets_result(
+                        await run_maintenance_with_isolation(
+                            get_targets_for_governor,
+                            gid,
+                            name="get_targets_for_governor",
+                            prefer_process=True,
+                            meta={"governor_id": gid},
+                        )
                     )
                 elif run_blocking_in_thread is not None:
                     targets = await run_blocking_in_thread(

--- a/target_utils.py
+++ b/target_utils.py
@@ -260,11 +260,11 @@ def _unwrap_targets_result(result: Any) -> dict[str, Any] | None:
     first, second = result[0], result[1]
     if isinstance(first, bool):
         if not first:
-            raise RuntimeError(f"Target maintenance failed: {second}")
+            raise RuntimeError("Target maintenance failed")
         return second if isinstance(second, dict) else None
     if isinstance(second, bool):
         if not second:
-            raise RuntimeError(f"Target maintenance failed: {first}")
+            raise RuntimeError("Target maintenance failed")
         return first if isinstance(first, dict) else None
     if isinstance(first, dict):
         return first

--- a/tests/test_target_utils_result_unwrap.py
+++ b/tests/test_target_utils_result_unwrap.py
@@ -34,3 +34,27 @@ def test_unwrap_targets_result_accepts_worker_parsed_tuple():
     target = {"GovernorID": "2441482", "TargetState": "ACTIVE"}
 
     assert target_utils._unwrap_targets_result((target, {"status": "success"})) == target
+
+
+def test_unwrap_targets_result_raises_for_failed_maintenance_tuple():
+    with pytest.raises(RuntimeError, match="Target maintenance failed"):
+        target_utils._unwrap_targets_result((False, "database unavailable"))
+
+
+@pytest.mark.asyncio
+async def test_run_target_lookup_reports_error_for_failed_maintenance(monkeypatch):
+    async def fake_run_maintenance_with_isolation(*_args, **_kwargs):
+        return False, "database unavailable"
+
+    monkeypatch.setattr(
+        file_utils,
+        "run_maintenance_with_isolation",
+        fake_run_maintenance_with_isolation,
+        raising=True,
+    )
+
+    res = await target_utils.run_target_lookup("2441482")
+
+    assert res is not None
+    assert res["status"] == "error"
+    assert res["message"] == "Internal error retrieving targets by ID"

--- a/tests/test_target_utils_result_unwrap.py
+++ b/tests/test_target_utils_result_unwrap.py
@@ -37,8 +37,13 @@ def test_unwrap_targets_result_accepts_worker_parsed_tuple():
 
 
 def test_unwrap_targets_result_raises_for_failed_maintenance_tuple():
-    with pytest.raises(RuntimeError, match="Target maintenance failed"):
-        target_utils._unwrap_targets_result((False, "database unavailable"))
+    raw_error = "Return code 1. Output:\n" + ("secret-ish output " * 100)
+
+    with pytest.raises(RuntimeError) as exc:
+        target_utils._unwrap_targets_result((False, raw_error))
+
+    assert str(exc.value) == "Target maintenance failed"
+    assert "secret-ish output" not in str(exc.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_target_utils_result_unwrap.py
+++ b/tests/test_target_utils_result_unwrap.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+import file_utils
+import target_utils
+
+
+@pytest.mark.asyncio
+async def test_run_target_lookup_unwraps_ok_tuple_from_maintenance(monkeypatch):
+    target = {
+        "GovernorID": "2441482",
+        "GovernorName": "Alice",
+        "TargetState": "ACTIVE",
+        "KVK_NO": 15,
+    }
+
+    async def fake_run_maintenance_with_isolation(*_args, **_kwargs):
+        return True, target
+
+    monkeypatch.setattr(
+        file_utils,
+        "run_maintenance_with_isolation",
+        fake_run_maintenance_with_isolation,
+        raising=True,
+    )
+
+    res = await target_utils.run_target_lookup("2441482")
+
+    assert res == {"status": "found", "data": target}
+
+
+def test_unwrap_targets_result_accepts_worker_parsed_tuple():
+    target = {"GovernorID": "2441482", "TargetState": "ACTIVE"}
+
+    assert target_utils._unwrap_targets_result((target, {"status": "success"})) == target


### PR DESCRIPTION
## Summary

- Fix `/mykvktargets` target lookup when the maintenance/offload wrapper returns a tuple shape.
- Prevent tuple-wrapped target results from reaching embed rendering as if they were dictionaries.
- Preserve maintenance failures as internal lookup errors instead of masking them as no-target results.
- Avoid embedding raw subprocess/stdout failure payloads in raised exception text.

## Root Cause

`run_target_lookup()` only unwrapped one maintenance result shape. In production, `run_maintenance_with_isolation()` can return tuple shapes such as `(True, target_dict)` or `(target_dict, worker_meta)`. The `(True, target_dict)` case left `tgt` as a tuple, which caused `AttributeError: 'tuple' object has no attribute 'get'` when rendering the target embed.

## Changes

- Add `_unwrap_targets_result()` in `target_utils.py` for supported maintenance result shapes.
- Use the helper in both numeric GovernorID and name-resolved lookup paths.
- Raise on failed maintenance tuple results like `(False, error_message)` so callers return an internal error instead of a false not-found.
- Keep raised maintenance failure text generic to avoid noisy or sensitive log payloads.
- Add regression coverage for `(True, target_dict)`, `(target_dict, worker_meta)`, and failed-maintenance tuple shapes.

## Tests

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_target_utils_result_unwrap.py` — 4 passed
- `.\.venv\Scripts\python.exe -m pytest -q tests -k "target or kvk"` — 288 passed, 1159 deselected
- `.\.venv\Scripts\python.exe -m pytest -q tests` — 1443 passed, 2 skipped
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py` — passed
- `.\.venv\Scripts\python.exe -m pre_commit run --files target_utils.py tests/test_target_utils_result_unwrap.py` — passed