### PR TITLE
[codex] Repair Ark signup embed actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ background, operational, promotion, domain, or template-support material.
   - `python scripts/validate_architecture_boundaries.py`
   - `python scripts/validate_deferred_items.py`
   - `python scripts/select_tests.py`
+- Before PR handoff, run or justify skipping a CodeRabbit follow-up review for non-trivial code
+  changes.
+- Run or justify skipping a Codex Security review when a change touches security-sensitive
+  surfaces such as permissions, Discord interactions, SQL/data access, file handling,
+  secrets/config, deployment, network calls, user-controlled input, or restart-sensitive
+  persistence.
 
 ## Repository / Promotion Model
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -21,6 +21,13 @@ pytest -q tests
 python scripts/analyse_pytest_log_noise.py
 ```
 
+Before PR handoff, also run or justify skipping these AI-assisted review gates:
+
+- CodeRabbit follow-up review for non-trivial code changes.
+- Codex Security review when the change touches permissions, Discord interactions, SQL/data
+  access, file handling, secrets/config, deployment, network calls, user-controlled input, or
+  restart-sensitive persistence.
+
 `pytest` runs are isolated from production operational log files. Expected negative-path logs
 remain visible through pytest output and `caplog`; when a saved audit artifact is needed, capture
 the run explicitly, for example:

--- a/ark/registration_flow.py
+++ b/ark/registration_flow.py
@@ -399,6 +399,7 @@ class ArkRegistrationController:
         on_select,
         heading: str,
         only_governor_ids: set[str] | None = None,
+        on_timeout_callback=None,
     ) -> None:
         options = build_unique_gov_options(accounts)
 
@@ -426,6 +427,7 @@ class ArkRegistrationController:
             author_id=interaction.user.id,
             options=options,
             on_select=on_select,
+            on_timeout_callback=on_timeout_callback,
         )
 
         if self._response_is_done(interaction):
@@ -721,9 +723,12 @@ class ArkRegistrationController:
     async def switch(self, interaction: discord.Interaction) -> None:
         async def _close_menu(inter: discord.Interaction, message: str) -> None:
             if inter.response.is_done():
-                await inter.edit_original_response(content=message, view=None)
+                await inter.followup.send(message, ephemeral=True)
             else:
                 await inter.response.edit_message(content=message, view=None)
+
+        async def _repair_registration_message() -> None:
+            await self.refresh_registration_message(interaction.client)
 
         await interaction.response.defer(ephemeral=True)
         match = await self._ensure_open_match(interaction)
@@ -789,6 +794,7 @@ class ArkRegistrationController:
                 on_select=_apply,
                 heading="Select an **inactive** governor to switch to:",
                 only_governor_ids=eligible_targets,
+                on_timeout_callback=_repair_registration_message,
             )
 
         await self._prompt_governor_selection(
@@ -797,6 +803,7 @@ class ArkRegistrationController:
             on_select=_select_new,
             heading="Select the **current** governor to switch off:",
             only_governor_ids=active_govs,
+            on_timeout_callback=_repair_registration_message,
         )
 
     async def _apply_switch(

--- a/commands/ark_cmds.py
+++ b/commands/ark_cmds.py
@@ -317,11 +317,11 @@ def register_ark(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def ark_force_announce(
         ctx: discord.ApplicationContext,
-        match_id: int = discord.Option(
+        match_id: int | None = discord.Option(
             int,
             "Optional Ark match ID fallback when the match is not in the dropdown",
             required=False,
-            default=0,
+            default=None,
             min_value=1,
         ),
     ):
@@ -352,9 +352,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
                 ARK_MATCH_STATUS_CANCELLED.lower(),
                 ARK_MATCH_STATUS_COMPLETED.lower(),
             }:
-                await interaction.followup.send(
-                    "Match is cancelled or completed.", ephemeral=True
-                )
+                await interaction.followup.send("Match is cancelled or completed.", ephemeral=True)
                 return
 
             controller = ArkRegistrationController(match_id=int(match_id), config=config)
@@ -367,9 +365,12 @@ def register_ark(bot: ext_commands.Bot) -> None:
                 update_refresh_timestamp=True,
             )
             if not msg_ref:
-                await interaction.followup.send(
-                    "Failed to refresh the registration message.", ephemeral=True
+                error_message = (
+                    "Failed to repost the registration announcement."
+                    if announce
+                    else "Failed to refresh the registration message."
                 )
+                await interaction.followup.send(error_message, ephemeral=True)
                 return
 
             await insert_audit_log(
@@ -379,7 +380,9 @@ def register_ark(bot: ext_commands.Bot) -> None:
                 actor_discord_id=interaction.user.id,
                 match_id=int(match_id),
                 governor_id=None,
-                details_json={"source": "CommandDropdown"},
+                details_json={
+                    "source": "CommandManual" if manual_match_id else "CommandDropdown"
+                },
             )
 
             action = "announcement reposted" if announce else "signup embed refreshed"
@@ -408,7 +411,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
         async def _on_cancel(interaction: discord.Interaction):
             await interaction.response.edit_message(content="Closed.", view=None)
 
-        manual_match_id = match_id if isinstance(match_id, int) and match_id > 0 else 0
+        manual_match_id = None if isinstance(match_id, discord.Option) else match_id
         if manual_match_id:
             await _send_registration_result(
                 ctx.interaction,
@@ -431,7 +434,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
         )
 
         await ctx.interaction.edit_original_response(
-            content="Pick an active Ark match, then choose refresh or force announce:",
+            content=view.message_content(),
             view=view,
         )
         return

--- a/commands/ark_cmds.py
+++ b/commands/ark_cmds.py
@@ -65,7 +65,12 @@ from core.interaction_safety import safe_command, safe_defer
 from decoraters import channel_only, is_admin_or_leadership_only, track_usage
 from ui.views.ark_reminder_prefs_view import ArkReminderPrefsView  # NEW
 from ui.views.ark_report_view import ArkReportPlayersView
-from ui.views.ark_views import AmendArkMatchView, CancelArkMatchView, CreateArkMatchView
+from ui.views.ark_views import (
+    AmendArkMatchView,
+    ArkRegistrationMaintenanceView,
+    CancelArkMatchView,
+    CreateArkMatchView,
+)
 from ui.views.team_builder_views import ArkTeamBuilderView
 from versioning import versioned
 
@@ -111,7 +116,7 @@ async def _dispatch_cancel_dms_background(
 def register_ark(bot: ext_commands.Bot) -> None:
     @bot.slash_command(
         name="ark_create_match",
-        description="Create an Ark of Osiris match (leadership)",
+        description="Set up an Ark of Osiris match (leadership)",
         guild_ids=[GUILD_ID],
     )
     @versioned("v1.03")
@@ -253,7 +258,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
                 match_id = await create_match(req)
                 if not match_id:
                     await interaction.response.send_message(
-                        "❌ Failed to create match in SQL.", ephemeral=True
+                        "❌ Failed to save match.", ephemeral=True
                     )
                     return
 
@@ -312,60 +317,124 @@ def register_ark(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def ark_force_announce(
         ctx: discord.ApplicationContext,
-        match_id: int = discord.Option(int, "Ark match ID"),
+        match_id: int = discord.Option(
+            int,
+            "Optional Ark match ID fallback when the match is not in the dropdown",
+            required=False,
+            default=0,
+            min_value=1,
+        ),
     ):
         await safe_defer(ctx, ephemeral=True)
 
         config = await get_config()
         if not config:
             await ctx.interaction.edit_original_response(
-                content="❌ ArkConfig is missing or invalid. Contact an admin."
+                content="ArkConfig is missing or invalid. Contact an admin."
             )
             return
 
-        match = await get_match(match_id)
-        if not match:
-            await ctx.interaction.edit_original_response(content="❌ Match not found.")
-            return
+        async def _send_registration_result(
+            interaction: discord.Interaction,
+            *,
+            match_id: int,
+            announce: bool,
+        ) -> None:
+            if not interaction.response.is_done():
+                await interaction.response.defer(ephemeral=True)
 
-        if (match.get("Status") or "").lower() in {
-            ARK_MATCH_STATUS_CANCELLED.lower(),
-            ARK_MATCH_STATUS_COMPLETED.lower(),
-        }:
-            await ctx.interaction.edit_original_response(
-                content="❌ Match is cancelled or completed."
+            match = await get_match(match_id)
+            if not match:
+                await interaction.followup.send("Match not found.", ephemeral=True)
+                return
+
+            if (match.get("Status") or "").lower() in {
+                ARK_MATCH_STATUS_CANCELLED.lower(),
+                ARK_MATCH_STATUS_COMPLETED.lower(),
+            }:
+                await interaction.followup.send(
+                    "Match is cancelled or completed.", ephemeral=True
+                )
+                return
+
+            controller = ArkRegistrationController(match_id=int(match_id), config=config)
+            msg_ref = await controller.ensure_registration_message(
+                client=interaction.client,
+                announce=announce,
+                force_announce=announce,
+                force_repost=announce,
+                target_channel_id=match.get("RegistrationChannelId"),
+                update_refresh_timestamp=True,
+            )
+            if not msg_ref:
+                await interaction.followup.send(
+                    "Failed to refresh the registration message.", ephemeral=True
+                )
+                return
+
+            await insert_audit_log(
+                action_type=(
+                    "registration_force_announce" if announce else "registration_manual_refresh"
+                ),
+                actor_discord_id=interaction.user.id,
+                match_id=int(match_id),
+                governor_id=None,
+                details_json={"source": "CommandDropdown"},
+            )
+
+            action = "announcement reposted" if announce else "signup embed refreshed"
+            await interaction.followup.send(
+                (
+                    f"Registration {action}: "
+                    f"https://discord.com/channels/{ctx.guild_id}/{msg_ref.channel_id}/{msg_ref.message_id}"
+                ),
+                ephemeral=True,
+            )
+
+        async def _on_refresh(interaction: discord.Interaction, sel):
+            await _send_registration_result(
+                interaction,
+                match_id=int(sel.match_id),
+                announce=False,
+            )
+
+        async def _on_force_announce(interaction: discord.Interaction, sel):
+            await _send_registration_result(
+                interaction,
+                match_id=int(sel.match_id),
+                announce=True,
+            )
+
+        async def _on_cancel(interaction: discord.Interaction):
+            await interaction.response.edit_message(content="Closed.", view=None)
+
+        manual_match_id = match_id if isinstance(match_id, int) and match_id > 0 else 0
+        if manual_match_id:
+            await _send_registration_result(
+                ctx.interaction,
+                match_id=int(manual_match_id),
+                announce=True,
             )
             return
 
-        controller = ArkRegistrationController(match_id=int(match_id), config=config)
-        msg_ref = await controller.ensure_registration_message(
-            client=ctx.interaction.client,
-            announce=True,
-            force_announce=True,
-            force_repost=True,
-            target_channel_id=match.get("RegistrationChannelId"),
-            update_refresh_timestamp=True,
-        )
-        if not msg_ref:
-            await ctx.interaction.edit_original_response(
-                content="❌ Failed to repost the registration message."
-            )
+        matches = await list_open_matches()
+        if not matches:
+            await ctx.interaction.edit_original_response(content="No active Ark matches found.")
             return
 
-        await insert_audit_log(
-            action_type="registration_force_announce",
-            actor_discord_id=ctx.user.id,
-            match_id=int(match_id),
-            governor_id=None,
-            details_json={"source": "Command"},
+        view = ArkRegistrationMaintenanceView(
+            author_id=ctx.user.id,
+            matches=matches,
+            on_refresh=_on_refresh,
+            on_force_announce=_on_force_announce,
+            on_cancel=_on_cancel,
         )
 
         await ctx.interaction.edit_original_response(
-            content=(
-                "✅ Registration announcement reposted: "
-                f"https://discord.com/channels/{ctx.guild_id}/{msg_ref.channel_id}/{msg_ref.message_id}"
-            )
+            content="Pick an active Ark match, then choose refresh or force announce:",
+            view=view,
         )
+        return
 
     @bot.slash_command(
         name="ark_amend_match",
@@ -590,7 +659,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
         )
 
         await ctx.interaction.edit_original_response(
-            content="Select a match and the fields to amend:",
+            content="Pick a match and the fields to amend:",
             view=view,
         )
 
@@ -717,7 +786,7 @@ def register_ark(bot: ext_commands.Bot) -> None:
         )
 
         await ctx.interaction.edit_original_response(
-            content="Select a match to cancel:",
+            content="Pick a match to cancel:",
             view=view,
         )
 

--- a/docs/reference/K98 Bot - Coding Execution Guidelines.md
+++ b/docs/reference/K98 Bot - Coding Execution Guidelines.md
@@ -304,7 +304,28 @@ Additional rules:
 
 See `K98 Bot - Testing Standards.md` for the fuller matrix.
 
-## 15. Output Format For Delivered Work
+## 15. AI Review Gates
+
+Before PR handoff, run or justify skipping these AI-assisted review gates:
+
+- CodeRabbit follow-up review for non-trivial code changes.
+- Codex Security review when security-sensitive surfaces are touched.
+
+Security-sensitive surfaces include:
+
+- permission checks or role boundaries
+- Discord commands, views, modals, callbacks, or user-facing interaction flows
+- SQL/data access, imports, exports, reports, or SQL-backed caches
+- file handling, path handling, uploads, downloads, archives, or generated artifacts
+- secrets, tokens, environment variables, runtime config, or deployment scripts
+- network calls, webhooks, external integrations, or user-controlled input parsing
+- restart-sensitive persistence, rehydration, scheduler state, or duplicate-action prevention
+
+For documentation-only, comment-only, or purely mechanical changes, these gates may be skipped
+when the skip is stated in the delivery output. If either review reports actionable issues, fix
+only issues within the approved scope unless the user approves expanding the task.
+
+## 16. Output Format For Delivered Work
 
 When delivering code or a task pack, provide:
 
@@ -315,12 +336,13 @@ When delivering code or a task pack, provide:
 5. refactor findings in touched areas
 6. test plan and commands run
 7. deployment / migration order
-8. follow-on debt or deferred improvements
+8. CodeRabbit and Codex Security review status, including skip reasons
+9. follow-on debt or deferred improvements
 
 For documentation-only changes, state that no runtime code, SQL, helper reuse, or restart behaviour
 changed.
 
-## 16. Definition Of Done
+## 17. Definition Of Done
 
 A task is done only when:
 
@@ -336,9 +358,11 @@ A task is done only when:
 - [ ] restart safety is preserved
 - [ ] tests were added, updated, or explicitly ruled out
 - [ ] quality gates were considered
+- [ ] CodeRabbit review was run or explicitly skipped
+- [ ] Codex Security review was run or explicitly skipped based on risk triggers
 - [ ] deferred debt is captured using the Deferred Optimisation Framework format
 
-## 17. Quality Gates
+## 18. Quality Gates
 
 Run or recommend these before completion:
 
@@ -354,7 +378,14 @@ python scripts/validate_command_registration.py
 For SQL-heavy, configuration-heavy, or domain-specific tasks, also include targeted validation
 commands relevant to the subsystem.
 
-## 18. If Uncertain
+Add AI-assisted review gates before PR handoff:
+
+- CodeRabbit follow-up review for non-trivial code changes.
+- Codex Security review for changes touching the security-sensitive surfaces listed in section 15.
+
+If a gate is skipped, record the reason in the delivery output.
+
+## 19. If Uncertain
 
 When unsure:
 

--- a/docs/reference/K98 Bot - Skills & Refactor Triggers.md
+++ b/docs/reference/K98 Bot - Skills & Refactor Triggers.md
@@ -57,6 +57,15 @@ Ability to consider:
 - local validation
 - production promotion and migration order
 
+### AI-Assisted Review Judgement
+
+Ability to:
+
+- use CodeRabbit as a follow-up reviewer for non-trivial code changes before PR handoff
+- use Codex Security when security-sensitive surfaces are touched
+- distinguish review gates from tests and avoid replacing local validation with AI review
+- document clear skip reasons for documentation-only, comment-only, or mechanical changes
+
 ## 2. Refactor Triggers
 
 These triggers should prompt cleanup in the touched area or a structured deferred item.
@@ -114,6 +123,18 @@ Expected response:
 - update tests as part of the refactor
 - do not leave tests describing old layer boundaries
 
+### Trigger H - Security-Sensitive Surface Touched
+
+Security-sensitive surfaces include permissions, Discord interactions, SQL/data access, file
+handling, secrets/config, deployment, network calls, user-controlled input, and restart-sensitive
+persistence.
+
+Expected response:
+
+- run or justify skipping Codex Security review before PR handoff
+- fix validated issues within the approved scope
+- capture larger out-of-scope security hardening work using the Deferred Optimisation Framework
+
 ## 3. Review Questions Before Coding
 
 1. Which layer should own this behaviour?
@@ -124,7 +145,8 @@ Expected response:
 6. What state must survive restart?
 7. What test types are required?
 8. Which conditional reference docs apply?
-9. What technical debt is obvious enough that leaving it untouched would likely repeat the
+9. Does the task trigger CodeRabbit or Codex Security review gates?
+10. What technical debt is obvious enough that leaving it untouched would likely repeat the
    problem later?
 
 ## 4. Review Questions Before Marking Complete
@@ -136,6 +158,7 @@ Expected response:
 5. Did I explicitly list any debt I chose not to fix?
 6. Would another engineer understand the flow from logs if it failed in production?
 7. Would the feature still behave correctly after a restart?
+8. Were CodeRabbit and Codex Security run or explicitly skipped with reasons?
 
 ## 5. Practical Use In Task Packs
 
@@ -168,6 +191,7 @@ Before completion:
 - [ ] tests added, updated, or explicitly ruled out
 - [ ] logging adequate
 - [ ] restart safety preserved
+- [ ] CodeRabbit and Codex Security review gates run or skipped with reasons
 - [ ] follow-on debt listed if still present
 
 ## 7. Deferred Optimisation Handling

--- a/docs/reference/K98 Bot - Testing Standards.md
+++ b/docs/reference/K98 Bot - Testing Standards.md
@@ -172,6 +172,13 @@ For documentation-only changes, the architecture/deferred/test-selector scripts 
 minimum useful gate. Runtime pytest may be skipped when no code or test files changed, but the skip
 must be stated.
 
+AI-assisted review gates are separate from tests, but should be considered before PR handoff:
+
+- Run or justify skipping CodeRabbit follow-up review for non-trivial code changes.
+- Run or justify skipping Codex Security review when the change touches permissions, Discord
+  interactions, SQL/data access, file handling, secrets/config, deployment, network calls,
+  user-controlled input, or restart-sensitive persistence.
+
 ## 9. Assertions To Prefer
 
 Prefer tests that assert:
@@ -219,3 +226,4 @@ A change is test-ready when:
 - [ ] existing related tests were reviewed
 - [ ] focused and general validation commands are identified
 - [ ] documentation-only skips are explicitly justified
+- [ ] CodeRabbit and Codex Security review decisions are documented before PR handoff

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -24,7 +24,11 @@ guard/state, and upload-refresh behaviour; it was smoke tested successfully and 
 production. Phase 3 local validation blockers were audited on 2026-05-20 and closed as a no-op:
 the focused DB/non-DB blocker tests, full suite, and pytest log-noise validation all passed under
 the documented `.venv` workflow without `RUN_DB_TESTS=1`. Phase 4 KVK_ALL upload-route extraction
-is now the next upload-routing programme slice; the remaining active backlog is listed below.
+was completed in PR 110 (`codex/kvk-all-upload-route`), smoke tested successfully on 2026-05-26,
+and promoted to production: KVK_ALL now delegates through `upload_routes/kvk_all_route.py` while
+preserving multi-attachment handling, SQL preflight behaviour, Discord output, sheet link button
+behaviour, and non-blocking auto-export scheduling. Phase 5 remaining fast-path consolidation is
+now the next upload-routing programme slice; the remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
@@ -95,22 +99,13 @@ issues list.
 - Dependencies: Complete the active DL_bot upload-routing phases first; preserve current production schema export as a drift/safety mechanism while preventing direct overwrite of `main`.
 
 ### Deferred Optimisation
-- Area: `DL_bot.py` KVK_ALL upload routing
-- Type: architecture
-- Description: KVK_ALL upload routing still lives in the legacy root bot listener with attachment filtering, offload dispatch, import result handling, Discord rendering, and export scheduling mixed together.
-- Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
-- Impact: medium
-- Risk: medium
-- Dependencies: Start with `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`; preserve existing Discord output and auto-export behaviour; broader restart/performance hardening remains assigned to the KVK_ALL modernisation programme.
-
-### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After the first upload-route slices, `DL_bot.py` will still own MGE, honor, weekly activity, rally, inventory, and fallback queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
-- Suggested Fix: Phase 5 should consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering, and add route-level structured logging without changing importer contracts or Discord output.
+- Description: After the first upload-route slices, `DL_bot.py` still owns MGE results import, KVK honor ingest, weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
+- Suggested Fix: Phase 5 should audit and consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering only where behaviour parity is testable, and add route-level structured logging without changing importer contracts or Discord output.
 - Impact: medium
 - Risk: medium
-- Dependencies: Complete and validate the player-location, PreKvK, validation-blocker, and KVK_ALL phases first so the general router is based on proven route contracts.
+- Dependencies: Start with `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`; player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested, so Phase 5 can be scoped against proven route contracts.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -48,13 +48,17 @@ PR 96 (`import-locations-command-orchestration-cleanup`) was smoke tested succes
 
 The `/import_locations` command cleanup is complete. This task is fresh work around `DL_bot.py` upload routing and related validation blockers.
 
-Current `DL_bot.py` still contains multiple fast-path upload routes inside the root `on_message` listener, including player location CSV import, PreKvK snapshot ingest, KVK Honour ingest, weekly activity import, rally import, KVK_ALL import, and fallback monitored-channel queueing.
+Current `DL_bot.py` still contains multiple fast-path upload routes inside the root `on_message`
+listener. Player location CSV import, PreKvK snapshot ingest, and KVK_ALL import have been
+extracted into the `upload_routes` pattern; MGE results import, KVK Honour ingest, weekly activity
+import, rally forts import, inventory upload-first routing, and fallback monitored-channel queueing
+remain inline.
 
 The active deferred backlog identifies these DL_bot-specific architecture items:
 
 - PreKvK upload routing still mixes filename matching, KVK lookup, offload dispatch, and Discord rendering.
 - Player location CSV auto-import still couples `DL_bot.py` to `commands/location_cmds.py` refresh signalling.
-- KVK_ALL upload routing still mixes attachment filtering, import handling, Discord rendering, and export scheduling.
+- KVK_ALL upload routing was extracted in Phase 4 and no longer lives inline in `DL_bot.py`.
 - Local validation previously had DB and non-DB environment blockers that affected safe PR
   validation; Phase 3 later audited these and closed them as a no-op after current `main` passed
   focused blocker tests, full pytest, and log-noise validation.
@@ -131,7 +135,7 @@ The active deferred backlog identifies these DL_bot-specific architecture items:
 - Suggested Fix: Move KVK_ALL upload orchestration into a dedicated service or route module in a later phase, leaving `DL_bot.py` responsible for event delegation and Discord response plumbing.
 - Impact: medium
 - Risk: medium
-- Dependencies: Preserve existing Discord output and auto-export behaviour.
+- Dependencies: Resolved by Phase 4 in PR 110 (`codex/kvk-all-upload-route`); KVK_ALL now delegates to `upload_routes/kvk_all_route.py` and preserves existing Discord output and auto-export behaviour.
 ```
 
 7. Codex Skills To Use
