### PR TITLE
[codex] Extract fallback upload queue route

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -101,7 +101,6 @@ logger.info("[LOCK] Child lock acquired at %s (PID %d)", BOT_LOCK_PATH, os.getpi
 # sys.path.append(os.path.expanduser(r"~\AppData\Roaming\Python\Python311\site-packages"))
 
 import asyncio
-from asyncio import QueueFull
 import json
 import signal
 import threading
@@ -133,6 +132,10 @@ from Commands import register_commands
 from embed_utils import send_embed
 from kvk_all_importer import _auto_export_kvk
 from log_health import LogHeadroomError, preflight_from_env_sync
+from upload_routes.fallback_queue_route import (
+    FallbackQueueRouteDeps,
+    handle_fallback_queue_upload,
+)
 from upload_routes.honor_route import HonorRouteDeps, handle_honor_upload
 from upload_routes.inventory_route import InventoryRouteDeps, handle_inventory_upload
 from upload_routes.kvk_all_route import KvkAllRouteDeps, handle_kvk_all_upload
@@ -147,7 +150,7 @@ from upload_routes.weekly_activity_route import (
     WeeklyActivityRouteDeps,
     handle_weekly_activity_upload,
 )
-from utils import live_queue, update_live_queue_embed, utcnow
+from utils import live_queue, live_queue_lock, update_live_queue_embed, utcnow
 
 # === Load environment variables ===
 if not TOKEN:
@@ -679,60 +682,20 @@ async def on_message(message: discord.Message):
         return
 
     # === Main monitored channels: enqueue heavy imports for worker processes ===
-    if message.channel.id in CHANNEL_IDS:
-        logger.info("✅ Channel %s is monitored.", message.channel.id)
-
-        for attachment in message.attachments:
-            logger.info("📎 Attachment: %s", attachment.filename)
-            if attachment.filename.lower().endswith((".xlsx", ".xls", ".csv")):
-                logger.info("📥 Enqueuing message %s for worker", message.id)
-                queue = channel_queues.get(message.channel.id)
-                if not queue:
-                    logger.warning(
-                        "No queue configured for channel %s; message %s not enqueued",
-                        message.channel.id,
-                        message.id,
-                    )
-                    continue
-                try:
-                    queue.put_nowait(message)
-                except QueueFull:
-                    logger.warning(
-                        "⚠️ Queue full for channel %s; dropping message %s",
-                        message.channel.id,
-                        message.id,
-                    )
-                else:
-                    # Protect the in-memory live_queue mutation with a lock to reduce risks
-                    # if any other threads or off-loop tasks access live_queue.
-                    try:
-                        with LIVE_QUEUE_LOCK:
-                            live_queue["jobs"].append(
-                                {
-                                    "filename": attachment.filename,
-                                    "user": str(message.author),
-                                    "channel": message.channel.name,
-                                    "uploaded": utcnow().isoformat(),
-                                    "status": "🕐 Queued",
-                                }
-                            )
-                    except Exception:
-                        # Never crash on queue bookkeeping; log debug info for investigation.
-                        logger.debug("Failed to append to live_queue (continuing)", exc_info=True)
-                    try:
-                        await update_live_queue_embed(bot, NOTIFY_CHANNEL_ID)
-                    except Exception:
-                        logger.exception("Failed to update live queue embed")
-
-                    # NEW: schedule a background log-backup trigger (best-effort) for main imports
-                    # This reduces the window where transaction log bursts between scheduled backups can cause aborts.
-                    try:
-                        asyncio.create_task(trigger_log_backup_background())
-                    except Exception:
-                        logger.exception(
-                            "Failed to schedule background log-backup trigger for queued import"
-                        )
-
+    await handle_fallback_queue_upload(
+        message,
+        FallbackQueueRouteDeps(
+            channel_ids=CHANNEL_IDS,
+            channel_queues=channel_queues,
+            live_queue=live_queue,
+            live_queue_lock=live_queue_lock,
+            bot=bot,
+            notify_channel_id=NOTIFY_CHANNEL_ID,
+            update_live_queue_embed=update_live_queue_embed,
+            trigger_log_backup_background=trigger_log_backup_background,
+            utcnow=utcnow,
+        ),
+    )
     await bot.process_commands(message)
 
 
@@ -744,11 +707,6 @@ async def on_message(message: discord.Message):
 _closing = False
 _closing_lock = threading.Lock()
 _SHUTDOWN_TIMEOUT_SECONDS = 10
-
-# Lock to guard in-memory live_queue mutations across threads if needed.
-# In normal operation the event-loop mutates this, but some helper threads or future changes
-# might touch it; this lock reduces risk of race conditions.
-LIVE_QUEUE_LOCK = threading.Lock()
 
 
 async def _write_shutdown_markers(exit_code: int = 0, reason: str = "signal"):

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -36,9 +36,14 @@ fields, and best-effort background task scheduling. Phase 5B inventory and weekl
 extraction was completed in PR 114 (`codex/dlbot-upload-routing-phase-5b`), smoke tested
 successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production, and
 closed: `DL_bot.py` now delegates those routes through `upload_routes/inventory_route.py` and
-`upload_routes/weekly_activity_route.py`. Phase 5C Rally Forts upload-route extraction is now the
-next upload-routing programme slice; Phase 5D is expected to be the final upload-routing sub-phase
-for main monitored-channel fallback queueing before Phase 6 lifecycle/startup separation.
+`upload_routes/weekly_activity_route.py`. Phase 5C Rally Forts upload-route extraction was
+completed in PR 115 (`codex/dlbot-upload-routing-phase-5c`), smoke tested successfully, merged,
+deployed to production, and pushed to production: `DL_bot.py` now delegates Rally Forts handling
+through `upload_routes/rally_forts_route.py` while preserving filename matching, local download
+staging, lazy importer loading, SQL preflight, offload dispatch, aggregate Discord output,
+safe filename rejection, disabled-channel fall-through, and best-effort log-backup scheduling.
+Phase 5D is now the final upload-routing sub-phase for main monitored-channel fallback queueing
+before Phase 6 lifecycle/startup separation.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
@@ -111,11 +116,11 @@ issues list.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After Phase 5B, `DL_bot.py` still owns Rally Forts ingest and main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, and weekly activity ingest now delegate through the `upload_routes` pattern, but the remaining inline routes still contain route-specific preflight/offload/rendering/logging and queue-bookkeeping patterns.
-- Suggested Fix: Continue Phase 5 with small sub-phases that consolidate the remaining fast paths into the `upload_routes` pattern. Phase 5C should extract Rally Forts ingest into a focused route module while preserving filename matching, local download staging, importer contracts, SQL preflight, per-file result aggregation, Discord output, and log-backup scheduling. Phase 5D should separately scope the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
+- Description: After Phase 5C, `DL_bot.py` still owns the main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, weekly activity ingest, and Rally Forts ingest now delegate through the `upload_routes` pattern, but the fallback queue path still mixes monitored-channel matching, worker queue handoff, `live_queue` bookkeeping, queue embed updates, and best-effort log-backup scheduling in the listener.
+- Suggested Fix: Complete Phase 5 with a final Phase 5D audit/scope pass for the main monitored-channel fallback queue route. Extract the fallback queue path into a focused `upload_routes` boundary only if the audit confirms route-order, queue ownership, `channel_queues`, `live_queue`, queue embed, worker handoff, and background log-backup side effects can be preserved with focused tests. Keep broader worker/lifecycle ownership and `processing_pipeline.py` refactors out of Phase 5D unless explicitly approved.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5B is complete, smoke tested, deployed, and production-pushed; start Phase 5C from `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`.
+- Dependencies: Phase 5C is complete, smoke tested, merged, deployed, and production-pushed; start Phase 5D from `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
 
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
@@ -21,6 +21,8 @@ We are starting Phase 5 of the DL_bot upload-routing optimisation programme afte
   `upload_routes/inventory_route.py` and `upload_routes/weekly_activity_route.py`, was smoke tested
   successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production,
   and closed.
+- Phase 5C extracted Rally Forts ingest into `upload_routes/rally_forts_route.py`, was smoke
+  tested successfully, merged, deployed to production, and pushed to production.
 
 ## Completion Note
 
@@ -104,14 +106,49 @@ Validation evidence included:
 Observed full-suite result: `1511 passed, 2 skipped`. Pytest log-noise validation confirmed
 production operational logs were unchanged.
 
-Phase 5C Rally Forts upload-route extraction is now the next active upload-routing programme
-slice. Starter packet:
+Phase 5C Rally Forts upload-route extraction was completed in PR 115. Its starter packet is
+retained for delivery history:
 `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`.
 
-Phase 5D is expected to be required as the final upload-routing sub-phase for main
-monitored-channel fallback queueing because that path touches `channel_queues`, `live_queue`,
-worker-process handoff, queue embed updates, and background log-backup scheduling. Keeping it
-separate avoids mixing Rally importer extraction with queue/lifecycle ownership changes.
+## Phase 5C Completion Note
+
+Status: Phase 5C complete in PR 115 (`codex/dlbot-upload-routing-phase-5c`), smoke tested
+successfully, merged, deployed to production, and pushed to production.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates Rally Forts upload handling through `handle_rally_forts_upload()`.
+- `upload_routes/rally_forts_route.py` preserves daily and all-time Rally filename matching,
+  local `LOG_DIR/downloads` staging, lazy `forts_ingest` import behaviour, SQL preflight order,
+  offload arguments, per-file result aggregation, final Discord embed shape, and best-effort
+  background log-backup scheduling.
+- Disabled `FORT_RALLY_CHANNEL_ID=0` falls through without sending embeds, matching the existing
+  disabled-channel convention.
+- Rally upload filenames containing path separators are rejected before local save.
+- `forts_ingest.py`, SQL objects, stored procedures, views, file formats, importer contracts, and
+  worker queue ownership were not changed.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py tests\test_weekly_activity_upload_route.py tests\test_honor_upload_route.py tests\test_mge_results_upload_route.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed final full-suite result after review fixes: `1528 passed, 2 skipped`. Pytest log-noise
+validation confirmed production operational logs were unchanged.
+
+Phase 5D is now the final upload-routing sub-phase for main monitored-channel fallback queueing.
+Starter packet:
+`docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
 
 Phase 5 is the remaining fast-path upload-route consolidation slice. It should use the proven
 `upload_routes` pattern to reduce `DL_bot.py` listener responsibilities while preserving production
@@ -125,9 +162,9 @@ modules or an approved shared upload-router boundary.
 The desired end state is:
 
 - `DL_bot.py` delegates remaining upload message handling and keeps only listener/event plumbing.
-- MGE results import, KVK Honour ingest, weekly activity ingest, and inventory upload-first routing
-  have clear route ownership after Phase 5B. Rally forts ingest and fallback monitored-channel
-  queueing remain to be extracted in later Phase 5 sub-phases.
+- MGE results import, KVK Honour ingest, weekly activity ingest, inventory upload-first routing,
+  and Rally Forts ingest have clear route ownership after Phase 5C. Fallback monitored-channel
+  queueing remains to be extracted in Phase 5D.
 - Shared SQL preflight, offload dispatch, import embed rendering, and route-level structured
   logging are consolidated only where behaviour parity is safe and testable.
 - Current Discord output, importer contracts, accepted filenames/extensions, side effects, fallback
@@ -155,6 +192,7 @@ Before audit work, read:
 - `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 - `docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md`
 - `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`
 
 Use `C:\K98-bot-SQL-Server` as the SQL source of truth for any importer, DAL, export, stored
 procedure, view, or output-contract assumptions reviewed during this phase.
@@ -174,8 +212,8 @@ procedure, view, or output-contract assumptions reviewed during this phase.
 ### Deferred Optimisation
 - Area: `DL_bot.py` remaining fast-path upload routes
 - Type: architecture
-- Description: After Phase 5B, `DL_bot.py` still owns Rally Forts ingest and main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, and weekly activity ingest now delegate through the `upload_routes` pattern.
-- Suggested Fix: Continue Phase 5 with small sub-phases: Phase 5C should extract Rally Forts ingest into the `upload_routes` pattern, and Phase 5D should separately scope the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
+- Description: After Phase 5C, `DL_bot.py` still owns main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, weekly activity ingest, and Rally Forts ingest now delegate through the `upload_routes` pattern.
+- Suggested Fix: Complete Phase 5 with a final Phase 5D audit/scope pass for the main monitored-channel fallback queue route because it touches worker queue ownership, `channel_queues`, `live_queue`, and queue embed side effects.
 - Impact: medium
 - Risk: medium
 - Dependencies: Player-location, PreKvK, validation-blocker, and KVK_ALL phases are complete and production smoke tested; preserve existing Discord output and importer contracts.
@@ -194,9 +232,8 @@ In scope for Step 1 audit:
   contracts.
 - Capture out-of-scope findings structurally.
 
-Likely remaining route candidates:
+Likely remaining route candidate:
 
-- Rally forts XLSX auto-ingest route.
 - Main monitored-channel fallback queue route.
 
 Out of scope until separately approved:
@@ -250,17 +287,13 @@ Likely tests:
 
 ## Design Questions
 
-- Should Phase 5C extract Rally Forts only, leaving fallback monitored-channel queueing to a final
-  Phase 5D? Current recommendation: yes, because the fallback queue path has worker/lifecycle
-  side effects that should not be mixed with Rally importer extraction.
+- Should Phase 5D extract fallback monitored-channel queueing into a route module, or should the
+  audit recommend leaving it in `DL_bot.py` until Phase 6 lifecycle/queue ownership work?
 - Which shared dependency object or helper should be introduced without over-abstracting the route
   pattern proven by player-location, PreKvK, and KVK_ALL?
-- Which repeated embed-rendering patterns are identical enough to consolidate safely, and which
-  should remain route-local to preserve exact Discord output?
-- Should fallback monitored-channel queueing become a route module, or should it remain at the end
-  of `DL_bot.py` until Phase 6 lifecycle/queue ownership is scoped?
-- Which SQL contracts need source-of-truth validation before implementation, and which are already
-  covered by existing tests?
+- Which queue side effects are identical enough to preserve inside a route module, and which
+  should remain in `DL_bot.py` until Phase 6?
+- Is any SQL-facing contract actually touched by Phase 5D? Current expectation: no.
 - What is the minimal first PR that reduces listener complexity without creating a hard-to-review
   broad router rewrite?
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
@@ -23,9 +23,50 @@ We are starting Phase 5C of the DL_bot upload-routing optimisation programme aft
   successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production,
   and closed.
 
-Phase 5C is the next small upload-routing slice. It should keep using the proven `upload_routes`
-pattern and `upload_routes/common.py` helpers where behaviour matches. Do not pull the main
-monitored-channel fallback queue into this phase unless explicitly approved after the audit packet.
+Phase 5C was the next small upload-routing slice. It kept using the proven `upload_routes`
+pattern and `upload_routes/common.py` helpers where behaviour matched, without pulling the main
+monitored-channel fallback queue into the Rally Forts route extraction.
+
+## Completion Note
+
+Status: Phase 5C complete in PR 115 (`codex/dlbot-upload-routing-phase-5c`), smoke tested
+successfully, merged, deployed to production, and pushed to production.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates Rally Forts upload handling through `handle_rally_forts_upload()`.
+- `upload_routes/rally_forts_route.py` owns Rally Forts Discord route matching, daily/all-time
+  filename classification, local download staging under `LOG_DIR/downloads`, lazy importer loading,
+  SQL preflight handoff, offload dispatch, result aggregation, Discord output, and best-effort
+  log-backup scheduling.
+- `FORT_RALLY_CHANNEL_ID=0` is treated as disabled route configuration and falls through without
+  sending embeds, matching the existing upload-route convention for disabled channel IDs.
+- Attachment names containing path separators are rejected before local save to prevent path
+  traversal or directory-component staging.
+- `forts_ingest.py` and Rally SQL/importer contracts were not changed.
+- Phase 5D remains required as the final upload-routing sub-phase for main monitored-channel
+  fallback queueing.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_rally_forts_upload_route.py tests\test_weekly_activity_upload_route.py tests\test_honor_upload_route.py tests\test_mge_results_upload_route.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed final full-suite result after review fixes: `1528 passed, 2 skipped`. Pytest log-noise
+validation confirmed production operational logs were unchanged.
+
+The next starter packet is
+`docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
 
 ## Goal
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md
@@ -1,0 +1,255 @@
+# DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter
+
+We are starting Phase 5D of the DL_bot upload-routing optimisation programme after:
+
+- Phase 1 player-location upload routing was smoke tested successfully and pushed to production.
+- Phase 2A PreKvK upload route extraction was smoke tested successfully and pushed to production.
+- Phase 2B PreKvK SQL compatibility cleanup was deployed, smoke tested successfully, and pushed to
+  production.
+- Phase 2C delivered the public read-only `/prekvk report` image report, was smoke tested
+  successfully, and pushed to production.
+- Phase 2D refactored the scheduled PreKvK stats-alert path onto the Phase 2C report service
+  architecture, was smoke tested successfully, and pushed to production.
+- Phase 3 local validation blockers were audited and closed as a no-op after the focused blocker
+  tests, full suite, and log-noise validation all passed under `.venv`.
+- Phase 4 extracted the KVK_ALL route into `upload_routes/kvk_all_route.py`, was smoke tested
+  successfully on 2026-05-26, and was pushed to production.
+- Phase 5A extracted MGE results and KVK Honor upload routing into
+  `upload_routes/mge_results_route.py` and `upload_routes/honor_route.py`, added
+  `upload_routes/common.py`, was smoke tested successfully on 2026-05-26, deployed to production,
+  and closed.
+- Phase 5B extracted inventory upload-first routing and weekly activity ingest into
+  `upload_routes/inventory_route.py` and `upload_routes/weekly_activity_route.py`, was smoke tested
+  successfully on 2026-05-26 with inventory and alliance weekly uploads, deployed to production,
+  and closed.
+- Phase 5C extracted Rally Forts ingest into `upload_routes/rally_forts_route.py`, was smoke
+  tested successfully, merged, deployed to production, and pushed to production.
+
+Phase 5D is expected to be the final upload-routing sub-phase before Phase 6 startup/lifecycle
+separation. It is intentionally more sensitive than the previous upload-route slices because the
+remaining inline path owns queue handoff, live queue bookkeeping, and queue embed side effects.
+
+## Goal
+
+Audit and, if approved, extract the main monitored-channel fallback queue route from `DL_bot.py`
+into a focused upload-route boundary while preserving production behaviour.
+
+The desired end state is:
+
+- `DL_bot.py` keeps listener/event plumbing and delegates monitored-channel fallback queueing
+  through an approved boundary.
+- Route order and fall-through behaviour are preserved after all specific fast-path upload routes.
+- Accepted fallback attachments remain unchanged: `.xlsx`, `.xls`, and `.csv`.
+- Existing worker queue handoff through `channel_queues` is preserved.
+- Existing `QueueFull` behaviour is preserved.
+- Existing `live_queue["jobs"]` bookkeeping and `update_live_queue_embed()` side effects are
+  preserved.
+- Existing best-effort log-backup scheduling for queued imports is preserved.
+- No worker-process, `processing_pipeline.py`, queue persistence, SQL/importer, or lifecycle
+  ownership changes are introduced unless explicitly approved after the audit packet.
+
+Step 1 is an audit/design packet, not implementation. Stop before code changes until the Phase 5D
+route classification and implementation scope are approved.
+
+## Required Reading
+
+Before audit work, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md`
+
+Use `docs/reference/runbook_diagnostics.md` only if the audit needs deeper diagnostics, telemetry,
+offload, queue recovery, or log-backup context. Use `docs/reference/runbook_startup.md`,
+`docs/reference/runbook_shutdown.md`, and `docs/reference/singleton_lock.md` only if the audit
+discovers startup, shutdown, or lifecycle implications that cannot be classified without them.
+
+## Skills To Use
+
+- `k98-architecture-scope`
+- `k98-discord-command-feature`
+- `k98-test-selection`
+- `k98-deferred-optimisation-capture`
+- `k98-pr-review` before any PR handoff
+- `k98-promotion-check` only before production promotion/deployment
+
+Use `k98-sql-validation` only if the audit unexpectedly reaches SQL-facing importer contracts.
+The intended Phase 5D route boundary should not change SQL objects.
+
+## Source Deferred Item
+
+### Deferred Optimisation
+- Area: `DL_bot.py` remaining fast-path upload routes
+- Type: architecture
+- Description: After Phase 5C, `DL_bot.py` still owns the main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, weekly activity ingest, and Rally Forts ingest now delegate through the `upload_routes` pattern, but the fallback queue path still mixes monitored-channel matching, worker queue handoff, `live_queue` bookkeeping, queue embed updates, and best-effort log-backup scheduling in the listener.
+- Suggested Fix: Complete Phase 5 with a final Phase 5D audit/scope pass for the main monitored-channel fallback queue route. Extract the fallback queue path into a focused `upload_routes` boundary only if the audit confirms route-order, queue ownership, `channel_queues`, `live_queue`, queue embed, worker handoff, and background log-backup side effects can be preserved with focused tests. Keep broader worker/lifecycle ownership and `processing_pipeline.py` refactors out of Phase 5D unless explicitly approved.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 5C is complete, smoke tested, merged, deployed, and production-pushed.
+
+## Phase 5D Scope
+
+In scope for Step 1 audit:
+
+- Audit the current main monitored-channel fallback branch in `DL_bot.py`.
+- Map exact route order after inventory, player location, MGE results, PreKvK, Honor, weekly
+  activity, Rally Forts, and KVK_ALL routes.
+- Audit `CHANNEL_IDS` matching and disabled/empty configuration behaviour.
+- Audit `bot_helpers.channel_queues` construction and queue lookup expectations.
+- Audit `QueueFull` handling and message drop logging.
+- Audit `live_queue["jobs"]` mutation, `LIVE_QUEUE_LOCK`, and `update_live_queue_embed()` calls.
+- Audit `trigger_log_backup_background()` scheduling after successful queue handoff.
+- Identify whether a thin `upload_routes/fallback_queue_route.py` can preserve behaviour without
+  moving worker ownership.
+- Identify focused route tests required for behaviour parity.
+- Capture worker/lifecycle/persistence findings structurally when they exceed the approved route
+  boundary.
+
+Likely Phase 5D route candidate:
+
+- `upload_routes/fallback_queue_route.py`
+
+Out of scope until separately approved:
+
+- Rewriting `channel_queues` ownership or worker startup.
+- Rewriting `processing_pipeline.py`, importer execution, or worker process orchestration.
+- Changing queue size, retry, duplicate enqueue, or drop semantics.
+- Changing live queue persistence in `utils.py`.
+- Changing queue embed content or persistence semantics unless required for parity.
+- Changing monitored-channel config semantics.
+- Changing SQL schema, importers, workbook/file formats, or downstream processing contracts.
+- Broad `DL_bot.py` startup/lifecycle or `bot_instance.py` refactor.
+
+## Current Files To Review
+
+Likely route/listener files:
+
+- `DL_bot.py`
+- `upload_routes/common.py`
+- `upload_routes/player_location_route.py`
+- `upload_routes/prekvk_route.py`
+- `upload_routes/kvk_all_route.py`
+- `upload_routes/mge_results_route.py`
+- `upload_routes/honor_route.py`
+- `upload_routes/inventory_route.py`
+- `upload_routes/weekly_activity_route.py`
+- `upload_routes/rally_forts_route.py`
+- `upload_routes/__init__.py`
+
+Likely queue/worker/helper files:
+
+- `bot_config.py`
+- `bot_helpers.py`
+- `utils.py`
+- `processing_pipeline.py`
+- `file_utils.py`
+- `log_health.py`
+
+Likely tests:
+
+- `tests/test_processing_pipeline.py`
+- `tests/test_live_queue_persistence.py`
+- `tests/test_utils_live_queue.py`
+- `tests/test_offload_callable_integration.py`
+- `tests/test_offload_monitor_once.py`
+- `tests/test_offload_registry_rotation.py`
+- `tests/test_offload_serialization.py`
+- `tests/test_maintenance_suite.py`
+- existing upload-route tests
+- new focused fallback queue route tests if implementation is approved
+
+## Design Questions
+
+- Should Phase 5D extract fallback queueing into `upload_routes/fallback_queue_route.py`, or should
+  the audit recommend leaving this path inline until Phase 6 because queue/lifecycle ownership is
+  too tightly coupled?
+- If extracted, should the route receive `channel_queues`, `live_queue`, `LIVE_QUEUE_LOCK`,
+  `update_live_queue_embed`, and `trigger_log_backup_background` through a dependency dataclass?
+- Should the route return `True` when a monitored-channel message has attachments but no supported
+  `.xlsx/.xls/.csv` file, preserving the current listener behaviour of processing commands after
+  the branch?
+- Should queue embed update failures remain logged and non-fatal exactly as today?
+- Should `QueueFull` remain a logged drop with no user-facing Discord embed?
+- Should live queue bookkeeping continue to append once per accepted attachment even though the
+  message is enqueued once per accepted attachment under current behaviour?
+- What focused tests prove parity without invoking real worker processes?
+- Should Phase 6 begin immediately after Phase 5D, or should a short phase-end cleanup PR update
+  docs/backlog first?
+
+## Step 1 Required Output
+
+Phase 5D Step 1 must produce:
+
+- Audit Summary
+- Current Fallback Queue Route Map
+- Route Order And Fall-Through Map
+- Queue / Worker Handoff Map
+- Live Queue / Queue Embed Side-Effect Map
+- Local File / Attachment Filtering Map
+- Shared Helper Recommendation
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Phase 6 Recommendation
+- Approval Questions
+- Explicit Stop Point
+
+Do not write bot code, tests, SQL, or deployment scripts during Step 1.
+
+## Validation Requirements
+
+For audit/design-only work:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+For implementation after approval, choose validation based on the approved Phase 5D route slice:
+
+- focused new fallback queue route tests
+- relevant existing queue/live-queue tests
+- relevant existing processing pipeline smoke/regression tests where practical
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
+- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
+- `.\.venv\Scripts\python.exe -m pre_commit run -a`
+- `.\.venv\Scripts\python.exe -m pytest -q tests`
+- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` when running full-suite or
+  deployment-oriented validation
+
+## Acceptance Criteria
+
+- Fallback monitored-channel queue handling is either delegated through an approved boundary or
+  explicitly kept inline with a documented reason.
+- `DL_bot.py` route order and fall-through behaviour are preserved.
+- Accepted fallback attachment extensions remain `.xlsx`, `.xls`, and `.csv`.
+- Worker queue handoff through `channel_queues` is preserved.
+- `QueueFull` handling is preserved.
+- `live_queue` bookkeeping and queue embed update side effects are preserved.
+- Best-effort log-backup scheduling after queued imports is preserved.
+- No new direct SQL is added to Discord listener/route layers.
+- No worker/lifecycle/startup refactor is bundled into the route extraction.
+- Out-of-scope worker, lifecycle, persistence, queue-embed, SQL, or processing-pipeline findings
+  are captured structurally.
+- The implementation packet explicitly states whether Phase 6 remains required. Current expected
+  answer: yes, Phase 6 is required for startup/lifecycle separation after Phase 5D.
+
+## Explicit Stop Point
+
+Stop after the Phase 5D audit/design packet.
+
+Do not implement route extraction, alter queue ownership, change worker behaviour, change
+processing-pipeline behaviour, or open a PR until the audit packet, route classification, and first
+implementation scope have each been approved.

--- a/tests/test_fallback_queue_route.py
+++ b/tests/test_fallback_queue_route.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from asyncio import QueueFull
+from datetime import UTC, datetime
+
+import pytest
+
+from upload_routes import fallback_queue_route as route
+
+
+class _FakeAttachment:
+    def __init__(self, filename: str):
+        self.filename = filename
+
+
+class _FakeChannel:
+    def __init__(self, channel_id: int = 10, name: str = "uploads"):
+        self.id = channel_id
+        self.name = name
+
+
+class _FakeAuthor:
+    def __str__(self) -> str:
+        return "uploader"
+
+
+class _FakeMessage:
+    def __init__(self, channel_id: int = 10, attachments=None):
+        self.id = 987654321
+        self.channel = _FakeChannel(channel_id)
+        self.author = _FakeAuthor()
+        self.attachments = (
+            attachments if attachments is not None else [_FakeAttachment("stats.xlsx")]
+        )
+
+
+class _FakeQueue:
+    def __init__(self, *, full: bool = False):
+        self.full = full
+        self.items = []
+
+    def put_nowait(self, item):
+        if self.full:
+            raise QueueFull
+        self.items.append(item)
+
+
+class _FakeLock:
+    def __init__(self, *, enter_exception: Exception | None = None):
+        self.enter_exception = enter_exception
+        self.entered = 0
+
+    async def __aenter__(self):
+        self.entered += 1
+        if self.enter_exception is not None:
+            raise self.enter_exception
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _message(channel_id: int = 10, attachments=None) -> _FakeMessage:
+    return _FakeMessage(channel_id, attachments)
+
+
+def _deps(**overrides):
+    live_queue = overrides.get("live_queue", {"jobs": []})
+    queue = overrides.get("queue", _FakeQueue())
+    channel_queues = overrides.get("channel_queues", {10: queue})
+    updated = []
+    created = []
+
+    async def update_live_queue_embed(bot, notify_channel_id):
+        updated.append((bot, notify_channel_id))
+        if "update_exception" in overrides:
+            raise overrides["update_exception"]
+
+    async def trigger_log_backup_background():
+        return None
+
+    def create_task(coro):
+        created.append(coro)
+        if "create_task_exception" in overrides:
+            raise overrides["create_task_exception"]
+        coro.close()
+        return None
+
+    deps = route.FallbackQueueRouteDeps(
+        channel_ids=overrides.get("channel_ids", [10]),
+        channel_queues=channel_queues,
+        live_queue=live_queue,
+        live_queue_lock=overrides.get("live_queue_lock", _FakeLock()),
+        bot=overrides.get("bot", object()),
+        notify_channel_id=overrides.get("notify_channel_id", 99),
+        update_live_queue_embed=update_live_queue_embed,
+        trigger_log_backup_background=overrides.get(
+            "trigger_log_backup_background", trigger_log_backup_background
+        ),
+        utcnow=overrides.get(
+            "utcnow",
+            lambda: datetime(2026, 5, 26, 12, 30, tzinfo=UTC),
+        ),
+        create_task=create_task,
+    )
+    return deps, queue, live_queue, updated, created
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_ignores_unmonitored_channel():
+    deps, queue, live_queue, updated, created = _deps()
+
+    handled = await route.handle_fallback_queue_upload(_message(channel_id=99), deps)
+
+    assert handled is False
+    assert queue.items == []
+    assert live_queue["jobs"] == []
+    assert updated == []
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_ignores_unsupported_attachments_but_handles_channel():
+    deps, queue, live_queue, updated, created = _deps()
+
+    handled = await route.handle_fallback_queue_upload(
+        _message(attachments=[_FakeAttachment("notes.txt")]), deps
+    )
+
+    assert handled is True
+    assert queue.items == []
+    assert live_queue["jobs"] == []
+    assert updated == []
+    assert created == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("filename", ["stats.xlsx", "stats.xls", "stats.csv"])
+async def test_fallback_route_accepts_existing_extensions(filename: str):
+    deps, queue, live_queue, updated, created = _deps()
+    message = _message(attachments=[_FakeAttachment(filename)])
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message]
+    assert live_queue["jobs"] == [
+        {
+            "filename": filename,
+            "user": "uploader",
+            "channel": "uploads",
+            "uploaded": "2026-05-26T12:30:00+00:00",
+            "status": "🕐 Queued",
+        }
+    ]
+    assert len(updated) == 1
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_missing_queue_does_not_append_or_update():
+    deps, _queue, live_queue, updated, created = _deps(channel_queues={})
+
+    handled = await route.handle_fallback_queue_upload(_message(), deps)
+
+    assert handled is True
+    assert live_queue["jobs"] == []
+    assert updated == []
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_queue_full_drops_without_side_effects():
+    deps, queue, live_queue, updated, created = _deps(queue=_FakeQueue(full=True))
+
+    handled = await route.handle_fallback_queue_upload(_message(), deps)
+
+    assert handled is True
+    assert queue.items == []
+    assert live_queue["jobs"] == []
+    assert updated == []
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_live_queue_append_failure_is_non_fatal():
+    deps, queue, live_queue, updated, created = _deps(
+        live_queue_lock=_FakeLock(enter_exception=RuntimeError("lock failed"))
+    )
+    message = _message()
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message]
+    assert live_queue["jobs"] == []
+    assert len(updated) == 1
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_embed_update_failure_is_non_fatal():
+    deps, queue, live_queue, updated, created = _deps(update_exception=RuntimeError("discord down"))
+    message = _message()
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message]
+    assert len(live_queue["jobs"]) == 1
+    assert len(updated) == 1
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_backup_scheduling_failure_is_non_fatal():
+    deps, queue, live_queue, updated, created = _deps(
+        create_task_exception=RuntimeError("scheduler down")
+    )
+    message = _message()
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message]
+    assert len(live_queue["jobs"]) == 1
+    assert len(updated) == 1
+    assert len(created) == 1
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_backup_awaitable_construction_failure_is_non_fatal():
+    def trigger_log_backup_background():
+        raise RuntimeError("factory down")
+
+    deps, queue, live_queue, updated, created = _deps(
+        trigger_log_backup_background=trigger_log_backup_background
+    )
+    message = _message()
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message]
+    assert len(live_queue["jobs"]) == 1
+    assert len(updated) == 1
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_route_preserves_enqueue_per_accepted_attachment_behavior():
+    deps, queue, live_queue, updated, created = _deps()
+    message = _message(
+        attachments=[
+            _FakeAttachment("first.xlsx"),
+            _FakeAttachment("skip.txt"),
+            _FakeAttachment("second.csv"),
+        ]
+    )
+
+    handled = await route.handle_fallback_queue_upload(message, deps)
+
+    assert handled is True
+    assert queue.items == [message, message]
+    assert [job["filename"] for job in live_queue["jobs"]] == ["first.xlsx", "second.csv"]
+    assert len(updated) == 2
+    assert len(created) == 2

