### PR TITLE
[codex] Speed up slow pytest paths

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -32,6 +32,13 @@ the run explicitly, for example:
 Use `python scripts/analyse_pytest_log_noise.py` to verify that pytest did not write to
 `logs/log.txt`, `logs/error_log.txt`, `logs/crash.log`, or `logs/telemetry_log.jsonl`.
 
+When a full-suite run feels slow, capture durations with the audit artifact so the next
+optimisation task has actionable timing evidence:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -vv tests --durations=30 --durations-min=1.0 2>&1 | Tee-Object -FilePath .codex_pytest_audit.log
+```
+
 Optional: for fast local searches, place `rg.exe` at `C:\discord_file_downloader\tools\rg.exe`.
 `dev.ps1` adds `tools\` to `PATH` when that binary exists.
 

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -26,6 +26,15 @@ upload routing and related test-environment blockers, not as a continuation of t
 both this backlog and the current `K98-bot-mirror` GitHub issues list.
 
 ### Deferred Optimisation
+- Area: `tests/test_processing_pipeline.py`, `tests/test_processing_pipeline_build_cache.py`, `tests/test_processing_pipeline_run_step_and_normalization.py`, `tests/test_event_cache.py`, slow full-suite pytest paths
+- Type: performance
+- Description: Production smoke validation for the pytest log-isolation delivery passed, but the saved duration audit shows several unit tests spending real wall-clock time in expensive pipeline, timeout, lock, or offload paths. The worst offenders were `tests/test_processing_pipeline.py::test_run_stats_copy_archive_success` at 252.28s, `tests/test_processing_pipeline.py::test_run_stats_copy_archive_unexpected_shape` at 234.79s, `tests/test_event_cache.py::test_refresh_event_cache_times_out` at 45.00s, `tests/test_processing_pipeline_run_step_and_normalization.py::test_run_step_with_sync_and_async` at 17.27s, `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_offloaded_and_completes` at 17.26s, and `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_timeout_handled` at 16.32s.
+- Suggested Fix: Start with the two `tests/test_processing_pipeline.py` cases and audit which downstream stages still execute after `run_stats_copy_archive` is mocked. Patch heavy unit-test boundaries such as cache rebuilds, post-import maintenance, ProcConfig preflight/import, exports, lock waits, and intentional timeout sleeps so unit coverage asserts orchestration and failure handling without real multi-second waits. Add duration-focused regression validation using `pytest -vv --durations=30 --durations-min=1.0` and keep full-suite log-noise validation intact.
+- Impact: high
+- Risk: medium
+- Dependencies: Preserve negative-path coverage and production timeout behaviour; do not weaken `scripts/analyse_pytest_log_noise.py` or live integration gating.
+
+### Deferred Optimisation
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
 - Description: The primary Discord application-command set is currently at the 100 top-level command limit. Phase 2C avoided the limit by grouping PreKvK commands under `/prekvk`, but future standalone slash commands can still break startup sync with Discord error 30032 unless command surface consolidation is planned before new command work.

--- a/docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md
+++ b/docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md
@@ -1,0 +1,90 @@
+# Codex Chat Starter - Slow Pytest Optimisation
+
+Use this starter to begin the deferred optimisation captured from the production pytest
+log-isolation smoke audit.
+
+## Copy/Paste Starter
+
+Codex, start a new deferred optimisation task to investigate and resolve the root causes of
+slow-running pytest tests discovered after the pytest log-isolation production smoke validation.
+
+Before doing implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+
+Primary evidence:
+
+- Full audit log: `C:\Users\cwatt\Downloads\.codex_pytest_audit.log`
+- Production smoke result: `1450 passed, 2 skipped, 19 warnings in 638.91s`
+- Command used:
+
+```powershell
+pytest -q tests -v --durations=30 --durations-min=1.0 2>&1 | Tee-Object -FilePath .codex_pytest_audit.log
+```
+
+Start with the worst-performing tests from the audit:
+
+1. `tests/test_processing_pipeline.py::test_run_stats_copy_archive_success` - 252.28s
+2. `tests/test_processing_pipeline.py::test_run_stats_copy_archive_unexpected_shape` - 234.79s
+3. `tests/test_event_cache.py::test_refresh_event_cache_times_out` - 45.00s
+4. `tests/test_processing_pipeline_run_step_and_normalization.py::test_run_step_with_sync_and_async` - 17.27s
+5. `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_offloaded_and_completes` - 17.26s
+6. `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_timeout_handled` - 16.32s
+
+Likely first hypothesis:
+
+The two `tests/test_processing_pipeline.py` tests mock `run_stats_copy_archive`, but their
+successful mocked result still lets `execute_processing_pipeline()` continue into expensive
+downstream stages such as cache rebuilds, post-import maintenance, ProcConfig preflight/import,
+exports, lock waits, or timeout paths. These tests should remain unit tests and should not spend
+real wall-clock minutes exercising production-style downstream work.
+
+Mandatory workflow:
+
+1. Audit/scope review first, then stop with findings before implementation.
+2. Classify each slow test as expected wait, insufficient mock boundary, unmocked dependency
+   access, excessive retry/backoff, or genuine defect.
+3. Propose a remediation plan that preserves negative-path coverage and production timeout
+   behaviour.
+4. Implement only after approval.
+5. Validate with focused duration runs and the normal repo gates.
+
+Audit commands to run first:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -vv `
+  tests/test_processing_pipeline.py `
+  tests/test_processing_pipeline_build_cache.py `
+  tests/test_processing_pipeline_run_step_and_normalization.py `
+  tests/test_event_cache.py `
+  --durations=0 --durations-min=0.1
+```
+
+Expected validation after remediation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe -m pytest -vv `
+  tests/test_processing_pipeline.py `
+  tests/test_processing_pipeline_build_cache.py `
+  tests/test_processing_pipeline_run_step_and_normalization.py `
+  tests/test_event_cache.py `
+  --durations=30 --durations-min=1.0
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+.\.venv\Scripts\python.exe -m pytest -q tests
+```
+
+Do not suppress genuine failures. Do not remove timeout coverage; replace real multi-second waits
+with controlled fakes, patched constants, or explicit boundary mocks where safe.
+
+## Deferred Item Link
+
+This starter implements the slow pytest performance item in
+`docs/reference/deferred_optimisations.md`.

--- a/docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md
+++ b/docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md
@@ -1,3 +1,283 @@
+# Codex Task Pack — Slow Pytest Optimisation
+
+## 1. Task Header
+
+- Task name: Slow Pytest Optimisation
+- Date: 2026-05-19
+- Owner/context: Deferred optimisation from pytest log-isolation production smoke audit
+- Task type: deferred optimisation batch
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+
+Then follow any additional conditional references from `docs/reference/README.md`.
+
+## 3. Objective
+
+Investigate and resolve the root causes of slow-running pytest tests discovered after the pytest log-isolation production smoke validation.
+
+Reduce full-suite runtime and failure-review noise without weakening timeout coverage, negative-path coverage, production timeout behaviour, or log-noise validation.
+
+## 4. Background
+
+Production smoke validation passed with:
+
+```text
+1450 passed, 2 skipped, 19 warnings in 638.91s
+
+Command used:
+
+pytest -q tests -v --durations=30 --durations-min=1.0 2>&1 | Tee-Object -FilePath .codex_pytest_audit.log
+
+Primary audit log:
+
+C:\Users\cwatt\Downloads\.codex_pytest_audit.log
+
+Worst-performing tests from the duration audit:
+
+252.28s tests/test_processing_pipeline.py::test_run_stats_copy_archive_success
+234.79s tests/test_processing_pipeline.py::test_run_stats_copy_archive_unexpected_shape
+45.00s  tests/test_event_cache.py::test_refresh_event_cache_times_out
+17.27s  tests/test_processing_pipeline_run_step_and_normalization.py::test_run_step_with_sync_and_async
+17.26s  tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_offloaded_and_completes
+16.32s  tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_timeout_handled
+```
+
+Likely first hypothesis:
+
+The two tests/test_processing_pipeline.py tests mock run_stats_copy_archive, but their successful mocked result still lets execute_processing_pipeline() continue into expensive downstream stages such as cache rebuilds, post-import maintenance, ProcConfig preflight/import, exports, lock waits, or timeout paths. These tests should remain unit tests and should not spend real wall-clock minutes exercising production-style downstream work.
+
+5. Scope
+In Scope
+Audit the slowest pytest paths listed above.
+Start with:
+tests/test_processing_pipeline.py
+tests/test_processing_pipeline_build_cache.py
+tests/test_processing_pipeline_run_step_and_normalization.py
+tests/test_event_cache.py
+Classify each slow test as:
+expected wait
+insufficient mock boundary
+unmocked dependency access
+excessive retry/backoff
+genuine defect
+Patch heavy unit-test boundaries where safe:
+cache rebuilds
+post-import maintenance
+ProcConfig preflight/import
+exports
+lock waits
+intentional timeout sleeps
+offload paths
+Preserve orchestration assertions and negative-path assertions.
+Add focused duration regression validation.
+Out of Scope
+Do not suppress genuine failures.
+Do not remove timeout coverage.
+Do not weaken scripts/analyse_pytest_log_noise.py.
+Do not convert production timeout behaviour into test-only behaviour unless cleanly injected, patched, or faked at the test boundary.
+Do not broaden into unrelated test-environment blockers unless discovered as direct causes of the listed slow tests.
+Do not perform command-surface, SQL deployment, or DL_bot routing optimisation work in this task.
+6. Source Deferred Items
+
+### Deferred Optimisation
+- Area: `tests/test_processing_pipeline.py`, `tests/test_processing_pipeline_build_cache.py`, `tests/test_processing_pipeline_run_step_and_normalization.py`, `tests/test_event_cache.py`, slow full-suite pytest paths
+- Type: performance
+- Description: Production smoke validation for the pytest log-isolation delivery passed, but the saved duration audit shows several unit tests spending real wall-clock time in expensive pipeline, timeout, lock, or offload paths. The worst offenders were `tests/test_processing_pipeline.py::test_run_stats_copy_archive_success` at 252.28s, `tests/test_processing_pipeline.py::test_run_stats_copy_archive_unexpected_shape` at 234.79s, `tests/test_event_cache.py::test_refresh_event_cache_times_out` at 45.00s, `tests/test_processing_pipeline_run_step_and_normalization.py::test_run_step_with_sync_and_async` at 17.27s, `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_offloaded_and_completes` at 17.26s, and `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_timeout_handled` at 16.32s.
+- Suggested Fix: Start with the two `tests/test_processing_pipeline.py` cases and audit which downstream stages still execute after `run_stats_copy_archive` is mocked. Patch heavy unit-test boundaries such as cache rebuilds, post-import maintenance, ProcConfig preflight/import, exports, lock waits, and intentional timeout sleeps so unit coverage asserts orchestration and failure handling without real multi-second waits. Add duration-focused regression validation using `pytest -vv --durations=30 --durations-min=1.0` and keep full-suite log-noise validation intact.
+- Impact: high
+- Risk: medium
+- Dependencies: Preserve negative-path coverage and production timeout behaviour; do not weaken `scripts/analyse_pytest_log_noise.py` or live integration gating.
+7. Codex Skills To Use
+Skill	Decision	Notes
+k98-architecture-scope	use	Required before implementation to confirm affected services, test boundaries, cache/offload ownership, and approval checkpoints.
+k98-discord-command-feature	not applicable	No slash command, view, modal, embed, or Discord interaction change is planned.
+k98-sql-validation	use if needed	Use only if audit finds live SQL access, ProcConfig SQL dependencies, SQL-backed cache calls, or DB integration leakage in these tests.
+k98-test-selection	use	Required before validation to combine focused duration tests with repo gates.
+k98-deferred-optimisation-capture	use	Capture any additional out-of-scope test-performance or environment blockers structurally.
+k98-pr-review	use	Required before PR handoff.
+k98-promotion-check	not applicable unless promoted	Use only if this proceeds to production promotion.
+8. Mandatory Workflow
+Audit / scope review first, then stop for approval.
+Classify each slow test before implementation.
+Propose a remediation plan that preserves coverage and production timeout behaviour.
+Implement only after approval.
+Validate with focused duration runs and normal repo gates.
+Provide final delivery output using the required delivery shape.
+9. Audit Requirements
+
+Run first:
+
+.\.venv\Scripts\python.exe -m pytest -vv `
+  tests/test_processing_pipeline.py `
+  tests/test_processing_pipeline_build_cache.py `
+  tests/test_processing_pipeline_run_step_and_normalization.py `
+  tests/test_event_cache.py `
+  --durations=0 --durations-min=0.1
+
+Audit each listed slow test for:
+
+real sleeps or asyncio.sleep
+real timeout constants
+retry/backoff loops
+lock wait behaviour
+offload/subprocess execution
+downstream orchestration after mocked success
+SQL or Google Sheets access leakage
+cache rebuilds or export calls
+post-import maintenance
+missing boundary mocks
+test assertions that accidentally require production wall-clock timing
+
+Produce an audit table:
+
+Test	Current duration	Classification	Cause	Proposed fix	Coverage preserved
+10. Architecture Targets
+Concern	Target
+Test boundary fixes	tests/ fixtures, monkeypatches, fakes, or helper factories
+Production timeout constants	Patch in tests only where safe, or inject cleanly without changing production defaults
+Pipeline orchestration	Keep production code behaviour unchanged unless audit proves a genuine defect
+Cache/offload dependencies	Mock at service boundary, not deep internals, where practical
+SQL access	Gate integration behaviour or patch DAL/service boundary
+Documentation	Update deferred item or notes only if scope changes
+11. Likely Files
+Review
+tests/test_processing_pipeline.py
+tests/test_processing_pipeline_build_cache.py
+tests/test_processing_pipeline_run_step_and_normalization.py
+tests/test_event_cache.py
+processing_pipeline.py
+event_cache.py
+cache/offload helpers used by the above tests
+scripts/analyse_pytest_log_noise.py
+docs/reference/deferred_optimisations.md
+Modify
+
+To be confirmed after audit. Likely:
+
+tests/test_processing_pipeline.py
+tests/test_processing_pipeline_build_cache.py
+tests/test_processing_pipeline_run_step_and_normalization.py
+tests/test_event_cache.py
+Create
+
+Only if justified:
+
+shared pytest fixture/helper for fast timeout/backoff/offload fakes
+12. Implementation Requirements
+Keep tests meaningful; do not simply skip slow tests.
+Replace real multi-second waits with controlled fakes, patched constants, or explicit boundary mocks.
+Preserve negative-path and timeout-path assertions.
+Preserve production timeout defaults.
+Keep integration-style coverage clearly separated from unit tests.
+Avoid weakening log-noise checks.
+Avoid broad production refactors unless the audit proves a genuine defect.
+Capture any new out-of-scope findings as structured deferred optimisations.
+13. Refactor Decisions
+
+During audit, classify findings:
+
+Issue	Decision	Reason
+Slow unit test caused by missing downstream mock	fix now	Directly in scope.
+Real timeout/sleep needed for production but not unit test	fix now	Replace with fake/patch in test.
+Live SQL/Sheets dependency leaking into unit test	fix now or defer with marker	Fix if local to listed tests; defer if broader test-environment blocker.
+Broad pipeline architecture concern	defer	Capture structurally unless required to fix the listed duration issue.
+Existing unrelated slow test outside target list	defer	Capture separately unless trivial and safe.
+14. Testing Requirements
+
+Expected validation after remediation:
+
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+
+Focused duration validation:
+
+.\.venv\Scripts\python.exe -m pytest -vv `
+  tests/test_processing_pipeline.py `
+  tests/test_processing_pipeline_build_cache.py `
+  tests/test_processing_pipeline_run_step_and_normalization.py `
+  tests/test_event_cache.py `
+  --durations=30 --durations-min=1.0
+
+Log-noise validation:
+
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+
+Full-suite validation:
+
+.\.venv\Scripts\python.exe -m pytest -q tests
+
+Optional broader gates if touched production code or shared helpers:
+
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+15. Acceptance Criteria
+ Audit/scope review completed before implementation.
+ Each targeted slow test is classified.
+ Root cause is identified for each targeted slow test.
+ Unit tests no longer spend real wall-clock minutes in production-style downstream work.
+ Negative-path coverage is preserved.
+ Timeout-path coverage is preserved.
+ Production timeout behaviour is not weakened.
+ No genuine failures are suppressed.
+ scripts/analyse_pytest_log_noise.py remains valid.
+ Focused duration run shows material improvement.
+ Full pytest -q tests is run or any blocker is documented.
+ Any new out-of-scope debt is captured structurally.
+16. Required Delivery Output
+
+Use this delivery shape:
+
+Summary
+File Manifest
+New Files
+Modified Files
+SQL Changes
+Helpers Reused
+Refactor Findings
+Test Plan
+Deployment Steps
+Deferred Optimisations
+17. PR Summary Template
+## Summary
+
+- Optimised slow pytest paths identified by the pytest duration audit.
+- Replaced real wall-clock waits/heavy downstream unit-test paths with controlled fakes or boundary mocks.
+- Preserved negative-path and timeout coverage.
+
+## Changes
+
+- <change item>
+- <change item>
+
+## Tests
+
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe -m pytest -vv tests/test_processing_pipeline.py tests/test_processing_pipeline_build_cache.py tests/test_processing_pipeline_run_step_and_normalization.py tests/test_event_cache.py --durations=30 --durations-min=1.0`
+- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+
+## Deferred Optimisations
+
+- None, or structured deferred items.
+
+## Risk / Rollback
+
+- Risk: medium; test-only timing changes must not reduce coverage of production timeout behaviour.
+- Rollback: revert test-boundary changes and restore previous pytest behaviour.
+
 # Codex Chat Starter - Slow Pytest Optimisation
 
 Use this starter to begin the deferred optimisation captured from the production pytest