@@ -299,13 +303,19 @@ Phase breakdown:
      environment blocker tests passed (`20 passed`), full pytest passed (`1461 passed, 2 skipped`),
      and pytest log-noise validation passed with production operational logs unchanged.
 6. **Phase 4 - KVK_ALL upload route**
-   - Extract the higher-risk multi-attachment KVK_ALL route after smaller routes prove the pattern.
-   - Preserve structured importer failures, health output, link button, and auto-export scheduling.
+   - Completed in PR 110 (`codex/kvk-all-upload-route`) and smoke tested successfully on
+     2026-05-26.
+   - Extracted the higher-risk multi-attachment KVK_ALL route into
+     `upload_routes/kvk_all_route.py` after smaller routes proved the pattern.
+   - Preserved structured importer failures, health output, link button, and auto-export
+     scheduling.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 7. **Phase 5 - Remaining upload fast-path consolidation**
-   - Consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing, shared
-     SQL-preflight/offload handling, shared import embed rendering, and route-level structured
-     logging into the general upload-routing layer.
+   - Next active slice.
+   - Audit and consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing,
+     shared SQL-preflight/offload handling, shared import embed rendering where safe, and
+     route-level structured logging into the general upload-routing layer.
+   - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
 8. **Phase 6 - Startup/lifecycle separation**
    - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
      `bot_instance.py` review.