--- a/upload_routes/fallback_queue_route.py
+++ b/upload_routes/fallback_queue_route.py
@@ -1,0 +1,97 @@
+"""Fallback monitored-channel queue route for the legacy Discord message listener."""
+
+from __future__ import annotations
+
+import asyncio
+from asyncio import QueueFull
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from upload_routes.common import schedule_best_effort
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_FALLBACK_EXTENSIONS = (".xlsx", ".xls", ".csv")
+
+
+@dataclass(frozen=True)
+class FallbackQueueRouteDeps:
+    channel_ids: set[int] | list[int] | tuple[int, ...]
+    channel_queues: Mapping[int, Any]
+    live_queue: dict[str, Any]
+    live_queue_lock: Any
+    bot: Any
+    notify_channel_id: int
+    update_live_queue_embed: Callable[[Any, int], Awaitable[Any]]
+    trigger_log_backup_background: Callable[[], Awaitable[Any]]
+    utcnow: Callable[[], Any]
+    create_task: Callable[[Awaitable[Any]], Any] = asyncio.create_task
+
+
+async def handle_fallback_queue_upload(message: Any, deps: FallbackQueueRouteDeps) -> bool:
+    """Queue supported attachments from monitored channels for worker processing."""
+    if message.channel.id not in deps.channel_ids:
+        return False
+
+    logger.info("✅ Channel %s is monitored.", message.channel.id)
+
+    for attachment in message.attachments:
+        logger.info("📎 Attachment: %s", attachment.filename)
+        if not attachment.filename.lower().endswith(SUPPORTED_FALLBACK_EXTENSIONS):
+            continue
+
+        logger.info("📥 Enqueuing message %s for worker", message.id)
+        queue = deps.channel_queues.get(message.channel.id)
+        if not queue:
+            logger.warning(
+                "No queue configured for channel %s; message %s not enqueued",
+                message.channel.id,
+                message.id,
+            )
+            continue
+
+        try:
+            queue.put_nowait(message)
+        except QueueFull:
+            logger.warning(
+                "⚠️ Queue full for channel %s; dropping message %s",
+                message.channel.id,
+                message.id,
+            )
+        else:
+            try:
+                async with deps.live_queue_lock:
+                    deps.live_queue["jobs"].append(
+                        {
+                            "filename": attachment.filename,
+                            "user": str(message.author),
+                            "channel": message.channel.name,
+                            "uploaded": deps.utcnow().isoformat(),
+                            "status": "🕐 Queued",
+                        }
+                    )
+            except Exception:
+                logger.debug("Failed to append to live_queue (continuing)", exc_info=True)
+
+            try:
+                await deps.update_live_queue_embed(deps.bot, deps.notify_channel_id)
+            except Exception:
+                logger.exception("Failed to update live queue embed")
+
+            try:
+                backup_task = deps.trigger_log_backup_background()
+            except Exception:
+                logger.exception(
+                    "Failed to schedule background log-backup trigger for queued import"
+                )
+            else:
+                schedule_best_effort(
+                    deps.create_task,
+                    backup_task,
+                    logger,
+                    "Failed to schedule background log-backup trigger for queued import",
+                )
+
+    return True


