### PR TITLE
[codex] Extract Phase 5B upload routes

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -135,6 +135,7 @@ from embed_utils import send_embed
 from kvk_all_importer import _auto_export_kvk
 from log_health import LogHeadroomError, preflight_from_env_sync
 from upload_routes.honor_route import HonorRouteDeps, handle_honor_upload
+from upload_routes.inventory_route import InventoryRouteDeps, handle_inventory_upload
 from upload_routes.kvk_all_route import KvkAllRouteDeps, handle_kvk_all_upload
 from upload_routes.mge_results_route import MgeResultsRouteDeps, handle_mge_results_upload
 from upload_routes.player_location_route import (
@@ -142,8 +143,11 @@ from upload_routes.player_location_route import (
     handle_player_location_upload,
 )
 from upload_routes.prekvk_route import PreKvkRouteDeps, handle_prekvk_upload
+from upload_routes.weekly_activity_route import (
+    WeeklyActivityRouteDeps,
+    handle_weekly_activity_upload,
+)
 from utils import live_queue, update_live_queue_embed, utcnow
-from weekly_activity_importer import ingest_weekly_activity_excel
 
 # === Load environment variables ===
 if not TOKEN:
@@ -561,31 +565,14 @@ async def on_message(message: discord.Message):
             logger.exception("mge_dm_followup_route_unexpected_failed")
 
     # === Fast-path: inventory image upload-first import ===
-    if (
-        INVENTORY_UPLOAD_CHANNEL_ID
-        and message.channel.id == INVENTORY_UPLOAD_CHANNEL_ID
-        and message.attachments
+    if await handle_inventory_upload(
+        message,
+        InventoryRouteDeps(
+            inventory_upload_channel_id=INVENTORY_UPLOAD_CHANNEL_ID,
+            bot=bot,
+        ),
     ):
-        try:
-            from ui.views.inventory_views import handle_inventory_upload_message
-
-            handled = await handle_inventory_upload_message(message, bot)
-            if handled:
-                return
-        except Exception:
-            logger.exception(
-                "inventory_upload_first_route_failed message_id=%s channel_id=%s",
-                getattr(message, "id", None),
-                getattr(getattr(message, "channel", None), "id", None),
-            )
-            try:
-                await message.channel.send(
-                    f"<@{message.author.id}> Inventory import failed unexpectedly. Please try again.",
-                    delete_after=120,
-                )
-            except Exception:
-                pass
-            return
+        return
 
     # === Fast-path: Player Location CSV auto-import ===
     if await handle_player_location_upload(
@@ -646,90 +633,22 @@ async def on_message(message: discord.Message):
         return
 
     # --- Fast-path: Weekly activity ingest ---
-    if message.channel.id == ACTIVITY_UPLOAD_CHANNEL_ID and message.attachments:
-        target = next(
-            (
-                a
-                for a in message.attachments
-                if a.filename.lower().endswith("1198_alliance_activity.xlsx")
-            ),
-            None,
-        )
-        if target:
-            target_ch = message.channel
-            try:
-                notify = await _get_notify_channel()
-                if notify:
-                    target_ch = notify
-            except Exception:
-                pass
-
-            try:
-                file_bytes = await target.read()
-                # NEW: preflight check
-                ok = await ensure_sql_headroom_or_notify(target_ch)
-                if not ok:
-                    return
-
-                snap_id, row_count = await _offload_callable(
-                    ingest_weekly_activity_excel,
-                    content=file_bytes,
-                    snapshot_ts_utc=message.created_at,
-                    message_id=message.id,
-                    channel_id=message.channel.id,
-                    server=os.environ.get("SQL_SERVER"),
-                    database=os.environ.get("SQL_DATABASE"),
-                    username=os.environ.get("SQL_USERNAME"),
-                    password=os.environ.get("SQL_PASSWORD"),
-                    source_filename=target.filename,
-                    name="ingest_weekly_activity_excel",
-                    prefer_process=True,
-                    meta={"filename": target.filename},
-                )
-                if snap_id == 0:
-                    await send_embed(
-                        target_ch,
-                        "Alliance Activity Import",
-                        {"Status": "Duplicate detected for this week. Skipped."},
-                        0xF1C40F,
-                    )
-                else:
-                    await send_embed(
-                        target_ch,
-                        "Alliance Activity Import ✅",
-                        {
-                            "SnapshotId": str(snap_id),
-                            "Rows": str(row_count),
-                            "Filename": target.filename,
-                            "Channel": f"#{message.channel.name} ({message.channel.id})",
-                            "Uploader": f"{message.author} ({message.author.id})",
-                            "Note": "",
-                        },
-                        0x2ECC71,
-                    )
-
-                    # schedule a background log-backup trigger (best-effort)
-                    try:
-                        asyncio.create_task(trigger_log_backup_background())
-                    except Exception:
-                        logger.exception("Failed to schedule background log-backup trigger")
-
-            except Exception as e:
-                await send_embed(
-                    target_ch,
-                    "Alliance Activity Import ❌",
-                    {
-                        "Error": f"{type(e).__name__}: {e}",
-                        "Filename": target.filename,
-                        "Channel": f"#{message.channel.name} ({message.channel.id})",
-                        "Uploader": f"{message.author} ({message.author.id})",
-                    },
-                    0xE74C3C,
-                    mention=None,
-                )
-            finally:
-                # do not fall through to other pipeline logic
-                return
+    if await handle_weekly_activity_upload(
+        message,
+        WeeklyActivityRouteDeps(
+            activity_upload_channel_id=ACTIVITY_UPLOAD_CHANNEL_ID,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+            server=os.environ.get("SQL_SERVER"),
+            database=os.environ.get("SQL_DATABASE"),
+            username=os.environ.get("SQL_USERNAME"),
+            password=os.environ.get("SQL_PASSWORD"),
+        ),
+    ):
+        return
 
     # === Fast-path: Rally Forts XLSX auto-ingest (hardened) ===
     if message.channel.id == FORT_RALLY_CHANNEL_ID and message.attachments:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -27,8 +27,13 @@ the documented `.venv` workflow without `RUN_DB_TESTS=1`. Phase 4 KVK_ALL upload
 was completed in PR 110 (`codex/kvk-all-upload-route`), smoke tested successfully on 2026-05-26,
 and promoted to production: KVK_ALL now delegates through `upload_routes/kvk_all_route.py` while
 preserving multi-attachment handling, SQL preflight behaviour, Discord output, sheet link button
-behaviour, and non-blocking auto-export scheduling. Phase 5 remaining fast-path consolidation is
-now the next upload-routing programme slice; the remaining active backlog is listed below.
+behaviour, and non-blocking auto-export scheduling. Phase 5A MGE results and KVK Honor upload-route
+extraction was completed in PR 113 (`codex/dlbot-upload-routing-phase-5a`), smoke tested
+successfully on 2026-05-26, deployed to production, and closed: `DL_bot.py` now delegates those
+routes through `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, with shared
+route helpers in `upload_routes/common.py` for notify-channel fallback, source/uploader embed
+fields, and best-effort background task scheduling. Phase 5B is now the next upload-routing
+programme slice; the remaining active backlog is listed below.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
@@ -101,11 +106,11 @@ issues list.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After the first upload-route slices, `DL_bot.py` still owns MGE results import, KVK honor ingest, weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
-- Suggested Fix: Phase 5 should audit and consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering only where behaviour parity is testable, and add route-level structured logging without changing importer contracts or Discord output.
+- Description: After Phase 5A, `DL_bot.py` still owns weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener. MGE results import and KVK Honor ingest now delegate through `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, but the remaining inline routes still contain repeated preflight/offload/rendering/logging and queue-bookkeeping patterns.
+- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Reuse `upload_routes/common.py` where the contract is already identical, add shared SQL-preflight/offload/rendering/logging helpers only when behaviour parity is clear and covered, and avoid changing importer contracts, Discord output, route order, or fallback queue behaviour.
 - Impact: medium
 - Risk: medium
-- Dependencies: Start with `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`; player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested, so Phase 5 can be scoped against proven route contracts.
+- Dependencies: Phase 5A is complete and production smoke tested; start Phase 5B from `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -49,10 +49,10 @@ PR 96 (`import-locations-command-orchestration-cleanup`) was smoke tested succes
 The `/import_locations` command cleanup is complete. This task is fresh work around `DL_bot.py` upload routing and related validation blockers.
 
 Current `DL_bot.py` still contains multiple fast-path upload routes inside the root `on_message`
-listener. Player location CSV import, PreKvK snapshot ingest, and KVK_ALL import have been
-extracted into the `upload_routes` pattern; MGE results import, KVK Honour ingest, weekly activity
-import, rally forts import, inventory upload-first routing, and fallback monitored-channel queueing
-remain inline.
+listener. Player location CSV import, PreKvK snapshot ingest, KVK_ALL import, MGE results import,
+and KVK Honour ingest have been extracted into the `upload_routes` pattern. Weekly activity import,
+rally forts import, inventory upload-first routing, and fallback monitored-channel queueing remain
+inline after Phase 5A.
 
 The active deferred backlog identifies these DL_bot-specific architecture items:
 
@@ -311,8 +311,11 @@ Phase breakdown:
      scheduling.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 7. **Phase 5 - Remaining upload fast-path consolidation**
-   - Next active slice.
-   - Audit and consolidate MGE, honor, weekly activity, rally, inventory, fallback queueing,
+   - Active programme after Phase 4.
+   - Phase 5A completed MGE results and KVK Honor route extraction in PR 113
+     (`codex/dlbot-upload-routing-phase-5a`), smoke tested successfully on 2026-05-26, deployed
+     to production, and closed.
+   - Continue with small sub-phases for weekly activity, rally, inventory, fallback queueing,
      shared SQL-preflight/offload handling, shared import embed rendering where safe, and
      route-level structured logging into the general upload-routing layer.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
@@ -357,6 +360,21 @@ Phase 4 delivery notes:
   user-facing abort notification and does not emit a duplicate route-level abort embed.
 - PR 110 (`codex/kvk-all-upload-route`) was smoke tested successfully and promoted to production.
 - Phase 5 remaining fast-path consolidation is now the next active upload-routing programme slice.
+
+Phase 5A delivery notes:
+
+- MGE results upload routing is extracted into `upload_routes/mge_results_route.py`.
+- KVK Honor upload routing is extracted into `upload_routes/honor_route.py`.
+- `upload_routes/common.py` now provides shared notify-channel fallback, source/uploader embed
+  field construction, and best-effort task scheduling for later route slices.
+- The MGE importer remains lazily loaded inside the route handler to preserve startup resilience.
+- The MGE and Honor routes run SQL headroom preflight before workbook reads.
+- Focused route tests cover matching, non-matching, SQL preflight aborts, importer success/failure,
+  exception rendering, side effects, report summary fields, Honor test-mode handling, and Honor
+  stats-refresh best-effort behaviour.
+- PR 113 (`codex/dlbot-upload-routing-phase-5a`) was smoke tested successfully, deployed to
+  production, and closed.
+- Phase 5B inventory and weekly activity route extraction is now the next active slice.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
@@ -14,6 +14,53 @@ We are starting Phase 5 of the DL_bot upload-routing optimisation programme afte
   tests, full suite, and log-noise validation all passed under `.venv`.
 - Phase 4 extracted the KVK_ALL route into `upload_routes/kvk_all_route.py`, was smoke tested
   successfully on 2026-05-26, and was pushed to production.
+- Phase 5A extracted the MGE results and KVK Honor routes into `upload_routes/mge_results_route.py`
+  and `upload_routes/honor_route.py`, added shared route helpers in `upload_routes/common.py`, was
+  smoke tested successfully on 2026-05-26, deployed to production, and closed.
+
+## Completion Note
+
+Status: Phase 5A complete in PR 113 (`codex/dlbot-upload-routing-phase-5a`), smoke tested
+successfully on 2026-05-26, deployed to production, and closed.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates MGE results auto-import through `handle_mge_results_upload()`.
+- `DL_bot.py` delegates KVK Honor upload ingest through `handle_honor_upload()`.
+- `upload_routes/common.py` provides shared notify-channel fallback, source/uploader embed fields,
+  and best-effort task scheduling for reuse by later Phase 5 sub-phases.
+- The MGE importer remains lazily loaded inside the route handler so MGE import dependency failures
+  cannot block bot startup or unrelated message routes.
+- SQL headroom preflight runs before workbook reads in the new MGE and Honor routes to avoid
+  unnecessary attachment I/O when imports will abort.
+- Current Discord output, importer contracts, SQL preflight behaviour, Honor stats refresh,
+  background log-backup scheduling, route order, and fall-through behaviour were preserved.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_mge_results_upload_route.py tests/test_honor_upload_route.py tests/test_dl_bot_mge_auto_import.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_mge_results_import.py tests/test_mge_results_import_service.py tests/test_honor_importer.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed full-suite result: `1498 passed, 2 skipped`. Pytest log-noise validation confirmed
+production operational logs were unchanged.
+
+Production smoke evidence confirmed the Honor route passed SQL preflight, parsed and ingested
+`1198_honor.xlsx` for `KVK_NO=15`, created `ScanID=40` with `93` rows, and scheduled a successful
+background log-backup trigger.
+
+Phase 5B inventory and weekly activity route extraction is now the next active upload-routing
+programme slice. Starter packet:
+`docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`.
 
 Phase 5 is the remaining fast-path upload-route consolidation slice. It should use the proven
 `upload_routes` pattern to reduce `DL_bot.py` listener responsibilities while preserving production
@@ -27,8 +74,9 @@ modules or an approved shared upload-router boundary.
 The desired end state is:
 
 - `DL_bot.py` delegates remaining upload message handling and keeps only listener/event plumbing.
-- MGE results import, KVK Honour ingest, weekly activity ingest, rally forts ingest, inventory
-  upload-first routing, and fallback monitored-channel queueing have clear route ownership.
+- MGE results import and KVK Honour ingest have clear route ownership after Phase 5A. Weekly
+  activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel
+  queueing remain to be extracted in later Phase 5 sub-phases.
 - Shared SQL preflight, offload dispatch, import embed rendering, and route-level structured
   logging are consolidated only where behaviour parity is safe and testable.
 - Current Discord output, importer contracts, accepted filenames/extensions, side effects, fallback
@@ -54,6 +102,7 @@ Before audit work, read:
 - `docs/reference/deferred_optimisations.md`
 - `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
 - `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`
 
 Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any importer, DAL, export, stored
 procedure, view, or output-contract assumptions reviewed during this phase.
@@ -73,8 +122,8 @@ procedure, view, or output-contract assumptions reviewed during this phase.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After the first upload-route slices, `DL_bot.py` still owns MGE results import, KVK honor ingest, weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns.
-- Suggested Fix: Phase 5 should audit and consolidate the remaining fast paths into the `upload_routes` pattern, add shared SQL-preflight/offload handling where safe, centralise repeated import embed rendering only where behaviour parity is testable, and add route-level structured logging without changing importer contracts or Discord output.
+- Description: After Phase 5A, `DL_bot.py` still owns weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns. MGE results import and KVK Honor ingest now delegate through the `upload_routes` pattern.
+- Suggested Fix: Continue Phase 5 in small sub-phases, starting with inventory upload-first routing and weekly activity ingest in Phase 5B. Reuse `upload_routes/common.py` where behaviour parity is clear and covered, and only add new shared helpers when later routes prove the same contract.
 - Impact: medium
 - Risk: medium
 - Dependencies: Player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested; preserve existing Discord output and importer contracts.
@@ -96,8 +145,6 @@ In scope for Step 1 audit:
 Likely remaining route candidates:
 
 - Inventory upload-first route currently delegated to `ui.views.inventory_views.handle_inventory_upload_message`.
-- MGE results auto-import route.
-- KVK Honour ingest route.
 - Weekly activity ingest route.
 - Rally forts XLSX auto-ingest route.
 - Main monitored-channel fallback queue route.
@@ -119,6 +166,9 @@ Likely route/listener files:
 - `upload_routes/player_location_route.py`
 - `upload_routes/prekvk_route.py`
 - `upload_routes/kvk_all_route.py`
+- `upload_routes/mge_results_route.py`
+- `upload_routes/honor_route.py`
+- `upload_routes/common.py`
 - `upload_routes/__init__.py`
 
 Likely importer/service/helper files:

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
@@ -1,0 +1,256 @@
+# DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter
+
+We are starting Phase 5B of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+- Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
+  tests, full suite, and log-noise validation all passed under `.venv`.
+- Phase 4 extracted the KVK_ALL route into `upload_routes/kvk_all_route.py`, was smoke tested
+  successfully on 2026-05-26, and was pushed to production.
+- Phase 5A extracted MGE results and KVK Honor upload routing into
+  `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, added
+  `upload_routes/common.py`, was smoke tested successfully on 2026-05-26, deployed to production,
+  and closed.
+
+Phase 5B is the next small upload-routing slice. It should keep using the proven `upload_routes`
+pattern and the new `upload_routes/common.py` helpers where the behaviour matches, without forcing
+a broad router framework before rally and fallback queueing are scoped.
+
+## Goal
+
+Extract or wrap the next two lower-risk remaining upload paths from `DL_bot.py`:
+
+- Inventory upload-first routing currently delegated inline to
+  `ui.views.inventory_views.handle_inventory_upload_message`.
+- Weekly activity upload ingest currently implemented inline in `DL_bot.py`.
+
+The desired end state is:
+
+- `DL_bot.py` delegates inventory upload-first handling through an `upload_routes` route module for
+  route-order consistency while preserving the existing inventory service/view behaviour.
+- `DL_bot.py` delegates weekly activity ingest through an `upload_routes` route module while
+  preserving accepted filename matching, SQL preflight behaviour, importer contract, duplicate-skip
+  output, success/error embeds, log-backup scheduling, and fall-through behaviour.
+- `upload_routes/common.py` is reused for notify-channel fallback, source/uploader embed fields, and
+  best-effort task scheduling where appropriate.
+- New shared helpers are introduced only when the Phase 5B route contracts prove identical enough to
+  test. Do not create a generic upload-router abstraction in this phase.
+- No SQL schema, stored procedure, view, file-format, or importer-contract changes are introduced.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the Phase 5B
+route classification and first implementation scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for weekly activity table, view, index, and
+output-contract assumptions reviewed during this phase.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Source Deferred Item
+
+### Deferred Optimisation
+- Area: `DL_bot.py` remaining fast-path upload routes
+- Type: architecture
+- Description: After Phase 5A, `DL_bot.py` still owns weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener. MGE results import and KVK Honor ingest now delegate through `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, but the remaining inline routes still contain repeated preflight/offload/rendering/logging and queue-bookkeeping patterns.
+- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Phase 5B should wrap inventory upload-first routing for route-order consistency and extract weekly activity ingest into a focused route module. Reuse `upload_routes/common.py` where the contract is already identical, add shared helpers only when behaviour parity is clear and covered, and avoid changing importer contracts, Discord output, route order, or fallback queue behaviour.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 5A is complete and production smoke tested; preserve existing inventory and weekly activity user-facing behaviour.
+
+## Phase 5B Scope
+
+In scope for Step 1 audit:
+
+- Audit the current inventory upload-first branch in `DL_bot.py`.
+- Audit `ui.views.inventory_views.handle_inventory_upload_message` only enough to confirm its route
+  contract and side effects; do not refactor inventory service/view internals in this phase.
+- Audit the current weekly activity branch in `DL_bot.py`.
+- Map route order and fall-through behaviour before and after the planned extraction.
+- Validate weekly activity SQL-facing assumptions against `C:\K98-bot-SQL-Server`.
+- Identify which shared helpers from `upload_routes/common.py` should be reused.
+- Identify focused route tests required for behaviour parity.
+- Capture out-of-scope findings structurally.
+
+Likely Phase 5B route candidates:
+
+- `upload_routes/inventory_route.py`
+- `upload_routes/weekly_activity_route.py`
+
+Out of scope until separately approved:
+
+- Changing inventory parsing, OCR/vision flows, pending session behaviour, materials multi-screenshot
+  behaviour, or inventory SQL/service contracts.
+- Moving business logic out of `ui.views.inventory_views.py`; Phase 5B may wrap the existing handler
+  but should not redesign the inventory interaction flow.
+- Changing weekly activity workbook format, parser rules, importer result contract, duplicate
+  detection, SQL tables, views, indexes, or Google Sheets/reporting consumers.
+- Extracting rally forts upload routing.
+- Extracting main monitored-channel fallback queueing.
+- Rewriting `channel_queues`, `live_queue`, `processing_pipeline.py`, or worker process ownership.
+- Broad `DL_bot.py` startup/lifecycle or `bot_instance.py` refactor.
+
+## Current Files To Review
+
+Likely route/listener files:
+
+- `DL_bot.py`
+- `upload_routes/common.py`
+- `upload_routes/player_location_route.py`
+- `upload_routes/prekvk_route.py`
+- `upload_routes/kvk_all_route.py`
+- `upload_routes/mge_results_route.py`
+- `upload_routes/honor_route.py`
+- `upload_routes/__init__.py`
+
+Likely inventory files:
+
+- `ui/views/inventory_views.py`
+- `inventory/` package files as needed for route contract confirmation
+- `tests/test_inventory_upload_flow.py`
+- `tests/test_inventory_views.py`
+- `tests/test_inventory_*`
+
+Likely weekly activity files:
+
+- `weekly_activity_importer.py`
+- `file_utils.py`
+- `embed_utils.py`
+- `log_health.py`
+- `tests/test_weekly_activity_importer.py` if present
+- nearby weekly/activity tests discovered by `rg`
+
+Likely SQL repo objects to validate:
+
+- `dbo.AllianceActivitySnapshotHeader`
+- `dbo.AllianceActivitySnapshotRow`
+- `dbo.AllianceActivityDelta`
+- `dbo.AllianceActivityDaily`
+- `dbo.vAllianceActivitySnapshots`
+- `dbo.vAllianceActivity_DailyDelta`
+- `dbo.vAllianceActivity_WeeklyDelta`
+- `dbo.vAllianceActivity_WeeklyCumulative`
+- `dbo.vWeekly_AllianceActivity`
+- related indexes and constraints on the tables above
+
+## Design Questions
+
+- Should Phase 5B create a very thin inventory route wrapper around
+  `handle_inventory_upload_message()` without moving inventory logic, or should inventory remain
+  inline until a dedicated inventory service/view audit is scheduled?
+- Should the weekly activity route use the same dependency-object pattern as MGE/Honor/PreKvK, with
+  injected `send_embed`, `ensure_sql_headroom_or_notify`, `offload_callable`, and
+  `trigger_log_backup_background`?
+- Should weekly activity notify-channel fallback use `resolve_notify_channel()` from
+  `upload_routes/common.py`, preserving current fallback to the source channel when notify lookup
+  fails?
+- Should duplicate weekly activity uploads keep the current minimal embed with only
+  `Status: Duplicate detected for this week. Skipped.`, or should richer source/uploader fields be
+  deferred to preserve exact output?
+- Which repeated route behaviours are now mature enough for shared helpers, and which should remain
+  route-local until rally/fallback queue extraction proves the broader contract?
+- What is the minimal route test surface that proves inventory and weekly activity behaviour parity
+  without duplicating inventory-service and importer tests?
+
+## Step 1 Required Output
+
+Phase 5B Step 1 must produce:
+
+- Audit Summary
+- Current Inventory Route Map
+- Current Weekly Activity Route Map
+- Route Order And Fall-Through Map
+- Weekly Activity SQL Contract Map
+- Discord Output Preservation Map
+- Shared Helper Recommendation
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the approved Phase 5B route slice:
+
+- focused new inventory route tests
+- focused new weekly activity route tests
+- relevant existing inventory upload tests
+- relevant existing weekly activity importer tests
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` when running full-suite or
+  deployment-oriented validation
+
+If live SQL integration is intentionally needed, document and validate the opt-in path:
+
+```powershell
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected live DB tests>
+```
+
+## Acceptance Criteria
+
+- Inventory upload-first route handling is delegated through the approved `upload_routes` boundary
+  or explicitly deferred with a structured reason.
+- Weekly activity upload ingest is delegated through the approved `upload_routes` boundary within
+  the approved scope.
+- `DL_bot.py` route order and fall-through behaviour are preserved.
+- Inventory user-facing behaviour and inventory service/view contracts are preserved.
+- Weekly activity accepted filename matching remains `1198_alliance_activity.xlsx`.
+- Weekly activity SQL preflight, importer call arguments, duplicate-skip output, success/error
+  embeds, and log-backup scheduling are preserved.
+- No new direct SQL is added to Discord listener/route layers.
+- `upload_routes/common.py` is reused where behaviour parity is clear and covered.
+- Out-of-scope rally, fallback queue, inventory internals, SQL, lifecycle, or worker findings are
+  captured structurally.
+
+## Explicit Stop Point
+
+Stop after the Phase 5B audit/design packet.
+
+Do not implement route extraction, alter SQL, change upload routing behaviour, or open a PR until
+the audit packet, route classification, and first implementation scope have each been approved.

--- a/tests/test_inventory_upload_route.py
+++ b/tests/test_inventory_upload_route.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from upload_routes import inventory_route as route
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int = 10):
+        self.id = channel_id
+        self.sent = []
+
+    async def send(self, *args, **kwargs):
+        self.sent.append((args, kwargs))
+
+
+class _FakeAuthor:
+    id = 123456789
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.id = 987
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = attachments if attachments is not None else [object()]
+
+
+def _deps(**overrides):
+    calls = []
+
+    async def upload_handler(message, bot):
+        calls.append((message, bot))
+        if "handler_exception" in overrides:
+            raise overrides["handler_exception"]
+        return overrides.get("handler_result", True)
+
+    deps = route.InventoryRouteDeps(
+        inventory_upload_channel_id=overrides.get("channel_id", 10),
+        bot=overrides.get("bot", object()),
+        upload_handler=upload_handler,
+    )
+    return deps, calls
+
+
+@pytest.mark.asyncio
+async def test_inventory_route_ignores_unconfigured_channel():
+    deps, calls = _deps(channel_id=0)
+
+    handled = await route.handle_inventory_upload(_FakeMessage(), deps)
+
+    assert handled is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_inventory_route_ignores_other_channels():
+    deps, calls = _deps()
+
+    handled = await route.handle_inventory_upload(_FakeMessage(channel_id=99), deps)
+
+    assert handled is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_inventory_route_ignores_empty_attachments():
+    deps, calls = _deps()
+
+    handled = await route.handle_inventory_upload(_FakeMessage(attachments=[]), deps)
+
+    assert handled is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_inventory_route_delegates_and_returns_handler_result():
+    bot = object()
+    message = _FakeMessage()
+    deps, calls = _deps(bot=bot, handler_result=False)
+
+    handled = await route.handle_inventory_upload(message, deps)
+
+    assert handled is False
+    assert calls == [(message, bot)]
+
+
+@pytest.mark.asyncio
+async def test_inventory_route_exception_sends_existing_fallback_message():
+    message = _FakeMessage()
+    deps, calls = _deps(handler_exception=RuntimeError("boom"))
+
+    handled = await route.handle_inventory_upload(message, deps)
+
+    assert handled is True
+    assert len(calls) == 1
+    assert message.channel.sent == [
+        (
+            ("<@123456789> Inventory import failed unexpectedly. Please try again.",),
+            {"delete_after": 120},
+        )
+    ]

--- a/tests/test_weekly_activity_upload_route.py
+++ b/tests/test_weekly_activity_upload_route.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from upload_routes import weekly_activity_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str, payload: bytes = b"xlsx"):
+        self.filename = filename
+        self._payload = payload
+        self.reads = 0
+
+    async def read(self) -> bytes:
+        self.reads += 1
+        return self._payload
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int = 10, name: str = "activity"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.id = 987
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments
+            if attachments is not None
+            else [_FakeAttachment("1198_alliance_activity.xlsx")]
+        )
+        self.created_at = datetime(2026, 5, 26, 12, 30, tzinfo=UTC)
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _deps(**overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+    preflight_channels = []
+
+    async def get_notify_channel():
+        if "notify_exception" in overrides:
+            raise overrides["notify_exception"]
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+        if "send_exception" in overrides:
+            raise overrides["send_exception"]
+
+    async def ensure_sql_headroom_or_notify(ch):
+        preflight_channels.append(ch)
+        return overrides.get("sql_ok", True)
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_exception" in overrides:
+            raise overrides["offload_exception"]
+        return overrides.get("offload_result", (42, 7))
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    deps = route.WeeklyActivityRouteDeps(
+        activity_upload_channel_id=10,
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        server="server",
+        database="database",
+        username="username",
+        password="password",
+        create_task=create_task,
+    )
+    return deps, sent, offloads, created_tasks, preflight_channels
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_ignores_other_channels():
+    deps, sent, offloads, _created, _preflight = _deps()
+
+    handled = await route.handle_weekly_activity_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_ignores_empty_attachments():
+    deps, sent, offloads, _created, _preflight = _deps()
+
+    handled = await route.handle_weekly_activity_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_ignores_non_matching_filename():
+    deps, sent, offloads, _created, _preflight = _deps()
+
+    handled = await route.handle_weekly_activity_upload(
+        _message(attachments=[_FakeAttachment("activity.xlsx")]), deps
+    )
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_sql_preflight_abort_preserves_read_order():
+    attachment = _FakeAttachment("1198_alliance_activity.xlsx")
+    deps, sent, offloads, _created, preflight = _deps(sql_ok=False)
+
+    handled = await route.handle_weekly_activity_upload(_message(attachments=[attachment]), deps)
+
+    assert handled is True
+    assert attachment.reads == 1
+    assert len(preflight) == 1
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_success_preserves_import_contract_and_embed():
+    deps, sent, offloads, created, _preflight = _deps()
+
+    handled = await route.handle_weekly_activity_upload(_message(), deps)
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    assert func is route.ingest_weekly_activity_excel
+    assert args == ()
+    assert kwargs == {
+        "content": b"xlsx",
+        "snapshot_ts_utc": datetime(2026, 5, 26, 12, 30, tzinfo=UTC),
+        "message_id": 987,
+        "channel_id": 10,
+        "server": "server",
+        "database": "database",
+        "username": "username",
+        "password": "password",
+        "source_filename": "1198_alliance_activity.xlsx",
+        "name": "ingest_weekly_activity_excel",
+        "prefer_process": True,
+        "meta": {"filename": "1198_alliance_activity.xlsx"},
+    }
+    assert len(created) == 1
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Alliance Activity Import \u2705"
+    assert fields == {
+        "SnapshotId": "42",
+        "Rows": "7",
+        "Filename": "1198_alliance_activity.xlsx",
+        "Channel": "#activity (10)",
+        "Uploader": "uploader (123456789)",
+        "Note": "",
+    }
+    assert color == 0x2ECC71
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_duplicate_preserves_minimal_embed():
+    deps, sent, _offloads, created, _preflight = _deps(offload_result=(0, 0))
+
+    handled = await route.handle_weekly_activity_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Alliance Activity Import"
+    assert fields == {"Status": "Duplicate detected for this week. Skipped."}
+    assert color == 0xF1C40F
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_import_exception_sends_existing_error():
+    deps, sent, _offloads, created, _preflight = _deps(offload_exception=RuntimeError("boom"))
+
+    handled = await route.handle_weekly_activity_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Alliance Activity Import \u274c"
+    assert fields["Error"] == "RuntimeError: boom"
+    assert fields["Filename"] == "1198_alliance_activity.xlsx"
+    assert fields["Channel"] == "#activity (10)"
+    assert fields["Uploader"] == "uploader (123456789)"
+    assert color == 0xE74C3C
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_error_embed_failure_is_swallowed():
+    deps, sent, _offloads, created, _preflight = _deps(
+        offload_exception=RuntimeError("boom"),
+        send_exception=RuntimeError("discord down"),
+    )
+
+    handled = await route.handle_weekly_activity_upload(_message(), deps)
+
+    assert handled is True
+    assert created == []
+    assert sent[-1][1] == "Alliance Activity Import \u274c"
+
+
+@pytest.mark.asyncio
+async def test_weekly_activity_route_notify_failure_falls_back_to_source_channel():
+    deps, sent, _offloads, _created, preflight = _deps(notify_exception=RuntimeError("notify down"))
+    message = _message()
+
+    handled = await route.handle_weekly_activity_upload(message, deps)
+
+    assert handled is True
+    assert preflight == [message.channel]
+    assert sent[-1][0] is message.channel

--- a/upload_routes/inventory_route.py
+++ b/upload_routes/inventory_route.py
@@ -1,0 +1,51 @@
+"""Inventory upload-first route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class InventoryRouteDeps:
+    inventory_upload_channel_id: int
+    bot: Any
+    upload_handler: Callable[[Any, Any], Awaitable[bool]] | None = None
+
+
+async def _default_upload_handler(message: Any, bot: Any) -> bool:
+    from ui.views.inventory_views import handle_inventory_upload_message
+
+    return await handle_inventory_upload_message(message, bot)
+
+
+async def handle_inventory_upload(message: Any, deps: InventoryRouteDeps) -> bool:
+    """Delegate inventory image uploads through the upload route boundary."""
+    if (
+        not deps.inventory_upload_channel_id
+        or message.channel.id != deps.inventory_upload_channel_id
+        or not message.attachments
+    ):
+        return False
+
+    handler = deps.upload_handler or _default_upload_handler
+    try:
+        return await handler(message, deps.bot)
+    except Exception:
+        logger.exception(
+            "inventory_upload_first_route_failed message_id=%s channel_id=%s",
+            getattr(message, "id", None),
+            getattr(getattr(message, "channel", None), "id", None),
+        )
+        try:
+            await message.channel.send(
+                f"<@{message.author.id}> Inventory import failed unexpectedly. Please try again.",
+                delete_after=120,
+            )
+        except Exception:
+            logger.debug("inventory_upload_first_error_notice_failed", exc_info=True)
+        return True

--- a/upload_routes/weekly_activity_route.py
+++ b/upload_routes/weekly_activity_route.py
@@ -1,0 +1,117 @@
+"""Weekly alliance activity workbook upload route for the legacy listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from upload_routes.common import message_source_fields, resolve_notify_channel, schedule_best_effort
+from weekly_activity_importer import ingest_weekly_activity_excel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WeeklyActivityRouteDeps:
+    activity_upload_channel_id: int
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    server: str | None
+    database: str | None
+    username: str | None
+    password: str | None
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+
+
+def _is_weekly_activity_filename(filename: str) -> bool:
+    return filename.lower().endswith("1198_alliance_activity.xlsx")
+
+
+async def handle_weekly_activity_upload(message: Any, deps: WeeklyActivityRouteDeps) -> bool:
+    """Handle weekly alliance activity workbooks from the configured upload channel."""
+    if message.channel.id != deps.activity_upload_channel_id or not message.attachments:
+        return False
+
+    target = next(
+        (a for a in message.attachments if _is_weekly_activity_filename(a.filename)),
+        None,
+    )
+    if target is None:
+        return False
+
+    target_ch = await resolve_notify_channel(
+        deps.get_notify_channel,
+        message.channel,
+        logger,
+        "weekly_activity_upload",
+    )
+
+    try:
+        file_bytes = await target.read()
+        ok = await deps.ensure_sql_headroom_or_notify(target_ch)
+        if not ok:
+            return True
+
+        snap_id, row_count = await deps.offload_callable(
+            ingest_weekly_activity_excel,
+            content=file_bytes,
+            snapshot_ts_utc=message.created_at,
+            message_id=message.id,
+            channel_id=message.channel.id,
+            server=deps.server,
+            database=deps.database,
+            username=deps.username,
+            password=deps.password,
+            source_filename=target.filename,
+            name="ingest_weekly_activity_excel",
+            prefer_process=True,
+            meta={"filename": target.filename},
+        )
+        if snap_id == 0:
+            await deps.send_embed(
+                target_ch,
+                "Alliance Activity Import",
+                {"Status": "Duplicate detected for this week. Skipped."},
+                0xF1C40F,
+            )
+        else:
+            await deps.send_embed(
+                target_ch,
+                "Alliance Activity Import \u2705",
+                {
+                    "SnapshotId": str(snap_id),
+                    "Rows": str(row_count),
+                    "Filename": target.filename,
+                    **message_source_fields(message),
+                    "Note": "",
+                },
+                0x2ECC71,
+            )
+            schedule_best_effort(
+                deps.create_task,
+                deps.trigger_log_backup_background(),
+                logger,
+                "Failed to schedule background log-backup trigger",
+            )
+    except Exception as e:
+        try:
+            await deps.send_embed(
+                target_ch,
+                "Alliance Activity Import \u274c",
+                {
+                    "Error": f"{type(e).__name__}: {e}",
+                    "Filename": target.filename,
+                    **message_source_fields(message),
+                },
+                0xE74C3C,
+                mention=None,
+            )
+        except Exception:
+            logger.exception("weekly_activity_error_notification_failed")
+    return True


### PR DESCRIPTION
## Summary

- Extract inventory upload-first handling into `upload_routes/inventory_route.py` as a thin wrapper around the existing inventory view handler.
- Extract weekly alliance activity upload ingest into `upload_routes/weekly_activity_route.py` while preserving route order, filename matching, SQL preflight behaviour, importer contract, duplicate/success/error embeds, and log-backup scheduling.
- Add focused route tests and include the Phase 5B task pack plus deferred/task-pack documentation updates.

## Validation

- `./.venv/Scripts/python.exe -m pytest -q tests/test_inventory_upload_route.py tests/test_weekly_activity_upload_route.py tests/test_inventory_upload_flow.py` -> `22 passed`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py` -> passed
- `./.venv/Scripts/python.exe scripts/select_tests.py` -> completed
- `./.venv/Scripts/python.exe scripts/smoke_imports.py` -> passed
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` -> completed, active primary count `82`
- `./.venv/Scripts/python.exe -m pre_commit run -a` -> passed
- `./.venv/Scripts/python.exe -m pytest -q tests` -> `1511 passed, 2 skipped`
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py` -> `1511 passed, 2 skipped`; production operational logs unchanged

## Security / Review Notes

- No SQL schema or importer-contract changes.
- No new direct SQL added to Discord listener or route layers.
- Diff-scoped pre-review found no blocking issues. Codex Security full scan was not run because this is a behaviour-preserving route extraction with no new upload parser, SQL sink, permission check, secret handling, or persistence surface; existing file/SQL sinks remain unchanged and are covered by focused/full validation.

## Risk / Rollback

- Risk is medium-low: this changes listener delegation boundaries for upload routes, but preserves route order and output contracts.
- Rollback is the PR revert; no database migration or config rollout required.