### PR TITLE
[codex] Extract Rally Forts upload route

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -103,7 +103,6 @@ logger.info("[LOCK] Child lock acquired at %s (PID %d)", BOT_LOCK_PATH, os.getpi
 import asyncio
 from asyncio import QueueFull
 import json
-import re
 import signal
 import threading
 
@@ -143,6 +142,7 @@ from upload_routes.player_location_route import (
     handle_player_location_upload,
 )
 from upload_routes.prekvk_route import PreKvkRouteDeps, handle_prekvk_upload
+from upload_routes.rally_forts_route import RallyFortsRouteDeps, handle_rally_forts_upload
 from upload_routes.weekly_activity_route import (
     WeeklyActivityRouteDeps,
     handle_weekly_activity_upload,
@@ -534,14 +534,6 @@ async def _get_notify_channel():
     return ch
 
 
-def is_rally_daily(fn: str) -> bool:
-    return re.search(r"^Rally_data_\d{2}-\d{2}-\d{4}\.xlsx$", fn, re.I) is not None
-
-
-def is_rally_alltime(fn: str) -> bool:
-    return re.search(r"Rally[_\s]?data.*all[\s_]?time.*\.xlsx$", fn, re.I) is not None
-
-
 # === Global Error Logging ===
 @bot.event
 async def on_error(event_method, *args, **kwargs):
@@ -651,150 +643,19 @@ async def on_message(message: discord.Message):
         return
 
     # === Fast-path: Rally Forts XLSX auto-ingest (hardened) ===
-    if message.channel.id == FORT_RALLY_CHANNEL_ID and message.attachments:
-        notify_ch = await _get_notify_channel() or message.channel
-
-        if not FORT_RALLY_CHANNEL_ID:
-            # channel id missing from env/config – surface it loudly
-            await send_embed(
-                notify_ch,
-                "Rally Forts Import ❌",
-                {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
-                0xE74C3C,
-            )
-            return
-
-        # Lazy import so missing deps don't crash startup
-        try:
-            from forts_ingest import import_rally_alltime_xlsx, import_rally_daily_xlsx
-        except Exception as e:
-            await send_embed(
-                notify_ch,
-                "Rally Forts Import ❌",
-                {
-                    "Error": f"Import failure: {type(e).__name__}: {e}",
-                    "Hint": "Ensure forts_ingest.py and its dependencies (pandas, pyodbc) are installed in the venv.",
-                },
-                0xE74C3C,
-            )
-            return
-
-        try:
-            os.makedirs(os.path.join(LOG_DIR, "downloads"), exist_ok=True)
-        except Exception:
-            pass
-
-        results = []
-        matched_any = False
-        for att in message.attachments:
-            if not att.filename.lower().endswith(".xlsx"):
-                continue
-
-            local_path = os.path.join(LOG_DIR, "downloads", att.filename)
-            try:
-                await att.save(local_path)
-                fn = att.filename
-                logger.info("[RALLY] Saved %s to %s", fn, local_path)
-
-                if is_rally_alltime(fn):
-                    matched_any = True
-                    logger.info("[RALLY] Detected ALL-TIME file: %s", fn)
-                    # NEW: preflight check per-file
-                    ok = await ensure_sql_headroom_or_notify(notify_ch)
-                    if not ok:
-                        results.append(("err", fn, "Aborted: SQL log headroom insufficient"))
-                        continue
-
-                    res = await _offload_callable(
-                        import_rally_alltime_xlsx,
-                        local_path,
-                        name="import_rally_alltime_xlsx",
-                        prefer_process=True,
-                        meta={"path": local_path},
-                    )
-                    results.append(("ok", fn, res))
-
-                    # schedule a background log-backup trigger (best-effort) for each successful file
-                    try:
-                        asyncio.create_task(trigger_log_backup_background())
-                    except Exception:
-                        logger.exception("Failed to schedule background log-backup trigger")
-                elif is_rally_daily(fn):
-                    matched_any = True
-                    logger.info("[RALLY] Detected DAILY file: %s", fn)
-                    ok = await ensure_sql_headroom_or_notify(notify_ch)
-                    if not ok:
-                        results.append(("err", fn, "Aborted: SQL log headroom insufficient"))
-                        continue
-
-                    res = await _offload_callable(
-                        import_rally_daily_xlsx,
-                        local_path,
-                        name="import_rally_daily_xlsx",
-                        prefer_process=True,
-                        meta={"path": local_path},
-                    )
-                    results.append(("ok", fn, res))
-
-                    # schedule a background log-backup trigger (best-effort) for each successful file
-                    try:
-                        asyncio.create_task(trigger_log_backup_background())
-                    except Exception:
-                        logger.exception("Failed to schedule background log-backup trigger")
-                else:
-                    results.append(("skip", fn, "Unrecognized rally filename"))
-            except Exception as e:
-                logger.exception("[RALLY] Error processing attachment %s", att.filename)
-                results.append(("err", att.filename, f"{type(e).__name__}: {e}"))
-
-        # If nothing matched (e.g., wrong filenames or no .xlsx), surface that
-        if not matched_any and not results:
-            await send_embed(
-                notify_ch,
-                "Rally Forts Import ⚠️",
-                {
-                    "Info": "No rally .xlsx attachments matched expected patterns.",
-                    "Expected Daily": "Rally_data_DD-MM-YYYY.xlsx",
-                    "Expected All-Time": "Rally_data_All_Time*.xlsx",
-                },
-                0xE67E22,
-            )
-            return
-
-        fields = {
-            "Source Channel": f"#{message.channel.name} ({message.channel.id})",
-            "Uploaded By": f"{message.author} ({message.author.id})",
-        }
-        oks = [r for r in results if r[0] == "ok"]
-        errs = [r for r in results if r[0] == "err"]
-        skips = [r for r in results if r[0] == "skip"]
-
-        for _, fn, res in oks[:5]:
-            if isinstance(res, dict):
-                rows = res.get("rows")
-                asof = res.get("as_of")
-                extra = f"rows={rows}" + (f"; as_of={asof}" if asof else "")
-            else:
-                extra = str(res)
-            fields[f"✅ {fn}"] = extra or "ok"
-
-        for _, fn, why in skips[:5]:
-            fields[f"⏭️ {fn}"] = why
-
-        for _, fn, err in errs[:5]:
-            fields[f"❌ {fn}"] = err
-
-        color = 0x2ECC71 if oks and not errs else (0xE67E22 if oks and errs else 0xE74C3C)
-        title = "Rally Forts Import" + (
-            " ✅" if oks and not errs else " ⚠️" if oks and errs else " ❌"
-        )
-
-        try:
-            await send_embed(notify_ch, title, fields, color)
-        except Exception:
-            logger.exception("Failed to send Rally Forts import embed")
-
-        return  # don't enqueue into the heavy stats pipeline
+    if await handle_rally_forts_upload(
+        message,
+        RallyFortsRouteDeps(
+            fort_rally_channel_id=FORT_RALLY_CHANNEL_ID,
+            log_dir=LOG_DIR,
+            get_notify_channel=_get_notify_channel,
+            send_embed=send_embed,
+            ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+            offload_callable=_offload_callable,
+            trigger_log_backup_background=trigger_log_backup_background,
+        ),
+    ):
+        return
 
     # === KVK (all kingdoms) ingest ===
     if await handle_kvk_all_upload(

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -32,8 +32,13 @@ extraction was completed in PR 113 (`codex/dlbot-upload-routing-phase-5a`), smok
 successfully on 2026-05-26, deployed to production, and closed: `DL_bot.py` now delegates those
 routes through `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, with shared
 route helpers in `upload_routes/common.py` for notify-channel fallback, source/uploader embed
-fields, and best-effort background task scheduling. Phase 5B is now the next upload-routing
-programme slice; the remaining active backlog is listed below.
+fields, and best-effort background task scheduling. Phase 5B inventory and weekly activity route
+extraction was completed in PR 114 (`codex/dlbot-upload-routing-phase-5b`), smoke tested
+successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production, and
+closed: `DL_bot.py` now delegates those routes through `upload_routes/inventory_route.py` and
+`upload_routes/weekly_activity_route.py`. Phase 5C Rally Forts upload-route extraction is now the
+next upload-routing programme slice; Phase 5D is expected to be the final upload-routing sub-phase
+for main monitored-channel fallback queueing before Phase 6 lifecycle/startup separation.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
@@ -106,11 +111,11 @@ issues list.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After Phase 5A, `DL_bot.py` still owns weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener. MGE results import and KVK Honor ingest now delegate through `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, but the remaining inline routes still contain repeated preflight/offload/rendering/logging and queue-bookkeeping patterns.
-- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Reuse `upload_routes/common.py` where the contract is already identical, add shared SQL-preflight/offload/rendering/logging helpers only when behaviour parity is clear and covered, and avoid changing importer contracts, Discord output, route order, or fallback queue behaviour.
+- Description: After Phase 5B, `DL_bot.py` still owns Rally Forts ingest and main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, and weekly activity ingest now delegate through the `upload_routes` pattern, but the remaining inline routes still contain route-specific preflight/offload/rendering/logging and queue-bookkeeping patterns.
+- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Phase 5C should extract Rally Forts ingest into a focused route module while preserving filename matching, local download staging, importer contracts, SQL preflight, per-file result aggregation, Discord output, and log-backup scheduling. Phase 5D should separately scope the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5A is complete and production smoke tested; start Phase 5B from `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`.
+- Dependencies: Phase 5B is complete, smoke tested, deployed, and production-pushed; start Phase 5C from `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle

--- a/docs/reference/weekly_activity_importer.md
+++ b/docs/reference/weekly_activity_importer.md
@@ -4,7 +4,11 @@ Purpose: document the weekly alliance activity Excel import path.
 
 ## Main Files
 
-- `DL_bot.py` handles uploads in `ACTIVITY_UPLOAD_CHANNEL_ID`.
+- `DL_bot.py` delegates uploads in `ACTIVITY_UPLOAD_CHANNEL_ID` through
+  `upload_routes/weekly_activity_route.py`.
+- `upload_routes/weekly_activity_route.py` owns Discord route matching, SQL preflight, offload
+  dispatch, duplicate/success/error embeds, notify-channel fallback, and best-effort log-backup
+  scheduling.
 - `weekly_activity_importer.py` parses and writes activity snapshots.
 - SQL schema lives in `C:\K98-bot-SQL-Server`.
 
@@ -66,4 +70,12 @@ Validate these objects against the SQL repo before changing importer behaviour.
 
 ## Tests
 
-No dedicated unit test file exists for the weekly activity importer. Integration coverage is exercised via manual upload testing in the development environment.
+- Focused route coverage lives in `tests/test_weekly_activity_upload_route.py`.
+- No dedicated unit test file exists for the weekly activity importer. Importer integration coverage
+  is exercised via manual upload testing in the development environment.
+
+## Delivery Notes
+
+- Phase 5B extracted weekly activity routing into `upload_routes/weekly_activity_route.py`.
+- Alliance weekly upload was smoke tested successfully on 2026-05-26 after PR 114 was merged and
+  pushed to production.

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -48,11 +48,11 @@ PR 96 (`import-locations-command-orchestration-cleanup`) was smoke tested succes
 
 The `/import_locations` command cleanup is complete. This task is fresh work around `DL_bot.py` upload routing and related validation blockers.
 
-Current `DL_bot.py` still contains multiple fast-path upload routes inside the root `on_message`
-listener. Player location CSV import, PreKvK snapshot ingest, KVK_ALL import, MGE results import,
-and KVK Honour ingest have been extracted into the `upload_routes` pattern. Weekly activity import,
-rally forts import, inventory upload-first routing, and fallback monitored-channel queueing remain
-inline after Phase 5A.
+Current `DL_bot.py` still contains two upload-related branches inside the root `on_message`
+listener after Phase 5B: Rally Forts ingest and main monitored-channel fallback queueing. Player
+location CSV import, PreKvK snapshot ingest, KVK_ALL import, MGE results import, KVK Honour ingest,
+inventory upload-first routing, and weekly activity ingest have been extracted into the
+`upload_routes` pattern.
 
 The active deferred backlog identifies these DL_bot-specific architecture items:
 
@@ -315,9 +315,12 @@ Phase breakdown:
    - Phase 5A completed MGE results and KVK Honor route extraction in PR 113
      (`codex/dlbot-upload-routing-phase-5a`), smoke tested successfully on 2026-05-26, deployed
      to production, and closed.
-   - Continue with small sub-phases for weekly activity, rally, inventory, fallback queueing,
-     shared SQL-preflight/offload handling, shared import embed rendering where safe, and
-     route-level structured logging into the general upload-routing layer.
+   - Phase 5B completed inventory upload-first and weekly activity route extraction in PR 114
+     (`codex/dlbot-upload-routing-phase-5b`), smoke tested successfully on 2026-05-26 with
+     inventory and alliance weekly uploads, deployed to production, and closed.
+   - Continue with Phase 5C for Rally Forts route extraction and Phase 5D for main
+     monitored-channel fallback queueing. Phase 5D is expected to be the final upload-routing
+     sub-phase before Phase 6 lifecycle/startup separation.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
 8. **Phase 6 - Startup/lifecycle separation**
    - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
@@ -374,7 +377,22 @@ Phase 5A delivery notes:
   stats-refresh best-effort behaviour.
 - PR 113 (`codex/dlbot-upload-routing-phase-5a`) was smoke tested successfully, deployed to
   production, and closed.
-- Phase 5B inventory and weekly activity route extraction is now the next active slice.
+- Phase 5B inventory and weekly activity route extraction was the next active slice.
+
+Phase 5B delivery notes:
+
+- Inventory upload-first routing is extracted into `upload_routes/inventory_route.py`.
+- Weekly activity upload routing is extracted into `upload_routes/weekly_activity_route.py`.
+- `DL_bot.py` now delegates both through the `upload_routes` pattern while preserving route order,
+  fall-through behaviour, inventory service/view contracts, weekly accepted filename matching,
+  weekly SQL preflight/importer arguments, duplicate/success/error embeds, notify fallback, and
+  best-effort log-backup scheduling.
+- Focused route tests cover inventory delegation/error handling and weekly activity matching,
+  non-matching fall-through, SQL preflight abort, success, duplicate skip, importer exception,
+  Discord error-notification failure, and notify fallback.
+- PR 114 (`codex/dlbot-upload-routing-phase-5b`) was smoke tested successfully with inventory and
+  alliance weekly uploads, deployed to production, and closed.
+- Phase 5C Rally Forts route extraction is now the next active slice.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
@@ -17,6 +17,10 @@ We are starting Phase 5 of the DL_bot upload-routing optimisation programme afte
 - Phase 5A extracted the MGE results and KVK Honor routes into `upload_routes/mge_results_route.py`
   and `upload_routes/honor_route.py`, added shared route helpers in `upload_routes/common.py`, was
   smoke tested successfully on 2026-05-26, deployed to production, and closed.
+- Phase 5B extracted inventory upload-first routing and weekly activity ingest into
+  `upload_routes/inventory_route.py` and `upload_routes/weekly_activity_route.py`, was smoke tested
+  successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production,
+  and closed.
 
 ## Completion Note
 
@@ -58,9 +62,56 @@ Production smoke evidence confirmed the Honor route passed SQL preflight, parsed
 `1198_honor.xlsx` for `KVK_NO=15`, created `ScanID=40` with `93` rows, and scheduled a successful
 background log-backup trigger.
 
-Phase 5B inventory and weekly activity route extraction is now the next active upload-routing
-programme slice. Starter packet:
+Phase 5B inventory and weekly activity route extraction was completed in PR 114. Its starter packet
+is retained for delivery history:
 `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`.
+
+## Phase 5B Completion Note
+
+Status: Phase 5B complete in PR 114 (`codex/dlbot-upload-routing-phase-5b`), smoke tested
+successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production, and
+closed.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates inventory upload-first handling through `handle_inventory_upload()`.
+- `DL_bot.py` delegates weekly activity ingest through `handle_weekly_activity_upload()`.
+- `upload_routes/inventory_route.py` wraps the existing
+  `ui.views.inventory_views.handle_inventory_upload_message()` contract without moving inventory
+  parsing, OCR/vision, pending session, materials, or SQL/service internals.
+- `upload_routes/weekly_activity_route.py` preserves accepted filename matching
+  (`1198_alliance_activity.xlsx`), notify-channel fallback, file-read/preflight order, importer
+  arguments, duplicate skip output, success/error embeds, exception shielding, and best-effort
+  background log-backup scheduling.
+- Focused route tests cover inventory delegation/error handling and weekly activity matching,
+  non-matching fall-through, SQL preflight abort, success, duplicate skip, importer exception,
+  Discord error-notification failure, and notify fallback.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests/test_inventory_upload_route.py tests/test_weekly_activity_upload_route.py tests/test_inventory_upload_flow.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed full-suite result: `1511 passed, 2 skipped`. Pytest log-noise validation confirmed
+production operational logs were unchanged.
+
+Phase 5C Rally Forts upload-route extraction is now the next active upload-routing programme
+slice. Starter packet:
+`docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`.
+
+Phase 5D is expected to be required as the final upload-routing sub-phase for main
+monitored-channel fallback queueing because that path touches `channel_queues`, `live_queue`,
+worker-process handoff, queue embed updates, and background log-backup scheduling. Keeping it
+separate avoids mixing Rally importer extraction with queue/lifecycle ownership changes.
 
 Phase 5 is the remaining fast-path upload-route consolidation slice. It should use the proven
 `upload_routes` pattern to reduce `DL_bot.py` listener responsibilities while preserving production
@@ -74,8 +125,8 @@ modules or an approved shared upload-router boundary.
 The desired end state is:
 
 - `DL_bot.py` delegates remaining upload message handling and keeps only listener/event plumbing.
-- MGE results import and KVK Honour ingest have clear route ownership after Phase 5A. Weekly
-  activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel
+- MGE results import, KVK Honour ingest, weekly activity ingest, and inventory upload-first routing
+  have clear route ownership after Phase 5B. Rally forts ingest and fallback monitored-channel
   queueing remain to be extracted in later Phase 5 sub-phases.
 - Shared SQL preflight, offload dispatch, import embed rendering, and route-level structured
   logging are consolidated only where behaviour parity is safe and testable.
@@ -103,6 +154,7 @@ Before audit work, read:
 - `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
 - `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 - `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`
 
 Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any importer, DAL, export, stored
 procedure, view, or output-contract assumptions reviewed during this phase.
@@ -122,8 +174,8 @@ procedure, view, or output-contract assumptions reviewed during this phase.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After Phase 5A, `DL_bot.py` still owns weekly activity ingest, rally forts ingest, inventory upload-first routing, and fallback monitored-channel queue handling directly in the root listener, with repeated preflight/offload/rendering/logging patterns. MGE results import and KVK Honor ingest now delegate through the `upload_routes` pattern.
-- Suggested Fix: Continue Phase 5 in small sub-phases, starting with inventory upload-first routing and weekly activity ingest in Phase 5B. Reuse `upload_routes/common.py` where behaviour parity is clear and covered, and only add new shared helpers when later routes prove the same contract.
+- Description: After Phase 5B, `DL_bot.py` still owns Rally Forts ingest and main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, and weekly activity ingest now delegate through the `upload_routes` pattern.
+- Suggested Fix: Continue Phase 5 with small sub-phases: Phase 5C should extract Rally Forts ingest into the `upload_routes` pattern, and Phase 5D should separately scope the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
 - Impact: medium
 - Risk: medium
 - Dependencies: Player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested; preserve existing Discord output and importer contracts.
@@ -144,8 +196,6 @@ In scope for Step 1 audit:
 
 Likely remaining route candidates:
 
-- Inventory upload-first route currently delegated to `ui.views.inventory_views.handle_inventory_upload_message`.
-- Weekly activity ingest route.
 - Rally forts XLSX auto-ingest route.
 - Main monitored-channel fallback queue route.
 
@@ -200,11 +250,9 @@ Likely tests:
 
 ## Design Questions
 
-- Should Phase 5 extract all remaining fast paths in one PR, or split into smaller route families
-  such as MGE/Honor/Weekly first, Rally second, fallback queue last?
-- Should inventory upload-first remain delegated to `ui.views.inventory_views` for this phase, or
-  should a thin `upload_routes/inventory_route.py` wrap that existing handler for route-order
-  consistency?
+- Should Phase 5C extract Rally Forts only, leaving fallback monitored-channel queueing to a final
+  Phase 5D? Current recommendation: yes, because the fallback queue path has worker/lifecycle
+  side effects that should not be mixed with Rally importer extraction.
 - Which shared dependency object or helper should be introduced without over-abstracting the route
   pattern proven by player-location, PreKvK, and KVK_ALL?
 - Which repeated embed-rendering patterns are identical enough to consolidate safely, and which

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
@@ -19,9 +19,30 @@ We are starting Phase 5B of the DL_bot upload-routing optimisation programme aft
   `upload_routes/common.py`, was smoke tested successfully on 2026-05-26, deployed to production,
   and closed.
 
-Phase 5B is the next small upload-routing slice. It should keep using the proven `upload_routes`
-pattern and the new `upload_routes/common.py` helpers where the behaviour matches, without forcing
-a broad router framework before rally and fallback queueing are scoped.
+## Completion Note
+
+Status: Phase 5B complete in PR 114 (`codex/dlbot-upload-routing-phase-5b`), smoke tested
+successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production, and
+closed.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates inventory upload-first handling through `handle_inventory_upload()`.
+- `DL_bot.py` delegates weekly activity ingest through `handle_weekly_activity_upload()`.
+- `upload_routes/inventory_route.py` wraps the existing inventory view handler without redesigning
+  inventory service/view internals.
+- `upload_routes/weekly_activity_route.py` preserves accepted filename matching, SQL preflight
+  behaviour, importer arguments, duplicate/success/error embeds, notify fallback, exception
+  shielding, and best-effort log-backup scheduling.
+- Focused route tests and the full suite passed before PR handoff. Production smoke confirmed
+  inventory and alliance weekly uploads after merge and production push.
+
+Phase 5C Rally Forts route extraction is now the next active slice. Phase 5D is expected to be
+required as the final upload-routing sub-phase for main monitored-channel fallback queueing.
+
+Phase 5B was the next small upload-routing slice. It kept using the proven `upload_routes`
+pattern and the new `upload_routes/common.py` helpers where the behaviour matched, without forcing
+a broad router framework before rally and fallback queueing were scoped.
 
 ## Goal
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
@@ -1,0 +1,255 @@
+# DL_bot Upload Routing - Phase 5C Rally Forts Route Starter
+
+We are starting Phase 5C of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+- Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
+  tests, full suite, and log-noise validation all passed under `.venv`.
+- Phase 4 extracted the KVK_ALL route into `upload_routes/kvk_all_route.py`, was smoke tested
+  successfully on 2026-05-26, and was pushed to production.
+- Phase 5A extracted MGE results and KVK Honor upload routing into
+  `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, added
+  `upload_routes/common.py`, was smoke tested successfully on 2026-05-26, deployed to production,
+  and closed.
+- Phase 5B extracted inventory upload-first routing and weekly activity ingest into
+  `upload_routes/inventory_route.py` and `upload_routes/weekly_activity_route.py`, was smoke tested
+  successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production,
+  and closed.
+
+Phase 5C is the next small upload-routing slice. It should keep using the proven `upload_routes`
+pattern and `upload_routes/common.py` helpers where behaviour matches. Do not pull the main
+monitored-channel fallback queue into this phase unless explicitly approved after the audit packet.
+
+## Goal
+
+Extract Rally Forts XLSX auto-ingest from `DL_bot.py` into a focused route module while preserving
+production behaviour.
+
+The desired end state is:
+
+- `DL_bot.py` delegates Rally Forts upload handling through an `upload_routes` route module.
+- Route order and fall-through behaviour are preserved.
+- Accepted file matching is preserved:
+  - daily: `Rally_data_DD-MM-YYYY.xlsx`
+  - all-time: `Rally[_\s]?data.*all[\s_]?time.*\.xlsx`
+- Local download staging under `LOG_DIR/downloads` is preserved unless a safer equivalent is
+  explicitly approved.
+- Lazy import behaviour for `forts_ingest` is preserved so missing optional dependencies do not
+  crash startup.
+- SQL preflight behaviour, offload dispatch, per-file result aggregation, skip/error rendering,
+  final Discord embed shape, and best-effort log-backup scheduling are preserved.
+- No SQL schema, stored procedure, view, file-format, importer-contract, or worker queue changes
+  are introduced.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the Phase 5C
+route classification and implementation scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
+
+Use `C:\K98-bot-SQL-Server` as the SQL source of truth for Rally Forts table, staging table, view,
+stored procedure, index, and output-contract assumptions reviewed during this phase.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-sql-validation`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+## Source Deferred Item
+
+### Deferred Optimisation
+- Area: `DL_bot.py` remaining fast-path upload routes
+- Type: architecture
+- Description: After Phase 5B, `DL_bot.py` still owns Rally Forts ingest and main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, and weekly activity ingest now delegate through the `upload_routes` pattern, but the remaining inline routes still contain route-specific preflight/offload/rendering/logging and queue-bookkeeping patterns.
+- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Phase 5C should extract Rally Forts ingest into a focused route module while preserving filename matching, local download staging, importer contracts, SQL preflight, per-file result aggregation, Discord output, and log-backup scheduling. Phase 5D should separately scope the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 5B is complete, smoke tested, deployed, and production-pushed; preserve Rally Forts user-facing behaviour and importer contracts.
+
+## Phase 5C Scope
+
+In scope for Step 1 audit:
+
+- Audit the current Rally Forts branch in `DL_bot.py`.
+- Audit `is_rally_daily()` and `is_rally_alltime()` route matching.
+- Audit `forts_ingest.import_rally_daily_xlsx()` and `forts_ingest.import_rally_alltime_xlsx()`
+  only enough to confirm route contract, local-path contract, SQL objects, result shape, and
+  side effects.
+- Map route order and fall-through behaviour before and after the planned extraction.
+- Validate Rally Forts SQL-facing assumptions against `C:\K98-bot-SQL-Server`.
+- Identify which shared helpers from `upload_routes/common.py` should be reused.
+- Identify focused route tests required for behaviour parity.
+- Capture out-of-scope findings structurally.
+
+Likely Phase 5C route candidate:
+
+- `upload_routes/rally_forts_route.py`
+
+Out of scope until separately approved:
+
+- Extracting main monitored-channel fallback queueing.
+- Rewriting `channel_queues`, `live_queue`, `processing_pipeline.py`, or worker process ownership.
+- Changing Rally workbook formats, parser rules, importer result contracts, duplicate detection,
+  SQL tables, staging tables, stored procedures, views, indexes, or export/reporting consumers.
+- Moving Rally importer SQL access out of `forts_ingest.py`.
+- Changing local file download retention, naming, or cleanup semantics unless needed for parity.
+- Broad `DL_bot.py` startup/lifecycle or `bot_instance.py` refactor.
+
+## Current Files To Review
+
+Likely route/listener files:
+
+- `DL_bot.py`
+- `upload_routes/common.py`
+- `upload_routes/player_location_route.py`
+- `upload_routes/prekvk_route.py`
+- `upload_routes/kvk_all_route.py`
+- `upload_routes/mge_results_route.py`
+- `upload_routes/honor_route.py`
+- `upload_routes/inventory_route.py`
+- `upload_routes/weekly_activity_route.py`
+- `upload_routes/__init__.py`
+
+Likely Rally files:
+
+- `forts_ingest.py`
+- `file_utils.py`
+- `embed_utils.py`
+- `log_health.py`
+- `tests/test_file_utils.py`
+- `tests/test_file_utils_build_cmd.py`
+- nearby Rally/Forts tests discovered by `rg`
+
+Likely SQL repo objects to validate:
+
+- `dbo.stg_RallyDaily`
+- `dbo.stg_RallyAllTime`
+- `dbo.cur_RallyDaily`
+- `dbo.cur_RallyTotals_Base`
+- `dbo.IngestionLog`
+- `dbo.sp_Import_Rally_Daily`
+- `dbo.sp_Import_Rally_AllTime`
+- `dbo.v_RallyDaily_Latest`
+- `dbo.v_RallyTotals_Current`
+- `dbo.vFortsCompleted_WeekToDate`
+- `dbo.sp_Rebuild_RALLY_EXPORT`
+- related indexes and constraints on the tables above
+
+## Design Questions
+
+- Should Phase 5C move `is_rally_daily()` and `is_rally_alltime()` into the new Rally route module
+  as route-local helpers?
+- Should the route preserve local download staging exactly with `att.save(local_path)`, or should
+  download path handling be dependency-injected for tests while keeping the production path the
+  same?
+- Should Rally notify-channel fallback use `resolve_notify_channel()` from
+  `upload_routes/common.py`, preserving current fallback to the source channel when notify lookup
+  fails?
+- Should per-success log-backup scheduling use `schedule_best_effort()` from
+  `upload_routes/common.py`?
+- Should import failure and final embed send failures be swallowed or logged in exactly the same
+  way as the inline branch?
+- What route tests prove behaviour parity without adding live SQL or filesystem-heavy integration
+  coverage?
+- Should Phase 5D be required? Current recommendation: yes. Phase 5D should be the final
+  upload-routing sub-phase and should focus only on the main monitored-channel fallback queue route.
+
+## Step 1 Required Output
+
+Phase 5C Step 1 must produce:
+
+- Audit Summary
+- Current Rally Forts Route Map
+- Route Order And Fall-Through Map
+- Rally SQL Contract Map
+- Discord Output Preservation Map
+- Local Download / File Handling Map
+- Shared Helper Recommendation
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Phase 5D Recommendation
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, SQL, tests, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the approved Phase 5C route slice:
+
+- focused new Rally Forts route tests
+- relevant existing file/path helper tests
+- relevant `forts_ingest` tests if present or added with SQL mocked/faked
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` when running full-suite or
+  deployment-oriented validation
+
+If live SQL integration is intentionally needed, document and validate the opt-in path:
+
+```powershell
+$env:RUN_DB_TESTS="1"
+.\.venv\Scripts\python.exe -m pytest -q <selected live DB tests>
+```
+
+## Acceptance Criteria
+
+- Rally Forts upload handling is delegated through the approved `upload_routes` boundary.
+- `DL_bot.py` route order and fall-through behaviour are preserved.
+- Daily and all-time Rally filename matching remains unchanged.
+- Local download staging behaviour is preserved.
+- Lazy import failure handling is preserved.
+- SQL preflight, offload arguments, importer result handling, skip/error aggregation, final embed
+  content, and best-effort log-backup scheduling are preserved.
+- No new direct SQL is added to Discord listener/route layers.
+- `upload_routes/common.py` is reused where behaviour parity is clear and covered.
+- Out-of-scope fallback queue, SQL, lifecycle, worker, or importer-internal findings are captured
+  structurally.
+- The implementation packet explicitly states whether Phase 5D remains required. Current expected
+  answer: yes, Phase 5D is required for fallback monitored-channel queueing and should be the final
+  upload-routing sub-phase.
+
+## Explicit Stop Point
+
+Stop after the Phase 5C audit/design packet.
+
+Do not implement route extraction, alter SQL, change upload routing behaviour, or open a PR until
+the audit packet, route classification, and first implementation scope have each been approved.

--- a/tests/test_rally_forts_upload_route.py
+++ b/tests/test_rally_forts_upload_route.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from upload_routes import rally_forts_route as route
+
+
+class _FakeAttachment:
+    def __init__(
+        self,
+        filename: str,
+        payload: bytes = b"xlsx",
+        *,
+        save_exception: Exception | None = None,
+    ):
+        self.filename = filename
+        self.payload = payload
+        self.save_exception = save_exception
+        self.saved_paths: list[str] = []
+
+    async def save(self, path: str) -> None:
+        self.saved_paths.append(path)
+        if self.save_exception is not None:
+            raise self.save_exception
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int, name: str = "rally"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    id = 123456789
+
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments
+            if attachments is not None
+            else [_FakeAttachment("Rally_data_26-05-2026.xlsx")]
+        )
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _fake_daily_importer(*_args, **_kwargs):
+    raise AssertionError("offload test double should not call daily importer directly")
+
+
+def _fake_alltime_importer(*_args, **_kwargs):
+    raise AssertionError("offload test double should not call all-time importer directly")
+
+
+def _deps(tmp_path, **overrides):
+    sent = []
+    offloads = []
+    created_tasks = []
+    preflight_channels = []
+
+    async def get_notify_channel():
+        if "notify_exception" in overrides:
+            raise overrides["notify_exception"]
+        return overrides.get("notify_channel")
+
+    async def send_embed(ch, title, fields, color, mention=None):
+        sent.append((ch, title, fields, color, mention))
+        if "send_exception" in overrides:
+            raise overrides["send_exception"]
+
+    async def ensure_sql_headroom_or_notify(ch):
+        preflight_channels.append(ch)
+        return overrides.get("sql_ok", True)
+
+    async def offload_callable(func, *args, **kwargs):
+        offloads.append((func, args, kwargs))
+        if "offload_exception" in overrides:
+            raise overrides["offload_exception"]
+        return overrides.get("offload_result", {"status": "success", "rows": 7})
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return None
+
+    def importer_loader():
+        if "importer_exception" in overrides:
+            raise overrides["importer_exception"]
+        return (
+            overrides.get("alltime_importer", _fake_alltime_importer),
+            overrides.get("daily_importer", _fake_daily_importer),
+        )
+
+    deps = route.RallyFortsRouteDeps(
+        fort_rally_channel_id=overrides.get("fort_rally_channel_id", 10),
+        log_dir=str(tmp_path),
+        get_notify_channel=overrides.get("get_notify_channel", get_notify_channel),
+        send_embed=send_embed,
+        ensure_sql_headroom_or_notify=ensure_sql_headroom_or_notify,
+        offload_callable=offload_callable,
+        trigger_log_backup_background=trigger_log_backup_background,
+        create_task=create_task,
+        importer_loader=overrides.get("importer_loader", importer_loader),
+    )
+    return deps, sent, offloads, created_tasks, preflight_channels
+
+
+def test_rally_filename_matching_preserves_patterns():
+    assert route.is_rally_daily("Rally_data_26-05-2026.xlsx")
+    assert route.is_rally_daily("rally_data_26-05-2026.xlsx")
+    assert not route.is_rally_daily("Rally_data_All_Time.xlsx")
+
+    assert route.is_rally_alltime("Rally_data_All_Time.xlsx")
+    assert route.is_rally_alltime("Rally data all time May.xlsx")
+    assert route.is_rally_alltime("rally_data_anything_all_time_report.xlsx")
+    assert not route.is_rally_alltime("Rally_data_26-05-2026.xlsx")
+
+
+@pytest.mark.asyncio
+async def test_rally_route_ignores_other_channels(tmp_path):
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_rally_route_ignores_empty_attachments(tmp_path):
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(_message(attachments=[]), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
+async def test_rally_route_no_xlsx_warns_and_handles(tmp_path):
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(
+        _message(attachments=[_FakeAttachment("notes.txt")]), deps
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Rally Forts Import \u26a0\ufe0f"
+    assert fields == {
+        "Info": "No rally .xlsx attachments matched expected patterns.",
+        "Expected Daily": "Rally_data_DD-MM-YYYY.xlsx",
+        "Expected All-Time": "Rally_data_All_Time*.xlsx",
+    }
+    assert color == 0xE67E22
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_rally_route_importer_load_failure_sends_existing_error(tmp_path):
+    deps, sent, offloads, _created, _preflight = _deps(
+        tmp_path, importer_exception=RuntimeError("missing dep")
+    )
+
+    handled = await route.handle_rally_forts_upload(_message(), deps)
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert fields["Error"] == "Import failure: RuntimeError: missing dep"
+    assert "forts_ingest.py" in fields["Hint"]
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_daily_success_preserves_save_offload_and_embed_contract(tmp_path):
+    attachment = _FakeAttachment("Rally_data_26-05-2026.xlsx")
+    deps, sent, offloads, created, preflight = _deps(
+        tmp_path,
+        offload_result={"status": "success", "rows": 7, "as_of": "2026-05-26"},
+    )
+    message = _message(attachments=[attachment])
+
+    handled = await route.handle_rally_forts_upload(message, deps)
+
+    assert handled is True
+    expected_path = os.path.join(str(tmp_path), "downloads", "Rally_data_26-05-2026.xlsx")
+    assert attachment.saved_paths == [expected_path]
+    assert preflight == [message.channel]
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    assert func is _fake_daily_importer
+    assert args == (expected_path,)
+    assert kwargs == {
+        "name": "import_rally_daily_xlsx",
+        "prefer_process": True,
+        "meta": {"path": expected_path},
+    }
+    assert len(created) == 1
+    _ch, title, fields, color, mention = sent[-1]
+    assert title == "Rally Forts Import \u2705"
+    assert fields == {
+        "Source Channel": "#rally (10)",
+        "Uploaded By": "uploader (123456789)",
+        "\u2705 Rally_data_26-05-2026.xlsx": "rows=7; as_of=2026-05-26",
+    }
+    assert color == 0x2ECC71
+    assert mention is None
+
+
+@pytest.mark.asyncio
+async def test_rally_alltime_success_preserves_import_contract(tmp_path):
+    deps, sent, offloads, created, _preflight = _deps(
+        tmp_path, offload_result={"status": "success", "rows": 4}
+    )
+
+    handled = await route.handle_rally_forts_upload(
+        _message(attachments=[_FakeAttachment("Rally_data_All_Time.xlsx")]), deps
+    )
+
+    assert handled is True
+    assert len(offloads) == 1
+    func, args, kwargs = offloads[0]
+    expected_path = os.path.join(str(tmp_path), "downloads", "Rally_data_All_Time.xlsx")
+    assert func is _fake_alltime_importer
+    assert args == (expected_path,)
+    assert kwargs["name"] == "import_rally_alltime_xlsx"
+    assert kwargs["prefer_process"] is True
+    assert kwargs["meta"] == {"path": expected_path}
+    assert len(created) == 1
+    assert sent[-1][1] == "Rally Forts Import \u2705"
+    assert sent[-1][2]["\u2705 Rally_data_All_Time.xlsx"] == "rows=4"
+
+
+@pytest.mark.asyncio
+async def test_rally_sql_preflight_abort_happens_after_save_before_offload(tmp_path):
+    attachment = _FakeAttachment("Rally_data_26-05-2026.xlsx")
+    deps, sent, offloads, created, preflight = _deps(tmp_path, sql_ok=False)
+    message = _message(attachments=[attachment])
+
+    handled = await route.handle_rally_forts_upload(message, deps)
+
+    assert handled is True
+    assert attachment.saved_paths == [
+        os.path.join(str(tmp_path), "downloads", "Rally_data_26-05-2026.xlsx")
+    ]
+    assert preflight == [message.channel]
+    assert offloads == []
+    assert created == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert fields["\u274c Rally_data_26-05-2026.xlsx"] == (
+        "Aborted: SQL log headroom insufficient"
+    )
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_unrecognized_xlsx_is_saved_and_reported_as_skip(tmp_path):
+    attachment = _FakeAttachment("rally_notes.xlsx")
+    deps, sent, offloads, created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(
+        _message(attachments=[attachment]), deps
+    )
+
+    assert handled is True
+    assert attachment.saved_paths == [os.path.join(str(tmp_path), "downloads", "rally_notes.xlsx")]
+    assert offloads == []
+    assert created == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert fields["\u23ed\ufe0f rally_notes.xlsx"] == "Unrecognized rally filename"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_per_attachment_exception_is_aggregated(tmp_path):
+    deps, sent, offloads, created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(
+        _message(
+            attachments=[
+                _FakeAttachment(
+                    "Rally_data_26-05-2026.xlsx",
+                    save_exception=RuntimeError("disk full"),
+                )
+            ]
+        ),
+        deps,
+    )
+
+    assert handled is True
+    assert offloads == []
+    assert created == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert fields["\u274c Rally_data_26-05-2026.xlsx"] == "RuntimeError: disk full"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_mixed_success_and_error_uses_warning_embed(tmp_path):
+    deps, sent, offloads, created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(
+        _message(
+            attachments=[
+                _FakeAttachment("Rally_data_26-05-2026.xlsx"),
+                _FakeAttachment(
+                    "Rally_data_27-05-2026.xlsx",
+                    save_exception=RuntimeError("disk full"),
+                ),
+            ]
+        ),
+        deps,
+    )
+
+    assert handled is True
+    assert len(offloads) == 1
+    assert len(created) == 1
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u26a0\ufe0f"
+    assert "\u2705 Rally_data_26-05-2026.xlsx" in fields
+    assert fields["\u274c Rally_data_27-05-2026.xlsx"] == "RuntimeError: disk full"
+    assert color == 0xE67E22
+
+
+@pytest.mark.asyncio
+async def test_rally_final_embed_failure_is_swallowed(tmp_path):
+    deps, sent, _offloads, created, _preflight = _deps(
+        tmp_path, send_exception=RuntimeError("discord down")
+    )
+
+    handled = await route.handle_rally_forts_upload(_message(), deps)
+
+    assert handled is True
+    assert len(created) == 1
+    assert sent[-1][1] == "Rally Forts Import \u2705"
+
+
+@pytest.mark.asyncio
+async def test_rally_notify_failure_falls_back_to_source_channel(tmp_path):
+    deps, sent, _offloads, _created, preflight = _deps(
+        tmp_path, notify_exception=RuntimeError("notify down")
+    )
+    message = _message()
+
+    handled = await route.handle_rally_forts_upload(message, deps)
+
+    assert handled is True
+    assert preflight == [message.channel]
+    assert sent[-1][0] is message.channel

--- a/tests/test_rally_forts_upload_route.py
+++ b/tests/test_rally_forts_upload_route.py
@@ -367,19 +367,14 @@ async def test_rally_notify_failure_falls_back_to_source_channel(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_rally_fort_rally_channel_id_zero_is_detected_before_channel_filter(tmp_path):
-    """Misconfigured channel ID (0) must be detected and reported."""
+async def test_rally_fort_rally_channel_id_zero_disables_route(tmp_path):
     deps, sent, offloads, _created, _preflight = _deps(tmp_path, fort_rally_channel_id=0)
 
-    # Message has attachments but channel ID is 0
     handled = await route.handle_rally_forts_upload(_message(), deps)
 
-    assert handled is True
+    assert handled is False
+    assert sent == []
     assert offloads == []
-    _ch, title, fields, color, _mention = sent[-1]
-    assert title == "Rally Forts Import \u274c"
-    assert "FORT_RALLY_CHANNEL_ID is 0" in fields["Error"]
-    assert color == 0xE74C3C
 
 
 @pytest.mark.asyncio

--- a/tests/test_rally_forts_upload_route.py
+++ b/tests/test_rally_forts_upload_route.py
@@ -368,3 +368,57 @@ async def test_rally_notify_failure_falls_back_to_source_channel(tmp_path):
     assert handled is True
     assert preflight == [message.channel]
     assert sent[-1][0] is message.channel
+
+
+@pytest.mark.asyncio
+async def test_rally_fort_rally_channel_id_zero_is_detected_before_channel_filter(tmp_path):
+    """Misconfigured channel ID (0) must be detected and reported."""
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path, fort_rally_channel_id=0)
+
+    # Message has attachments but channel ID is 0
+    handled = await route.handle_rally_forts_upload(_message(), deps)
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert "FORT_RALLY_CHANNEL_ID is 0" in fields["Error"]
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_rejects_path_traversal_filenames(tmp_path):
+    """Filenames with path separators must be rejected to prevent path traversal."""
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path)
+
+    # Attempt path traversal with directory separators
+    handled = await route.handle_rally_forts_upload(
+        _message(attachments=[_FakeAttachment("../../etc/Rally_data_26-05-2026.xlsx")]),
+        deps,
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert "\u274c ../../etc/Rally_data_26-05-2026.xlsx" in fields
+    assert "path separators not allowed" in fields["\u274c ../../etc/Rally_data_26-05-2026.xlsx"]
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_rejects_backslash_path_traversal(tmp_path):
+    """Filenames with backslash separators must be rejected on all platforms."""
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(
+        _message(attachments=[_FakeAttachment("..\\..\\Rally_data_26-05-2026.xlsx")]),
+        deps,
+    )
+
+    assert handled is True
+    assert offloads == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert "\u274c ..\\..\\Rally_data_26-05-2026.xlsx" in fields
+    assert color == 0xE74C3C

--- a/tests/test_rally_forts_upload_route.py
+++ b/tests/test_rally_forts_upload_route.py
@@ -152,6 +152,17 @@ async def test_rally_route_ignores_empty_attachments(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_rally_route_zero_channel_id_falls_through(tmp_path):
+    deps, sent, offloads, _created, _preflight = _deps(tmp_path, fort_rally_channel_id=0)
+
+    handled = await route.handle_rally_forts_upload(_message(channel_id=10), deps)
+
+    assert handled is False
+    assert sent == []
+    assert offloads == []
+
+
+@pytest.mark.asyncio
 async def test_rally_route_no_xlsx_warns_and_handles(tmp_path):
     deps, sent, offloads, _created, _preflight = _deps(tmp_path)
 
@@ -266,9 +277,7 @@ async def test_rally_sql_preflight_abort_happens_after_save_before_offload(tmp_p
     assert created == []
     _ch, title, fields, color, _mention = sent[-1]
     assert title == "Rally Forts Import \u274c"
-    assert fields["\u274c Rally_data_26-05-2026.xlsx"] == (
-        "Aborted: SQL log headroom insufficient"
-    )
+    assert fields["\u274c Rally_data_26-05-2026.xlsx"] == ("Aborted: SQL log headroom insufficient")
     assert color == 0xE74C3C
 
 
@@ -277,9 +286,7 @@ async def test_rally_unrecognized_xlsx_is_saved_and_reported_as_skip(tmp_path):
     attachment = _FakeAttachment("rally_notes.xlsx")
     deps, sent, offloads, created, _preflight = _deps(tmp_path)
 
-    handled = await route.handle_rally_forts_upload(
-        _message(attachments=[attachment]), deps
-    )
+    handled = await route.handle_rally_forts_upload(_message(attachments=[attachment]), deps)
 
     assert handled is True
     assert attachment.saved_paths == [os.path.join(str(tmp_path), "downloads", "rally_notes.xlsx")]
@@ -288,6 +295,24 @@ async def test_rally_unrecognized_xlsx_is_saved_and_reported_as_skip(tmp_path):
     _ch, title, fields, color, _mention = sent[-1]
     assert title == "Rally Forts Import \u274c"
     assert fields["\u23ed\ufe0f rally_notes.xlsx"] == "Unrecognized rally filename"
+    assert color == 0xE74C3C
+
+
+@pytest.mark.asyncio
+async def test_rally_unsafe_attachment_filename_is_rejected_before_save(tmp_path):
+    attachment = _FakeAttachment("..\\Rally_data_26-05-2026.xlsx")
+    deps, sent, offloads, created, preflight = _deps(tmp_path)
+
+    handled = await route.handle_rally_forts_upload(_message(attachments=[attachment]), deps)
+
+    assert handled is True
+    assert attachment.saved_paths == []
+    assert preflight == []
+    assert offloads == []
+    assert created == []
+    _ch, title, fields, color, _mention = sent[-1]
+    assert title == "Rally Forts Import \u274c"
+    assert fields["\u274c ..\\Rally_data_26-05-2026.xlsx"] == "Unsafe attachment filename"
     assert color == 0xE74C3C
 
 

--- a/upload_routes/rally_forts_route.py
+++ b/upload_routes/rally_forts_route.py
@@ -42,6 +42,19 @@ def _load_importers() -> tuple[Callable[..., Any], Callable[..., Any]]:
     return import_rally_alltime_xlsx, import_rally_daily_xlsx
 
 
+def _safe_attachment_filename(filename: str) -> str | None:
+    safe_name = os.path.basename(filename)
+    if (
+        not safe_name
+        or safe_name in {".", ".."}
+        or safe_name != filename
+        or "/" in filename
+        or "\\" in filename
+    ):
+        return None
+    return safe_name
+
+
 async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> bool:
     """Handle Rally Forts XLSX imports from the configured Fort Rally channel."""
     if message.channel.id != deps.fort_rally_channel_id or not message.attachments:
@@ -53,15 +66,6 @@ async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> 
         logger,
         "rally_forts_upload",
     )
-
-    if not deps.fort_rally_channel_id:
-        await deps.send_embed(
-            notify_ch,
-            "Rally Forts Import \u274c",
-            {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
-            0xE74C3C,
-        )
-        return True
 
     try:
         importer_loader = deps.importer_loader or _load_importers
@@ -90,10 +94,16 @@ async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> 
         if not attachment.filename.lower().endswith(".xlsx"):
             continue
 
-        local_path = os.path.join(downloads_dir, attachment.filename)
+        filename = attachment.filename
+        safe_filename = _safe_attachment_filename(filename)
+        if safe_filename is None:
+            logger.warning("[RALLY] Rejected unsafe attachment filename: %r", filename)
+            results.append(("err", filename, "Unsafe attachment filename"))
+            continue
+
+        local_path = os.path.join(downloads_dir, safe_filename)
         try:
             await attachment.save(local_path)
-            filename = attachment.filename
             logger.info("[RALLY] Saved %s to %s", filename, local_path)
 
             if is_rally_alltime(filename):

--- a/upload_routes/rally_forts_route.py
+++ b/upload_routes/rally_forts_route.py
@@ -44,25 +44,11 @@ def _load_importers() -> tuple[Callable[..., Any], Callable[..., Any]]:
 
 async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> bool:
     """Handle Rally Forts XLSX imports from the configured Fort Rally channel."""
-    if not message.attachments:
-        return False
-
-    if not deps.fort_rally_channel_id:
-        notify_ch = await resolve_notify_channel(
-            deps.get_notify_channel,
-            message.channel,
-            logger,
-            "rally_forts_upload",
-        )
-        await deps.send_embed(
-            notify_ch,
-            "Rally Forts Import \u274c",
-            {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
-            0xE74C3C,
-        )
-        return True
-
-    if message.channel.id != deps.fort_rally_channel_id:
+    if (
+        not deps.fort_rally_channel_id
+        or message.channel.id != deps.fort_rally_channel_id
+        or not message.attachments
+    ):
         return False
 
     notify_ch = await resolve_notify_channel(

--- a/upload_routes/rally_forts_route.py
+++ b/upload_routes/rally_forts_route.py
@@ -44,7 +44,25 @@ def _load_importers() -> tuple[Callable[..., Any], Callable[..., Any]]:
 
 async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> bool:
     """Handle Rally Forts XLSX imports from the configured Fort Rally channel."""
-    if message.channel.id != deps.fort_rally_channel_id or not message.attachments:
+    if not message.attachments:
+        return False
+
+    if not deps.fort_rally_channel_id:
+        notify_ch = await resolve_notify_channel(
+            deps.get_notify_channel,
+            message.channel,
+            logger,
+            "rally_forts_upload",
+        )
+        await deps.send_embed(
+            notify_ch,
+            "Rally Forts Import \u274c",
+            {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
+            0xE74C3C,
+        )
+        return True
+
+    if message.channel.id != deps.fort_rally_channel_id:
         return False
 
     notify_ch = await resolve_notify_channel(
@@ -53,15 +71,6 @@ async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> 
         logger,
         "rally_forts_upload",
     )
-
-    if not deps.fort_rally_channel_id:
-        await deps.send_embed(
-            notify_ch,
-            "Rally Forts Import \u274c",
-            {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
-            0xE74C3C,
-        )
-        return True
 
     try:
         importer_loader = deps.importer_loader or _load_importers
@@ -90,7 +99,18 @@ async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> 
         if not attachment.filename.lower().endswith(".xlsx"):
             continue
 
-        local_path = os.path.join(downloads_dir, attachment.filename)
+        # Sanitize filename to prevent path traversal
+        # Reject any filename containing path separators (both / and \)
+        if "/" in attachment.filename or "\\" in attachment.filename:
+            logger.warning(
+                "[RALLY] Rejecting unsafe filename with path components: %s",
+                attachment.filename,
+            )
+            results.append(("err", attachment.filename, "Invalid filename: path separators not allowed"))
+            continue
+
+        safe_filename = os.path.basename(attachment.filename)
+        local_path = os.path.join(downloads_dir, safe_filename)
         try:
             await attachment.save(local_path)
             filename = attachment.filename

--- a/upload_routes/rally_forts_route.py
+++ b/upload_routes/rally_forts_route.py
@@ -1,0 +1,195 @@
+"""Rally Forts workbook upload route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+import os
+import re
+from typing import Any
+
+from upload_routes.common import resolve_notify_channel, schedule_best_effort
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RallyFortsRouteDeps:
+    fort_rally_channel_id: int
+    log_dir: str
+    get_notify_channel: Callable[[], Awaitable[Any | None]]
+    send_embed: Callable[..., Awaitable[None]]
+    ensure_sql_headroom_or_notify: Callable[[Any], Awaitable[bool]]
+    offload_callable: Callable[..., Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+    importer_loader: Callable[[], tuple[Callable[..., Any], Callable[..., Any]]] | None = None
+
+
+def is_rally_daily(filename: str) -> bool:
+    return re.search(r"^Rally_data_\d{2}-\d{2}-\d{4}\.xlsx$", filename, re.I) is not None
+
+
+def is_rally_alltime(filename: str) -> bool:
+    return re.search(r"Rally[_\s]?data.*all[\s_]?time.*\.xlsx$", filename, re.I) is not None
+
+
+def _load_importers() -> tuple[Callable[..., Any], Callable[..., Any]]:
+    from forts_ingest import import_rally_alltime_xlsx, import_rally_daily_xlsx
+
+    return import_rally_alltime_xlsx, import_rally_daily_xlsx
+
+
+async def handle_rally_forts_upload(message: Any, deps: RallyFortsRouteDeps) -> bool:
+    """Handle Rally Forts XLSX imports from the configured Fort Rally channel."""
+    if message.channel.id != deps.fort_rally_channel_id or not message.attachments:
+        return False
+
+    notify_ch = await resolve_notify_channel(
+        deps.get_notify_channel,
+        message.channel,
+        logger,
+        "rally_forts_upload",
+    )
+
+    if not deps.fort_rally_channel_id:
+        await deps.send_embed(
+            notify_ch,
+            "Rally Forts Import \u274c",
+            {"Error": "FORT_RALLY_CHANNEL_ID is 0 (unset). Check .env/bot_config."},
+            0xE74C3C,
+        )
+        return True
+
+    try:
+        importer_loader = deps.importer_loader or _load_importers
+        import_rally_alltime_xlsx, import_rally_daily_xlsx = importer_loader()
+    except Exception as e:
+        await deps.send_embed(
+            notify_ch,
+            "Rally Forts Import \u274c",
+            {
+                "Error": f"Import failure: {type(e).__name__}: {e}",
+                "Hint": "Ensure forts_ingest.py and its dependencies (pandas, pyodbc) are installed in the venv.",
+            },
+            0xE74C3C,
+        )
+        return True
+
+    downloads_dir = os.path.join(deps.log_dir, "downloads")
+    try:
+        os.makedirs(downloads_dir, exist_ok=True)
+    except Exception:
+        pass
+
+    results: list[tuple[str, str, Any]] = []
+    matched_any = False
+    for attachment in message.attachments:
+        if not attachment.filename.lower().endswith(".xlsx"):
+            continue
+
+        local_path = os.path.join(downloads_dir, attachment.filename)
+        try:
+            await attachment.save(local_path)
+            filename = attachment.filename
+            logger.info("[RALLY] Saved %s to %s", filename, local_path)
+
+            if is_rally_alltime(filename):
+                matched_any = True
+                logger.info("[RALLY] Detected ALL-TIME file: %s", filename)
+                ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+                if not ok:
+                    results.append(("err", filename, "Aborted: SQL log headroom insufficient"))
+                    continue
+
+                result = await deps.offload_callable(
+                    import_rally_alltime_xlsx,
+                    local_path,
+                    name="import_rally_alltime_xlsx",
+                    prefer_process=True,
+                    meta={"path": local_path},
+                )
+                results.append(("ok", filename, result))
+                schedule_best_effort(
+                    deps.create_task,
+                    deps.trigger_log_backup_background(),
+                    logger,
+                    "Failed to schedule background log-backup trigger",
+                )
+            elif is_rally_daily(filename):
+                matched_any = True
+                logger.info("[RALLY] Detected DAILY file: %s", filename)
+                ok = await deps.ensure_sql_headroom_or_notify(notify_ch)
+                if not ok:
+                    results.append(("err", filename, "Aborted: SQL log headroom insufficient"))
+                    continue
+
+                result = await deps.offload_callable(
+                    import_rally_daily_xlsx,
+                    local_path,
+                    name="import_rally_daily_xlsx",
+                    prefer_process=True,
+                    meta={"path": local_path},
+                )
+                results.append(("ok", filename, result))
+                schedule_best_effort(
+                    deps.create_task,
+                    deps.trigger_log_backup_background(),
+                    logger,
+                    "Failed to schedule background log-backup trigger",
+                )
+            else:
+                results.append(("skip", filename, "Unrecognized rally filename"))
+        except Exception as e:
+            logger.exception("[RALLY] Error processing attachment %s", attachment.filename)
+            results.append(("err", attachment.filename, f"{type(e).__name__}: {e}"))
+
+    if not matched_any and not results:
+        await deps.send_embed(
+            notify_ch,
+            "Rally Forts Import \u26a0\ufe0f",
+            {
+                "Info": "No rally .xlsx attachments matched expected patterns.",
+                "Expected Daily": "Rally_data_DD-MM-YYYY.xlsx",
+                "Expected All-Time": "Rally_data_All_Time*.xlsx",
+            },
+            0xE67E22,
+        )
+        return True
+
+    fields = {
+        "Source Channel": f"#{message.channel.name} ({message.channel.id})",
+        "Uploaded By": f"{message.author} ({message.author.id})",
+    }
+    oks = [result for result in results if result[0] == "ok"]
+    errs = [result for result in results if result[0] == "err"]
+    skips = [result for result in results if result[0] == "skip"]
+
+    for _, filename, result in oks[:5]:
+        if isinstance(result, dict):
+            rows = result.get("rows")
+            as_of = result.get("as_of")
+            extra = f"rows={rows}" + (f"; as_of={as_of}" if as_of else "")
+        else:
+            extra = str(result)
+        fields[f"\u2705 {filename}"] = extra or "ok"
+
+    for _, filename, why in skips[:5]:
+        fields[f"\u23ed\ufe0f {filename}"] = why
+
+    for _, filename, err in errs[:5]:
+        fields[f"\u274c {filename}"] = err
+
+    color = 0x2ECC71 if oks and not errs else (0xE67E22 if oks and errs else 0xE74C3C)
+    title = "Rally Forts Import" + (
+        " \u2705" if oks and not errs else " \u26a0\ufe0f" if oks and errs else " \u274c"
+    )
+
+    try:
+        await deps.send_embed(notify_ch, title, fields, color)
+    except Exception:
+        logger.exception("Failed to send Rally Forts import embed")
+
+    return True


### PR DESCRIPTION
## Summary

- Extracts the Rally Forts XLSX auto-ingest branch from `DL_bot.py` into `upload_routes/rally_forts_route.py`.
- Preserves Rally filename matching, local `LOG_DIR/downloads` staging, lazy `forts_ingest` import behavior, SQL preflight order, offload contracts, aggregate Discord embed output, and best-effort log-backup scheduling.
- Adds focused Rally route parity tests and updates the upload-routing programme docs/task packs through Phase 5C.

## Changes

- Adds `RallyFortsRouteDeps` and `handle_rally_forts_upload()`.
- Moves `is_rally_daily()` and `is_rally_alltime()` out of `DL_bot.py` into the Rally route module.
- Leaves `forts_ingest.py` and all SQL/importer contracts unchanged.
- Reuses `resolve_notify_channel()` and `schedule_best_effort()` from `upload_routes/common.py`.
- Keeps Phase 5D deferred for main monitored-channel fallback queue extraction.

## Tests

```powershell
.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py
.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py tests\test_weekly_activity_upload_route.py tests\test_honor_upload_route.py tests\test_mge_results_upload_route.py
.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
.\.venv\Scripts\python.exe scripts\select_tests.py
.\.venv\Scripts\python.exe scripts\smoke_imports.py
.\.venv\Scripts\python.exe scripts\validate_command_registration.py
.\.venv\Scripts\python.exe -m pytest -q tests
.\.venv\Scripts\python.exe -m pre_commit run -a
.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
```

Full suite: `1525 passed, 2 skipped`.

## Security Review

Not run locally before PR creation. This touches Discord upload/file routing, so Codex Security review should be run or explicitly waived before merge.

## Risk / Rollback

Risk is medium: this moves a production upload fast path but keeps importer, SQL, file staging, and Discord output contracts unchanged. Rollback is reverting this PR to restore the inline Rally branch in `DL_bot.py`.