### PR TITLE
[codex] Extract Phase 5A upload routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,6 @@ background, operational, promotion, domain, or template-support material.
   - `python scripts/validate_architecture_boundaries.py`
   - `python scripts/validate_deferred_items.py`
   - `python scripts/select_tests.py`
-- Before PR handoff, run or justify skipping a CodeRabbit follow-up review for non-trivial code
-  changes.
 - Run or justify skipping a Codex Security review when a change touches security-sensitive
   surfaces such as permissions, Discord interactions, SQL/data access, file handling,
   secrets/config, deployment, network calls, user-controlled input, or restart-sensitive

--- a/DL_bot.py
+++ b/DL_bot.py
@@ -132,10 +132,11 @@ from bot_config import (
 from bot_helpers import channel_queues
 from Commands import register_commands
 from embed_utils import send_embed
-from honor_importer import ingest_honor_snapshot, parse_honor_xlsx
 from kvk_all_importer import _auto_export_kvk
 from log_health import LogHeadroomError, preflight_from_env_sync
+from upload_routes.honor_route import HonorRouteDeps, handle_honor_upload
 from upload_routes.kvk_all_route import KvkAllRouteDeps, handle_kvk_all_upload
+from upload_routes.mge_results_route import MgeResultsRouteDeps, handle_mge_results_upload
 from upload_routes.player_location_route import (
     PlayerLocationRouteDeps,
     handle_player_location_upload,
@@ -601,83 +602,18 @@ async def on_message(message: discord.Message):
         return
 
     # === Fast-path: MGE results auto-import ===
-    if message.channel.id == MGE_DATA_CHANNEL_ID and message.attachments:
-        notify_ch = await _get_notify_channel() or message.channel
-        target = next(
-            (a for a in message.attachments if a.filename.lower().endswith(".xlsx")),
-            None,
-        )
-        if not target:
-            await send_embed(
-                notify_ch,
-                "MGE Results Import ⚠️",
-                {
-                    "Info": "No .xlsx file found.",
-                    "Expected": "mge_rankings_kd####_YYYYMMDD.xlsx",
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE67E22,
-            )
-            return
-
-        try:
-            file_bytes = await target.read()
-
-            # optional: same preflight used by other imports
-            ok = await ensure_sql_headroom_or_notify(notify_ch)
-            if not ok:
-                return
-
-            result = await _offload_callable(
-                __import__(
-                    "mge.mge_results_import", fromlist=["import_results_auto"]
-                ).import_results_auto,
-                file_bytes,
-                target.filename,
-                message.author.id,
-                name="import_results_auto",
-                prefer_process=True,
-                meta={"filename": target.filename, "channel_id": message.channel.id},
-            )
-
-            fields = {
-                "EventId": str(result["event_id"]),
-                "Mode": str(result["event_mode"]),
-                "Rows": str(result["rows"]),
-                "ImportId": str(result["import_id"]),
-                "File": target.filename,
-            }
-
-            # include report summary
-            report = result.get("report") or {}
-            if report.get("type") == "open_top15":
-                fields["Report"] = "Open Top-15 generated"
-            elif report.get("type") == "controlled_awarded_vs_actual":
-                fields["Awarded"] = str(report.get("awarded_total", 0))
-                fields["Matched"] = str(report.get("matched_actual_total", 0))
-
-            await send_embed(notify_ch, "MGE Results Import ✅", fields, 0x2ECC71)
-
-            try:
-                asyncio.create_task(trigger_log_backup_background())
-            except Exception:
-                logger.exception("Failed to schedule background log-backup trigger")
-
-        except Exception as e:
-            await send_embed(
-                notify_ch,
-                "MGE Results Import ❌",
-                {
-                    "Error": f"{type(e).__name__}: {e}",
-                    "File": target.filename,
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE74C3C,
-            )
-        finally:
-            return
+    if await handle_mge_results_upload(
+        message,
+        MgeResultsRouteDeps(
+            mge_data_channel_id=MGE_DATA_CHANNEL_ID,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+        ),
+    ):
+        return
 
     # === Fast-path: Pre-KVK snapshot ingest (dynamic KVK lookup) ===
     if await handle_prekvk_upload(
@@ -695,126 +631,19 @@ async def on_message(message: discord.Message):
         return
 
     # === Fast-path: KVK Honour ingest (full snapshots, multiple/day) ===
-    if message.channel.id == HONOR_CHANNEL_ID and message.attachments:
-        notify_ch = await _get_notify_channel() or message.channel
-
-        # Accept canonical + common variants (TEST_/DEMO_/SAMPLE_ prefix, extra words), .xlsx only
-        honor_name_rx = re.compile(
-            r"^(?:test_|demo_|sample_)?1198[_\s-]*honor.*\.xlsx$", re.IGNORECASE
-        )
-
-        target = next(
-            (a for a in message.attachments if honor_name_rx.match(a.filename.strip())), None
-        )
-
-        if not target:
-            await send_embed(
-                notify_ch,
-                "KVK Honor Import ⚠️",
-                {
-                    "Info": "No matching file found.",
-                    "Expected": "1198_honor.xlsx  • also accepts *1198_honor*.xlsx with optional TEST_/DEMO_/SAMPLE_ prefix",
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE67E22,
-            )
-            return
-
-        try:
-            # Decide test-mode from message text or filename
-            msg_text = (message.content or "").lower()
-            is_test = ("[test]" in msg_text) or (" test " in f" {msg_text} ")
-            is_test = is_test or target.filename.lower().startswith(("test_", "demo_", "sample_"))
-
-            # Read bytes once
-            file_bytes = await target.read()
-
-            # NEW: pre-parse for row count (used only for the status embed)
-            try:
-                pre_df = await _offload_callable(
-                    parse_honor_xlsx,
-                    file_bytes,
-                    name="parse_honor_xlsx",
-                    prefer_process=True,
-                    meta={"filename": target.filename},
-                )
-                row_count = len(pre_df)
-            except Exception:
-                row_count = 0  # don't fail the import if pre-parse fails
-
-            # NEW: preflight check
-            ok = await ensure_sql_headroom_or_notify(notify_ch)
-            if not ok:
-                return
-
-            # Ingest (blocking DB work off-loop) via offload helper
-            kvk_no, scan_id = await _offload_callable(
-                ingest_honor_snapshot,
-                file_bytes,
-                source_filename=target.filename,
-                scan_ts_utc=message.created_at,  # aware UTC from Discord
-                name="ingest_honor_snapshot",
-                prefer_process=True,
-                meta={"filename": target.filename},
-            )
-
-            # Success embed
-            await send_embed(
-                notify_ch,
-                "KVK Honor Import ✅" + (" (TEST)" if is_test else ""),
-                {
-                    "KVK": str(kvk_no),
-                    "ScanID": str(scan_id),
-                    "Rows": str(row_count),
-                    "Filename": target.filename,
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0x2ECC71,
-            )
-
-            # schedule a background log-backup trigger (best-effort)
-            try:
-                asyncio.create_task(trigger_log_backup_background())
-            except Exception:
-                logger.exception("Failed to schedule background log-backup trigger")
-
-            # Optional: refresh stats embed so Honour Top-3 appears/refreshes.
-            # Respect test-mode so it won't ping or claim daily limits.
-            try:
-                from stats_alerts.interface import send_stats_update_embed
-
-                sql_conn_str = (
-                    f"DRIVER={{ODBC Driver 17 for SQL Server}};"
-                    f"SERVER={os.environ.get('SQL_SERVER')};DATABASE={os.environ.get('SQL_DATABASE')};UID={os.environ.get('SQL_USERNAME')};PWD={os.environ.get('SQL_PASSWORD')};"
-                )
-                ts = utcnow().strftime("%Y-%m-%d %H:%M UTC")
-                await send_stats_update_embed(
-                    bot,
-                    ts,
-                    True,  # is_kvk=True (season path)
-                    sql_conn_str,
-                    is_test=is_test,  # <- critical
-                )
-            except Exception:
-                # Non-blocking nicety; ignore failures
-                pass
-
-        except Exception as e:
-            await send_embed(
-                notify_ch,
-                "KVK Honor Import ❌",
-                {
-                    "Error": f"{type(e).__name__}: {e}",
-                    "Filename": target.filename,
-                    "Channel": f"#{message.channel.name} ({message.channel.id})",
-                    "Uploader": f"{message.author} ({message.author.id})",
-                },
-                0xE74C3C,
-            )
-        finally:
-            return  # do not fall through to other pipelines
+    if await handle_honor_upload(
+        message,
+        HonorRouteDeps(
+            honor_channel_id=HONOR_CHANNEL_ID,
+            bot=bot,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+        ),
+    ):
+        return
 
     # --- Fast-path: Weekly activity ingest ---
     if message.channel.id == ACTIVITY_UPLOAD_CHANNEL_ID and message.attachments:

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -21,9 +21,8 @@ pytest -q tests
 python scripts/analyse_pytest_log_noise.py
 ```
 
-Before PR handoff, also run or justify skipping these AI-assisted review gates:
+Before PR handoff, also run or justify skipping this AI-assisted review gate:
 
-- CodeRabbit follow-up review for non-trivial code changes.
 - Codex Security review when the change touches permissions, Discord interactions, SQL/data
   access, file handling, secrets/config, deployment, network calls, user-controlled input, or
   restart-sensitive persistence.

--- a/docs/reference/K98 Bot - Coding Execution Guidelines.md
+++ b/docs/reference/K98 Bot - Coding Execution Guidelines.md
@@ -304,11 +304,10 @@ Additional rules:
 
 See `K98 Bot - Testing Standards.md` for the fuller matrix.
 
-## 15. AI Review Gates
+## 15. AI Review Gate
 
-Before PR handoff, run or justify skipping these AI-assisted review gates:
+Before PR handoff, run or justify skipping this AI-assisted review gate:
 
-- CodeRabbit follow-up review for non-trivial code changes.
 - Codex Security review when security-sensitive surfaces are touched.
 
 Security-sensitive surfaces include:
@@ -321,9 +320,9 @@ Security-sensitive surfaces include:
 - network calls, webhooks, external integrations, or user-controlled input parsing
 - restart-sensitive persistence, rehydration, scheduler state, or duplicate-action prevention
 
-For documentation-only, comment-only, or purely mechanical changes, these gates may be skipped
-when the skip is stated in the delivery output. If either review reports actionable issues, fix
-only issues within the approved scope unless the user approves expanding the task.
+For documentation-only, comment-only, or purely mechanical changes, this gate may be skipped when
+the skip is stated in the delivery output. If review reports actionable issues, fix only issues
+within the approved scope unless the user approves expanding the task.
 
 ## 16. Output Format For Delivered Work
 
@@ -336,7 +335,7 @@ When delivering code or a task pack, provide:
 5. refactor findings in touched areas
 6. test plan and commands run
 7. deployment / migration order
-8. CodeRabbit and Codex Security review status, including skip reasons
+8. Codex Security review status, including skip reason when not run
 9. follow-on debt or deferred improvements
 
 For documentation-only changes, state that no runtime code, SQL, helper reuse, or restart behaviour
@@ -358,7 +357,6 @@ A task is done only when:
 - [ ] restart safety is preserved
 - [ ] tests were added, updated, or explicitly ruled out
 - [ ] quality gates were considered
-- [ ] CodeRabbit review was run or explicitly skipped
 - [ ] Codex Security review was run or explicitly skipped based on risk triggers
 - [ ] deferred debt is captured using the Deferred Optimisation Framework format
 
@@ -378,12 +376,11 @@ python scripts/validate_command_registration.py
 For SQL-heavy, configuration-heavy, or domain-specific tasks, also include targeted validation
 commands relevant to the subsystem.
 
-Add AI-assisted review gates before PR handoff:
+Add the AI-assisted review gate before PR handoff:
 
-- CodeRabbit follow-up review for non-trivial code changes.
 - Codex Security review for changes touching the security-sensitive surfaces listed in section 15.
 
-If a gate is skipped, record the reason in the delivery output.
+If the gate is skipped, record the reason in the delivery output.
 
 ## 19. If Uncertain
 

--- a/docs/reference/K98 Bot - Skills & Refactor Triggers.md
+++ b/docs/reference/K98 Bot - Skills & Refactor Triggers.md
@@ -61,9 +61,8 @@ Ability to consider:
 
 Ability to:
 
-- use CodeRabbit as a follow-up reviewer for non-trivial code changes before PR handoff
 - use Codex Security when security-sensitive surfaces are touched
-- distinguish review gates from tests and avoid replacing local validation with AI review
+- distinguish security review from tests and avoid replacing local validation with AI review
 - document clear skip reasons for documentation-only, comment-only, or mechanical changes
 
 ## 2. Refactor Triggers
@@ -145,7 +144,7 @@ Expected response:
 6. What state must survive restart?
 7. What test types are required?
 8. Which conditional reference docs apply?
-9. Does the task trigger CodeRabbit or Codex Security review gates?
+9. Does the task trigger Codex Security review?
 10. What technical debt is obvious enough that leaving it untouched would likely repeat the
    problem later?
 
@@ -158,7 +157,7 @@ Expected response:
 5. Did I explicitly list any debt I chose not to fix?
 6. Would another engineer understand the flow from logs if it failed in production?
 7. Would the feature still behave correctly after a restart?
-8. Were CodeRabbit and Codex Security run or explicitly skipped with reasons?
+8. Was Codex Security run or explicitly skipped with reasons?
 
 ## 5. Practical Use In Task Packs
 
@@ -191,7 +190,7 @@ Before completion:
 - [ ] tests added, updated, or explicitly ruled out
 - [ ] logging adequate
 - [ ] restart safety preserved
-- [ ] CodeRabbit and Codex Security review gates run or skipped with reasons
+- [ ] Codex Security review gate run or skipped with reasons
 - [ ] follow-on debt listed if still present
 
 ## 7. Deferred Optimisation Handling

--- a/docs/reference/K98 Bot - Testing Standards.md
+++ b/docs/reference/K98 Bot - Testing Standards.md
@@ -172,9 +172,9 @@ For documentation-only changes, the architecture/deferred/test-selector scripts 
 minimum useful gate. Runtime pytest may be skipped when no code or test files changed, but the skip
 must be stated.
 
-AI-assisted review gates are separate from tests, but should be considered before PR handoff:
+The AI-assisted security review gate is separate from tests, but should be considered before PR
+handoff:
 
-- Run or justify skipping CodeRabbit follow-up review for non-trivial code changes.
 - Run or justify skipping Codex Security review when the change touches permissions, Discord
   interactions, SQL/data access, file handling, secrets/config, deployment, network calls,
   user-controlled input, or restart-sensitive persistence.
@@ -226,4 +226,4 @@ A change is test-ready when:
 - [ ] existing related tests were reviewed
 - [ ] focused and general validation commands are identified
 - [ ] documentation-only skips are explicitly justified
-- [ ] CodeRabbit and Codex Security review decisions are documented before PR handoff
+- [ ] Codex Security review decision is documented before PR handoff

--- a/docs/templates/Codex Task Pack Template.md
+++ b/docs/templates/Codex Task Pack Template.md
@@ -80,7 +80,6 @@ instead of deleting a skill silently.
 | `k98-deferred-optimisation-capture` | Audit or implementation finds out-of-scope debt, refactor triggers, duplicate helpers, direct SQL in commands/views, restart-safety gaps, or cleanup candidates. |
 | `k98-pr-review` | Before merge or PR handoff, to check architecture, SQL alignment, tests, deferred items, Discord safety, and promotion readiness. |
 | `k98-promotion-check` | Before production promotion, production PR creation, production merge, SQL deployment sequencing, or bot-machine deployment. |
-| `coderabbit:code-review` | Before PR handoff for non-trivial code changes, after local validation, to catch follow-up review issues. |
 | `codex-security:security-scan` | When security-sensitive surfaces are touched, including permissions, Discord interactions, SQL/data access, file handling, secrets/config, deployment, network calls, user-controlled input, or restart-sensitive persistence. |
 
 ### Skill Decisions
@@ -94,7 +93,6 @@ instead of deleting a skill silently.
 | `k98-deferred-optimisation-capture` | `<use | not applicable>` | `<why>` |
 | `k98-pr-review` | `<use | not applicable>` | `<why>` |
 | `k98-promotion-check` | `<use | not applicable>` | `<why>` |
-| `coderabbit:code-review` | `<use | not applicable>` | `<why>` |
 | `codex-security:security-scan` | `<use | not applicable>` | `<why>` |
 
 ## 8. Mandatory Workflow
@@ -106,8 +104,7 @@ Default workflow:
 3. Implementation plan, then stop for approval.
 4. Implementation after approval.
 5. Validation and final review.
-6. CodeRabbit follow-up review for non-trivial code changes, or documented skip reason.
-7. Codex Security review when risk triggers apply, or documented skip reason.
+6. Codex Security review when risk triggers apply, or documented skip reason.
 
 Proceed in one pass only when the user explicitly approves it.
 
@@ -216,9 +213,8 @@ consider:
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
 ```
 
-Before PR handoff, include AI-assisted review gate decisions:
+Before PR handoff, include the AI-assisted review gate decision:
 
-- CodeRabbit follow-up review for non-trivial code changes, or a documented skip reason.
 - Codex Security review when security-sensitive surfaces are touched, or a documented skip reason.
 
 ## 15. Acceptance Criteria
@@ -231,7 +227,6 @@ Before PR handoff, include AI-assisted review gate decisions:
 - [ ] Restart safety is preserved or explicitly not applicable.
 - [ ] Tests were added/updated or a clear testing exception is documented.
 - [ ] Quality gates were run or documented.
-- [ ] CodeRabbit follow-up review was run or explicitly skipped.
 - [ ] Codex Security review was run or explicitly skipped based on risk triggers.
 - [ ] Deferred optimisations are captured structurally.
 
@@ -271,7 +266,6 @@ changed.
 
 ## AI Review Gates
 
-- CodeRabbit: <run | skipped, with reason>
 - Codex Security: <run | skipped, with reason>
 
 ## Deferred Optimisations

--- a/tests/test_honor_upload_route.py
+++ b/tests/test_honor_upload_route.py
@@ -161,8 +161,7 @@ async def test_honor_route_sql_preflight_abort_skips_ingest():
 
     assert handled is True
     assert sent == []
-    assert len(offloads) == 1
-    assert offloads[0][0] is route.parse_honor_xlsx
+    assert offloads == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_honor_upload_route.py
+++ b/tests/test_honor_upload_route.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import logging
+
+import pytest
+
+from upload_routes import honor_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"xlsx"):
+        self.filename = filename
+        self._payload = payload
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "honor"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeBot:
+    pass
+
+
+class _FakeParsedHonor:
+    def __len__(self) -> int:
+        return 4
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None, content: str = ""):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments if attachments is not None else [_FakeAttachment("1198_honor.xlsx")]
+        )
+        self.content = content
+        self.created_at = datetime(2026, 5, 24, 10, 30, tzinfo=UTC)
+
+
+def _message(channel_id: int = 10, attachments=None, content: str = "") -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments, content)
+
+
+def _deps(**overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+    stats_refreshes = []
+
+    async def get_notify_channel():
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+
+    async def ensure_sql_headroom_or_notify(ch):
+        return overrides.get("sql_ok", True)
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if func is route.parse_honor_xlsx:
+            if "parse_exception" in overrides:
+                raise overrides["parse_exception"]
+            return overrides.get("parse_result", _FakeParsedHonor())
+        if "ingest_exception" in overrides:
+            raise overrides["ingest_exception"]
+        return overrides.get("ingest_result", (15, 9))
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    async def send_stats_update_embed(*args, **kwargs):
+        stats_refreshes.append((args, kwargs))
+        if "stats_exception" in overrides:
+            raise overrides["stats_exception"]
+
+    deps = route.HonorRouteDeps(
+        honor_channel_id=10,
+        bot=overrides.get("bot", _FakeBot()),
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        create_task=create_task,
+        send_stats_update_embed=overrides.get("send_stats_update_embed", send_stats_update_embed),
+        now_utc=lambda: datetime(2026, 5, 24, 12, 45, tzinfo=UTC),
+        sql_conn_str_factory=lambda: "conn",
+    )
+    return deps, sent, offloads, created_tasks, stats_refreshes
+
+
+@pytest.mark.asyncio
+async def test_honor_route_ignores_other_channels():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_honor_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_honor_route_ignores_empty_attachments():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_honor_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_honor_route_no_matching_file_warns_and_handles():
+    deps, sent, offloads, _created, _stats = _deps()
+
+    handled = await route.handle_honor_upload(
+        _message(attachments=[_FakeAttachment("unrelated.xlsx")]), deps
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "KVK Honor Import \u26a0\ufe0f"
+    assert fields["Info"] == "No matching file found."
+    assert fields["Expected"] == (
+        "1198_honor.xlsx  \u2022 also accepts *1198_honor*.xlsx with optional "
+        "TEST_/DEMO_/SAMPLE_ prefix"
+    )
+    assert fields["Channel"] == "#honor (10)"
+    assert fields["Uploader"] == "uploader (123456789)"
+    assert color == 0xE67E22
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_honor_route_sql_preflight_abort_skips_ingest():
+    deps, sent, offloads, _created, _stats = _deps(sql_ok=False)
+
+    handled = await route.handle_honor_upload(_message(), deps)
+
+    assert handled is True
+    assert sent == []
+    assert len(offloads) == 1
+    assert offloads[0][0] is route.parse_honor_xlsx
+
+
+@pytest.mark.asyncio
+async def test_honor_route_success_preserves_import_contract_and_side_effects():
+    deps, sent, offloads, created, stats = _deps()
+
+    handled = await route.handle_honor_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 2
+    parse_func, parse_args, parse_kwargs = offloads[0]
+    assert parse_func is route.parse_honor_xlsx
+    assert parse_args == (b"xlsx",)
+    assert parse_kwargs["name"] == "parse_honor_xlsx"
+    assert parse_kwargs["prefer_process"] is True
+    assert parse_kwargs["meta"] == {"filename": "1198_honor.xlsx"}
+    ingest_func, ingest_args, ingest_kwargs = offloads[1]
+    assert ingest_func is route.ingest_honor_snapshot
+    assert ingest_args == (b"xlsx",)
+    assert ingest_kwargs["source_filename"] == "1198_honor.xlsx"
+    assert ingest_kwargs["scan_ts_utc"] == datetime(2026, 5, 24, 10, 30, tzinfo=UTC)
+    assert ingest_kwargs["name"] == "ingest_honor_snapshot"
+    assert ingest_kwargs["prefer_process"] is True
+    assert ingest_kwargs["meta"] == {"filename": "1198_honor.xlsx"}
+    assert len(created) == 1
+    assert len(stats) == 1
+    stats_args, stats_kwargs = stats[0]
+    assert stats_args == (deps.bot, "2026-05-24 12:45 UTC", True, "conn")
+    assert stats_kwargs == {"is_test": False}
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "KVK Honor Import \u2705"
+    assert fields["KVK"] == "15"
+    assert fields["ScanID"] == "9"
+    assert fields["Rows"] == "4"
+    assert fields["Filename"] == "1198_honor.xlsx"
+    assert color == 0x2ECC71
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_honor_route_test_mode_preserved_for_prefixed_filename():
+    deps, sent, _offloads, _created, stats = _deps()
+
+    handled = await route.handle_honor_upload(
+        _message(attachments=[_FakeAttachment("test_1198_honor.xlsx")]), deps
+    )
+
+    assert handled is True
+    assert sent[-1][1] == "KVK Honor Import \u2705 (TEST)"
+    assert stats[-1][1] == {"is_test": True}
+
+
+@pytest.mark.asyncio
+async def test_honor_route_parse_failure_preserves_zero_row_count():
+    deps, sent, offloads, _created, _stats = _deps(parse_exception=ValueError("bad sheet"))
+
+    handled = await route.handle_honor_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 2
+    _ch, _title, fields, _color, _mention = sent[-1]
+    assert fields["Rows"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_honor_route_ingest_exception_sends_existing_error():
+    deps, sent, _offloads, created, stats = _deps(ingest_exception=RuntimeError("boom"))
+
+    handled = await route.handle_honor_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    assert stats == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "KVK Honor Import \u274c"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert fields["Filename"] == "1198_honor.xlsx"
+    assert fields["Channel"] == "#honor (10)"
+    assert fields["Uploader"] == "uploader (123456789)"
+    assert color == 0xE74C3C
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_honor_route_stats_refresh_failure_is_best_effort(caplog):
+    deps, sent, _offloads, created, stats = _deps(stats_exception=RuntimeError("stats down"))
+    caplog.set_level(logging.DEBUG, logger=route.__name__)
+
+    handled = await route.handle_honor_upload(_message(), deps)
+
+    assert handled is True
+    assert len(created) == 1
+    assert len(stats) == 1
+    assert sent[-1][1] == "KVK Honor Import \u2705"
+    assert "Failed to refresh stats embed after KVK Honor import" in caplog.text

--- a/tests/test_mge_results_upload_route.py
+++ b/tests/test_mge_results_upload_route.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import pytest
+
+from upload_routes import mge_results_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"xlsx"):
+        self.filename = filename
+        self._payload = payload
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "mge-data"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments
+            if attachments is not None
+            else [_FakeAttachment("mge_rankings_kd1198_20260311.xlsx")]
+        )
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _success_result(**overrides):
+    result = {
+        "event_id": 42,
+        "event_mode": "open",
+        "rows": 3,
+        "import_id": 77,
+        "report": {"type": "open_top15"},
+    }
+    result.update(overrides)
+    return result
+
+
+def _deps(**overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+
+    async def get_notify_channel():
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+
+    async def ensure_sql_headroom_or_notify(ch):
+        return overrides.get("sql_ok", True)
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_exception" in overrides:
+            raise overrides["offload_exception"]
+        return overrides.get("offload_result", _success_result())
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    deps = route.MgeResultsRouteDeps(
+        mge_data_channel_id=10,
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        create_task=create_task,
+    )
+    return deps, sent, offloads, created_tasks
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_ignores_other_channels():
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_mge_results_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_ignores_empty_attachments():
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_mge_results_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_no_xlsx_warns_and_handles():
+    deps, sent, offloads, _created = _deps()
+
+    handled = await route.handle_mge_results_upload(
+        _message(attachments=[_FakeAttachment("notes.txt")]), deps
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "MGE Results Import \u26a0\ufe0f"
+    assert fields["Info"] == "No .xlsx file found."
+    assert fields["Expected"] == "mge_rankings_kd####_YYYYMMDD.xlsx"
+    assert fields["Channel"] == "#mge-data (10)"
+    assert fields["Uploader"] == "uploader (123456789)"
+    assert color == 0xE67E22
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_sql_preflight_abort_skips_import():
+    deps, sent, offloads, _created = _deps(sql_ok=False)
+
+    handled = await route.handle_mge_results_upload(_message(), deps)
+
+    assert handled is True
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_success_preserves_import_contract_and_side_effects():
+    deps, sent, offloads, created = _deps()
+
+    handled = await route.handle_mge_results_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    assert func is route.import_results_auto
+    assert args == (b"xlsx", "mge_rankings_kd1198_20260311.xlsx", 123456789)
+    assert kwargs["name"] == "import_results_auto"
+    assert kwargs["prefer_process"] is True
+    assert kwargs["meta"] == {
+        "filename": "mge_rankings_kd1198_20260311.xlsx",
+        "channel_id": 10,
+    }
+    assert len(created) == 1
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "MGE Results Import \u2705"
+    assert fields["EventId"] == "42"
+    assert fields["Mode"] == "open"
+    assert fields["Rows"] == "3"
+    assert fields["ImportId"] == "77"
+    assert fields["File"] == "mge_rankings_kd1198_20260311.xlsx"
+    assert fields["Report"] == "Open Top-15 generated"
+    assert color == 0x2ECC71
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_controlled_report_preserves_summary_fields():
+    deps, sent, _offloads, _created = _deps(
+        offload_result=_success_result(
+            event_mode="fixed",
+            report={
+                "type": "controlled_awarded_vs_actual",
+                "awarded_total": 7,
+                "matched_actual_total": 5,
+            },
+        )
+    )
+
+    handled = await route.handle_mge_results_upload(_message(), deps)
+
+    assert handled is True
+    _ch, _title, fields, _color, _mention = sent[-1]
+    assert fields["Awarded"] == "7"
+    assert fields["Matched"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_mge_results_route_importer_exception_sends_existing_error():
+    deps, sent, _offloads, created = _deps(offload_exception=RuntimeError("boom"))
+
+    handled = await route.handle_mge_results_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "MGE Results Import \u274c"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert fields["File"] == "mge_rankings_kd1198_20260311.xlsx"
+    assert fields["Channel"] == "#mge-data (10)"
+    assert fields["Uploader"] == "uploader (123456789)"
+    assert color == 0xE74C3C
+    assert mention is None

--- a/tests/test_mge_results_upload_route.py
+++ b/tests/test_mge_results_upload_route.py
@@ -54,6 +54,10 @@ def _success_result(**overrides):
     return result
 
 
+def _fake_import_results_auto(*_args, **_kwargs):
+    raise AssertionError("offload test double should not call importer directly")
+
+
 def _deps(**overrides):
     sent = []
     offloads = []
@@ -150,13 +154,19 @@ async def test_mge_results_route_sql_preflight_abort_skips_import():
 @pytest.mark.asyncio
 async def test_mge_results_route_success_preserves_import_contract_and_side_effects():
     deps, sent, offloads, created = _deps()
+    route_import = _fake_import_results_auto
 
-    handled = await route.handle_mge_results_upload(_message(), deps)
+    original_loader = route._load_import_results_auto
+    route._load_import_results_auto = lambda: route_import
+    try:
+        handled = await route.handle_mge_results_upload(_message(), deps)
+    finally:
+        route._load_import_results_auto = original_loader
 
     assert handled is True
     assert len(offloads) == 1
     func, args, kwargs = offloads[0]
-    assert func is route.import_results_auto
+    assert func is route_import
     assert args == (b"xlsx", "mge_rankings_kd1198_20260311.xlsx", 123456789)
     assert kwargs["name"] == "import_results_auto"
     assert kwargs["prefer_process"] is True

--- a/upload_routes/common.py
+++ b/upload_routes/common.py
@@ -1,0 +1,49 @@
+"""Shared helpers for DL_bot upload message routes."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import logging
+from typing import Any
+
+
+async def resolve_notify_channel(
+    get_notify_channel: Callable[[], Awaitable[Any | None]],
+    fallback_channel: Any,
+    logger: logging.Logger,
+    route_name: str,
+) -> Any:
+    """Resolve the notification channel, falling back to the source channel."""
+    try:
+        return await get_notify_channel() or fallback_channel
+    except Exception:
+        logger.debug(
+            "%s_notify_channel_resolution_failed",
+            route_name,
+            exc_info=True,
+        )
+        return fallback_channel
+
+
+def message_source_fields(message: Any) -> dict[str, str]:
+    """Return the common source/uploader fields used by upload result embeds."""
+    return {
+        "Channel": f"#{message.channel.name} ({message.channel.id})",
+        "Uploader": f"{message.author} ({message.author.id})",
+    }
+
+
+def schedule_best_effort(
+    create_task: Callable[[Awaitable[Any]], Any],
+    awaitable: Awaitable[Any],
+    logger: logging.Logger,
+    failure_message: str,
+) -> None:
+    """Schedule a best-effort background task without affecting the route result."""
+    try:
+        create_task(awaitable)
+    except Exception:
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+        logger.exception(failure_message)

--- a/upload_routes/honor_route.py
+++ b/upload_routes/honor_route.py
@@ -1,0 +1,155 @@
+"""KVK Honor workbook upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+import os
+import re
+from typing import Any
+
+from honor_importer import ingest_honor_snapshot, parse_honor_xlsx
+from upload_routes.common import message_source_fields, resolve_notify_channel, schedule_best_effort
+from utils import utcnow
+
+logger = logging.getLogger(__name__)
+
+HONOR_NAME_RX = re.compile(
+    r"^(?:test_|demo_|sample_)?1198[_\s-]*honor.*\.xlsx$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class HonorRouteDeps:
+    honor_channel_id: int
+    bot: Any
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+    send_stats_update_embed: Callable[..., Awaitable[Any]] | None = None
+    now_utc: Callable[[], Any] = utcnow
+    sql_conn_str_factory: Callable[[], str] | None = None
+
+
+def _is_test_upload(message: Any, filename: str) -> bool:
+    msg_text = (message.content or "").lower()
+    return (
+        ("[test]" in msg_text)
+        or (" test " in f" {msg_text} ")
+        or filename.lower().startswith(("test_", "demo_", "sample_"))
+    )
+
+
+def _sql_conn_str_from_env() -> str:
+    return (
+        f"DRIVER={{ODBC Driver 17 for SQL Server}};"
+        f"SERVER={os.environ.get('SQL_SERVER')};DATABASE={os.environ.get('SQL_DATABASE')};UID={os.environ.get('SQL_USERNAME')};PWD={os.environ.get('SQL_PASSWORD')};"
+    )
+
+
+async def _refresh_stats_embed(deps: HonorRouteDeps, is_test: bool) -> None:
+    stats_refresh = deps.send_stats_update_embed
+    if stats_refresh is None:
+        from stats_alerts.interface import send_stats_update_embed as stats_refresh
+
+    sql_conn_str = (
+        deps.sql_conn_str_factory() if deps.sql_conn_str_factory else _sql_conn_str_from_env()
+    )
+    ts = deps.now_utc().strftime("%Y-%m-%d %H:%M UTC")
+    await stats_refresh(deps.bot, ts, True, sql_conn_str, is_test=is_test)
+
+
+async def handle_honor_upload(message: Any, deps: HonorRouteDeps) -> bool:
+    """Handle KVK Honor workbook imports from the configured upload channel."""
+    if message.channel.id != deps.honor_channel_id or not message.attachments:
+        return False
+
+    notify_ch = await resolve_notify_channel(
+        deps.get_notify_channel,
+        message.channel,
+        logger,
+        "honor_upload",
+    )
+
+    target = next(
+        (a for a in message.attachments if HONOR_NAME_RX.match(a.filename.strip())),
+        None,
+    )
+    if not target:
+        fields = {
+            "Info": "No matching file found.",
+            "Expected": "1198_honor.xlsx  • also accepts *1198_honor*.xlsx with optional TEST_/DEMO_/SAMPLE_ prefix",
+            **message_source_fields(message),
+        }
+        await deps.send_embed(notify_ch, "KVK Honor Import ⚠️", fields, 0xE67E22)
+        return True
+
+    try:
+        is_test = _is_test_upload(message, target.filename)
+        file_bytes = await target.read()
+
+        try:
+            pre_df = await deps.offload_callable(
+                parse_honor_xlsx,
+                file_bytes,
+                name="parse_honor_xlsx",
+                prefer_process=True,
+                meta={"filename": target.filename},
+            )
+            row_count = len(pre_df)
+        except Exception:
+            row_count = 0
+
+        ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+        if not ok:
+            return True
+
+        kvk_no, scan_id = await deps.offload_callable(
+            ingest_honor_snapshot,
+            file_bytes,
+            source_filename=target.filename,
+            scan_ts_utc=message.created_at,
+            name="ingest_honor_snapshot",
+            prefer_process=True,
+            meta={"filename": target.filename},
+        )
+
+        fields = {
+            "KVK": str(kvk_no),
+            "ScanID": str(scan_id),
+            "Rows": str(row_count),
+            "Filename": target.filename,
+            **message_source_fields(message),
+        }
+        await deps.send_embed(
+            notify_ch,
+            "KVK Honor Import ✅" + (" (TEST)" if is_test else ""),
+            fields,
+            0x2ECC71,
+        )
+
+        schedule_best_effort(
+            deps.create_task,
+            deps.trigger_log_backup_background(),
+            logger,
+            "Failed to schedule background log-backup trigger",
+        )
+
+        try:
+            await _refresh_stats_embed(deps, is_test)
+        except Exception:
+            logger.debug("Failed to refresh stats embed after KVK Honor import", exc_info=True)
+    except Exception as e:
+        fields = {
+            "Error": f"{type(e).__name__}: {e}",
+            "Filename": target.filename,
+            **message_source_fields(message),
+        }
+        await deps.send_embed(notify_ch, "KVK Honor Import ❌", fields, 0xE74C3C)
+    return True

--- a/upload_routes/honor_route.py
+++ b/upload_routes/honor_route.py
@@ -104,6 +104,7 @@ async def handle_honor_upload(message: Any, deps: HonorRouteDeps) -> bool:
             )
             row_count = len(pre_df)
         except Exception:
+            logger.debug("honor_upload_row_count_parse_failed", exc_info=True)
             row_count = 0
 
         ok = await deps.ensure_sql_headroom_or_notify(notify_ch)

--- a/upload_routes/honor_route.py
+++ b/upload_routes/honor_route.py
@@ -92,8 +92,12 @@ async def handle_honor_upload(message: Any, deps: HonorRouteDeps) -> bool:
 
     try:
         is_test = _is_test_upload(message, target.filename)
-        file_bytes = await target.read()
 
+        ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+        if not ok:
+            return True
+
+        file_bytes = await target.read()
         try:
             pre_df = await deps.offload_callable(
                 parse_honor_xlsx,
@@ -106,10 +110,6 @@ async def handle_honor_upload(message: Any, deps: HonorRouteDeps) -> bool:
         except Exception:
             logger.debug("honor_upload_row_count_parse_failed", exc_info=True)
             row_count = 0
-
-        ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
-        if not ok:
-            return True
 
         kvk_no, scan_id = await deps.offload_callable(
             ingest_honor_snapshot,

--- a/upload_routes/mge_results_route.py
+++ b/upload_routes/mge_results_route.py
@@ -56,11 +56,11 @@ async def handle_mge_results_upload(message: Any, deps: MgeResultsRouteDeps) -> 
         return True
 
     try:
-        file_bytes = await target.read()
-
         ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
         if not ok:
             return True
+
+        file_bytes = await target.read()
 
         result = await deps.offload_callable(
             _load_import_results_auto(),

--- a/upload_routes/mge_results_route.py
+++ b/upload_routes/mge_results_route.py
@@ -1,0 +1,99 @@
+"""MGE results workbook upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from mge.mge_results_import import import_results_auto
+from upload_routes.common import message_source_fields, resolve_notify_channel, schedule_best_effort
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MgeResultsRouteDeps:
+    mge_data_channel_id: int
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+
+
+async def handle_mge_results_upload(message: Any, deps: MgeResultsRouteDeps) -> bool:
+    """Handle automatic MGE results imports from the configured data channel."""
+    if message.channel.id != deps.mge_data_channel_id or not message.attachments:
+        return False
+
+    notify_ch = await resolve_notify_channel(
+        deps.get_notify_channel,
+        message.channel,
+        logger,
+        "mge_results_upload",
+    )
+
+    target = next(
+        (a for a in message.attachments if a.filename.lower().endswith(".xlsx")),
+        None,
+    )
+    if not target:
+        fields = {
+            "Info": "No .xlsx file found.",
+            "Expected": "mge_rankings_kd####_YYYYMMDD.xlsx",
+            **message_source_fields(message),
+        }
+        await deps.send_embed(notify_ch, "MGE Results Import ⚠️", fields, 0xE67E22)
+        return True
+
+    try:
+        file_bytes = await target.read()
+
+        ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+        if not ok:
+            return True
+
+        result = await deps.offload_callable(
+            import_results_auto,
+            file_bytes,
+            target.filename,
+            message.author.id,
+            name="import_results_auto",
+            prefer_process=True,
+            meta={"filename": target.filename, "channel_id": message.channel.id},
+        )
+
+        fields = {
+            "EventId": str(result["event_id"]),
+            "Mode": str(result["event_mode"]),
+            "Rows": str(result["rows"]),
+            "ImportId": str(result["import_id"]),
+            "File": target.filename,
+        }
+
+        report = result.get("report") or {}
+        if report.get("type") == "open_top15":
+            fields["Report"] = "Open Top-15 generated"
+        elif report.get("type") == "controlled_awarded_vs_actual":
+            fields["Awarded"] = str(report.get("awarded_total", 0))
+            fields["Matched"] = str(report.get("matched_actual_total", 0))
+
+        await deps.send_embed(notify_ch, "MGE Results Import ✅", fields, 0x2ECC71)
+        schedule_best_effort(
+            deps.create_task,
+            deps.trigger_log_backup_background(),
+            logger,
+            "Failed to schedule background log-backup trigger",
+        )
+    except Exception as e:
+        fields = {
+            "Error": f"{type(e).__name__}: {e}",
+            "File": target.filename,
+            **message_source_fields(message),
+        }
+        await deps.send_embed(notify_ch, "MGE Results Import ❌", fields, 0xE74C3C)
+    return True

--- a/upload_routes/mge_results_route.py
+++ b/upload_routes/mge_results_route.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from mge.mge_results_import import import_results_auto
 from upload_routes.common import message_source_fields, resolve_notify_channel, schedule_best_effort
 
 logger = logging.getLogger(__name__)
@@ -23,6 +22,12 @@ class MgeResultsRouteDeps:
     offload_callable: Callable[..., Awaitable[Any]]
     trigger_log_backup_background: Callable[[], Awaitable[Any]]
     create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+
+
+def _load_import_results_auto() -> Callable[..., dict[str, Any]]:
+    from mge.mge_results_import import import_results_auto
+
+    return import_results_auto
 
 
 async def handle_mge_results_upload(message: Any, deps: MgeResultsRouteDeps) -> bool:
@@ -58,7 +63,7 @@ async def handle_mge_results_upload(message: Any, deps: MgeResultsRouteDeps) -> 
             return True
 
         result = await deps.offload_callable(
-            import_results_auto,
+            _load_import_results_auto(),
             file_bytes,
             target.filename,
             message.author.id,


### PR DESCRIPTION
## Summary

- Extract the Phase 5A DL_bot upload fast paths for MGE results and KVK Honor into dedicated `upload_routes` modules.
- Add a small shared upload-route helper module for notify-channel fallback, common source/uploader fields, and best-effort task scheduling so later Phase 5B/5C work can reuse the same conventions without copy-paste.
- Keep `DL_bot.py` responsible for listener ordering and delegation only for these routes, preserving route order, fall-through behavior, Discord output, importer contracts, SQL preflight behavior, stats refresh, and log-backup scheduling.
- Include the updated repository docs requested for this PR.

## Review Status

Draft replacement for closed PR #112. PR #112 was closed after Copilot review jobs errored with exit code 1 and the Claude review failed. Keep this PR in draft until review automation is ready to be retried.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_mge_results_upload_route.py tests/test_honor_upload_route.py tests/test_dl_bot_mge_auto_import.py` -> 19 passed
- `./.venv/Scripts/python.exe -m pytest -q tests/test_mge_results_import.py tests/test_mge_results_import_service.py tests/test_honor_importer.py` -> 11 passed
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py` -> passed
- `./.venv/Scripts/python.exe scripts/select_tests.py` -> ran
- `./.venv/Scripts/python.exe scripts/smoke_imports.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` -> passed with existing secondary-surface duplicate notices
- `./.venv/Scripts/python.exe -m pre_commit run -a` -> passed
- `./.venv/Scripts/python.exe -m pytest -q tests` -> 1498 passed, 2 skipped
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py` -> 1498 passed, 2 skipped; production operational logs unchanged

## SQL Changes

None.

## Deferred Optimisations

- Phase 5B/5C should continue extracting the remaining upload routes in small slices: inventory wrapper, weekly activity, rally forts, and monitored-channel fallback queueing.
- Shared helper extraction should remain evidence-led: reuse `upload_routes.common` where behavior is identical, and add new shared helpers only when later routes prove the same contract clearly enough to test.