### PR TITLE
Extract KVK_ALL upload route

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -133,8 +133,9 @@ from bot_helpers import channel_queues
 from Commands import register_commands
 from embed_utils import send_embed
 from honor_importer import ingest_honor_snapshot, parse_honor_xlsx
-from kvk_all_importer import _auto_export_kvk, ingest_kvk_all_excel
+from kvk_all_importer import _auto_export_kvk
 from log_health import LogHeadroomError, preflight_from_env_sync
+from upload_routes.kvk_all_route import KvkAllRouteDeps, handle_kvk_all_upload
 from upload_routes.player_location_route import (
     PlayerLocationRouteDeps,
     handle_player_location_upload,
@@ -1048,185 +1049,25 @@ async def on_message(message: discord.Message):
         return  # don't enqueue into the heavy stats pipeline
 
     # === KVK (all kingdoms) ingest ===
-    if message.channel.id == PROKINGDOM_CHANNEL_ID and message.attachments:
-        notify_ch = await _get_notify_channel() or message.channel
-
-        # Log what Discord actually gave us
-        try:
-            logger.info(
-                "[KVK] msg=%s attachments=%s", message.id, [a.filename for a in message.attachments]
-            )
-        except Exception:
-            pass
-
-        # Find ALL excel/csv attachments (process each)
-        excel_attachments = [
-            a
-            for a in message.attachments
-            if a.filename.lower().strip().endswith((".xlsx", ".xls", ".csv"))
-        ]
-
-        if not excel_attachments:
-            await send_embed(
-                notify_ch,
-                "KVK All-Kingdom Import ⚠️",
-                {
-                    "Info": "No .xlsx/.xls/.csv attachment found.",
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE67E22,
-            )
-            return
-
-        # Process each matching attachment independently
-        for att in excel_attachments:
-            try:
-                logger.info("[KVK] Reading attachment: %s (%s bytes)", att.filename, att.size)
-                file_bytes = await att.read()
-
-                # NEW: preflight check
-                ok = await ensure_sql_headroom_or_notify(notify_ch)
-                if not ok:
-                    await send_embed(
-                        notify_ch,
-                        "KVK All-Kingdom Import Aborted ❌",
-                        {"File": att.filename, "Reason": "SQL log headroom insufficient"},
-                        0xE74C3C,
-                    )
-                    continue
-
-                # Offload heavy importer to an isolated process when available
-                result = await _offload_callable(
-                    ingest_kvk_all_excel,
-                    content=file_bytes,
-                    source_filename=att.filename,
-                    uploader_id=message.author.id,
-                    scan_ts_utc=message.created_at,
-                    server=os.environ.get("SQL_SERVER"),
-                    database=os.environ.get("SQL_DATABASE"),
-                    username=os.environ.get("SQL_USERNAME"),
-                    password=os.environ.get("SQL_PASSWORD"),
-                    name="ingest_kvk_all_excel",
-                    prefer_process=True,
-                    meta={"filename": att.filename},
-                )
-
-                # Handle structured importer failures (no traceback)
-                if isinstance(result, dict) and not result.get("success", True):
-                    # concise log (no stacktrace) and user-facing embed
-                    logger.info("[KVK] Import failed for %s: %s", att.filename, result.get("error"))
-                    await send_embed(
-                        notify_ch,
-                        "KVK All-Kingdom Import ❌",
-                        {
-                            "Filename": att.filename,
-                            "Channel": f"#{message.channel.name} ({message.channel.id})",
-                            "Uploader": f"{message.author} ({message.author.id})",
-                            "Error": result.get("error"),
-                            "Sheet": result.get("sheet", "unknown"),
-                        },
-                        0xE74C3C,
-                    )
-                    continue  # move on to next attachment
-
-                kvk_no = int(result["kvk_no"])
-                scan_id = int(result["scan_id"])
-                rows = int(result["row_count"])
-                neg = int(result["negatives"])
-                dur_s = float(result["duration_s"])
-                staged = int(
-                    result.get("staged_rows", rows)
-                )  # fallback to final rows if not provided
-                proc_ms = float(result.get("proc_ms", max(0.0, dur_s * 1000.0)))
-                io_ms = max(0.0, dur_s * 1000.0 - proc_ms)
-
-                # Tiny badge + color flip if negatives > 0
-                neg_badge = "0" if neg == 0 else f"{neg} ⚠️"
-                color = 0x2ECC71 if neg == 0 else 0xE67E22  # green vs orange
-                title = "KVK All-Kingdom Import ✅" if neg == 0 else "KVK All-Kingdom Import ⚠️"
-
-                # Optional recompute timing (returned by new importer)
-                recompute_ms = float(result.get("recompute_ms", 0.0))
-
-                sheet_used = result.get("sheet", "unknown")
-
-                fields = {
-                    "KVK": str(kvk_no),
-                    "ScanID": str(scan_id),
-                    "Rows": str(rows),
-                    "Staged": str(staged),  # ← NEW
-                    "Negative Corrections": neg_badge,
-                    "Duration": f"{dur_s:.2f}s",
-                    # Health line: proc / I/O (+ recompute if available)
-                    "Health": (
-                        f"proc `{proc_ms:.0f}ms` • I/O `{io_ms:.0f}ms`"
-                        + (f" • recompute `{recompute_ms:.0f}ms`" if recompute_ms > 0 else "")
-                    ),
-                    "File": att.filename,
-                    "Sheet": sheet_used,
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                }
-                embed = discord.Embed(title=title, color=color)
-                for k, v in fields.items():
-                    embed.add_field(name=k, value=str(v), inline=True)
-
-                # Optional: keep your bot’s branding thumbnail for consistency
-                try:
-                    from constants import CUSTOM_AVATAR_URL
-
-                    if CUSTOM_AVATAR_URL:
-                        embed.set_thumbnail(url=CUSTOM_AVATAR_URL)
-                except Exception:
-                    pass
-
-                # Add a link button to the stats sheet (graceful no-op if ID missing)
-                view = None
-                try:
-                    sheet_id = (
-                        ALL_KVK_SHEET_ID
-                        or os.environ.get("KVK_SHEET_ID")
-                        or os.environ.get("ALL_KVK_SHEET_ID")
-                    )
-                    if sheet_id:
-                        url = f"https://docs.google.com/spreadsheets/d/{sheet_id}"
-                        view = discord.ui.View()
-                        view.add_item(
-                            discord.ui.Button(
-                                label="📄 Open KVK_ALLPLAYER_OUTPUT",
-                                url=url,
-                                style=discord.ButtonStyle.link,
-                            )
-                        )
-                except Exception:
-                    logger.info("[KVK EXPORT] ALL KVK SHEET ID INVALID")
-                    view = None  # never block on UI bits
-
-                await notify_ch.send(embed=embed, view=view)
-
-                # Auto-export to Google Sheets (non-blocking) — keep your existing logic
-                if KVK_AUTO_EXPORT:
-                    logger.info(
-                        "[KVK_EXPORT] Scheduling auto-export for KVK %s (Scan %s)", kvk_no, scan_id
-                    )
-                    asyncio.create_task(_auto_export_kvk(kvk_no, notify_ch, bot.loop))
-
-            except Exception as e:
-                # Log + surface any error per-attachment
-                logger.exception("[KVK] Import failed for %s: %s", att.filename, e)
-                await send_embed(
-                    notify_ch,
-                    "KVK All-Kingdom Import ❌",
-                    {
-                        "Error": f"{type(e).__name__}: {e}",
-                        "File": att.filename,
-                        "Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploader": f"{message.author} ({message.author.id})",
-                    },
-                    0xE74C3C,
-                )
-        return  # don't enqueue into other pipelines
+    if await handle_kvk_all_upload(
+        message,
+        KvkAllRouteDeps(
+            prokingdom_channel_id=PROKINGDOM_CHANNEL_ID,
+            bot=bot,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            auto_export_enabled=KVK_AUTO_EXPORT,
+            auto_export_scheduler=_auto_export_kvk,
+            get_sheet_id=lambda: (
+                ALL_KVK_SHEET_ID
+                or os.environ.get("KVK_SHEET_ID")
+                or os.environ.get("ALL_KVK_SHEET_ID")
+            ),
+        ),
+    ):
+        return
 
     # === Main monitored channels: enqueue heavy imports for worker processes ===
     if message.channel.id in CHANNEL_IDS:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -21,13 +21,15 @@ successfully. Phase 2C delivered the public read-only `/prekvk report` image rep
 tested successfully, and was pushed to production. Phase 2D refactored the scheduled PreKvK
 stats-alert path onto the Phase 2C report service architecture while preserving scheduled embed,
 guard/state, and upload-refresh behaviour; it was smoke tested successfully and pushed to
-production. Phase 3 local validation blockers are now the next upload-routing programme slice; the
-remaining active backlog is listed below.
+production. Phase 3 local validation blockers were audited on 2026-05-20 and closed as a no-op:
+the focused DB/non-DB blocker tests, full suite, and pytest log-noise validation all passed under
+the documented `.venv` workflow without `RUN_DB_TESTS=1`. Phase 4 KVK_ALL upload-route extraction
+is now the next upload-routing programme slice; the remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
-upload routing and related test-environment blockers, not as a continuation of the
-`/import_locations` command cleanup. Start that task with a new audit/scope pass and review
-both this backlog and the current `K98-bot-mirror` GitHub issues list.
+upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
+with a new audit/scope pass and review both this backlog and the current `K98-bot-mirror` GitHub
+issues list.
 
 ### Deferred Optimisation
 - Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
@@ -75,24 +77,6 @@ both this backlog and the current `K98-bot-mirror` GitHub issues list.
 - Dependencies: Confirm secondary cogs remain disabled by default in production and no operator workflow depends on loading them.
 
 ### Deferred Optimisation
-- Area: tests/stats_service.py, tests/targets_sql_cache_subproc.py, tests/prekvk_stats.py, tests/proc_config_import_phase2.py, tests/sheets_sync_flow.py
-- Type: consistency
-- Description: Several non-Ark unit tests still reach live SQL Server or connection construction when run in the Codex/local PR validation environment without the bot machine's ODBC setup.
-- Suggested Fix: Add subsystem-specific DAL/service boundary patches or explicit integration markers, then gate live DB coverage behind RUN_DB_TESTS=1.
-- Impact: high
-- Risk: medium
-- Dependencies: Agreement on which non-Ark tests should remain live DB integration coverage.
-
-### Deferred Optimisation
-- Area: tests/test_dl_bot_mge_auto_import.py, tests/test_integration_end_to_end_fake_worker.py, tests/test_maintenance_suite.py
-- Type: consistency
-- Description: Full-suite validation in the Codex/local PR environment has non-DB environment blockers: DL_bot expects venv/Scripts/python.exe while the documented command uses .venv, and subprocess worker tests fail with WinError 5 in the sandbox.
-- Suggested Fix: Make startup interpreter validation configurable for tests and mark subprocess worker tests with an environment capability gate when process spawning is unavailable.
-- Impact: medium
-- Risk: medium
-- Dependencies: Local validation environment contract for venv naming and subprocess permissions.
-
-### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase object retirement
 - Type: cleanup
 - Description: After Phase 2B compatibility wrappers remove active scan-window logic, `dbo.PreKvk_Phases` and any compatibility-only phase objects may remain as unused legacy SQL surface.
@@ -117,7 +101,7 @@ both this backlog and the current `K98-bot-mirror` GitHub issues list.
 - Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
 - Impact: medium
 - Risk: medium
-- Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
+- Dependencies: Start with `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`; preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -55,7 +55,9 @@ The active deferred backlog identifies these DL_bot-specific architecture items:
 - PreKvK upload routing still mixes filename matching, KVK lookup, offload dispatch, and Discord rendering.
 - Player location CSV auto-import still couples `DL_bot.py` to `commands/location_cmds.py` refresh signalling.
 - KVK_ALL upload routing still mixes attachment filtering, import handling, Discord rendering, and export scheduling.
-- Local validation has DB and non-DB environment blockers that affect safe PR validation.
+- Local validation previously had DB and non-DB environment blockers that affected safe PR
+  validation; Phase 3 later audited these and closed them as a no-op after current `main` passed
+  focused blocker tests, full pytest, and log-noise validation.
 
 ## 5. Scope
 
@@ -93,7 +95,7 @@ The active deferred backlog identifies these DL_bot-specific architecture items:
 - Suggested Fix: Add subsystem-specific DAL/service boundary patches or explicit integration markers, then gate live DB coverage behind RUN_DB_TESTS=1.
 - Impact: high
 - Risk: medium
-- Dependencies: Agreement on which non-Ark tests should remain live DB integration coverage.
+- Dependencies: Resolved by Phase 3 no-op audit on 2026-05-20; focused tests and full suite passed without live DB opt-in.
 
 ### Deferred Optimisation
 - Area: tests/test_dl_bot_mge_auto_import.py, tests/test_integration_end_to_end_fake_worker.py, tests/test_maintenance_suite.py
@@ -102,7 +104,7 @@ The active deferred backlog identifies these DL_bot-specific architecture items:
 - Suggested Fix: Make startup interpreter validation configurable for tests and mark subprocess worker tests with an environment capability gate when process spawning is unavailable.
 - Impact: medium
 - Risk: medium
-- Dependencies: Local validation environment contract for venv naming and subprocess permissions.
+- Dependencies: Resolved by Phase 3 no-op audit on 2026-05-20; `.venv` interpreter and subprocess-worker tests passed locally.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py` PreKvK upload routing
@@ -291,11 +293,15 @@ Phase breakdown:
    - Define command/channel surface, permissions, limits, empty-data behaviour, and mobile-safe
      Discord output before implementation.
 5. **Phase 3 - Local validation blockers**
-   - Fix or capability-gate DB/non-DB local validation blockers that affect confidence in the
-     routing work.
+   - Completed as a no-op on 2026-05-20 after the listed blockers no longer reproduced on current
+     `main`.
+   - Validation evidence: focused DB-facing blocker tests passed (`28 passed`), focused non-DB
+     environment blocker tests passed (`20 passed`), full pytest passed (`1461 passed, 2 skipped`),
+     and pytest log-noise validation passed with production operational logs unchanged.
 6. **Phase 4 - KVK_ALL upload route**
    - Extract the higher-risk multi-attachment KVK_ALL route after smaller routes prove the pattern.
    - Preserve structured importer failures, health output, link button, and auto-export scheduling.
+   - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 7. **Phase 5 - Remaining upload fast-path consolidation**
    - Consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing, shared
      SQL-preflight/offload handling, shared import embed rendering, and route-level structured
@@ -321,6 +327,14 @@ Phase 2B starter:
 - Phase 2B is audit/design only until explicitly approved for SQL changes.
 - It must validate dependencies on `dbo.PreKvk_Phases`, `dbo.fn_PreKvkPhaseDelta`, and
   KVK-specific PreKvK phase views against `C:\K98-bot-SQL-Server` before proposing cleanup.
+
+Phase 3 delivery notes:
+
+- Phase 3 local validation blockers were audited on current `main` and closed as a no-op.
+- No bot code, SQL, tests, deployment scripts, or upload-routing behaviour changed.
+- The two validation-blocker deferred items were removed from the active backlog after the focused
+  blocker reproductions, full test suite, and log-noise validation all passed under `.venv`.
+- Phase 4 KVK_ALL upload-route extraction is now the next active upload-routing programme slice.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md
@@ -11,8 +11,36 @@ We are starting Phase 3 of the DL_bot upload-routing optimisation programme afte
 - Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
   architecture, was smoke tested successfully, and pushed to production.
 
-Phase 3 is the required follow-on to improve local PR-validation confidence before the upload
-routing programme moves on to higher-blast-radius route extraction work.
+Phase 3 was the required follow-on to improve local PR-validation confidence before the upload
+routing programme moved on to higher-blast-radius route extraction work.
+
+## Completion Note
+
+Status: complete as a no-op on 2026-05-20.
+
+The Phase 3 audit found that the listed DB and non-DB local validation blockers no longer
+reproduce on current `main`. No bot code, SQL, tests, or deployment scripts were changed for this
+phase.
+
+Validation evidence:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_stats_service.py tests/test_targets_sql_cache_subproc.py tests/test_prekvk_stats.py tests/test_proc_config_import_phase2.py tests/test_sheets_sync_flow.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_dl_bot_mge_auto_import.py tests/test_integration_end_to_end_fake_worker.py tests/test_maintenance_suite.py
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed results:
+
+- Focused DB-facing blocker tests: `28 passed`.
+- Focused non-DB environment blocker tests: `20 passed`.
+- Full suite: `1461 passed, 2 skipped`.
+- Pytest log-noise validation: production operational logs unchanged.
+
+Phase 4 KVK_ALL upload-route extraction is the next upload-routing programme slice.
 
 ## Goal
 
@@ -219,3 +247,6 @@ Stop after the Phase 3 audit/design packet.
 
 Do not implement fixes, alter SQL, change upload routing, or open a PR until the audit packet,
 blocker classification, and first implementation scope have each been approved.
+
+Completion decision: the approved Phase 3 outcome was no-op completion because all source blockers
+were already resolved on current `main`.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md
@@ -1,0 +1,232 @@
+# DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter
+
+We are starting Phase 4 of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+- Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
+  tests, full suite, and log-noise validation all passed under `.venv`.
+
+Phase 4 is the next higher-blast-radius upload-routing slice: extract the KVK_ALL upload route from
+the root `DL_bot.py` listener into the established `upload_routes` pattern while preserving current
+production behaviour.
+
+## Goal
+
+Move KVK_ALL all-kingdom upload orchestration out of the inline `DL_bot.py` `on_message` branch and
+behind a dedicated route/service boundary.
+
+The desired end state is:
+
+- `DL_bot.py` delegates KVK_ALL message handling to a route module and keeps only listener/event
+  plumbing.
+- KVK_ALL attachment filtering, SQL preflight, offload dispatch, result interpretation, embed
+  rendering, sheet link button, per-attachment continuation, and auto-export scheduling are
+  covered by focused route tests.
+- Current Discord output, importer contract, structured failure handling, health line, and
+  fall-through behaviour are preserved unless an explicit behaviour change is approved.
+- No new SQL schema changes are introduced in this phase.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the KVK_ALL
+route classification and first PR scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 3 Local Validation Blockers Starter.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any KVK_ALL importer, DAL, export,
+view, stored procedure, or output-contract assumptions reviewed during this phase.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Source Deferred Item
+
+### Deferred Optimisation
+- Area: `DL_bot.py` KVK_ALL upload routing
+- Type: architecture
+- Description: KVK_ALL upload routing still lives in the legacy root bot listener with attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling mixed together.
+- Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
+- Impact: medium
+- Risk: medium
+- Dependencies: Preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
+
+## Phase 4 Scope
+
+In scope:
+
+- Audit the current KVK_ALL branch in `DL_bot.py`.
+- Map channel gating, accepted attachment extensions, no-file warning behaviour, per-attachment
+  processing, SQL headroom preflight, offload contract, structured importer failure handling,
+  success/warning embed fields, branding thumbnail, Google Sheet link button, and non-blocking
+  auto-export scheduling.
+- Extract KVK_ALL routing into `upload_routes/kvk_all_route.py` or an equivalent route module after
+  audit approval.
+- Preserve multi-attachment semantics: each matching attachment is processed independently, and a
+  failure for one attachment must not stop later attachments.
+- Preserve no fall-through into the monitored-channel queue after the KVK_ALL route handles a
+  message.
+- Add focused route tests around matching, non-matching, no matching attachment, preflight abort,
+  structured importer failure, success without negatives, success with negative corrections,
+  optional link button, auto-export scheduling, exception rendering, and multi-attachment
+  continuation.
+- Update docs/deferred backlog after implementation.
+
+Out of scope until separately approved:
+
+- Changing KVK_ALL importer behaviour or workbook format handling.
+- Changing SQL schema, stored procedures, views, export result sets, or Google Sheets export
+  contract.
+- Redesigning `kvk_all_importer.py`, `kvk/dal/kvk_all_import_dal.py`, or KVK export services beyond
+  route-boundary dependency injection needed for tests.
+- Broad upload-router consolidation for MGE, honor, weekly activity, rally, inventory, or fallback
+  queueing.
+- Broad `DL_bot.py` startup/lifecycle or `bot_instance.py` refactor.
+- KVK_ALL schema modernisation work, legacy SQL cleanup, or performance tuning outside the route
+  extraction.
+
+## Current Files To Review
+
+Likely route/listener files:
+
+- `DL_bot.py`
+- `upload_routes/player_location_route.py`
+- `upload_routes/prekvk_route.py`
+- `upload_routes/__init__.py`
+
+Likely KVK_ALL importer/service/DAL files:
+
+- `kvk_all_importer.py`
+- `kvk/dal/kvk_all_import_dal.py`
+- `kvk/services/kvk_all_import_service.py`
+- `kvk/services/kvk_export_service.py`
+- `kvk/schemas/kvk_all_schema.py`
+- `gsheet_module.py`
+- `log_health.py`
+- `file_utils.py`
+
+Likely tests:
+
+- `tests/test_kvk_all_importer.py`
+- `tests/test_kvk_all_import_dal.py`
+- `tests/test_kvk_all_import_service.py`
+- `tests/test_kvk_all_schema.py`
+- `tests/test_kvk_all_recompute_sql_contract.py`
+- `tests/test_kvk_export_service.py`
+- `tests/test_prekvk_upload_route.py`
+- `tests/test_player_location_upload_route.py`
+- new focused KVK_ALL route tests
+
+## Design Questions
+
+- What exact route dependency object should mirror the existing `PlayerLocationRouteDeps` and
+  `PreKvkRouteDeps` patterns?
+- Should the KVK_ALL route own embed construction directly, or should success/failure embed
+  builders be split into small route-local helpers for testability?
+- How should the route inject `discord.Embed`, `discord.ui.View`, and link-button creation so unit
+  tests can avoid brittle Discord internals while preserving output?
+- Should `_auto_export_kvk` remain imported from `kvk_all_importer.py` for this phase, or should
+  the route receive an injected auto-export scheduler callable?
+- Which KVK_ALL SQL contracts need validation against `C:\K98-bot-SQL-Server` before implementation,
+  and which are already covered by existing SQL contract tests?
+- What is the minimal route test surface that proves behaviour parity without duplicating importer
+  and SQL contract tests?
+- Are any KVK_ALL route observations large enough to defer to Phase 5 or the KVK_ALL schema
+  modernisation programme instead of fixing in this PR?
+
+## Step 1 Required Output
+
+Phase 4 Step 1 must produce:
+
+- Audit Summary
+- Current KVK_ALL Route Map
+- Importer / SQL Contract Map
+- Discord Output Preservation Map
+- Route Boundary Recommendation
+- Refactor Trigger Findings
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the selected KVK_ALL route slice:
+
+- focused new KVK_ALL route tests
+- `.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_import_service.py tests/test_kvk_all_schema.py tests/test_kvk_export_service.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_all_recompute_sql_contract.py`
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+
+If live SQL integration is intentionally needed, document and validate the opt-in path:
+
+```powershell
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected live DB tests>
+```
+
+## Acceptance Criteria
+
+- KVK_ALL route responsibilities are removed from the inline `DL_bot.py` listener branch within the
+  approved scope.
+- `DL_bot.py` delegates to the new route and preserves existing route order and fall-through
+  behaviour.
+- Accepted attachment extensions remain `.xlsx`, `.xls`, and `.csv`.
+- No-matching-file warning embed remains unchanged.
+- SQL headroom preflight aborts only the current attachment and keeps processing later matching
+  attachments.
+- Structured importer failures render the existing user-facing failure embed and continue to the
+  next attachment.
+- Success and warning embeds preserve KVK, ScanID, Rows, Staged, Negative Corrections, Duration,
+  Health, File, Sheet, Channel, and Uploader fields.
+- Sheet link button remains best-effort and never blocks the import result embed.
+- `KVK_AUTO_EXPORT` still schedules non-blocking auto-export with the same KVK and notify channel.
+- No new direct SQL is added to Discord listener/route layers.
+- Out-of-scope KVK_ALL or upload-router findings are captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 4 audit/design packet.
+
+Do not implement route extraction, alter SQL, change upload routing behaviour, or open a PR until
+the audit packet, KVK_ALL route boundary, and first implementation scope have each been approved.

--- a/tests/test_kvk_all_upload_route.py
+++ b/tests/test_kvk_all_upload_route.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from upload_routes import kvk_all_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"xlsx", size: int = 4):
+        self.filename = filename
+        self._payload = payload
+        self.size = size
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeEmbed:
+    def __init__(self, *, title: str, color: int):
+        self.title = title
+        self.color = color
+        self.fields: list[tuple[str, str, bool]] = []
+        self.thumbnail_url: str | None = None
+
+    def add_field(self, *, name: str, value: str, inline: bool) -> None:
+        self.fields.append((name, value, inline))
+
+    def set_thumbnail(self, *, url: str) -> None:
+        self.thumbnail_url = url
+
+    def field_dict(self) -> dict[str, str]:
+        return {name: value for name, value, _inline in self.fields}
+
+
+class _FakeButton:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeView:
+    def __init__(self):
+        self.items = []
+
+    def add_item(self, item) -> None:
+        self.items.append(item)
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "prokingdom"):
+        self.id = channel_id
+        self.name = name
+        self.sent = []
+
+    async def send(self, **kwargs) -> None:
+        self.sent.append(kwargs)
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeBot:
+    loop = object()
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments if attachments is not None else [_FakeAttachment("kvk_all.xlsx")]
+        )
+        self.id = 987654321
+        self.created_at = datetime(2026, 5, 24, 10, 30, tzinfo=UTC)
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _success_result(**overrides):
+    result = {
+        "kvk_no": 13,
+        "scan_id": 2,
+        "row_count": 10,
+        "negatives": 0,
+        "duration_s": 1.25,
+        "staged_rows": 10,
+        "proc_ms": 250.0,
+        "recompute_ms": 125.0,
+        "sheet": "Full Data",
+        "success": True,
+    }
+    result.update(overrides)
+    return result
+
+
+def _deps(**overrides):
+    sent_embeds = []
+    offloads = []
+    created_tasks = []
+    scheduled_exports = []
+    notify_channel = overrides.get("notify_channel")
+
+    async def get_notify_channel():
+        return notify_channel
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent_embeds.append((ch, title, fields, color, mention))
+
+    sql_results = list(overrides.get("sql_results", [overrides.get("sql_ok", True)]))
+
+    async def ensure_sql_headroom_or_notify(ch):
+        if sql_results:
+            return sql_results.pop(0)
+        return True
+
+    offload_results = list(overrides.get("offload_results", []))
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_exception" in overrides:
+            raise overrides["offload_exception"]
+        if offload_results:
+            result = offload_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return overrides.get("offload_result", _success_result())
+
+    def auto_export_scheduler(kvk_no, notify_ch, bot_loop):
+        scheduled_exports.append((kvk_no, notify_ch, bot_loop))
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    deps = route.KvkAllRouteDeps(
+        prokingdom_channel_id=10,
+        bot=overrides.get("bot", _FakeBot()),
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        auto_export_enabled=overrides.get("auto_export_enabled", False),
+        auto_export_scheduler=overrides.get("auto_export_scheduler", auto_export_scheduler),
+        create_task=create_task,
+        get_sheet_id=overrides.get("get_sheet_id", lambda: None),
+        embed_factory=_FakeEmbed,
+        view_factory=_FakeView,
+        button_factory=_FakeButton,
+        button_style_link="link",
+        custom_avatar_url=overrides.get("custom_avatar_url", ""),
+    )
+    return deps, sent_embeds, offloads, created_tasks, scheduled_exports
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_ignores_other_channels():
+    deps, sent, offloads, _created, _exports = _deps()
+
+    handled = await route.handle_kvk_all_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_ignores_empty_attachments():
+    deps, sent, offloads, _created, _exports = _deps()
+
+    handled = await route.handle_kvk_all_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_no_matching_file_warns_and_handles():
+    deps, sent, offloads, _created, _exports = _deps()
+
+    handled = await route.handle_kvk_all_upload(
+        _message(attachments=[_FakeAttachment("notes.txt")]), deps
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "KVK All-Kingdom Import \u26a0\ufe0f"
+    assert fields["Info"] == "No .xlsx/.xls/.csv attachment found."
+    assert color == 0xE67E22
+    assert mention is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename", ["kvk.xlsx", "kvk.xls", "kvk.csv"])
+async def test_kvk_all_route_accepts_existing_extensions(filename: str):
+    deps, _sent, offloads, _created, _exports = _deps()
+
+    handled = await route.handle_kvk_all_upload(
+        _message(attachments=[_FakeAttachment(filename, b"payload")]), deps
+    )
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, _args, kwargs = offloads[0]
+    assert func is route.ingest_kvk_all_excel
+    assert kwargs["content"] == b"payload"
+    assert kwargs["source_filename"] == filename
+    assert kwargs["name"] == "ingest_kvk_all_excel"
+    assert kwargs["prefer_process"] is True
+    assert kwargs["meta"] == {"filename": filename}
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_sql_preflight_abort_skips_only_current_attachment():
+    deps, sent, offloads, _created, _exports = _deps(
+        sql_results=[False, True],
+        offload_result=_success_result(scan_id=3),
+    )
+
+    handled = await route.handle_kvk_all_upload(
+        _message(attachments=[_FakeAttachment("first.xlsx"), _FakeAttachment("second.xlsx")]),
+        deps,
+    )
+
+    assert handled is True
+    assert len(offloads) == 1
+    assert offloads[0][2]["source_filename"] == "second.xlsx"
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "KVK All-Kingdom Import Aborted \u274c"
+    assert fields == {"File": "first.xlsx", "Reason": "SQL log headroom insufficient"}
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_structured_failure_sends_existing_error_and_continues():
+    deps, sent, offloads, _created, _exports = _deps(
+        offload_results=[
+            {"success": False, "error": "missing Full Data", "sheet": "Basic Data"},
+            _success_result(scan_id=4),
+        ],
+    )
+    msg = _message(attachments=[_FakeAttachment("bad.xlsx"), _FakeAttachment("good.xlsx")])
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
+
+    assert handled is True
+    assert len(offloads) == 2
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "KVK All-Kingdom Import \u274c"
+    assert fields["Filename"] == "bad.xlsx"
+    assert fields["Error"] == "missing Full Data"
+    assert fields["Sheet"] == "Basic Data"
+    assert color == 0xE74C3C
+    assert len(msg.channel.sent) == 1
+    assert msg.channel.sent[0]["embed"].field_dict()["ScanID"] == "4"
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_success_without_negatives_preserves_embed_and_link_button():
+    deps, _sent, offloads, created, exports = _deps(
+        auto_export_enabled=True,
+        custom_avatar_url="https://example.invalid/avatar.png",
+        get_sheet_id=lambda: "sheet123",
+        offload_result=_success_result(),
+    )
+    msg = _message()
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    assert len(msg.channel.sent) == 1
+    payload = msg.channel.sent[0]
+    embed = payload["embed"]
+    assert embed.title == "KVK All-Kingdom Import \u2705"
+    assert embed.color == 0x2ECC71
+    assert embed.thumbnail_url == "https://example.invalid/avatar.png"
+    fields = embed.field_dict()
+    assert fields["KVK"] == "13"
+    assert fields["ScanID"] == "2"
+    assert fields["Rows"] == "10"
+    assert fields["Staged"] == "10"
+    assert fields["Negative Corrections"] == "0"
+    assert fields["Duration"] == "1.25s"
+    assert fields["Health"] == "proc `250ms` \u2022 I/O `1000ms` \u2022 recompute `125ms`"
+    assert fields["File"] == "kvk_all.xlsx"
+    assert fields["Sheet"] == "Full Data"
+    view = payload["view"]
+    assert view.items[0].kwargs["label"] == "\U0001f4c4 Open KVK_ALLPLAYER_OUTPUT"
+    assert view.items[0].kwargs["url"] == "https://docs.google.com/spreadsheets/d/sheet123"
+    assert len(created) == 1
+    assert exports == [(13, msg.channel, deps.bot.loop)]
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_success_with_negative_corrections_uses_warning_embed():
+    deps, _sent, _offloads, _created, _exports = _deps(
+        offload_result=_success_result(negatives=2, recompute_ms=0.0)
+    )
+    msg = _message()
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
+
+    assert handled is True
+    embed = msg.channel.sent[0]["embed"]
+    fields = embed.field_dict()
+    assert embed.title == "KVK All-Kingdom Import \u26a0\ufe0f"
+    assert embed.color == 0xE67E22
+    assert fields["Negative Corrections"] == "2 \u26a0\ufe0f"
+    assert fields["Health"] == "proc `250ms` \u2022 I/O `1000ms`"
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_link_button_is_best_effort():
+    def broken_sheet_id():
+        raise RuntimeError("bad sheet config")
+
+    deps, _sent, _offloads, _created, _exports = _deps(get_sheet_id=broken_sheet_id)
+    msg = _message()
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
+
+    assert handled is True
+    assert msg.channel.sent[0]["embed"].field_dict()["KVK"] == "13"
+    assert msg.channel.sent[0]["view"] is None
+
+
+@pytest.mark.asyncio
+async def test_kvk_all_route_unexpected_exception_renders_error_and_continues():
+    deps, sent, offloads, _created, _exports = _deps(
+        offload_results=[RuntimeError("boom"), _success_result(scan_id=5)]
+    )
+    msg = _message(attachments=[_FakeAttachment("bad.xlsx"), _FakeAttachment("good.xlsx")])
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
+
+    assert handled is True
+    assert len(offloads) == 2
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "KVK All-Kingdom Import \u274c"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert fields["File"] == "bad.xlsx"
+    assert color == 0xE74C3C
+    assert msg.channel.sent[0]["embed"].field_dict()["ScanID"] == "5"

--- a/tests/test_kvk_all_upload_route.py
+++ b/tests/test_kvk_all_upload_route.py
@@ -232,18 +232,15 @@ async def test_kvk_all_route_sql_preflight_abort_skips_only_current_attachment()
         offload_result=_success_result(scan_id=3),
     )
 
-    handled = await route.handle_kvk_all_upload(
-        _message(attachments=[_FakeAttachment("first.xlsx"), _FakeAttachment("second.xlsx")]),
-        deps,
-    )
+    msg = _message(attachments=[_FakeAttachment("first.xlsx"), _FakeAttachment("second.xlsx")])
+
+    handled = await route.handle_kvk_all_upload(msg, deps)
 
     assert handled is True
     assert len(offloads) == 1
     assert offloads[0][2]["source_filename"] == "second.xlsx"
-    _ch, title, fields, color, _mention = sent[-1]
-    assert title == "KVK All-Kingdom Import Aborted \u274c"
-    assert fields == {"File": "first.xlsx", "Reason": "SQL log headroom insufficient"}
-    assert color == 0xE74C3C
+    assert sent == []
+    assert msg.channel.sent[0]["embed"].field_dict()["ScanID"] == "3"
 
 
 @pytest.mark.asyncio

--- a/upload_routes/kvk_all_route.py
+++ b/upload_routes/kvk_all_route.py
@@ -162,12 +162,6 @@ async def handle_kvk_all_upload(message: Any, deps: KvkAllRouteDeps) -> bool:
 
             ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
             if not ok:
-                await deps.send_embed(
-                    notify_ch,
-                    "KVK All-Kingdom Import Aborted \u274c",
-                    {"File": attachment.filename, "Reason": "SQL log headroom insufficient"},
-                    0xE74C3C,
-                )
                 continue
 
             result = await deps.offload_callable(

--- a/upload_routes/kvk_all_route.py
+++ b/upload_routes/kvk_all_route.py
@@ -76,7 +76,9 @@ def _resolve_sheet_id(deps: KvkAllRouteDeps) -> str | None:
     return os.environ.get("KVK_SHEET_ID") or os.environ.get("ALL_KVK_SHEET_ID")
 
 
-def _build_result_embed(deps: KvkAllRouteDeps, title: str, color: int, fields: dict[str, str]) -> Any:
+def _build_result_embed(
+    deps: KvkAllRouteDeps, title: str, color: int, fields: dict[str, str]
+) -> Any:
     embed_factory = deps.embed_factory or _default_embed_factory
     embed = embed_factory(title=title, color=color)
     for key, value in fields.items():
@@ -96,7 +98,9 @@ def _build_sheet_view(deps: KvkAllRouteDeps) -> Any | None:
         view_factory = deps.view_factory or _default_view_factory
         button_factory = deps.button_factory or _default_button_factory
         button_style_link = (
-            deps.button_style_link if deps.button_style_link is not None else _default_button_style_link()
+            deps.button_style_link
+            if deps.button_style_link is not None
+            else _default_button_style_link()
         )
         view = view_factory()
         view.add_item(
@@ -182,7 +186,9 @@ async def handle_kvk_all_upload(message: Any, deps: KvkAllRouteDeps) -> bool:
             )
 
             if isinstance(result, dict) and not result.get("success", True):
-                logger.info("[KVK] Import failed for %s: %s", attachment.filename, result.get("error"))
+                logger.info(
+                    "[KVK] Import failed for %s: %s", attachment.filename, result.get("error")
+                )
                 await deps.send_embed(
                     notify_ch,
                     "KVK All-Kingdom Import \u274c",

--- a/upload_routes/kvk_all_route.py
+++ b/upload_routes/kvk_all_route.py
@@ -1,0 +1,266 @@
+"""KVK all-kingdom workbook upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+import os
+from typing import Any
+
+from kvk_all_importer import ingest_kvk_all_excel
+
+logger = logging.getLogger(__name__)
+
+ACCEPTED_KVK_ALL_EXTENSIONS = (".xlsx", ".xls", ".csv")
+
+
+@dataclass(frozen=True)
+class KvkAllRouteDeps:
+    prokingdom_channel_id: int
+    bot: Any
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    auto_export_enabled: bool
+    auto_export_scheduler: Callable[[int, Any, Any], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+    get_sheet_id: Callable[[], str | None] | None = None
+    embed_factory: Callable[..., Any] | None = None
+    view_factory: Callable[[], Any] | None = None
+    button_factory: Callable[..., Any] | None = None
+    button_style_link: Any | None = None
+    custom_avatar_url: str | None = None
+
+
+def _default_embed_factory(**kwargs: Any) -> Any:
+    import discord
+
+    return discord.Embed(**kwargs)
+
+
+def _default_view_factory() -> Any:
+    import discord
+
+    return discord.ui.View()
+
+
+def _default_button_factory(**kwargs: Any) -> Any:
+    import discord
+
+    return discord.ui.Button(**kwargs)
+
+
+def _default_button_style_link() -> Any:
+    import discord
+
+    return discord.ButtonStyle.link
+
+
+def _resolve_custom_avatar_url(deps: KvkAllRouteDeps) -> str | None:
+    if deps.custom_avatar_url is not None:
+        return deps.custom_avatar_url
+    try:
+        from constants import CUSTOM_AVATAR_URL
+
+        return CUSTOM_AVATAR_URL
+    except Exception:
+        return None
+
+
+def _resolve_sheet_id(deps: KvkAllRouteDeps) -> str | None:
+    if deps.get_sheet_id is not None:
+        return deps.get_sheet_id()
+    return os.environ.get("KVK_SHEET_ID") or os.environ.get("ALL_KVK_SHEET_ID")
+
+
+def _build_result_embed(deps: KvkAllRouteDeps, title: str, color: int, fields: dict[str, str]) -> Any:
+    embed_factory = deps.embed_factory or _default_embed_factory
+    embed = embed_factory(title=title, color=color)
+    for key, value in fields.items():
+        embed.add_field(name=key, value=str(value), inline=True)
+
+    avatar_url = _resolve_custom_avatar_url(deps)
+    if avatar_url:
+        embed.set_thumbnail(url=avatar_url)
+    return embed
+
+
+def _build_sheet_view(deps: KvkAllRouteDeps) -> Any | None:
+    try:
+        sheet_id = _resolve_sheet_id(deps)
+        if not sheet_id:
+            return None
+        view_factory = deps.view_factory or _default_view_factory
+        button_factory = deps.button_factory or _default_button_factory
+        button_style_link = (
+            deps.button_style_link if deps.button_style_link is not None else _default_button_style_link()
+        )
+        view = view_factory()
+        view.add_item(
+            button_factory(
+                label="\U0001f4c4 Open KVK_ALLPLAYER_OUTPUT",
+                url=f"https://docs.google.com/spreadsheets/d/{sheet_id}",
+                style=button_style_link,
+            )
+        )
+        return view
+    except Exception:
+        logger.info("[KVK EXPORT] ALL KVK SHEET ID INVALID")
+        return None
+
+
+async def handle_kvk_all_upload(message: Any, deps: KvkAllRouteDeps) -> bool:
+    """Handle KVK all-kingdom uploads from the configured Pro Kingdom channel."""
+    if message.channel.id != deps.prokingdom_channel_id or not message.attachments:
+        return False
+
+    notify_ch = await deps.get_notify_channel() or message.channel
+
+    try:
+        logger.info(
+            "[KVK] msg=%s attachments=%s",
+            message.id,
+            [attachment.filename for attachment in message.attachments],
+        )
+    except Exception:
+        pass
+
+    excel_attachments = [
+        attachment
+        for attachment in message.attachments
+        if attachment.filename.lower().strip().endswith(ACCEPTED_KVK_ALL_EXTENSIONS)
+    ]
+
+    if not excel_attachments:
+        await deps.send_embed(
+            notify_ch,
+            "KVK All-Kingdom Import \u26a0\ufe0f",
+            {
+                "Info": "No .xlsx/.xls/.csv attachment found.",
+                "Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploader": f"{message.author} ({message.author.id})",
+            },
+            0xE67E22,
+        )
+        return True
+
+    for attachment in excel_attachments:
+        try:
+            logger.info(
+                "[KVK] Reading attachment: %s (%s bytes)",
+                attachment.filename,
+                getattr(attachment, "size", None),
+            )
+            file_bytes = await attachment.read()
+
+            ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+            if not ok:
+                await deps.send_embed(
+                    notify_ch,
+                    "KVK All-Kingdom Import Aborted \u274c",
+                    {"File": attachment.filename, "Reason": "SQL log headroom insufficient"},
+                    0xE74C3C,
+                )
+                continue
+
+            result = await deps.offload_callable(
+                ingest_kvk_all_excel,
+                content=file_bytes,
+                source_filename=attachment.filename,
+                uploader_id=message.author.id,
+                scan_ts_utc=message.created_at,
+                server=os.environ.get("SQL_SERVER"),
+                database=os.environ.get("SQL_DATABASE"),
+                username=os.environ.get("SQL_USERNAME"),
+                password=os.environ.get("SQL_PASSWORD"),
+                name="ingest_kvk_all_excel",
+                prefer_process=True,
+                meta={"filename": attachment.filename},
+            )
+
+            if isinstance(result, dict) and not result.get("success", True):
+                logger.info("[KVK] Import failed for %s: %s", attachment.filename, result.get("error"))
+                await deps.send_embed(
+                    notify_ch,
+                    "KVK All-Kingdom Import \u274c",
+                    {
+                        "Filename": attachment.filename,
+                        "Channel": f"#{message.channel.name} ({message.channel.id})",
+                        "Uploader": f"{message.author} ({message.author.id})",
+                        "Error": result.get("error"),
+                        "Sheet": result.get("sheet", "unknown"),
+                    },
+                    0xE74C3C,
+                )
+                continue
+
+            kvk_no = int(result["kvk_no"])
+            scan_id = int(result["scan_id"])
+            rows = int(result["row_count"])
+            neg = int(result["negatives"])
+            dur_s = float(result["duration_s"])
+            staged = int(result.get("staged_rows", rows))
+            proc_ms = float(result.get("proc_ms", max(0.0, dur_s * 1000.0)))
+            io_ms = max(0.0, dur_s * 1000.0 - proc_ms)
+            recompute_ms = float(result.get("recompute_ms", 0.0))
+            sheet_used = result.get("sheet", "unknown")
+
+            neg_badge = "0" if neg == 0 else f"{neg} \u26a0\ufe0f"
+            color = 0x2ECC71 if neg == 0 else 0xE67E22
+            title = (
+                "KVK All-Kingdom Import \u2705"
+                if neg == 0
+                else "KVK All-Kingdom Import \u26a0\ufe0f"
+            )
+
+            fields = {
+                "KVK": str(kvk_no),
+                "ScanID": str(scan_id),
+                "Rows": str(rows),
+                "Staged": str(staged),
+                "Negative Corrections": neg_badge,
+                "Duration": f"{dur_s:.2f}s",
+                "Health": (
+                    f"proc `{proc_ms:.0f}ms` \u2022 I/O `{io_ms:.0f}ms`"
+                    + (f" \u2022 recompute `{recompute_ms:.0f}ms`" if recompute_ms > 0 else "")
+                ),
+                "File": attachment.filename,
+                "Sheet": sheet_used,
+                "Channel": f"#{message.channel.name} ({message.channel.id})",
+                "Uploader": f"{message.author} ({message.author.id})",
+            }
+
+            embed = _build_result_embed(deps, title, color, fields)
+            view = _build_sheet_view(deps)
+            await notify_ch.send(embed=embed, view=view)
+
+            if deps.auto_export_enabled:
+                logger.info(
+                    "[KVK_EXPORT] Scheduling auto-export for KVK %s (Scan %s)",
+                    kvk_no,
+                    scan_id,
+                )
+                deps.create_task(
+                    deps.auto_export_scheduler(
+                        kvk_no,
+                        notify_ch,
+                        deps.bot.loop,
+                    )
+                )
+        except Exception as exc:
+            logger.exception("[KVK] Import failed for %s: %s", attachment.filename, exc)
+            await deps.send_embed(
+                notify_ch,
+                "KVK All-Kingdom Import \u274c",
+                {
+                    "Error": f"{type(exc).__name__}: {exc}",
+                    "File": attachment.filename,
+                    "Channel": f"#{message.channel.name} ({message.channel.id})",
+                    "Uploader": f"{message.author} ({message.author.id})",
+                },
+                0xE74C3C,
+            )
+    return True


### PR DESCRIPTION
## Summary

- Extract KVK_ALL all-kingdom upload orchestration from the inline `DL_bot.py` listener branch into `upload_routes/kvk_all_route.py`.
- Preserve current channel gating, attachment filtering, SQL preflight behavior, per-attachment continuation, structured importer failures, success/warning embeds, sheet link button behavior, and auto-export scheduling.
- Add focused route tests for KVK_ALL routing and include the Phase 4 task-pack/deferred-doc updates.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_kvk_all_upload_route.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_player_location_upload_route.py tests/test_prekvk_upload_route.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_import_service.py tests/test_kvk_all_schema.py tests/test_kvk_export_service.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_kvk_all_recompute_sql_contract.py`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe -m pytest -q tests` (`1473 passed, 2 skipped`)

## SQL / Deployment

- No SQL schema, stored procedure, view, export contract, or workbook-format changes.
- Production promotion should follow the normal mirror-to-production PR flow after review and smoke validation.

## Risk / Rollback

- Risk is medium because KVK_ALL is a high-volume multi-attachment upload route, but the PR keeps importer/export contracts unchanged and isolates the listener change behind focused route tests.
- Rollback is reverting this PR to restore the previous inline `DL_bot.py` listener branch.