@@ -334,7 +344,19 @@ Phase 3 delivery notes:
 - No bot code, SQL, tests, deployment scripts, or upload-routing behaviour changed.
 - The two validation-blocker deferred items were removed from the active backlog after the focused
   blocker reproductions, full test suite, and log-noise validation all passed under `.venv`.
-- Phase 4 KVK_ALL upload-route extraction is now the next active upload-routing programme slice.
+
+Phase 4 delivery notes:
+
+- KVK_ALL upload routing is extracted into the `upload_routes` pattern with `DL_bot.py` retaining
+  listener/delegation responsibility.
+- The route preserves accepted `.xlsx`, `.xls`, and `.csv` attachment filtering, no-file warning
+  output, per-attachment continuation, SQL preflight behaviour, structured importer failure
+  rendering, success/warning embeds, branding thumbnail, Google Sheet link button, and non-blocking
+  auto-export scheduling.
+- The SQL preflight review fix intentionally relies on `ensure_sql_headroom_or_notify()` for the
+  user-facing abort notification and does not emit a duplicate route-level abort embed.
+- PR 110 (`codex/kvk-all-upload-route`) was smoke tested successfully and promoted to production.
+- Phase 5 remaining fast-path consolidation is now the next active upload-routing programme slice.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md
@@ -13,9 +13,56 @@ We are starting Phase 4 of the DL_bot upload-routing optimisation programme afte
 - Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
   tests, full suite, and log-noise validation all passed under `.venv`.
 