@@ -16,6 +296,7 @@ Before doing implementation, read and follow:
 - `docs/reference/K98 Bot - Testing Standards.md`
 - `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
 - `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md`
 
 Primary evidence:
 

--- a/docs/task_packs/Codex Task Pack - Suppress False Positive Test Error Storms.md
+++ b/docs/task_packs/Codex Task Pack - Suppress False Positive Test Error Storms.md
@@ -254,6 +254,27 @@ expected negative-path logs remain assertable inside tests
  Runtime production logging behaviour is not weakened.
  Documentation/promotion guidance is updated if deployment validation steps change.
 
+## 15A. Delivery Status
+
+Delivered and promoted to production on 2026-05-19.
+
+Production smoke validation passed with:
+
+```powershell
+pytest -q tests -v 2>&1 | Tee-Object -FilePath .codex_pytest_audit.log
+```
+
+Observed result from the saved audit artifact:
+
+- `1450 passed, 2 skipped, 19 warnings`
+- production pytest smoke completed without false-positive operational error storms
+- pytest evidence is reviewed through pytest output, `caplog`, or `.codex_pytest_audit.log`
+- production operational logs remain runtime evidence, not negative-path unit-test evidence
+
+Follow-up finding: the production smoke audit exposed slow-running tests. That performance work
+is intentionally deferred and tracked in `docs/reference/deferred_optimisations.md` plus
+`docs/task_packs/Codex Chat Starter - Slow Pytest Optimisation.md`.
+
 ## 16. Required Delivery Output
 
 Summary

--- a/event_cache.py
+++ b/event_cache.py
@@ -32,6 +32,7 @@ UTC = UTC
 PRESERVE_EVENT_CACHE_ON_EMPTY_SECONDS = int(
     os.getenv("PRESERVE_EVENT_CACHE_ON_EMPTY_SECONDS", "3600")
 )
+EVENT_CACHE_MIN_REFRESH_TIMEOUT = float(os.getenv("EVENT_CACHE_MIN_REFRESH_TIMEOUT", "5.0"))
 
 
 # ---- Helpers -----------------------------------------------------------------
@@ -229,7 +230,7 @@ async def refresh_event_cache() -> int:
         ]
 
         # Bound the entire refresh so a misbehaving loader can't hang forever.
-        overall_timeout = max(5.0, per_loader_timeout * 1.5)
+        overall_timeout = max(EVENT_CACHE_MIN_REFRESH_TIMEOUT, per_loader_timeout * 1.5)
         try:
             ruins_raw, altars_raw, majors_raw, chronicles_raw = await asyncio.wait_for(
                 asyncio.gather(*tasks), timeout=overall_timeout

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
 
-from constants import GSHEETS_CALL_TIMEOUT
 import event_cache as ec
 import event_data_loader as edl
 
@@ -106,10 +105,12 @@ def test_refresh_event_cache_times_out(monkeypatch, caplog):
     Confirm that refresh_event_cache completes (bounded) and logs a timeout message.
     """
     caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(ec, "GSHEETS_CALL_TIMEOUT", 0.02)
+    monkeypatch.setattr(ec, "EVENT_CACHE_MIN_REFRESH_TIMEOUT", 0.05)
 
     async def long_loader(timeout=None):
         # Sleep longer than per-loader timeout
-        await asyncio.sleep(float(GSHEETS_CALL_TIMEOUT or 30) * 2)
+        await asyncio.sleep(1)
         return []
 
     async def quick_loader(timeout=None):

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -6,12 +6,48 @@ import pytest
 pytest_plugins = ("pytest_asyncio",)
 
 
+def _patch_lightweight_pipeline_boundaries(monkeypatch):
+    async def fake_send_status_embed(*args, **kwargs):
+        return True
+
+    async def fake_send_embed_safe(*args, **kwargs):
+        return True
+
+    async def fake_build_cache():
+        return None
+
+    async def fake_warm_cache():
+        return None
+
+    async def fake_run_maintenance_with_isolation(*args, **kwargs):
+        return True, "OK"
+
+    monkeypatch.setattr("processing_pipeline.send_status_embed", fake_send_status_embed)
+    monkeypatch.setattr("processing_pipeline.send_embed_safe", fake_send_embed_safe)
+    monkeypatch.setattr("processing_pipeline.get_channel_safe", lambda *a, **k: None)
+    monkeypatch.setattr("processing_pipeline.build_player_stats_cache", fake_build_cache)
+    monkeypatch.setattr("processing_pipeline.build_lastkvk_player_stats_cache", fake_build_cache)
+    monkeypatch.setattr(
+        "processing_pipeline.read_json_safe", lambda *a, **k: {"_meta": {"count": 0}}
+    )
+    monkeypatch.setattr(
+        "processing_pipeline.run_maintenance_with_isolation",
+        fake_run_maintenance_with_isolation,
+    )
+    monkeypatch.setattr("processing_pipeline.preflight_from_env_sync", lambda *a, **k: None)
+    monkeypatch.setattr("processing_pipeline.run_all_exports", lambda *a, **k: (True, "OK"))
+    monkeypatch.setattr("processing_pipeline.warm_name_cache", fake_warm_cache)
+    monkeypatch.setattr("processing_pipeline.warm_target_cache", fake_warm_cache)
+
+
 @pytest.mark.asyncio
 async def test_run_stats_copy_archive_success(monkeypatch, tmp_path):
     """
     Ensure execute_processing_pipeline handles a well-formed run_stats_copy_archive return.
     """
     from processing_pipeline import execute_processing_pipeline
+
+    _patch_lightweight_pipeline_boundaries(monkeypatch)
 
     # Mock run_stats_copy_archive to return expected tuple
     async def fake_run_stats_copy_archive(
@@ -42,6 +78,8 @@ async def test_run_stats_copy_archive_unexpected_shape(monkeypatch):
     and not crash.
     """
     from processing_pipeline import execute_processing_pipeline
+
+    _patch_lightweight_pipeline_boundaries(monkeypatch)
 
     async def bad_run(rank, seed, **kwargs):
         # Return something unexpected

--- a/tests/test_processing_pipeline_build_cache.py
+++ b/tests/test_processing_pipeline_build_cache.py
@@ -23,9 +23,15 @@ async def test_build_player_stats_cache_offloaded_and_completes(monkeypatch):
     async def fake_send_embed_safe(*args, **kwargs):
         return True
 
+    async def fake_run_maintenance_with_isolation(*args, **kwargs):
+        return True, "OK"
+
     monkeypatch.setattr(pp, "send_embed_safe", fake_send_embed_safe)
+    monkeypatch.setattr(pp, "send_status_embed", fake_send_embed_safe)
     monkeypatch.setattr(pp, "run_all_exports", lambda *a, **k: (True, "OK"))
-    monkeypatch.setattr(pp, "run_maintenance_with_isolation", lambda *a, **k: (True, "OK"))
+    monkeypatch.setattr(pp, "run_maintenance_with_isolation", fake_run_maintenance_with_isolation)
+    monkeypatch.setattr(pp, "preflight_from_env_sync", lambda *a, **k: None)
+    monkeypatch.setattr(pp, "read_json_safe", lambda *a, **k: {"_meta": {"count": 1}})
 
     # warm_name_cache / warm_target_cache must be async (processing_pipeline awaits them)
     async def fake_warm_name_cache():
@@ -116,9 +122,15 @@ async def test_build_player_stats_cache_timeout_handled(monkeypatch):
     async def fake_send_embed_safe(*a, **k):
         return True
 
+    async def fake_run_maintenance_with_isolation(*a, **k):
+        return True, "OK"
+
     monkeypatch.setattr(pp, "send_embed_safe", fake_send_embed_safe)
+    monkeypatch.setattr(pp, "send_status_embed", fake_send_embed_safe)
     monkeypatch.setattr(pp, "run_all_exports", lambda *a, **k: (True, "OK"))
-    monkeypatch.setattr(pp, "run_maintenance_with_isolation", lambda *a, **k: (True, "OK"))
+    monkeypatch.setattr(pp, "run_maintenance_with_isolation", fake_run_maintenance_with_isolation)
+    monkeypatch.setattr(pp, "preflight_from_env_sync", lambda *a, **k: None)
+    monkeypatch.setattr(pp, "read_json_safe", lambda *a, **k: {"_meta": {"count": 1}})
 
     async def fake_warm_name_cache():
         return None
@@ -136,12 +148,19 @@ async def test_build_player_stats_cache_timeout_handled(monkeypatch):
 
     monkeypatch.setattr(pp, "run_stats_copy_archive", fake_run_stats_copy_archive)
 
-    # build_player_stats_cache will sleep longer than timeout (sync function)
-    def slow_build():
-        time.sleep(0.5)
+    def fake_build_cache():
         return None
 
-    monkeypatch.setattr(pp, "build_player_stats_cache", slow_build)
+    monkeypatch.setattr(pp, "build_player_stats_cache", fake_build_cache)
+
+    original_run_step = pp.run_step
+
+    async def fake_run_step(func, *args, **kwargs):
+        if func is fake_build_cache:
+            raise TimeoutError
+        return await original_run_step(func, *args, **kwargs)
+
+    monkeypatch.setattr(pp, "run_step", fake_run_step)
 
     # Capture telemetry_logger.info calls
     calls = []

--- a/tests/test_processing_pipeline_run_step_and_normalization.py
+++ b/tests/test_processing_pipeline_run_step_and_normalization.py
@@ -56,12 +56,15 @@ async def test_run_step_with_sync_and_async(monkeypatch):
     monkeypatch.setattr(pp, "warm_target_cache", fake_warm_target_cache)
     monkeypatch.setattr(pp, "run_all_exports", fake_run_all_exports)
     monkeypatch.setattr(pp, "run_maintenance_with_isolation", fake_run_maintenance_with_isolation)
+    monkeypatch.setattr(pp, "preflight_from_env_sync", lambda *a, **k: None)
+    monkeypatch.setattr(pp, "read_json_safe", lambda *a, **k: {"_meta": {"count": 0}})
 
     # monkeypatch send_embed_safe to a no-op to avoid discord usage
     async def fake_send_embed_safe(*args, **kwargs):
         return True
 
     monkeypatch.setattr(pp, "send_embed_safe", fake_send_embed_safe)
+    monkeypatch.setattr(pp, "send_status_embed", fake_send_embed_safe)
 
     # monkeypatch get_channel_safe to return None safely
     monkeypatch.setattr(pp, "get_channel_safe", lambda *a, **k: None)


### PR DESCRIPTION
## Summary

- Optimised the slow pytest paths identified by the pytest duration audit.
- Added a stable `EVENT_CACHE_MIN_REFRESH_TIMEOUT` setting so timeout coverage can run quickly while preserving the production default.
- Tightened processing-pipeline unit-test boundaries so tests no longer spend real wall-clock time in downstream cache, maintenance, ProcConfig, export, or status-embed work.
- Included the slow-pytest task-pack/starter documentation update so the implementation and task context stay in sync.

## Root Cause

Several tests were unit tests in intent but still exercised production-style downstream waits or orchestration after their primary dependency was mocked. The event-cache timeout test also used the production refresh timeout floor directly, causing a real 45-second wait.

## Tests

- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe -m pytest -vv tests/test_processing_pipeline.py tests/test_processing_pipeline_build_cache.py tests/test_processing_pipeline_run_step_and_normalization.py tests/test_event_cache.py --durations=30 --durations-min=1.0` (`8 passed in 2.15s`, slowest call `1.16s`)
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py` (passed with existing duplicate-command summary)
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` (`1450 passed, 2 skipped in 37.91s`)
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1450 passed, 2 skipped in 36.96s`)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`

## Risk / Rollback

Risk is low-to-medium: most changes are test-boundary fakes, with one production constant that preserves the existing default. Rollback is to revert this commit and restore the prior timeout/test-boundary behaviour.