### PR TITLE
[codex] fix empty stats alert state repair

### DIFF
--- a/stats_alerts/state.py
+++ b/stats_alerts/state.py
@@ -1,5 +1,6 @@
 # stats_alerts/state.py
 import logging
+from pathlib import Path
 from typing import Any
 
 from constants import STATS_ALERT_LOG
@@ -13,6 +14,43 @@ _STATE_LOCK_PATH = f"{STATE_PATH}.lock"
 _LOCK_TIMEOUT_SECS = 5.0
 
 
+def _repair_empty_state_file() -> bool:
+    """Rewrite an empty/whitespace state file as a valid empty JSON object."""
+    path = Path(STATE_PATH)
+    if not path.exists():
+        return False
+
+    try:
+        with acquire_lock(_STATE_LOCK_PATH, timeout=_LOCK_TIMEOUT_SECS):
+            if not path.exists():
+                return False
+
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except Exception:
+                logger.exception("[STATE] Failed reading state file %s for repair.", STATE_PATH)
+                return False
+
+            if raw.strip():
+                return False
+
+            atomic_write_json(path, {})
+            logger.warning(
+                "[STATE] State file %s was empty; repaired with an empty JSON object.",
+                STATE_PATH,
+            )
+            return True
+    except TimeoutError:
+        logger.warning(
+            "[STATE] Timeout acquiring state lock while checking empty state file %s.",
+            STATE_PATH,
+        )
+        return False
+    except Exception:
+        logger.exception("[STATE] Failed checking empty state file %s.", STATE_PATH)
+        return False
+
+
 def load_state() -> dict[str, Any]:
     """
     Load persisted state from JSON file.
@@ -21,6 +59,9 @@ def load_state() -> dict[str, Any]:
     Uses file_utils.read_json_safe which logs JSON errors and returns a default.
     """
     try:
+        if _repair_empty_state_file():
+            return {}
+
         data = read_json_safe(STATE_PATH, default={})
         if isinstance(data, dict):
             return data

--- a/tests/test_stats_alerts_state.py
+++ b/tests/test_stats_alerts_state.py
@@ -1,0 +1,43 @@
+import json
+
+import stats_alerts.state as state_mod
+
+
+def _point_state_at(monkeypatch, tmp_path):
+    path = tmp_path / "stats_alert_log.csv.state.json"
+    monkeypatch.setattr(state_mod, "STATE_PATH", str(path))
+    monkeypatch.setattr(state_mod, "_STATE_LOCK_PATH", f"{path}.lock")
+    return path
+
+
+def test_load_state_repairs_empty_file(monkeypatch, tmp_path, caplog):
+    path = _point_state_at(monkeypatch, tmp_path)
+    path.write_text("", encoding="utf-8")
+
+    loaded = state_mod.load_state()
+
+    assert loaded == {}
+    assert json.loads(path.read_text(encoding="utf-8")) == {}
+    assert "JSON decode failed" not in caplog.text
+
+
+def test_load_state_repairs_whitespace_only_file(monkeypatch, tmp_path, caplog):
+    path = _point_state_at(monkeypatch, tmp_path)
+    path.write_text("  \n\t", encoding="utf-8")
+
+    loaded = state_mod.load_state()
+
+    assert loaded == {}
+    assert json.loads(path.read_text(encoding="utf-8")) == {}
+    assert "JSON decode failed" not in caplog.text
+
+
+def test_load_state_preserves_valid_state(monkeypatch, tmp_path):
+    path = _point_state_at(monkeypatch, tmp_path)
+    original = '{\n  "prekvk_msg_id": 123\n}'
+    path.write_text(original, encoding="utf-8")
+
+    loaded = state_mod.load_state()
+
+    assert loaded == {"prekvk_msg_id": 123}
+    assert path.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary

Fixes the noisy JSON decode failure when `logs/stats_alert_log.csv.state.json` exists but is empty or whitespace-only.

The active KVK path loads stats alert state to clear any stored Pre-KVK message id. If the state file had been created empty, `read_json_safe()` logged a JSON decode error even though the workflow continued. This change keeps the fix scoped to `stats_alerts.state`: it detects empty/whitespace state files under the existing state lock, rewrites them atomically as `{}`, and returns empty state before the generic JSON reader parses the file.

Non-empty malformed JSON still uses the existing logged fallback so real corruption remains visible.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_stats_alerts_state.py tests\test_rehydrate_sanitize_and_fileio.py`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`

`validate_command_registration.py` passed with the existing duplicate-command summary.