-Phase 4 is the next higher-blast-radius upload-routing slice: extract the KVK_ALL upload route from
-the root `DL_bot.py` listener into the established `upload_routes` pattern while preserving current
-production behaviour.
+## Completion Note
+
+Status: complete in PR 110 (`codex/kvk-all-upload-route`), smoke tested successfully on
+2026-05-26, and promoted to production.
+
+Phase 4 extracted the KVK_ALL upload route from the root `DL_bot.py` listener into
+`upload_routes/kvk_all_route.py` while preserving current production behaviour.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates KVK_ALL message handling to `handle_kvk_all_upload()` and keeps only
+  listener/event plumbing for this route.
+- KVK_ALL attachment filtering, SQL preflight, offload dispatch, result interpretation, embed
+  rendering, sheet link button, per-attachment continuation, and auto-export scheduling are covered
+  by focused route tests in `tests/test_kvk_all_upload_route.py`.
+- Current Discord output, importer contract, structured failure handling, health line, and
+  fall-through behaviour were preserved.
+- The SQL preflight review fix relies on `ensure_sql_headroom_or_notify()` for the user-facing
+  abort notification and avoids emitting a duplicate route-level abort embed.
+- No SQL schema, stored procedure, view, export contract, or workbook-format changes were made.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_all_upload_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_player_location_upload_route.py tests/test_prekvk_upload_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_all_importer.py tests/test_kvk_all_import_dal.py tests/test_kvk_all_import_service.py tests/test_kvk_all_schema.py tests/test_kvk_export_service.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_all_recompute_sql_contract.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+```
+
+Observed full-suite result after review fix: `1473 passed, 2 skipped`.
+
+Smoke evidence from production confirmed the route handled a KVK_ALL workbook, passed SQL
+preflight, staged/imported Full Data, scheduled auto-export for KVK 15 Scan 31, and wrote the
+expected Google Sheets export tabs.
+
+Phase 5 remaining fast-path upload-route consolidation is the next upload-routing programme slice.
+
+## Original Goal
+
+Phase 4 was the next higher-blast-radius upload-routing slice: extract the KVK_ALL upload route
+from the root `DL_bot.py` listener into the established `upload_routes` pattern while preserving
+current production behaviour.
 
 ## Goal
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
@@ -1,0 +1,231 @@
+# DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter
+
+We are starting Phase 5 of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+- Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
+  tests, full suite, and log-noise validation all passed under `.venv`.
+- Phase 4 extracted the KVK_ALL route into `upload_routes/kvk_all_route.py`, was smoke tested
+  successfully on 2026-05-26, and was pushed to production.
+
+Phase 5 is the remaining fast-path upload-route consolidation slice. It should use the proven
+`upload_routes` pattern to reduce `DL_bot.py` listener responsibilities while preserving production
+behaviour.
+
+## Goal
+
+Audit and extract the remaining inline upload fast paths from `DL_bot.py` into focused route
+modules or an approved shared upload-router boundary.
+
+The desired end state is:
+
+- `DL_bot.py` delegates remaining upload message handling and keeps only listener/event plumbing.
+- MGE results import, KVK Honour ingest, weekly activity ingest, rally forts ingest, inventory
+  upload-first routing, and fallback monitored-channel queueing have clear route ownership.
+- Shared SQL preflight, offload dispatch, import embed rendering, and route-level structured
+  logging are consolidated only where behaviour parity is safe and testable.
+- Current Discord output, importer contracts, accepted filenames/extensions, side effects, fallback
+  queue behaviour, and fall-through order are preserved unless an explicit behaviour change is
+  approved.
+- No new SQL schema changes are introduced in this phase.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the route
+classification and first PR scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any importer, DAL, export, stored
+procedure, view, or output-contract assumptions reviewed during this phase.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Source Deferred Item
+
+### Deferred Optimisation
+- Area: `DL_bot.py` remaining fast-path upload routes
+- Type: architecture
+- Description: After the first upload-route slices, `DL_bot.py` still owns MGE results import, KVK honor ingest, weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
+- Suggested Fix: Phase 5 should audit and consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering only where behaviour parity is testable, and add route-level structured logging without changing importer contracts or Discord output.
+- Impact: medium
+- Risk: medium
+- Dependencies: Player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested; preserve existing Discord output and importer contracts.
+
+## Phase 5 Scope
+
+In scope for Step 1 audit:
+
+- Audit remaining inline upload-related branches in `DL_bot.py`.
+- Map route order and fall-through behaviour.
+- Classify each remaining path as fix-now, defer, or not applicable for the first Phase 5 PR.
+- Identify shared helper candidates for SQL preflight, offload dispatch, notification-channel
+  resolution, import result rendering, and route logging.
+- Identify which route tests are required for behaviour parity.
+- Validate SQL-facing assumptions against `C:\K98-bot-SQL-Server` when reviewing importer or DAL
+  contracts.
+- Capture out-of-scope findings structurally.
+
+Likely remaining route candidates:
+
+- Inventory upload-first route currently delegated to `ui.views.inventory_views.handle_inventory_upload_message`.
+- MGE results auto-import route.
+- KVK Honour ingest route.
+- Weekly activity ingest route.
+- Rally forts XLSX auto-ingest route.
+- Main monitored-channel fallback queue route.
+
+Out of scope until separately approved:
+
+- Changing importer behaviour, workbook/file formats, or result contracts.
+- Changing SQL schema, stored procedures, views, export result sets, or Google Sheets contracts.
+- Broad `DL_bot.py` startup/lifecycle or `bot_instance.py` refactor.
+- KVK_ALL schema modernisation, legacy SQL cleanup, or performance tuning.
+- Rewriting the worker queue or processing pipeline beyond route-boundary dependency injection.
+- Consolidating slash-command surfaces.
+
+## Current Files To Review
+
+Likely route/listener files:
+
+- `DL_bot.py`
+- `upload_routes/player_location_route.py`
+- `upload_routes/prekvk_route.py`
+- `upload_routes/kvk_all_route.py`
+- `upload_routes/__init__.py`
+
+Likely importer/service/helper files:
+
+- `mge/mge_results_import.py`
+- `honor_importer.py`
+- `weekly_activity_importer.py`
+- `forts_ingest.py`
+- `ui/views/inventory_views.py`
+- `file_utils.py`
+- `embed_utils.py`
+- `bot_helpers.py`
+- `processing_pipeline.py`
+- `worker.py`
+- `log_health.py`
+
+Likely tests:
+
+- `tests/test_dl_bot_mge_auto_import.py`
+- `tests/test_mge_results_import.py`
+- `tests/test_mge_results_import_service.py`
+- `tests/test_honor_importer.py`
+- `tests/test_weekly_activity_importer.py` if present
+- `tests/test_inventory_*`
+- `tests/test_processing_pipeline.py`
+- `tests/test_live_queue_persistence.py`
+- existing upload-route tests
+- new focused route tests for selected Phase 5 slice
+
+## Design Questions
+
+- Should Phase 5 extract all remaining fast paths in one PR, or split into smaller route families
+  such as MGE/Honor/Weekly first, Rally second, fallback queue last?
+- Should inventory upload-first remain delegated to `ui.views.inventory_views` for this phase, or
+  should a thin `upload_routes/inventory_route.py` wrap that existing handler for route-order
+  consistency?
+- Which shared dependency object or helper should be introduced without over-abstracting the route
+  pattern proven by player-location, PreKvK, and KVK_ALL?
+- Which repeated embed-rendering patterns are identical enough to consolidate safely, and which
+  should remain route-local to preserve exact Discord output?
+- Should fallback monitored-channel queueing become a route module, or should it remain at the end
+  of `DL_bot.py` until Phase 6 lifecycle/queue ownership is scoped?
+- Which SQL contracts need source-of-truth validation before implementation, and which are already
+  covered by existing tests?
+- What is the minimal first PR that reduces listener complexity without creating a hard-to-review
+  broad router rewrite?
+
+## Step 1 Required Output
+
+Phase 5 Step 1 must produce:
+
+- Audit Summary
+- Current Remaining Route Map
+- Route Order And Fall-Through Map
+- Importer / SQL Contract Map
+- Discord Output Preservation Map
+- Shared Helper Recommendation
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the selected Phase 5 route slice:
+
+- focused new route tests
+- relevant importer/service tests for selected routes
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+
+If live SQL integration is intentionally needed, document and validate the opt-in path:
+
+```powershell
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected live DB tests>
+```
+
+## Acceptance Criteria
+
+- Remaining route responsibilities are mapped before implementation.
+- The approved first Phase 5 PR keeps `DL_bot.py` thinner without changing route order or
+  fall-through behaviour.
+- Current Discord output and importer contracts are preserved.
+- No new direct SQL is added to Discord listener/route layers.
+- Shared helper extraction is used only where behaviour parity is clear and covered.
+- Focused route tests cover matching, non-matching, preflight aborts, importer success/failure,
+  exception rendering, side effects, and fall-through for the selected slice.
+- Out-of-scope upload-router, lifecycle, SQL, or worker findings are captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 5 audit/design packet.
+
+Do not implement route extraction, alter SQL, change upload routing behaviour, or open a PR until
+the audit packet, route classification, and first implementation scope have each been approved.

--- a/docs/templates/Codex Task Pack Template.md
+++ b/docs/templates/Codex Task Pack Template.md
@@ -80,6 +80,8 @@ instead of deleting a skill silently.
 | `k98-deferred-optimisation-capture` | Audit or implementation finds out-of-scope debt, refactor triggers, duplicate helpers, direct SQL in commands/views, restart-safety gaps, or cleanup candidates. |
 | `k98-pr-review` | Before merge or PR handoff, to check architecture, SQL alignment, tests, deferred items, Discord safety, and promotion readiness. |
 | `k98-promotion-check` | Before production promotion, production PR creation, production merge, SQL deployment sequencing, or bot-machine deployment. |
+| `coderabbit:code-review` | Before PR handoff for non-trivial code changes, after local validation, to catch follow-up review issues. |
+| `codex-security:security-scan` | When security-sensitive surfaces are touched, including permissions, Discord interactions, SQL/data access, file handling, secrets/config, deployment, network calls, user-controlled input, or restart-sensitive persistence. |
 
 ### Skill Decisions
 
@@ -92,6 +94,8 @@ instead of deleting a skill silently.
 | `k98-deferred-optimisation-capture` | `<use | not applicable>` | `<why>` |
 | `k98-pr-review` | `<use | not applicable>` | `<why>` |
 | `k98-promotion-check` | `<use | not applicable>` | `<why>` |
+| `coderabbit:code-review` | `<use | not applicable>` | `<why>` |
+| `codex-security:security-scan` | `<use | not applicable>` | `<why>` |
 
 ## 8. Mandatory Workflow
 
@@ -102,6 +106,8 @@ Default workflow:
 3. Implementation plan, then stop for approval.
 4. Implementation after approval.
 5. Validation and final review.
+6. CodeRabbit follow-up review for non-trivial code changes, or documented skip reason.
+7. Codex Security review when risk triggers apply, or documented skip reason.
 
 Proceed in one pass only when the user explicitly approves it.
 
@@ -210,6 +216,11 @@ consider:
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
 ```
 
