### PR TITLE
[codex] group command surface batch one

### DIFF
--- a/bot_helpers.py
+++ b/bot_helpers.py
@@ -57,18 +57,19 @@ def prune_restart_log(log_file="restart_log.csv", max_entries=100):
         logger.warning(f"[LOG] Failed to prune {log_file}: {e}")
 
 
-def get_command_signature(command):
+def get_command_signature(command, *, name: str | None = None):
     if command is None:
         logger.warning("[SIGNATURE] Skipping null command object.")
         return None
     try:
         return {
-            "name": command.name,
+            "name": name or command.name,
             "description": command.description,
             "version": getattr(command.callback, "__version__", "v1.0"),
         }
     except Exception as e:
-        logger.warning(f"[SIGNATURE] Failed to extract signature from {command}: {e}")
+        command_name = name or getattr(command, "name", command)
+        logger.warning(f"[SIGNATURE] Failed to extract signature from {command_name}: {e}")
         return None
 
 

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -46,6 +46,7 @@ from bot_helpers import (
 )
 from bot_loader import bot
 from bot_startup_gate import claim_startup_once
+from commands.command_inventory import flatten_application_commands
 from constants import (
     COMMAND_CACHE_FILE,
     CREDENTIALS_FILE,
@@ -1662,8 +1663,11 @@ async def on_ready():
         logger.info(f"✅ Bot is ready – logged in as {bot.user} (ID: {bot.user.id})")
 
         commands = list(bot.application_commands)
+        signature_commands = list(flatten_application_commands(commands))
         current_signatures = [
-            sig for cmd in commands if (sig := get_command_signature(cmd)) is not None
+            sig
+            for name, cmd in signature_commands
+            if (sig := get_command_signature(cmd, name=name)) is not None
         ]
 
         logger.info("🧪 Reading command cache file...")
@@ -1719,8 +1723,8 @@ async def on_ready():
             logger.warning("⏩ Slash commands unchanged — skipping sync and update.")
 
         logger.warning("📋 Loaded slash commands:")
-        for cmd in commands:
-            logger.warning(f" - /{cmd.name} – {cmd.description}")
+        for name, cmd in signature_commands:
+            logger.warning(f" - /{name} – {cmd.description}")
 
         logger.info(f"[REMINDER_CACHE] Attempting to load from {REMINDER_TRACKING_FILE}")
         loaded_ids = await load_active_reminders(bot)

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -25,9 +25,7 @@ from bot_config import (
     GUILD_ID,
     NOTIFY_CHANNEL_ID,
     OFFSEASON_STATS_CHANNEL_ID,
-    MGE_LEADERSHIP_CHANNEL_ID,
 )
-from core.mge_permissions import is_admin_interaction
 from core.interaction_safety import get_operation_lock, safe_command, safe_defer
 from discord.ext import commands as ext_commands
 from commands.crystaltech_flow import run_crystaltech_flow
@@ -47,7 +45,6 @@ from stats_alerts.interface import send_stats_update_embed
 from stats_alerts.kvk_meta import is_currently_kvk
 from stats_module import run_stats_copy_archive
 from ui.views.admin_views import ConfirmRestartView, LogTailView
-from ui.views.mge_admin_completion_view import MgeAdminCompletionView
 from utils import utcnow
 from versioning import versioned
 
@@ -311,10 +308,15 @@ def register_admin(bot: ext_commands.Bot) -> None:
         except Exception:
             pass
 
-    @bot.slash_command(
+    ops_group = discord.SlashCommandGroup(
+        "ops",
+        "Operational admin controls",
+        guild_ids=[GUILD_ID],
+    )
+
+    @ops_group.command(
         name="run_sql_proc",
         description="Manually run the SQL stored procedure",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.03")
     @safe_command
@@ -412,10 +414,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
             content=summary if success else f"⚠️ Completed with issues:\n{summary}"
         )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="run_gsheets_export",
         description="Manually trigger Google Sheets export",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.04")
     @safe_command
@@ -510,8 +511,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         await ctx.interaction.edit_original_response(content=None, embed=embed)
 
-    @bot.slash_command(
-        name="restart_bot", description="Forcefully restart the bot", guild_ids=[GUILD_ID]
+    @ops_group.command(
+        name="restart_bot",
+        description="Forcefully restart the bot",
     )
     @versioned("v1.06")
     @safe_command
@@ -631,10 +633,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 pass
 
     # Commands.py — replace the whole function body of force_restart with this slimmer flow
-    @bot.slash_command(
+    @ops_group.command(
         name="force_restart",
         description="Force a restart via the watchdog mechanism (admin only).",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.07")
     @safe_command
@@ -710,10 +711,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
         # IMPORTANT: return immediately so we don’t block the loop
         return
 
-    @bot.slash_command(
+    @ops_group.command(
         name="resync_commands",
         description="Force resync of slash commands and update command cache",  # architecture-check: allow
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.09")
     @safe_command
@@ -809,10 +809,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                     )
                 )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="show_command_versions",
         description="List all currently loaded slash commands with their versions",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.03")
     @safe_command
@@ -860,10 +859,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to build command version list: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="validate_command_cache",
         description="Check for mismatched or missing entries in command_cache.json",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.04")
     @safe_command
@@ -937,8 +935,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
-        name="view_restart_log", description="View recent bot restarts", guild_ids=[GUILD_ID]
+    @ops_group.command(
+        name="view_restart_log",
+        description="View recent bot restarts",
     )
     @versioned("v1.01")
     @safe_command
@@ -1015,10 +1014,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to load restart log: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="import_proc_config",
         description="Manually run the ProcConfig import (admin only)",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.03")
     @safe_command
@@ -1126,10 +1124,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
             except Exception:
                 logger.debug("Failed to send failure response to user", exc_info=False)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="dl_bot_status",
         description="Check if the bot is running and connected to SQL.",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.03")
     @safe_command
@@ -1195,10 +1192,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="logs",
         description="Tail logs with filters & paging (general/error/crash).",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.10")
     @safe_command
@@ -1239,10 +1235,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
         await view.render(ctx.interaction)
         await ctx.interaction.edit_original_response(view=view)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="show_logs",
         description="Show recent entries from the general log file.",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.01")
     @safe_command
@@ -1306,10 +1301,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to read log: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="last_errors",
         description="Show recent entries from the error log.",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.01")
     @safe_command
@@ -1370,10 +1364,9 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to read error log: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="crash_log",
         description="Show recent entries from the crash log.",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.01")
     @safe_command
@@ -2029,32 +2022,4 @@ def register_admin(bot: ext_commands.Bot) -> None:
         embed.timestamp = datetime.utcnow()
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
-        name="mge_admin_completion",
-        description="Open MGE completion/reopen controls (admin only).",
-        guild_ids=[GUILD_ID],
-    )
-    @versioned("v1.0")
-    @safe_command
-    @track_usage()
-    async def mge_admin_completion(ctx: discord.ApplicationContext, event_id: int) -> None:
-        await safe_defer(ctx, ephemeral=True)
-        interaction = ctx.interaction
-        if interaction is None or not is_admin_interaction(interaction):
-            if interaction is not None:
-                await interaction.followup.send(
-                    "You do not have permission to use this command.",
-                    ephemeral=True,
-                )
-            return
-
-        view = MgeAdminCompletionView(
-            event_id=event_id,
-            leadership_channel_id=MGE_LEADERSHIP_CHANNEL_ID,
-            timeout=300,
-        )
-        await interaction.followup.send(
-            f"Admin completion controls for event {event_id}",
-            ephemeral=True,
-            view=view,
-        )
+    bot.add_application_command(ops_group)

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -63,6 +63,7 @@ from constants import (
     CREDENTIALS_FILE,
     CSV_LOG,
     DATABASE,
+    COMMAND_CACHE_FILE,
     EXIT_CODE_FILE,
     FAILED_LOG,
     PASSWORD,
@@ -749,17 +750,19 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 )
                 return
 
-            # === Update command_cache.json (atomically)  # architecture-check: allow
+            # === Update command cache (atomically)  # architecture-check: allow
             try:
                 # Load existing cache (if present)
                 try:
-                    with open("command_cache.json", encoding="utf-8") as f:
+                    with open(COMMAND_CACHE_FILE, encoding="utf-8") as f:
                         old_cache = {cmd["name"]: cmd for cmd in json.load(f)}
                 except FileNotFoundError:
                     old_cache = {}
                 except Exception as e:
                     logger.warning(
-                        "[COMMAND SYNC] Could not read existing command_cache.json: %s", e
+                        "[COMMAND SYNC] Could not read existing command cache %s: %s",
+                        COMMAND_CACHE_FILE,
+                        e,
                     )
                     old_cache = {}
 
@@ -783,7 +786,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                         updated.append(f"/{name} → `{cached_version}` ➜ `{version}`")
 
                 # Write atomically
-                atomic_json_write("command_cache.json", new_cache)
+                atomic_json_write(COMMAND_CACHE_FILE, new_cache)
 
                 summary = "\n".join(updated) if updated else "✅ No changes to cached versions."
                 # Keep under embed description limit
@@ -876,7 +879,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         # Load cache
         try:
-            with open("command_cache.json", encoding="utf-8") as f:
+            with open(COMMAND_CACHE_FILE, encoding="utf-8") as f:
                 raw = json.load(f)
                 cache = {entry["name"]: entry.get("version", "N/A") for entry in raw}
         except Exception as e:

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -28,6 +28,7 @@ from bot_config import (
 )
 from core.interaction_safety import get_operation_lock, safe_command, safe_defer
 from discord.ext import commands as ext_commands
+from commands.command_inventory import flatten_application_commands
 from commands.crystaltech_flow import run_crystaltech_flow
 from commands.telemetry_cmds import (
     _pick_log_source,
@@ -765,8 +766,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 new_cache = []
                 updated = []
 
-                for command in bot.application_commands:
-                    name = command.name
+                for name, command in flatten_application_commands(bot.application_commands):
                     version = getattr(command.callback, "__version__", "N/A")
                     description = command.description or ""
                     cached_version = old_cache.get(name, {}).get("version")
@@ -823,7 +823,10 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         try:
             # Sort for stable output
-            cmds = sorted(bot.application_commands, key=lambda c: c.name.lower())
+            cmds = sorted(
+                flatten_application_commands(bot.application_commands),
+                key=lambda item: item[0].lower(),
+            )
 
             embed = discord.Embed(
                 title="📦 Loaded Slash Command Versions",
@@ -833,16 +836,16 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
             # Discord embeds allow max 25 fields. If we have more, use a description list.
             if len(cmds) <= 25:
-                for command in cmds:
+                for command_name, command in cmds:
                     version = getattr(command.callback, "__version__", "N/A")
                     embed.add_field(
-                        name=f"/{command.name}", value=f"Version: `{version}`", inline=False
+                        name=f"/{command_name}", value=f"Version: `{version}`", inline=False
                     )
             else:
                 lines = []
-                for command in cmds:
+                for command_name, command in cmds:
                     version = getattr(command.callback, "__version__", "N/A")
-                    lines.append(f"/{command.name} — `{version}`")
+                    lines.append(f"/{command_name} — `{version}`")
                 text = "\n".join(lines)
                 # Keep under embed description limits (~4096 chars)
                 if len(text) > 3900:
@@ -888,15 +891,17 @@ def register_admin(bot: ext_commands.Bot) -> None:
             return
 
         # Build checks
-        loaded_cmds = sorted(bot.application_commands, key=lambda c: c.name.lower())
-        loaded_names = {c.name for c in loaded_cmds}
+        loaded_cmds = sorted(
+            flatten_application_commands(bot.application_commands),
+            key=lambda item: item[0].lower(),
+        )
+        loaded_names = {name for name, _command in loaded_cmds}
         cache_names = set(cache.keys())
 
         issues = []
 
         # Missing or mismatched
-        for command in loaded_cmds:
-            name = command.name
+        for name, command in loaded_cmds:
             version = getattr(command.callback, "__version__", "N/A")
             cached = cache.get(name)
             if cached is None:

--- a/commands/command_inventory.py
+++ b/commands/command_inventory.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+def flatten_application_commands(commands: Iterable[Any]) -> Iterator[tuple[str, Any]]:
+    """Yield slash commands with grouped subcommands expanded for inventory checks."""
+    for command in commands:
+        subcommands = getattr(command, "subcommands", None) or []
+        if not subcommands:
+            yield command.name, command
+            continue
+
+        for subcommand in subcommands:
+            nested = getattr(subcommand, "subcommands", None) or []
+            if nested:
+                for nested_command in nested:
+                    yield f"{command.name} {subcommand.name} {nested_command.name}", nested_command
+            else:
+                yield f"{command.name} {subcommand.name}", subcommand

--- a/commands/mge_cmds.py
+++ b/commands/mge_cmds.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import commands as ext_commands
 
 from bot_config import GUILD_ID, MGE_LEADERSHIP_CHANNEL_ID, MGE_SIMPLIFIED_FLOW_ENABLED
+from core.mge_permissions import is_admin_interaction
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import (
     channel_only,
@@ -20,6 +21,7 @@ from mge.mge_publish_discord_adapter import MgePublishDiscordAdapter
 from mge.mge_results_import import OverwriteConfirmationRequired, import_results_manual
 from mge.mge_review_service import get_review_pool_with_summary
 from ui.views.mge_commander_admin_view import MgeCommanderAdminView
+from ui.views.mge_admin_completion_view import MgeAdminCompletionView
 from ui.views.mge_leadership_board_view import MgeLeadershipBoardView
 from ui.views.mge_results_overwrite_confirm_view import MgeResultsOverwriteConfirmView
 from versioning import versioned
@@ -52,10 +54,15 @@ def _format_import_report(report: dict) -> str:
 def register_mge(bot: ext_commands.Bot) -> None:
     """Register MGE leadership command(s)."""
 
-    @bot.slash_command(
-        name="mge_leadership_board",
-        description="Open leadership board and roster builder for an MGE event",
+    group = discord.SlashCommandGroup(
+        "mge",
+        "MGE leadership and admin controls",
         guild_ids=[GUILD_ID],
+    )
+
+    @group.command(
+        name="leadership_board",
+        description="Open leadership board and roster builder for an MGE event",
     )
     @versioned("v1.03")
     @safe_command
@@ -123,10 +130,9 @@ def register_mge(bot: ext_commands.Bot) -> None:
             ephemeral=True,
         )
 
-    @bot.slash_command(
-        name="mge_import_results",
+    @group.command(
+        name="import_results",
         description="Manually import MGE results (.xlsx) for a completed event",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.02")
     @safe_command
@@ -235,10 +241,9 @@ def register_mge(bot: ext_commands.Bot) -> None:
             ephemeral=True,
         )
 
-    @bot.slash_command(
-        name="mge_refresh_cache",
+    @group.command(
+        name="refresh_cache",
         description="Refresh MGE commander caches from database",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.01")
     @safe_command
@@ -297,10 +302,9 @@ def register_mge(bot: ext_commands.Bot) -> None:
                 ephemeral=True,
             )
 
-    @bot.slash_command(
-        name="mge_refresh_award_reminders",
+    @group.command(
+        name="refresh_award_reminders",
         description="Refresh or repost MGE award reminders for a published event",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.0")
     @safe_command
@@ -335,10 +339,9 @@ def register_mge(bot: ext_commands.Bot) -> None:
             text += f"\nStatus: `{result.status}`"
         await ctx.followup.send(text, ephemeral=True)
 
-    @bot.slash_command(
-        name="mge_commanders",
+    @group.command(
+        name="commanders",
         description="Manage MGE commanders and variant assignment (admin only)",
-        guild_ids=[GUILD_ID],
     )
     @versioned("v1.0")
     @safe_command
@@ -357,3 +360,34 @@ def register_mge(bot: ext_commands.Bot) -> None:
             view=MgeCommanderAdminView(variants=variants),
             ephemeral=True,
         )
+
+    @group.command(
+        name="admin_completion",
+        description="Open MGE completion/reopen controls (admin only).",
+    )
+    @versioned("v1.0")
+    @safe_command
+    @track_usage()
+    async def mge_admin_completion(ctx: discord.ApplicationContext, event_id: int) -> None:
+        await safe_defer(ctx, ephemeral=True)
+        interaction = ctx.interaction
+        if interaction is None or not is_admin_interaction(interaction):
+            if interaction is not None:
+                await interaction.followup.send(
+                    "You do not have permission to use this command.",
+                    ephemeral=True,
+                )
+            return
+
+        view = MgeAdminCompletionView(
+            event_id=event_id,
+            leadership_channel_id=MGE_LEADERSHIP_CHANNEL_ID,
+            timeout=300,
+        )
+        await interaction.followup.send(
+            f"Admin completion controls for event {event_id}",
+            ephemeral=True,
+            view=view,
+        )
+
+    bot.add_application_command(group)

--- a/commands/mge_cmds.py
+++ b/commands/mge_cmds.py
@@ -7,8 +7,8 @@ import discord
 from discord.ext import commands as ext_commands
 
 from bot_config import GUILD_ID, MGE_LEADERSHIP_CHANNEL_ID, MGE_SIMPLIFIED_FLOW_ENABLED
-from core.mge_permissions import is_admin_interaction
 from core.interaction_safety import safe_command, safe_defer
+from core.mge_permissions import is_admin_interaction
 from decoraters import (
     channel_only,
     is_admin_and_notify_channel,
@@ -20,8 +20,8 @@ from mge.mge_embed_manager import sync_event_leadership_embed
 from mge.mge_publish_discord_adapter import MgePublishDiscordAdapter
 from mge.mge_results_import import OverwriteConfirmationRequired, import_results_manual
 from mge.mge_review_service import get_review_pool_with_summary
-from ui.views.mge_commander_admin_view import MgeCommanderAdminView
 from ui.views.mge_admin_completion_view import MgeAdminCompletionView
+from ui.views.mge_commander_admin_view import MgeCommanderAdminView
 from ui.views.mge_leadership_board_view import MgeLeadershipBoardView
 from ui.views.mge_results_overwrite_confirm_view import MgeResultsOverwriteConfirmView
 from versioning import versioned

--- a/docs/refactor/command_registration_audit.md
+++ b/docs/refactor/command_registration_audit.md
@@ -18,6 +18,20 @@
 
 This keeps one authoritative registration flow in production and avoids double registration.
 
+## 2026-05-19 command-surface balancing update
+
+Batch 1 grouped admin-heavy commands to restore headroom under Discord's 100 top-level command
+limit:
+
+- Primary top-level commands: `82`
+- Grouped subcommands statically detected: `21`
+- New groups: `/ops`, `/mge`
+- Existing group retained: `/prekvk`
+
+Current renamed paths are documented in `docs/reference/command_surface_audit.md`.
+`scripts/validate_command_registration.py` now warns at 90+ top-level commands and still fails
+above 100.
+
 ## Duplicate command names found
 
 These command names are declared in more than one source module:

--- a/docs/refactor/phase0_inventory.md
+++ b/docs/refactor/phase0_inventory.md
@@ -28,6 +28,12 @@ Secondary command entrypoints that exist in repo:
 
 ## 2) Slash command inventory
 
+> 2026-05-19 update: the Batch 1 command-surface balancing audit grouped operational admin
+> commands under `/ops` and MGE commands under `/mge`, reducing the primary top-level command
+> count to 82. See `docs/reference/command_surface_audit.md` for the current renamed command
+> paths. The older flat paths below remain useful historical inventory context, but should not be
+> treated as the current operator command list for `/ops` and `/mge`.
+
 ### 2.1 Primary slash commands (`Commands.py` via `register_commands`)
 
 | Command | Module | Domain | Permission/decorator profile | Typical output |

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -1,0 +1,68 @@
+# Command Surface Audit
+
+Last updated: 2026-05-19
+
+## Current Registration Summary
+
+`scripts/validate_command_registration.py` reports:
+
+```text
+primary=82 grouped_subcommands=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
+```
+
+Grouped command summary:
+
+| Group | Subcommands |
+|---|---:|
+| `/ops` | 14 |
+| `/mge` | 6 |
+| `/prekvk` | 1 statically detected, plus `/prekvk import_history` attached through the PreKvK admin helper |
+
+The primary command surface now has an 18-command buffer below Discord's 100 top-level
+application-command limit. The validator warns at 90+ and fails above 100.
+
+## Batch 1 Renamed Command Paths
+
+### Operational Admin Commands
+
+| Old path | New path |
+|---|---|
+| `/run_sql_proc` | `/ops run_sql_proc` |
+| `/run_gsheets_export` | `/ops run_gsheets_export` |
+| `/restart_bot` | `/ops restart_bot` |
+| `/force_restart` | `/ops force_restart` |
+| `/resync_commands` | `/ops resync_commands` |
+| `/show_command_versions` | `/ops show_command_versions` |
+| `/validate_command_cache` | `/ops validate_command_cache` |
+| `/view_restart_log` | `/ops view_restart_log` |
+| `/import_proc_config` | `/ops import_proc_config` |
+| `/dl_bot_status` | `/ops dl_bot_status` |
+| `/logs` | `/ops logs` |
+| `/show_logs` | `/ops show_logs` |
+| `/last_errors` | `/ops last_errors` |
+| `/crash_log` | `/ops crash_log` |
+
+Permission decorators and inline admin checks were preserved.
+
+### MGE Commands
+
+| Old path | New path |
+|---|---|
+| `/mge_leadership_board` | `/mge leadership_board` |
+| `/mge_import_results` | `/mge import_results` |
+| `/mge_refresh_cache` | `/mge refresh_cache` |
+| `/mge_refresh_award_reminders` | `/mge refresh_award_reminders` |
+| `/mge_commanders` | `/mge commanders` |
+| `/mge_admin_completion` | `/mge admin_completion` |
+
+Permission decorators, MGE leadership channel checks, and admin completion interaction checks were
+preserved.
+
+## Deferred Follow-Up Batches
+
+Next command-surface batches are staged in `docs/reference/deferred_optimisations.md`.
+Recommended order:
+
+1. Ark grouping under `/ark`, with operator communication for public paths.
+2. Public/player domain grouping across KVK, registry, inventory, calendar, and subscriptions.
+3. Secondary command surface retirement or clearer validator classification for disabled cogs.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -7,12 +7,12 @@ Last updated: 2026-05-19
 `scripts/validate_command_registration.py` reports:
 
 ```text
-primary=82 grouped_subcommands=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
+primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
 ```
 
 Grouped command summary:
 
-| Group | Subcommands |
+| Group | Statically detected subcommands |
 |---|---:|
 | `/ops` | 14 |
 | `/mge` | 6 |

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,7 +5,11 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after the DL_bot upload-routing Phase 2C PreKvK report production release. PR 96
+Last reviewed after the slow-pytest optimisation production release. PR 107
+(`pytest-log-delivery-docs`) resolved the high-impact pytest duration outliers found after the
+pytest log-isolation production smoke audit, reducing the duration audit from `1450 passed, 2
+skipped, 19 warnings in 638.91s` to `1450 passed, 2 skipped, 19 warnings in 54.86s`; it was smoke
+tested successfully and deployed to production. PR 96
 (`import-locations-command-orchestration-cleanup`) was smoke tested successfully and deployed to
 production. PR 97 (`dlbot-player-location-upload-route`) was smoke tested successfully and
 promoted to production. The governor fuzzy/name/partial-ID lookup standardisation item,
@@ -26,22 +30,49 @@ upload routing and related test-environment blockers, not as a continuation of t
 both this backlog and the current `K98-bot-mirror` GitHub issues list.
 
 ### Deferred Optimisation
-- Area: `tests/test_processing_pipeline.py`, `tests/test_processing_pipeline_build_cache.py`, `tests/test_processing_pipeline_run_step_and_normalization.py`, `tests/test_event_cache.py`, slow full-suite pytest paths
+- Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
 - Type: performance
-- Description: Production smoke validation for the pytest log-isolation delivery passed, but the saved duration audit shows several unit tests spending real wall-clock time in expensive pipeline, timeout, lock, or offload paths. The worst offenders were `tests/test_processing_pipeline.py::test_run_stats_copy_archive_success` at 252.28s, `tests/test_processing_pipeline.py::test_run_stats_copy_archive_unexpected_shape` at 234.79s, `tests/test_event_cache.py::test_refresh_event_cache_times_out` at 45.00s, `tests/test_processing_pipeline_run_step_and_normalization.py::test_run_step_with_sync_and_async` at 17.27s, `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_offloaded_and_completes` at 17.26s, and `tests/test_processing_pipeline_build_cache.py::test_build_player_stats_cache_timeout_handled` at 16.32s.
-- Suggested Fix: Start with the two `tests/test_processing_pipeline.py` cases and audit which downstream stages still execute after `run_stats_copy_archive` is mocked. Patch heavy unit-test boundaries such as cache rebuilds, post-import maintenance, ProcConfig preflight/import, exports, lock waits, and intentional timeout sleeps so unit coverage asserts orchestration and failure handling without real multi-second waits. Add duration-focused regression validation using `pytest -vv --durations=30 --durations-min=1.0` and keep full-suite log-noise validation intact.
-- Impact: high
+- Description: After PR 107 resolved the original slow pytest offenders, the new duration audit `C:\Users\cwatt\Downloads\.codex_pytest_audit-new.log` shows the remaining full-suite outliers are concentrated in Ark preference/ban negative paths, lock-timeout coverage, calendar failure-path retries, live queue persistence, maintenance subprocess timeout/success coverage, and one inventory vision import case. The slowest current timings are `tests/test_ark_preference_service.py::test_set_preference_rejects_unknown_governor` at 7.33s, `tests/test_ark_bans_enforcement.py::test_admin_add_allows_when_override_on` at 5.23s, `tests/test_lock_timeout.py::test_remove_view_tracker_entry_returns_false_when_locked` at 5.06s, `tests/test_lock_timeout.py::test_save_view_tracker_raises_on_lock` at 5.06s, `tests/test_calendar_service.py::test_refresh_full_stops_on_sync_failure` at 3.02s, and `tests/test_calendar_pipeline.py::test_pipeline_stops_on_sync_failure` at 3.01s.
+- Suggested Fix: Start a fresh audit from `.codex_pytest_audit-new.log` and classify each remaining slow path as intentional timeout coverage, missing test boundary, live dependency leakage, retry/backoff, or genuine defect. Preserve lock-timeout and subprocess timeout coverage, but replace real multi-second waits with patched timeout constants, fake clocks, controlled retry policies, or explicit service/DAL boundary fakes where safe. Keep the scope separate from PR 107 and validate with `pytest -vv tests --durations=30 --durations-min=1.0`, focused subsystem tests, `scripts/analyse_pytest_log_noise.py`, and `python -m pytest -q tests`.
+- Impact: medium
 - Risk: medium
-- Dependencies: Preserve negative-path coverage and production timeout behaviour; do not weaken `scripts/analyse_pytest_log_noise.py` or live integration gating.
+- Dependencies: Use the post-PR-107 audit baseline (`1450 passed, 2 skipped, 19 warnings in 54.86s`); preserve genuine timeout, subprocess, lock, negative-path, and log-noise coverage.
 
 ### Deferred Optimisation
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
-- Description: The primary Discord application-command set is currently at the 100 top-level command limit. Phase 2C avoided the limit by grouping PreKvK commands under `/prekvk`, but future standalone slash commands can still break startup sync with Discord error 30032 unless command surface consolidation is planned before new command work.
-- Suggested Fix: Run a command-surface balancing audit before the next command-heavy feature. Group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling in PR validation.
+- Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation remains planned.
+- Suggested Fix: Continue the command-surface programme through the staged follow-up batches below. Group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
 - Impact: high
 - Risk: medium
-- Dependencies: Coordinate with bot operators before renaming public command paths; preserve admin-only permission checks when commands move into groups.
+- Dependencies: Batch 1 `/ops` and `/mge` grouping validation remains clean; coordinate with bot operators before renaming public command paths; preserve admin-only permission checks when commands move into groups.
+
+### Deferred Optimisation
+- Area: `commands/ark_cmds.py`, `docs/ark/`, Ark command tests
+- Type: architecture
+- Description: Ark still exposes many top-level commands (`/ark_create_match`, `/ark_force_announce`, `/ark_amend_match`, `/ark_cancel_match`, `/ark_set_preference`, `/ark_clear_preference`, `/ark_ban_add`, `/ark_ban_revoke`, `/ark_ban_list`, `/ark_set_result`, `/ark_generate_draft`, `/create_ark_team`, plus public `/ark_reminder_prefs` and `/ark_report_players`). These are a natural `/ark` command group and could recover another large block of top-level command headroom, but several docs and public/operator workflows reference the flat paths.
+- Suggested Fix: Prepare a second command-surface migration batch that groups Ark commands under `/ark`, preserving `is_admin_or_leadership_only`, `channel_only`, public reminder/report behavior, autocomplete/options, and interaction responses. Coordinate operator communication for public path changes before implementation and update Ark docs/tests to the new paths.
+- Impact: high
+- Risk: medium
+- Dependencies: Batch 1 `/ops` and `/mge` grouping deployed cleanly; operators approve public Ark path migration and announcement timing.
+
+### Deferred Optimisation
+- Area: `commands/stats_cmds.py`, `commands/registry_cmds.py`, `commands/inventory_cmds.py`, `commands/calendar_cmds.py`, `commands/subscriptions_cmds.py`, user-facing command docs/tests
+- Type: architecture
+- Description: Public/player-facing command domains still use many top-level paths that could be grouped later (`/kvk`, `/registry`, `/inventory`, `/calendar`, `/subscriptions`). These commands are more discoverability-sensitive than admin-only surfaces and include heavily documented player workflows, so moving them without coordination could confuse users even though it would reduce startup sync risk further.
+- Suggested Fix: Scope a later public command-path migration with operator-approved UX rules, aliases/transition messaging if feasible, and focused docs/test updates. Prioritise admin-heavy subcommands inside each domain first, then evaluate whether player paths should remain flat for discoverability.
+- Impact: medium
+- Risk: medium
+- Dependencies: Operator approval for public command rename policy; updated command reference/announcement plan; Batch 1 validation remains below the warning threshold.
+
+### Deferred Optimisation
+- Area: `cogs/commands.py`, `subscribe.py`, `scripts/validate_command_registration.py`, startup command audit docs
+- Type: cleanup
+- Description: Disabled secondary command surfaces still declare duplicate command names (`/summary`, `/weeksummary`, `/history`, `/failures`, `/ping`, `/subscribe`). The validator reports these duplicates, but the output does not clearly separate intentionally disabled legacy surfaces from active startup-sync risk.
+- Suggested Fix: Decide whether to retire the disabled secondary cogs or enhance validator output to classify duplicates by active vs disabled registration path. If the files are retained, document the environment gating and keep duplicate warnings informational; if retired, remove or archive the dead command declarations with smoke/import coverage.
+- Impact: medium
+- Risk: low
+- Dependencies: Confirm secondary cogs remain disabled by default in production and no operator workflow depends on loading them.
 
 ### Deferred Optimisation
 - Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 PRIMARY_COMMAND_LIMIT = 100
+PRIMARY_COMMAND_WARNING_THRESHOLD = 90
 
 SECONDARY_MODULES = [
     ("cogs/commands.py (secondary)", ROOT / "cogs" / "commands.py"),
@@ -26,13 +27,17 @@ def _literal_string(node: ast.AST) -> str | None:
     return None
 
 
-def _call_name(call: ast.Call) -> str | None:
-    func = call.func
-    if isinstance(func, ast.Name):
-        return func.id
-    if isinstance(func, ast.Attribute):
-        return func.attr
+def _node_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _node_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
     return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    return _node_name(call.func)
 
 
 def collect_names(path: Path) -> set[str]:
@@ -63,13 +68,36 @@ def collect_names(path: Path) -> set[str]:
     return names
 
 
-def collect_primary_names() -> set[str]:
+def collect_primary_inventory() -> tuple[set[str], dict[str, set[str]]]:
     names: set[str] = set()
+    grouped: dict[str, set[str]] = {}
     for path in sorted((ROOT / "commands").glob("*.py")):
         if path.name == "__init__.py":
             continue
         source = path.read_text(encoding="utf-8-sig")
         tree = ast.parse(source, filename=str(path))
+        group_vars: dict[str, str] = {}
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                continue
+            if not (_call_name(node.value) or "").endswith("SlashCommandGroup"):
+                continue
+
+            group_name = None
+            if node.value.args:
+                group_name = _literal_string(node.value.args[0])
+            for kw in node.value.keywords:
+                if kw.arg == "name":
+                    group_name = _literal_string(kw.value) or group_name
+
+            if not group_name:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    group_vars[target.id] = group_name
+            names.add(group_name)
+            grouped.setdefault(group_name, set())
 
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -89,6 +117,14 @@ def collect_primary_names() -> set[str]:
                         and owner.id == "app_commands"
                     )
                     if not (is_bot_slash or is_app_command):
+                        if attr == "command" and isinstance(owner, ast.Name):
+                            group_name = group_vars.get(owner.id)
+                            if group_name:
+                                for kw in deco.keywords:
+                                    name = _literal_string(kw.value) if kw.arg == "name" else None
+                                    if name:
+                                        grouped.setdefault(group_name, set()).add(name)
+                                        break
                         continue
                     for kw in deco.keywords:
                         name = _literal_string(kw.value) if kw.arg == "name" else None
@@ -96,23 +132,18 @@ def collect_primary_names() -> set[str]:
                             names.add(name)
                             break
 
-            if isinstance(node, ast.Call) and _call_name(node) == "SlashCommandGroup":
-                if node.args:
-                    name = _literal_string(node.args[0])
-                    if name:
-                        names.add(name)
-                        continue
-                for kw in node.keywords:
-                    name = _literal_string(kw.value) if kw.arg == "name" else None
-                    if name:
-                        names.add(name)
-                        break
+    return names, grouped
 
+
+def collect_primary_names() -> set[str]:
+    names, _grouped = collect_primary_inventory()
     return names
 
 
 def main() -> int:
-    paths = {"commands package (authoritative)": collect_primary_names()}
+    primary_names, grouped = collect_primary_inventory()
+    grouped_subcommand_count = sum(len(commands) for commands in grouped.values())
+    paths = {"commands package (authoritative)": primary_names}
     paths.update({label: collect_names(path) for label, path in SECONDARY_MODULES})
     owners: dict[str, list[str]] = {}
     for label, names in paths.items():
@@ -124,10 +155,17 @@ def main() -> int:
     total_unique = len(set().union(*paths.values()))
     print(
         f"registration summary: primary={primary_count} "
+        f"grouped_subcommands={grouped_subcommand_count} "
         f"secondary_cogs={len(paths['cogs/commands.py (secondary)'])} "
         f"secondary_subscribe={len(paths['subscribe.py (secondary)'])} "
         f"total_unique={total_unique}"
     )
+
+    if grouped:
+        print("grouped command summary:")
+        for group_name in sorted(grouped):
+            subcommands = grouped[group_name]
+            print(f"  /{group_name}: {len(subcommands)} subcommand(s)")
 
     failed = False
     if primary_count > PRIMARY_COMMAND_LIMIT:
@@ -136,6 +174,11 @@ def main() -> int:
             "top-level application commands"
         )
         failed = True
+    elif primary_count >= PRIMARY_COMMAND_WARNING_THRESHOLD:
+        print(
+            f"primary command limit warning: {primary_count}/{PRIMARY_COMMAND_LIMIT} "
+            "top-level application commands"
+        )
 
     if not duplicates:
         print("no duplicates detected")

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -142,7 +142,7 @@ def collect_primary_names() -> set[str]:
 
 def main() -> int:
     primary_names, grouped = collect_primary_inventory()
-    grouped_subcommand_count = sum(len(commands) for commands in grouped.values())
+    grouped_subcommand_detected_count = sum(len(commands) for commands in grouped.values())
     paths = {"commands package (authoritative)": primary_names}
     paths.update({label: collect_names(path) for label, path in SECONDARY_MODULES})
     owners: dict[str, list[str]] = {}
@@ -155,14 +155,14 @@ def main() -> int:
     total_unique = len(set().union(*paths.values()))
     print(
         f"registration summary: primary={primary_count} "
-        f"grouped_subcommands={grouped_subcommand_count} "
+        f"grouped_subcommands_detected={grouped_subcommand_detected_count} "
         f"secondary_cogs={len(paths['cogs/commands.py (secondary)'])} "
         f"secondary_subscribe={len(paths['subscribe.py (secondary)'])} "
         f"total_unique={total_unique}"
     )
 
     if grouped:
-        print("grouped command summary:")
+        print("grouped command summary (statically detected):")
         for group_name in sorted(grouped):
             subcommands = grouped[group_name]
             print(f"  /{group_name}: {len(subcommands)} subcommand(s)")

--- a/tests/test_admin_command_cache_paths.py
+++ b/tests/test_admin_command_cache_paths.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_admin_command_cache_handlers_use_canonical_cache_path():
+    source = Path("commands/admin_cmds.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    in_scope = {"resync_commands", "validate_command_cache"}
+    functions = {
+        node.name: ast.get_source_segment(source, node) or ""
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name in in_scope
+    }
+
+    assert set(functions) == in_scope
+
+    combined = "\n".join(functions.values())
+    assert "COMMAND_CACHE_FILE" in combined
+    assert '"command_cache.json"' not in combined
+    assert "atomic_json_write(COMMAND_CACHE_FILE" in functions["resync_commands"]

--- a/tests/test_command_inventory.py
+++ b/tests/test_command_inventory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from commands.command_inventory import flatten_application_commands
+
+
+def _cmd(name: str, *, subcommands=None):
+    return SimpleNamespace(name=name, subcommands=subcommands or [])
+
+
+def test_flatten_application_commands_preserves_top_level_commands():
+    ping = _cmd("ping")
+
+    assert list(flatten_application_commands([ping])) == [("ping", ping)]
+
+
+def test_flatten_application_commands_expands_group_subcommands():
+    status = _cmd("status")
+    logs = _cmd("logs")
+    ops = _cmd("ops", subcommands=[status, logs])
+
+    assert list(flatten_application_commands([ops])) == [
+        ("ops status", status),
+        ("ops logs", logs),
+    ]
+
+
+def test_flatten_application_commands_expands_nested_subcommand_groups():
+    add = _cmd("add")
+    ban = _cmd("ban", subcommands=[add])
+    ark = _cmd("ark", subcommands=[ban])
+
+    assert list(flatten_application_commands([ark])) == [("ark ban add", add)]

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -40,6 +40,11 @@ def test_register_commands_smoke(monkeypatch):
     Commands.register_commands(fake_bot)
 
     assert len([name for name in registered_top_level if name]) <= 100
+    assert len([name for name in registered_top_level if name]) < 90
+    assert "ops" in registered_top_level
+    assert "mge" in registered_top_level
     assert "prekvk" in registered_top_level
+    assert "run_sql_proc" not in registered_top_level
+    assert "mge_refresh_award_reminders" not in registered_top_level
     assert "prekvk_report" not in registered_top_level
     assert "prekvk_import_history" not in registered_top_level

--- a/tests/test_command_signature_inventory.py
+++ b/tests/test_command_signature_inventory.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bot_helpers import get_command_signature
+
+
+def test_get_command_signature_uses_grouped_inventory_name():
+    def callback():
+        return None
+
+    callback.__version__ = "v9.01"
+    command = SimpleNamespace(
+        name="run_sql_proc",
+        description="Manually run the SQL stored procedure",
+        callback=callback,
+    )
+
+    assert get_command_signature(command, name="ops run_sql_proc") == {
+        "name": "ops run_sql_proc",
+        "description": "Manually run the SQL stored procedure",
+        "version": "v9.01",
+    }
+
+
+def test_bot_startup_uses_flattened_command_inventory_for_signatures():
+    source = open("bot_instance.py", encoding="utf-8").read()
+
+    assert "from commands.command_inventory import flatten_application_commands" in source
+    assert "signature_commands = list(flatten_application_commands(commands))" in source
+    assert "get_command_signature(cmd, name=name)" in source
+    assert "for name, cmd in signature_commands:" in source

--- a/tests/test_mge_award_reminder_refresh.py
+++ b/tests/test_mge_award_reminder_refresh.py
@@ -314,9 +314,13 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
     class _RecordedBot:
         def __init__(self):
             self.tree = _RecordedRegistrar()
+            self.application_commands = []
 
         def slash_command(self, *args, **kwargs):
             return self.tree.slash_command(*args, **kwargs)
+
+        def add_application_command(self, command):
+            self.application_commands.append(command)
 
     def _fake_is_admin_and_notify_channel(*, allow_leadership=False):
         captured["allow_leadership"] = allow_leadership
@@ -336,12 +340,10 @@ def test_refresh_award_reminders_command_uses_admin_decorator(monkeypatch):
     bot = _RecordedBot()
     mge_cmds.register_mge(bot)
 
-    refresh_commands = [
-        command for command in bot.tree.commands if command.name == "mge_refresh_award_reminders"
-    ]
-
     assert captured["allow_leadership"] is True
-    assert refresh_commands
+    assert [command.name for command in bot.application_commands] == ["mge"]
     assert any(
-        getattr(command.callback, "_admin_check_applied", False) for command in refresh_commands
+        getattr(command.callback, "_admin_check_applied", False)
+        for command in bot.application_commands[0].subcommands
+        if command.name == "refresh_award_reminders"
     )

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -41,13 +41,11 @@ def register_sample(bot):
 def test_main_warns_when_primary_command_count_nears_limit(tmp_path, monkeypatch, capsys):
     command_lines = []
     for index in range(validator.PRIMARY_COMMAND_WARNING_THRESHOLD):
-        command_lines.append(
-            f"""
+        command_lines.append(f"""
     @bot.slash_command(name="cmd_{index}", description="Command {index}")
     async def cmd_{index}(ctx):
         pass
-"""
-        )
+""")
     _write(
         tmp_path / "commands" / "many_cmds.py",
         "def register_many(bot):\n" + "\n".join(command_lines),

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import validate_command_registration as validator
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_collect_primary_inventory_counts_groups_and_subcommands(tmp_path, monkeypatch):
+    _write(
+        tmp_path / "commands" / "sample_cmds.py",
+        """
+import discord
+
+
+def register_sample(bot):
+    group = discord.SlashCommandGroup("ops", "Ops")
+
+    @group.command(name="status", description="Status")
+    async def status(ctx):
+        pass
+
+    @bot.slash_command(name="ping", description="Ping")
+    async def ping(ctx):
+        pass
+""",
+    )
+
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+
+    names, grouped = validator.collect_primary_inventory()
+
+    assert names == {"ops", "ping"}
+    assert grouped == {"ops": {"status"}}
+
+
+def test_main_warns_when_primary_command_count_nears_limit(tmp_path, monkeypatch, capsys):
+    command_lines = []
+    for index in range(validator.PRIMARY_COMMAND_WARNING_THRESHOLD):
+        command_lines.append(
+            f"""
+    @bot.slash_command(name="cmd_{index}", description="Command {index}")
+    async def cmd_{index}(ctx):
+        pass
+"""
+        )
+    _write(
+        tmp_path / "commands" / "many_cmds.py",
+        "def register_many(bot):\n" + "\n".join(command_lines),
+    )
+    _write(tmp_path / "cogs" / "commands.py", "")
+    _write(tmp_path / "subscribe.py", "")
+
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        validator,
+        "SECONDARY_MODULES",
+        [
+            ("cogs/commands.py (secondary)", tmp_path / "cogs" / "commands.py"),
+            ("subscribe.py (secondary)", tmp_path / "subscribe.py"),
+        ],
+    )
+
+    assert validator.main() == 0
+
+    output = capsys.readouterr().out
+    assert "primary command limit warning" in output
+    assert f"{validator.PRIMARY_COMMAND_WARNING_THRESHOLD}/100" in output


### PR DESCRIPTION
## Summary

Batch 1 of the command-surface balancing audit reduces Discord top-level application-command pressure by grouping admin-heavy commands:

- moves operational admin commands under `/ops`
- moves MGE admin/leadership commands under `/mge`
- moves MGE admin completion from `admin_cmds.py` into the MGE registrar so only one `/mge` group is registered
- enhances `scripts/validate_command_registration.py` to report statically detected grouped subcommands and warn at 90+ top-level commands while still failing above 100
- flattens grouped subcommands for command cache/version reporting so `/ops ...` handlers keep their version visibility
- flattens grouped subcommands during startup signature/cache diffing so grouped commands are not treated as missing after smoke load
- uses canonical `COMMAND_CACHE_FILE` for command cache reads/writes instead of the legacy root `command_cache.json` path
- adds `docs/reference/command_surface_audit.md` with the renamed paths
- captures follow-up deferred batches for Ark grouping, public/player domain grouping, and secondary cog cleanup

## Impact

The static command registration audit now reports:

```text
primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
```

This restores an 18-command buffer below Discord's 100 top-level command ceiling. Existing permission decorators and inline checks were preserved for moved commands. Runtime startup/cache checks now inventory grouped subcommands as `/ops ...`, `/mge ...`, and `/prekvk ...` entries instead of attempting to extract callback signatures from the group objects themselves.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_command_signature_inventory.py tests\test_command_inventory.py tests\test_admin_command_cache_paths.py` (`6 passed`)
- `.\.venv\Scripts\python.exe -m py_compile bot_helpers.py bot_instance.py commands\command_inventory.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1458 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` (`1458 passed, 2 skipped`; production operational logs unchanged)
- `git diff --check`

## Notes

`docs/reference/deferred_optimisations.md` already had unrelated slow-pytest backlog edits in the working tree before this task. This PR preserves those edits and adds the command-surface follow-up items requested in the task.