### PR DESCRIPTION
## Summary

- Extract the remaining monitored-channel fallback queue branch from `DL_bot.py` into `upload_routes/fallback_queue_route.py`.
- Preserve fallback route order after all specific upload routes and before `bot.process_commands(message)`.
- Preserve accepted fallback extensions, `channel_queues` handoff, `QueueFull` drop handling, `live_queue` bookkeeping, queue embed updates, and best-effort log-backup scheduling.
- Add focused route parity tests for matching, ignored files, missing/full queues, non-fatal side-effect failures, and multi-attachment enqueue behaviour.
- Include the Phase 5D starter pack plus Phase 5/Phase 5C/deferred-backlog documentation updates so the programme docs match the implemented slice.
- Address review feedback by keeping synchronous backup-awaitable construction failures non-fatal before task scheduling.
- Address review feedback by using the shared `utils.live_queue_lock` async lock for fallback queue live-queue mutations, matching `update_live_queue_embed()` and processing-pipeline updates.

## Validation

- `./.venv/Scripts/python.exe -m pytest -q tests/test_fallback_queue_route.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_fallback_queue_route.py tests/test_live_queue_persistence.py tests/test_utils_live_queue.py tests/test_processing_pipeline.py`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pytest -q tests` (`1539 passed, 2 skipped`)
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py` (`1539 passed, 2 skipped`; production operational logs unchanged)
- After adding docs to this PR: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- After adding docs to this PR: `./.venv/Scripts/python.exe scripts/select_tests.py`
- After backup scheduling review fix: `./.venv/Scripts/python.exe -m pytest -q tests/test_fallback_queue_route.py` (`12 passed`)
- After backup scheduling review fix: `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- After backup scheduling review fix: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- After backup scheduling review fix: `./.venv/Scripts/python.exe scripts/select_tests.py`
- After backup scheduling review fix: `./.venv/Scripts/python.exe -m pre_commit run -a`
- After shared-lock review fix: `./.venv/Scripts/python.exe -m pytest -q tests/test_fallback_queue_route.py tests/test_utils_live_queue.py tests/test_live_queue_persistence.py tests/test_processing_pipeline.py` (`17 passed`)
- After shared-lock review fix: `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- After shared-lock review fix: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- After shared-lock review fix: `./.venv/Scripts/python.exe scripts/select_tests.py`
- After shared-lock review fix: `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- After shared-lock review fix: `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- After shared-lock review fix: `./.venv/Scripts/python.exe -m pre_commit run -a`

## Notes

- No SQL changes.
- Worker, processing pipeline, queue ownership, and lifecycle/startup refactors remain out of scope for Phase 5D.
- Phase 6 remains required for broader startup/lifecycle separation and live queue ownership cleanup.
- Codex Security review should be run before ready-for-review handoff because this touches Discord message routing, file handling, queue state, and restart-sensitive queue metadata.