+Before PR handoff, include AI-assisted review gate decisions:
+
+- CodeRabbit follow-up review for non-trivial code changes, or a documented skip reason.
+- Codex Security review when security-sensitive surfaces are touched, or a documented skip reason.
+
 ## 15. Acceptance Criteria
 
 - [ ] Scope is complete and no out-of-scope work was mixed in.
@@ -220,6 +231,8 @@ consider:
 - [ ] Restart safety is preserved or explicitly not applicable.
 - [ ] Tests were added/updated or a clear testing exception is documented.
 - [ ] Quality gates were run or documented.
+- [ ] CodeRabbit follow-up review was run or explicitly skipped.
+- [ ] Codex Security review was run or explicitly skipped based on risk triggers.
 - [ ] Deferred optimisations are captured structurally.
 
 ## 16. Required Delivery Output
@@ -234,8 +247,9 @@ Use this delivery shape:
 6. Helpers Reused
 7. Refactor Findings
 8. Test Plan
-9. Deployment Steps
-10. Deferred Optimisations
+9. AI Review Gates
+10. Deployment Steps
+11. Deferred Optimisations
 
 For documentation-only work, state that no runtime code, SQL, helper reuse, or restart behaviour
 changed.
@@ -254,6 +268,11 @@ changed.
 ## Tests
 
 - <test command or verification>
+
+## AI Review Gates
+
+- CodeRabbit: <run | skipped, with reason>
+- Codex Security: <run | skipped, with reason>
 
 ## Deferred Optimisations
 

--- a/tests/test_ark_registration_flow.py
+++ b/tests/test_ark_registration_flow.py
@@ -49,6 +49,29 @@ class DummyInteraction:
         self.client = object()
 
 
+class DoneAfterDeferResponse(DummyResponse):
+    def __init__(self) -> None:
+        super().__init__()
+        self._done = False
+
+    async def defer(self, ephemeral: bool = True):
+        await super().defer(ephemeral=ephemeral)
+        self._done = True
+
+    def is_done(self) -> bool:
+        return self._done
+
+
+class PublicMessageGuardInteraction(DummyInteraction):
+    def __init__(self, user_id: int = 999) -> None:
+        super().__init__(user_id=user_id)
+        self.response = DoneAfterDeferResponse()
+        self.original_edits = []
+
+    async def edit_original_response(self, content=None, view=None):
+        self.original_edits.append({"content": content, "view": view})
+
+
 def _future_close() -> datetime:
     return datetime.now(UTC) + timedelta(hours=2)
 
@@ -170,7 +193,7 @@ async def test_join_player_adds_signup(monkeypatch):
     controller = ArkRegistrationController(match_id=1, config={"PlayersCap": 30, "SubsCap": 15})
     interaction = DummyInteraction()
 
-    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None):
+    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None, **_k):
         if only_governor_ids:
             await on_select(interaction, next(iter(only_governor_ids)))
         else:
@@ -241,7 +264,7 @@ async def test_leave_marks_withdrawn(monkeypatch):
     controller = ArkRegistrationController(match_id=2, config={"PlayersCap": 30, "SubsCap": 15})
     interaction = DummyInteraction()
 
-    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None):
+    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None, **_k):
         await on_select(interaction, "2441482")
 
     monkeypatch.setattr(controller, "_prompt_governor_selection", _prompt)
@@ -306,7 +329,7 @@ async def test_switch_updates_governor(monkeypatch):
     controller = ArkRegistrationController(match_id=3, config={"PlayersCap": 30, "SubsCap": 15})
     interaction = DummyInteraction()
 
-    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None):
+    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None, **_k):
         if only_governor_ids:
             await on_select(interaction, next(iter(only_governor_ids)))
         else:
@@ -512,7 +535,7 @@ async def test_join_player_blocks_duplicate_weekend_governor(monkeypatch):
     controller = ArkRegistrationController(match_id=13, config={"PlayersCap": 30, "SubsCap": 15})
     interaction = DummyInteraction()
 
-    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None):
+    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None, **_k):
         if only_governor_ids:
             await on_select(interaction, next(iter(only_governor_ids)))
         else:
@@ -730,6 +753,57 @@ async def test_switch_blocks_when_same_governor_selected(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_switch_auto_current_governor_does_not_edit_public_registration_message(monkeypatch):
+    controller = ArkRegistrationController(match_id=21, config={"PlayersCap": 30, "SubsCap": 15})
+    interaction = PublicMessageGuardInteraction(user_id=999)
+
+    async def _get_match(match_id):
+        return {
+            "MatchId": 21,
+            "Alliance": "K98",
+            "ArkWeekendDate": datetime(2026, 3, 7, tzinfo=UTC).date(),
+            "MatchDay": "Sat",
+            "MatchTimeUtc": datetime(2026, 3, 7, 11, 0, tzinfo=UTC).time(),
+            "SignupCloseUtc": _future_close(),
+            "Status": "Scheduled",
+        }
+
+    async def _get_roster(match_id):
+        return [
+            {
+                "GovernorId": 111,
+                "GovernorNameSnapshot": "Current",
+                "DiscordUserId": interaction.user.id,
+                "SlotType": "Player",
+            }
+        ]
+
+    async def _get_account_summary_stub(_user_id):
+        return _account_summary(
+            {
+                "Main": {"GovernorID": "111", "GovernorName": "Current"},
+                "Alt 1": {"GovernorID": "222", "GovernorName": "Target One"},
+                "Alt 2": {"GovernorID": "333", "GovernorName": "Target Two"},
+            }
+        )
+
+    monkeypatch.setattr("ark.registration_flow.get_match", _get_match)
+    monkeypatch.setattr("ark.registration_flow.get_roster", _get_roster)
+    monkeypatch.setattr(
+        "ark.registration_flow.get_account_summary_for_user",
+        _get_account_summary_stub,
+    )
+    monkeypatch.setattr(controller, "refresh_registration_message", lambda *_a, **_k: None)
+
+    await controller.switch(interaction)
+
+    assert interaction.original_edits == []
+    assert interaction.followup.sent
+    assert "Current governor selected" in interaction.followup.sent[0]["content"]
+    assert any(msg.get("view") is not None for msg in interaction.followup.sent)
+
+
+@pytest.mark.asyncio
 async def test_join_blocks_when_user_already_signed_up(monkeypatch):
     controller = ArkRegistrationController(match_id=17, config={"PlayersCap": 30, "SubsCap": 15})
     interaction = DummyInteraction()
@@ -757,7 +831,7 @@ async def test_join_blocks_when_user_already_signed_up(monkeypatch):
 
     called = {"prompt": False}
 
-    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None):
+    async def _prompt(interaction, *, accounts, on_select, heading, only_governor_ids=None, **_k):
         called["prompt"] = True
         await on_select(interaction, "2441482")
 

--- a/tests/test_ark_registration_maintenance_view.py
+++ b/tests/test_ark_registration_maintenance_view.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from datetime import date, time
+
+import discord
+import pytest
+
+from ui.views.ark_views import ArkGovernorSelectView, ArkRegistrationMaintenanceView
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.sent = []
+        self.edits = []
+        self._done = False
+
+    async def send_message(self, content=None, **kwargs):
+        self.sent.append({"content": content, **kwargs})
+        self._done = True
+
+    async def edit_message(self, content=None, view=None):
+        self.edits.append({"content": content, "view": view})
+        self._done = True
+
+    def is_done(self) -> bool:
+        return self._done
+
+
+class DummyFollowup:
+    def __init__(self) -> None:
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append({"content": content, **kwargs})
+
+
+class DummyUser:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+
+
+class DummyInteraction:
+    def __init__(self, user_id: int = 123) -> None:
+        self.user = DummyUser(user_id)
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_governor_select_timeout_disables_menu_and_runs_repair_callback():
+    called = {"repair": 0}
+
+    async def _repair():
+        called["repair"] += 1
+
+    view = ArkGovernorSelectView(
+        author_id=123,
+        options=[discord.SelectOption(label="Gov", value="1")],
+        on_select=lambda *_: None,
+        on_timeout_callback=_repair,
+    )
+    message = DummyMessage()
+    view.message = message
+
+    await view.on_timeout()
+
+    assert called["repair"] == 1
+    assert message.edits
+    assert all(item.disabled for item in view.children)
+
+
+@pytest.mark.asyncio
+async def test_governor_select_timeout_accepts_sync_repair_callback():
+    called = {"repair": 0}
+
+    def _repair():
+        called["repair"] += 1
+
+    view = ArkGovernorSelectView(
+        author_id=123,
+        options=[discord.SelectOption(label="Gov", value="1")],
+        on_select=lambda *_: None,
+        on_timeout_callback=_repair,
+    )
+
+    await view.on_timeout()
+
+    assert called["repair"] == 1
+
+
+@pytest.mark.asyncio
+async def test_registration_maintenance_view_select_enables_actions_and_calls_refresh():
+    captured = {}
+    matches = [
+        {
+            "MatchId": 44,
+            "Alliance": "k98A",
+            "ArkWeekendDate": date(2026, 5, 30),
+            "MatchDay": "Sat",
+            "MatchTimeUtc": time(20, 0),
+        }
+    ]
+
+    async def _refresh(_interaction, selection):
+        captured["refresh"] = selection.match_id
+
+    async def _force(_interaction, selection):
+        captured["force"] = selection.match_id
+
+    view = ArkRegistrationMaintenanceView(
+        author_id=123,
+        matches=matches,
+        on_refresh=_refresh,
+        on_force_announce=_force,
+    )
+    interaction = DummyInteraction()
+
+    view._apply_match_selection(44)
+    await view._on_refresh(interaction)
+
+    assert view.refresh_btn.disabled is False
+    assert view.force_btn.disabled is False
+    assert captured == {"refresh": 44}
+
+
+@pytest.mark.asyncio
+async def test_registration_maintenance_view_reports_refresh_callback_failure():
+    matches = [
+        {
+            "MatchId": 44,
+            "Alliance": "k98A",
+            "ArkWeekendDate": date(2026, 5, 30),
+            "MatchDay": "Sat",
+            "MatchTimeUtc": time(20, 0),
+        }
+    ]
+
+    async def _refresh(_interaction, _selection):
+        raise RuntimeError("boom")
+
+    view = ArkRegistrationMaintenanceView(
+        author_id=123,
+        matches=matches,
+        on_refresh=_refresh,
+        on_force_announce=lambda *_: None,
+    )
+    interaction = DummyInteraction()
+
+    view._apply_match_selection(44)
+    await view._on_refresh(interaction)
+
+    assert interaction.response.sent
+    assert "Failed to refresh" in interaction.response.sent[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_registration_maintenance_view_reports_force_callback_failure():
+    matches = [
+        {
+            "MatchId": 44,
+            "Alliance": "k98A",
+            "ArkWeekendDate": date(2026, 5, 30),
+            "MatchDay": "Sat",
+            "MatchTimeUtc": time(20, 0),
+        }
+    ]
+
+    async def _force(_interaction, _selection):
+        raise RuntimeError("boom")
+
+    view = ArkRegistrationMaintenanceView(
+        author_id=123,
+        matches=matches,
+        on_refresh=lambda *_: None,
+        on_force_announce=_force,
+    )
+    interaction = DummyInteraction()
+
+    view._apply_match_selection(44)
+    await view._on_force_announce(interaction)
+
+    assert interaction.response.sent
+    assert "Failed to repost" in interaction.response.sent[-1]["content"]

--- a/tests/test_ark_registration_maintenance_view.py
+++ b/tests/test_ark_registration_maintenance_view.py
@@ -128,6 +128,8 @@ async def test_registration_maintenance_view_select_enables_actions_and_calls_re
 
     assert view.refresh_btn.disabled is False
     assert view.force_btn.disabled is False
+    assert "k98A - 2026-05-30 Sat 20:00 UTC" in view.message_content()
+    assert "(ID 44)" in view.message_content()
     assert captured == {"refresh": 44}
 
 

--- a/tests/test_ark_reminder_prefs_command.py
+++ b/tests/test_ark_reminder_prefs_command.py
@@ -5,9 +5,26 @@ import pytest
 from commands import ark_cmds
 
 
-class DummyInteraction:
+class DummyResponse:
+    def is_done(self):
+        return True
+
+
+class DummyFollowup:
     def __init__(self):
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append({"content": content, **kwargs})
+
+
+class DummyInteraction:
+    def __init__(self, user_id: int = 123):
+        self.user = type("U", (), {"id": user_id})()
         self.edits = []
+        self.client = object()
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
 
     async def edit_original_response(self, *, content=None, view=None):
         self.edits.append({"content": content, "view": view})
@@ -16,7 +33,8 @@ class DummyInteraction:
 class DummyCtx:
     def __init__(self, user_id: int = 123):
         self.user = type("U", (), {"id": user_id})()
-        self.interaction = DummyInteraction()
+        self.interaction = DummyInteraction(user_id=user_id)
+        self.guild_id = 987
 
 
 class DummyBot:
@@ -66,3 +84,95 @@ async def test_ark_reminder_prefs_command_seeds_defaults(monkeypatch):
     assert kwargs["opt_out_start"] == 0
     assert kwargs["opt_out_checkin_12h"] == 0
     assert ctx.interaction.edits
+
+
+@pytest.mark.asyncio
+async def test_ark_force_announce_opens_active_match_dropdown(monkeypatch):
+    from datetime import date, time
+
+    bot = DummyBot()
+    ark_cmds.register_ark(bot)
+    cmd = bot.registered["ark_force_announce"]
+    while hasattr(cmd, "__wrapped__"):
+        cmd = cmd.__wrapped__
+
+    async def _safe_defer(_ctx, ephemeral=True):
+        return None
+
+    async def _get_config():
+        return {"PlayersCap": 30, "SubsCap": 15}
+
+    async def _list_open_matches():
+        return [
+            {
+                "MatchId": 44,
+                "Alliance": "k98A",
+                "ArkWeekendDate": date(2026, 5, 30),
+                "MatchDay": "Sat",
+                "MatchTimeUtc": time(20, 0),
+            }
+        ]
+
+    monkeypatch.setattr("commands.ark_cmds.safe_defer", _safe_defer)
+    monkeypatch.setattr("commands.ark_cmds.get_config", _get_config)
+    monkeypatch.setattr("commands.ark_cmds.list_open_matches", _list_open_matches)
+
+    ctx = DummyCtx(user_id=777)
+    await cmd(ctx)
+
+    assert ctx.interaction.edits
+    view = ctx.interaction.edits[-1]["view"]
+    assert view is not None
+    assert view.match_select.options[0].value == "44"
+
+
+@pytest.mark.asyncio
+async def test_ark_force_announce_manual_match_id_bypasses_dropdown(monkeypatch):
+    bot = DummyBot()
+    ark_cmds.register_ark(bot)
+    cmd = bot.registered["ark_force_announce"]
+    while hasattr(cmd, "__wrapped__"):
+        cmd = cmd.__wrapped__
+
+    async def _safe_defer(_ctx, ephemeral=True):
+        return None
+
+    async def _get_config():
+        return {"PlayersCap": 30, "SubsCap": 15}
+
+    async def _list_open_matches():
+        raise AssertionError("manual match_id path should not load dropdown matches")
+
+    async def _get_match(match_id):
+        return {
+            "MatchId": match_id,
+            "Status": "Scheduled",
+            "RegistrationChannelId": 123,
+        }
+
+    async def _audit(**_kwargs):
+        return 1
+
+    class _Controller:
+        def __init__(self, *, match_id, config):
+            self.match_id = match_id
+            self.config = config
+
+        async def ensure_registration_message(self, **kwargs):
+            assert kwargs["announce"] is True
+            assert kwargs["force_repost"] is True
+            return type("Ref", (), {"channel_id": 123, "message_id": 456})()
+
+    monkeypatch.setattr("commands.ark_cmds.safe_defer", _safe_defer)
+    monkeypatch.setattr("commands.ark_cmds.get_config", _get_config)
+    monkeypatch.setattr("commands.ark_cmds.list_open_matches", _list_open_matches)
+    monkeypatch.setattr("commands.ark_cmds.get_match", _get_match)
+    monkeypatch.setattr("commands.ark_cmds.insert_audit_log", _audit)
+    monkeypatch.setattr("commands.ark_cmds.ArkRegistrationController", _Controller)
+
+    ctx = DummyCtx(user_id=777)
+    await cmd(ctx, match_id=99)
+
+    assert not ctx.interaction.edits
+    assert ctx.interaction.followup.sent
+    assert "announcement reposted" in ctx.interaction.followup.sent[-1]["content"]

--- a/tests/test_ark_reminder_prefs_command.py
+++ b/tests/test_ark_reminder_prefs_command.py
@@ -150,7 +150,10 @@ async def test_ark_force_announce_manual_match_id_bypasses_dropdown(monkeypatch)
             "RegistrationChannelId": 123,
         }
 
-    async def _audit(**_kwargs):
+    captured = {}
+
+    async def _audit(**kwargs):
+        captured["audit"] = kwargs
         return 1
 
     class _Controller:
@@ -176,3 +179,45 @@ async def test_ark_force_announce_manual_match_id_bypasses_dropdown(monkeypatch)
     assert not ctx.interaction.edits
     assert ctx.interaction.followup.sent
     assert "announcement reposted" in ctx.interaction.followup.sent[-1]["content"]
+    assert captured["audit"]["details_json"]["source"] == "CommandManual"
+
+
+@pytest.mark.asyncio
+async def test_ark_force_announce_manual_failure_uses_repost_message(monkeypatch):
+    bot = DummyBot()
+    ark_cmds.register_ark(bot)
+    cmd = bot.registered["ark_force_announce"]
+    while hasattr(cmd, "__wrapped__"):
+        cmd = cmd.__wrapped__
+
+    async def _safe_defer(_ctx, ephemeral=True):
+        return None
+
+    async def _get_config():
+        return {"PlayersCap": 30, "SubsCap": 15}
+
+    async def _get_match(match_id):
+        return {
+            "MatchId": match_id,
+            "Status": "Scheduled",
+            "RegistrationChannelId": 123,
+        }
+
+    class _Controller:
+        def __init__(self, *, match_id, config):
+            self.match_id = match_id
+            self.config = config
+
+        async def ensure_registration_message(self, **_kwargs):
+            return None
+
+    monkeypatch.setattr("commands.ark_cmds.safe_defer", _safe_defer)
+    monkeypatch.setattr("commands.ark_cmds.get_config", _get_config)
+    monkeypatch.setattr("commands.ark_cmds.get_match", _get_match)
+    monkeypatch.setattr("commands.ark_cmds.ArkRegistrationController", _Controller)
+
+    ctx = DummyCtx(user_id=777)
+    await cmd(ctx, match_id=99)
+
+    assert ctx.interaction.followup.sent
+    assert "Failed to repost" in ctx.interaction.followup.sent[-1]["content"]

--- a/ui/views/ark_views.py
+++ b/ui/views/ark_views.py
@@ -601,6 +601,8 @@ RegistrationMaintenanceCallback = Callable[
 
 
 class ArkRegistrationMaintenanceView(discord.ui.View):
+    initial_content = "Pick an active Ark match, then choose refresh or force announce:"
+
     def __init__(
         self,
         *,
@@ -617,10 +619,11 @@ class ArkRegistrationMaintenanceView(discord.ui.View):
         self.on_refresh = on_refresh
         self.on_force_announce = on_force_announce
         self.on_cancel = on_cancel
+        self.match_labels_by_id: dict[int, str] = {}
 
         self.match_select = discord.ui.Select(
             placeholder="Select active Ark match",
-            options=[self._match_option(m) for m in matches][:25],
+            options=[self._match_option(m) for m in matches[:25]],
             min_values=1,
             max_values=1,
         )
@@ -647,8 +650,7 @@ class ArkRegistrationMaintenanceView(discord.ui.View):
         self.cancel_btn.callback = self._on_cancel
         self.add_item(self.cancel_btn)
 
-    @staticmethod
-    def _match_option(match: dict) -> discord.SelectOption:
+    def _match_option(self, match: dict) -> discord.SelectOption:
         alliance = (match.get("Alliance") or "").strip()
         weekend = match.get("ArkWeekendDate")
         day = match.get("MatchDay") or ""
@@ -658,7 +660,9 @@ class ArkRegistrationMaintenanceView(discord.ui.View):
         )
         weekend_str = weekend.strftime("%Y-%m-%d") if hasattr(weekend, "strftime") else str(weekend)
         label = f"{alliance} - {weekend_str} {day} {time_str} UTC"
-        return discord.SelectOption(label=label[:100], value=str(match["MatchId"]))
+        match_id = int(match["MatchId"])
+        self.match_labels_by_id[match_id] = label
+        return discord.SelectOption(label=label[:100], value=str(match_id))
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.author_id:
@@ -670,6 +674,15 @@ class ArkRegistrationMaintenanceView(discord.ui.View):
         self.selection.match_id = match_id
         self.refresh_btn.disabled = False
         self.force_btn.disabled = False
+
+    def message_content(self) -> str:
+        if not self.selection.match_id:
+            return self.initial_content
+        label = self.match_labels_by_id.get(self.selection.match_id, "selected match")
+        return (
+            f"Selected Ark match: {label} "
+            f"(ID {self.selection.match_id}). Choose refresh or force announce:"
+        )
 
     async def _send_error(self, interaction: discord.Interaction, message: str) -> None:
         if interaction.response.is_done():
@@ -698,7 +711,7 @@ class ArkRegistrationMaintenanceView(discord.ui.View):
             await interaction.response.send_message("No match selected.", ephemeral=True)
             return
         self._apply_match_selection(int(self.match_select.values[0]))
-        await interaction.response.edit_message(view=self)
+        await interaction.response.edit_message(content=self.message_content(), view=self)
 
     async def _on_refresh(self, interaction: discord.Interaction) -> None:
         if not self.selection.match_id:

--- a/ui/views/ark_views.py
+++ b/ui/views/ark_views.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime
+from inspect import isawaitable
 import logging
 
 import discord
@@ -589,7 +590,147 @@ class CancelArkMatchView(discord.ui.View):
         await interaction.response.edit_message(content="Cancelled.", view=None)
 
 
+@dataclass
+class ArkRegistrationMaintenanceSelection:
+    match_id: int | None = None
+
+
+RegistrationMaintenanceCallback = Callable[
+    [discord.Interaction, ArkRegistrationMaintenanceSelection], object
+]
+
+
+class ArkRegistrationMaintenanceView(discord.ui.View):
+    def __init__(
+        self,
+        *,
+        author_id: int,
+        matches: list[dict],
+        on_refresh: RegistrationMaintenanceCallback,
+        on_force_announce: RegistrationMaintenanceCallback,
+        on_cancel: OnCancel | None = None,
+        timeout: float = 300.0,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self.author_id = author_id
+        self.selection = ArkRegistrationMaintenanceSelection()
+        self.on_refresh = on_refresh
+        self.on_force_announce = on_force_announce
+        self.on_cancel = on_cancel
+
+        self.match_select = discord.ui.Select(
+            placeholder="Select active Ark match",
+            options=[self._match_option(m) for m in matches][:25],
+            min_values=1,
+            max_values=1,
+        )
+        self.match_select.callback = self._on_match
+        self.add_item(self.match_select)
+
+        self.refresh_btn = discord.ui.Button(
+            label="Refresh buttons",
+            style=discord.ButtonStyle.primary,
+            disabled=True,
+        )
+        self.refresh_btn.callback = self._on_refresh
+        self.add_item(self.refresh_btn)
+
+        self.force_btn = discord.ui.Button(
+            label="Repost + @everyone",
+            style=discord.ButtonStyle.danger,
+            disabled=True,
+        )
+        self.force_btn.callback = self._on_force_announce
+        self.add_item(self.force_btn)
+
+        self.cancel_btn = discord.ui.Button(label="Close", style=discord.ButtonStyle.secondary)
+        self.cancel_btn.callback = self._on_cancel
+        self.add_item(self.cancel_btn)
+
+    @staticmethod
+    def _match_option(match: dict) -> discord.SelectOption:
+        alliance = (match.get("Alliance") or "").strip()
+        weekend = match.get("ArkWeekendDate")
+        day = match.get("MatchDay") or ""
+        match_time = match.get("MatchTimeUtc")
+        time_str = (
+            match_time.strftime("%H:%M") if hasattr(match_time, "strftime") else str(match_time)
+        )
+        weekend_str = weekend.strftime("%Y-%m-%d") if hasattr(weekend, "strftime") else str(weekend)
+        label = f"{alliance} - {weekend_str} {day} {time_str} UTC"
+        return discord.SelectOption(label=label[:100], value=str(match["MatchId"]))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.author_id:
+            await interaction.response.send_message("This menu is not for you.", ephemeral=True)
+            return False
+        return True
+
+    def _apply_match_selection(self, match_id: int) -> None:
+        self.selection.match_id = match_id
+        self.refresh_btn.disabled = False
+        self.force_btn.disabled = False
+
+    async def _send_error(self, interaction: discord.Interaction, message: str) -> None:
+        if interaction.response.is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
+
+    async def _run_action(
+        self,
+        interaction: discord.Interaction,
+        callback: RegistrationMaintenanceCallback,
+        *,
+        log_message: str,
+        user_message: str,
+    ) -> None:
+        try:
+            result = callback(interaction, self.selection)
+            if isawaitable(result):
+                await result
+        except Exception:
+            logger.exception(log_message)
+            await self._send_error(interaction, user_message)
+
+    async def _on_match(self, interaction: discord.Interaction) -> None:
+        if not self.match_select.values:
+            await interaction.response.send_message("No match selected.", ephemeral=True)
+            return
+        self._apply_match_selection(int(self.match_select.values[0]))
+        await interaction.response.edit_message(view=self)
+
+    async def _on_refresh(self, interaction: discord.Interaction) -> None:
+        if not self.selection.match_id:
+            await interaction.response.send_message("No match selected.", ephemeral=True)
+            return
+        await self._run_action(
+            interaction,
+            self.on_refresh,
+            log_message="[ARK] Registration maintenance refresh handler failed",
+            user_message="Failed to refresh the registration message.",
+        )
+
+    async def _on_force_announce(self, interaction: discord.Interaction) -> None:
+        if not self.selection.match_id:
+            await interaction.response.send_message("No match selected.", ephemeral=True)
+            return
+        await self._run_action(
+            interaction,
+            self.on_force_announce,
+            log_message="[ARK] Registration maintenance force-announce handler failed",
+            user_message="Failed to repost the registration message.",
+        )
+
+    async def _on_cancel(self, interaction: discord.Interaction) -> None:
+        if self.on_cancel:
+            await self.on_cancel(interaction)
+            return
+        await interaction.response.edit_message(content="Closed.", view=None)
+
+
 GovernorSelectCallback = Callable[[discord.Interaction, str], object]
+TimeoutCallback = Callable[[], object]
 
 
 class ArkGovernorSelectView(discord.ui.View):
@@ -599,11 +740,13 @@ class ArkGovernorSelectView(discord.ui.View):
         author_id: int,
         options: list[discord.SelectOption],
         on_select: GovernorSelectCallback,
+        on_timeout_callback: TimeoutCallback | None = None,
         timeout: float = 120.0,
     ) -> None:
         super().__init__(timeout=timeout)
         self.author_id = author_id
         self._on_select = on_select
+        self._on_timeout_callback = on_timeout_callback
         self.message: discord.Message | None = None
 
         self.select = discord.ui.Select(
@@ -622,7 +765,15 @@ class ArkGovernorSelectView(discord.ui.View):
             if self.message:
                 await self.message.edit(view=self)
         except Exception:
-            pass
+            logger.exception("[ARK] Failed to disable governor selector after timeout")
+
+        if self._on_timeout_callback:
+            try:
+                result = self._on_timeout_callback()
+                if isawaitable(result):
+                    await result
+            except Exception:
+                logger.exception("[ARK] Governor selector timeout recovery failed")
 
     async def _handle_select(self, interaction: discord.Interaction):
         if interaction.user.id != self.author_id:


### PR DESCRIPTION
## Summary
- Fix Ark switch-governor flows so auto-selected steps do not remove buttons from the public signup embed.
- Add timeout recovery for governor selection views so the public registration message is refreshed when a follow-up selector expires.
- Replace `/ark_force_announce` raw match ID entry with an active-match dropdown that supports both no-ping button refresh and explicit `@everyone` repost.
- Include the current repository docs/task-pack updates requested for this PR.

## Validation
- `.\.venv\Scripts\python.exe -m py_compile commands\ark_cmds.py ark\registration_flow.py ui\views\ark_views.py tests\test_ark_registration_flow.py tests\test_ark_registration_maintenance_view.py tests\test_ark_reminder_prefs_command.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_registration_flow.py tests\test_ark_registration_maintenance_view.py tests\test_ark_reminder_prefs_command.py` (`24 passed`)
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_ui_imports.py tests\test_command_registration_smoke.py` (`2 passed`)
- `.\.venv\Scripts\python.exe -m pytest -q tests -k ark` (`508 passed, 2 skipped`)

## Review Gates
- Codex Security: passed. No reportable security findings in the reviewed diff. Local report: `C:\Users\cwatt\AppData\Local\Temp\codex-security-scans\discord_file_downloader\working-tree_20260526094921\report.md`.
- CodeRabbit: skipped/deferred by approval. The CLI is not installed and the official installer requires Linux/macOS/Windows WSL; WSL on this machine is not functional (`/bin/bash` missing).