### PR TITLE
[codex] Add startup lifecycle phase boundary

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -66,6 +66,7 @@ from constants import (
     USERNAME,
 )
 from core.interaction_safety import get_operation_lock
+from core.startup_lifecycle import StartupPhase, run_startup_phases
 from crystaltech_di import init_crystaltech_service
 from daily_KVK_overview_embed import post_or_update_daily_KVK_overview
 from embed_utils import expire_old_event_embeds, send_summary_embed
@@ -1534,19 +1535,11 @@ async def on_ready():
         logger.info("[STARTUP] on_ready called again — startup already completed; skipping.")
         return
 
-    # Install the global asyncio loop exception handler once the loop exists
-    try:
-        loop = asyncio.get_running_loop()
-        loop.set_exception_handler(global_asyncio_exception_handler)
-        logger.info("[BOOT] Global asyncio exception handler installed on running loop.")
-    except Exception as e:
-        logger.warning(f"[BOOT] Failed to set global loop exception handler: {e}")
-
-    # Defensive: ensure no console handlers linger (QueueHandler only).
-    try:
-        _drop_console_handlers_once()
-    except Exception:
-        pass
+    await run_startup_phases(
+        [
+            StartupPhase("ready_runtime_bootstrap", _run_ready_runtime_bootstrap),
+        ]
+    )
 
     # Start heartbeat now that the loop is running
 
@@ -1893,6 +1886,22 @@ async def on_ready():
 
     except Exception as e:
         logger.exception(f"[CRITICAL] Exception during on_ready: {e}")
+
+
+async def _run_ready_runtime_bootstrap() -> None:
+    # Install the global asyncio loop exception handler once the loop exists.
+    try:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(global_asyncio_exception_handler)
+        logger.info("[BOOT] Global asyncio exception handler installed on running loop.")
+    except Exception as e:
+        logger.warning(f"[BOOT] Failed to set global loop exception handler: {e}")
+
+    # Defensive: ensure no console handlers linger (QueueHandler only).
+    try:
+        _drop_console_handlers_once()
+    except Exception:
+        pass
 
 
 @bot.event

--- a/core/startup_lifecycle.py
+++ b/core/startup_lifecycle.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StartupPhase:
+    name: str
+    run: Callable[[], Awaitable[Any]]
+
+
+async def run_startup_phases(phases: list[StartupPhase]) -> None:
+    """Run startup phases in order while making lifecycle ownership explicit."""
+    for phase in phases:
+        logger.info("[STARTUP] phase started: %s", phase.name)
+        try:
+            await phase.run()
+        except Exception:
+            logger.exception("[STARTUP] phase failed: %s", phase.name)
+            raise
+        logger.info("[STARTUP] phase completed: %s", phase.name)

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -42,13 +42,19 @@ deployed to production, and pushed to production: `DL_bot.py` now delegates Rall
 through `upload_routes/rally_forts_route.py` while preserving filename matching, local download
 staging, lazy importer loading, SQL preflight, offload dispatch, aggregate Discord output,
 safe filename rejection, disabled-channel fall-through, and best-effort log-backup scheduling.
-Phase 5D is now the final upload-routing sub-phase for main monitored-channel fallback queueing
-before Phase 6 lifecycle/startup separation.
+Phase 5D fallback queue route extraction was completed in PR 116
+(`codex/dlbot-upload-routing-phase-5d`), smoke tested successfully on 2026-05-26, closed, and
+pushed to production: `DL_bot.py` now delegates the monitored-channel fallback queue path through
+`upload_routes/fallback_queue_route.py` while preserving route order, `.xlsx/.xls/.csv` fallback
+attachment handling, worker queue handoff, `QueueFull` drop behaviour, live queue bookkeeping,
+queue embed updates, shared `utils.live_queue_lock` usage, command fall-through, and best-effort
+log-backup scheduling. Phase 5 upload-routing consolidation is complete. Phase 6 startup/lifecycle
+separation is now the next DL_bot architecture batch.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
-upload routing, not as a continuation of the `/import_locations` command cleanup. Start that task
-with a new audit/scope pass and review both this backlog and the current `K98-bot-mirror` GitHub
-issues list.
+startup/lifecycle ownership, not as a continuation of upload routing. Start that task with a new
+audit/scope pass and review `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`,
+this backlog, and the current `K98-bot-mirror` GitHub issues list.
 
 ### Deferred Optimisation
 - Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
@@ -114,19 +120,10 @@ issues list.
 - Dependencies: Complete the active DL_bot upload-routing phases first; preserve current production schema export as a drift/safety mechanism while preventing direct overwrite of `main`.
 
 ### Deferred Optimisation
-- Area: `DL_bot.py` remaining fast-path upload routes
-- Type: architecture
-- Description: After Phase 5C, `DL_bot.py` still owns the main monitored-channel fallback queue handling directly in the root listener. Player location, PreKvK, KVK_ALL, MGE results, KVK Honor, inventory upload-first, weekly activity ingest, and Rally Forts ingest now delegate through the `upload_routes` pattern, but the fallback queue path still mixes monitored-channel matching, worker queue handoff, `live_queue` bookkeeping, queue embed updates, and best-effort log-backup scheduling in the listener.
-- Suggested Fix: Complete Phase 5 with a final Phase 5D audit/scope pass for the main monitored-channel fallback queue route. Extract the fallback queue path into a focused `upload_routes` boundary only if the audit confirms route-order, queue ownership, `channel_queues`, `live_queue`, queue embed, worker handoff, and background log-backup side effects can be preserved with focused tests. Keep broader worker/lifecycle ownership and `processing_pipeline.py` refactors out of Phase 5D unless explicitly approved.
-- Impact: medium
-- Risk: medium
-- Dependencies: Phase 5C is complete, smoke tested, merged, deployed, and production-pushed; start Phase 5D from `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
-
-### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across DL_bot and bot_instance, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, and lifecycle coordination for the wider bot.
-- Suggested Fix: Phase 6 should audit DL_bot and bot_instance together, define the target lifecycle ownership model, and separate startup/runtime wiring from upload routing after the fast-path router consolidation is complete.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, so lifecycle ownership can now be audited independently.
+- Suggested Fix: Start Phase 6 from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. Audit `DL_bot.py`, `bot_instance.py`, `bot_loader.py`, `bot_startup_gate.py`, `boot_safety.py`, `startup_utils.py`, `singleton_lock.py`, `bot_helpers.py`, `utils.py`, and startup/shutdown runbooks before proposing any implementation. Define a target ownership model for process entry, bot construction, command registration, event registration, startup sequencing, task supervision, queue worker lifecycle, graceful shutdown, singleton/runtime files, and restart-safe state. Stop for approval before code changes.
 - Impact: medium
 - Risk: medium
-- Dependencies: Defer until Phase 5 upload routing is complete so lifecycle changes are reviewed independently from upload-route behaviour.
+- Dependencies: Phase 5 upload routing is complete, smoke tested, closed, and production-pushed; proceed with audit/design before implementation.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
@@ -1,0 +1,117 @@
+# Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle
+
+Use this starter to begin Phase 6 after Phase 5 upload-routing consolidation was closed,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, start Phase 6 of the DL_bot architecture optimisation programme: startup/lifecycle
+separation.
+
+This is audit/design work first. Do not implement code changes until the Phase 6 audit packet,
+target lifecycle ownership model, and first PR-sized implementation scope have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Context:
+
+- Phase 5 upload routing is complete.
+- MGE results, KVK Honor, inventory upload-first, weekly activity, Rally Forts, and main
+  monitored-channel fallback queueing now delegate through focused `upload_routes` modules.
+- `DL_bot.py` is now much closer to upload listener/delegation ownership, so startup/lifecycle
+  separation can be audited independently.
+
+Phase 6 objective:
+
+Audit `DL_bot.py` and `bot_instance.py` together and define the target ownership model for process
+entry, bot construction, command registration, event registration, startup sequencing, task
+supervision, queue worker lifecycle, graceful shutdown, singleton/runtime files, and restart-safe
+state.
+
+Likely files to review:
+
+- `DL_bot.py`
+- `bot_instance.py`
+- `bot_loader.py`
+- `bot_startup_gate.py`
+- `boot_safety.py`
+- `startup_utils.py`
+- `singleton_lock.py`
+- `bot_helpers.py`
+- `utils.py`
+- `logging_setup.py`
+- `constants.py`
+- `Commands.py`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+
+Step 1 required output:
+
+- Audit Summary
+- Current Startup / Lifecycle Map
+- Current Shutdown / Recovery Map
+- Task Supervision And Scheduler Map
+- Queue Worker / Live Queue Lifecycle Map
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6 Architecture Direction
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+Out of scope until separately approved:
+
+- Upload-route behaviour changes.
+- Broad `DL_bot.py` or `bot_instance.py` rewrite in one PR.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes.
+- Worker/process orchestration changes beyond the approved first lifecycle slice.
+- Destructive lock, PID, cache, or persisted-state cleanup.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+Audit/design-only validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+Likely implementation validation after approval:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_command_registration_smoke.py tests\test_domain_registrars_no_legacy_register_commands.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_singleton_lock_Version2.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6 touches
+startup, secrets/config, file handling, network calls, Discord runtime behaviour, and
+restart-sensitive persistence.
+
+## Deferred Item Link
+
+This starter implements the startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md`.

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -311,22 +311,31 @@ Phase breakdown:
      scheduling.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 4 KVK_ALL Upload Route Starter.md`
 7. **Phase 5 - Remaining upload fast-path consolidation**
-   - Active programme after Phase 4.
+   - Completed after Phase 4.
    - Phase 5A completed MGE results and KVK Honor route extraction in PR 113
      (`codex/dlbot-upload-routing-phase-5a`), smoke tested successfully on 2026-05-26, deployed
      to production, and closed.
    - Phase 5B completed inventory upload-first and weekly activity route extraction in PR 114
      (`codex/dlbot-upload-routing-phase-5b`), smoke tested successfully on 2026-05-26 with
      inventory and alliance weekly uploads, deployed to production, and closed.
-   - Continue with Phase 5C for Rally Forts route extraction and Phase 5D for main
-     monitored-channel fallback queueing. Phase 5D is expected to be the final upload-routing
-     sub-phase before Phase 6 lifecycle/startup separation.
+   - Phase 5C completed Rally Forts route extraction in PR 115
+     (`codex/dlbot-upload-routing-phase-5c`), smoke tested successfully, merged, deployed to
+     production, and pushed to production.
+   - Phase 5D completed main monitored-channel fallback queue extraction in PR 116
+     (`codex/dlbot-upload-routing-phase-5d`), smoke tested successfully on 2026-05-26, closed,
+     pushed to production, and confirmed in production logs.
+   - Phase 5 is complete: MGE results, KVK Honor, inventory upload-first, weekly activity, Rally
+     Forts, and fallback monitored-channel queueing now delegate through focused `upload_routes`
+     modules.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
 8. **Phase 6 - Startup/lifecycle separation**
+   - Next active architecture batch after Phase 5 completion.
    - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
      `bot_instance.py` review.
    - Define the target ownership model for bot construction, startup checks, lifecycle wiring,
-     singleton/runtime concerns, and event registration separately from upload-route behaviour.
+     singleton/runtime concerns, event registration, task supervision, queue worker lifecycle,
+     shutdown, and restart-safe state separately from upload-route behaviour.
+   - Starter packet: `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
 
 Phase 2A delivery notes:
 
@@ -362,7 +371,8 @@ Phase 4 delivery notes:
 - The SQL preflight review fix intentionally relies on `ensure_sql_headroom_or_notify()` for the
   user-facing abort notification and does not emit a duplicate route-level abort embed.
 - PR 110 (`codex/kvk-all-upload-route`) was smoke tested successfully and promoted to production.
-- Phase 5 remaining fast-path consolidation is now the next active upload-routing programme slice.
+- Phase 5 remaining fast-path consolidation was the next active upload-routing programme slice and
+  has since completed.
 
 Phase 5A delivery notes:
 
@@ -392,7 +402,35 @@ Phase 5B delivery notes:
   Discord error-notification failure, and notify fallback.
 - PR 114 (`codex/dlbot-upload-routing-phase-5b`) was smoke tested successfully with inventory and
   alliance weekly uploads, deployed to production, and closed.
-- Phase 5C Rally Forts route extraction is now the next active slice.
+- Phase 5C Rally Forts route extraction was the next active slice and has since completed.
+
+Phase 5C delivery notes:
+
+- Rally Forts upload routing is extracted into `upload_routes/rally_forts_route.py`.
+- `DL_bot.py` delegates Rally Forts upload handling through `handle_rally_forts_upload()`.
+- The route preserves daily/all-time filename matching, local download staging under
+  `LOG_DIR/downloads`, lazy importer loading, SQL preflight handoff, offload dispatch, result
+  aggregation, Discord output, disabled-channel fall-through, unsafe filename rejection, and
+  best-effort log-backup scheduling.
+- PR 115 (`codex/dlbot-upload-routing-phase-5c`) was smoke tested successfully, merged, deployed
+  to production, and pushed to production.
+- Phase 5D fallback queue route extraction was the next active slice and has since completed.
+
+Phase 5D delivery notes:
+
+- Main monitored-channel fallback queue handling is extracted into
+  `upload_routes/fallback_queue_route.py`.
+- `DL_bot.py` delegates fallback queueing through `handle_fallback_queue_upload()` after all
+  specific upload routes and before `bot.process_commands(message)`, preserving route order and
+  command fall-through.
+- The route preserves `.xlsx/.xls/.csv` fallback attachment filtering, `channel_queues` handoff,
+  current enqueue-once-per-accepted-attachment behaviour, `QueueFull` drop logging, live queue
+  bookkeeping, queue embed updates, shared `utils.live_queue_lock` usage, and best-effort
+  log-backup scheduling.
+- PR 116 (`codex/dlbot-upload-routing-phase-5d`) was smoke tested successfully on 2026-05-26,
+  closed, pushed to production, and confirmed in production logs.
+- Phase 5 upload-routing consolidation is complete. Phase 6 startup/lifecycle separation is the
+  next active architecture batch.
 
 14. Testing Requirements
 

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -1,0 +1,399 @@
+# DL_bot Startup Lifecycle - Phase 6 Audit Starter
+
+## 1. Task Header
+
+- Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
+- Date: `2026-05-26`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and pushed to production`
+- Task type: `deferred optimisation batch`
+- One-pass approved: `no`
+
+## 2. Required Reading
+
+Before implementation, read the current repository instructions and indexed core standards:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
+- `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`
+
+Use `docs/reference/runbook_diagnostics.md` if the audit needs deeper diagnostics, telemetry,
+offload registry, queue recovery, watchdog, or log-backup context. Use `docs/reference/ENV_REFERENCE.md`
+if environment-variable ownership or runtime configuration validation becomes part of the design.
+
+SQL validation is not expected for the first Phase 6 audit unless the review unexpectedly reaches
+SQL-backed cache, import, export, report, or ProcConfig contracts. If it does, validate relevant
+schema, procedure, view, index, and `ProcConfig` details against:
+
+`C:\K98-bot-SQL-Server`
+
+## 3. Objective
+
+Perform a full audit of `DL_bot.py` and `bot_instance.py` startup/lifecycle responsibilities after
+Phase 5 upload routing has been separated. Produce a careful target ownership model and PR-sized
+implementation plan before any code changes.
+
+Phase 6 should separate process entry, bot construction, command/event registration, startup
+sequence, task supervision, queue worker lifecycle, graceful shutdown, singleton/runtime files, and
+restart-safe state concerns without changing upload-route behaviour.
+
+## 4. Background
+
+Phase 5 upload-routing consolidation is complete:
+
+- Phase 5A extracted MGE results and KVK Honor routes.
+- Phase 5B extracted inventory upload-first and weekly activity routes.
+- Phase 5C extracted Rally Forts routing.
+- Phase 5D extracted main monitored-channel fallback queueing.
+
+`DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
+lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
+`bot_helpers.py`, startup gates, singleton locks, background task monitors, queue workers, and
+shutdown handlers. Phase 6 should audit these boundaries before proposing code movement.
+
+## 5. Scope
+
+### In Scope
+
+- Audit `DL_bot.py` process entry, logging bootstrap, environment checks, singleton lock handling,
+  command registration, event listener ownership, signal handling, graceful shutdown, and
+  `bot.run()` flow.
+- Audit `bot_instance.py` bot construction, event registration, `on_ready()`, `full_startup_sequence()`,
+  task monitor usage, cache warming, view/handler rehydration, scheduler startup, queue worker
+  startup, live queue rehydration, and shutdown hooks.
+- Audit `bot_loader.py`, `bot_startup_gate.py`, `boot_safety.py`, `startup_utils.py`,
+  `singleton_lock.py`, `bot_helpers.py`, `utils.py`, `logging_setup.py`, and `constants.py` only
+  as needed to map lifecycle ownership.
+- Map runtime state that must survive restart: singleton locks, PID files, shutdown markers,
+  command cache, live queue cache, view/event/reminder trackers, offload registry, and scheduler
+  state.
+- Identify duplicate or unclear ownership between process-level startup, bot instance startup, and
+  helper modules.
+- Identify a safe Phase 6 first PR slice after the audit. The first implementation slice should be
+  smaller than the full lifecycle redesign.
+- Define focused tests and validation gates before implementation.
+- Capture out-of-scope findings structurally.
+
+### Out of Scope
+
+- No implementation during Step 1 audit.
+- No broad rewrite of `DL_bot.py` or `bot_instance.py` in one PR.
+- No upload-route behaviour changes.
+- No importer, workbook, SQL, Google Sheets, ProcConfig, or processing-pipeline contract changes.
+- No command-surface consolidation.
+- No deployment/promotion action without a separate promotion check.
+- No destructive lock, PID, cache, or persisted-state cleanup without explicit approval.
+
+## 6. Source Deferred Items
+
+```md
+### Deferred Optimisation
+- Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
+- Type: architecture
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, so lifecycle ownership can now be audited independently.
+- Suggested Fix: Start Phase 6 from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. Audit `DL_bot.py`, `bot_instance.py`, `bot_loader.py`, `bot_startup_gate.py`, `boot_safety.py`, `startup_utils.py`, `singleton_lock.py`, `bot_helpers.py`, `utils.py`, and startup/shutdown runbooks before proposing any implementation. Define a target ownership model for process entry, bot construction, command registration, event registration, startup sequencing, task supervision, queue worker lifecycle, graceful shutdown, singleton/runtime files, and restart-safe state. Stop for approval before code changes.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 5 upload routing is complete, smoke tested, closed, and production-pushed; proceed with audit/design before implementation.
+```
+
+## 7. Codex Skills To Use
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | use | Mandatory before implementation; Phase 6 is architecture-sensitive lifecycle work. |
+| `k98-discord-command-feature` | use | Startup/event registration, persistent views, rehydration, and scheduler startup affect Discord runtime behaviour. |
+| `k98-sql-validation` | use if needed | Only if the audit reaches SQL-backed cache/import/export/ProcConfig contracts. |
+| `k98-test-selection` | use | Required before validation; combine `scripts/select_tests.py` with lifecycle risk-based tests. |
+| `k98-deferred-optimisation-capture` | use | Capture out-of-scope lifecycle, queue, task, logging, or persistence findings structurally. |
+| `k98-pr-review` | use | Required before PR handoff because startup/lifecycle changes are high blast-radius. |
+| `k98-promotion-check` | use before promotion only | Required before production promotion, bot-machine pull/restart, or production PR creation. |
+| `codex-security:security-scan` | use before PR handoff if code changes | Startup, secrets/config, file handling, network calls, Discord interactions, and restart-sensitive persistence are security-sensitive surfaces. |
+
+## 8. Mandatory Workflow
+
+1. Audit / scope review, then stop for approval.
+2. Architecture validation and target ownership model, then stop for approval.
+3. PR-sized implementation plan, then stop for approval.
+4. Implementation only after approval.
+5. Validation and final review.
+6. Codex Security review for code changes, or documented skip reason for docs-only work.
+
+Do not proceed in one pass.
+
+## 9. Audit Requirements
+
+Review and map:
+
+- process entry and import-time side effects
+- logging bootstrap and file/queue logging ownership
+- environment and interpreter/startup checks
+- singleton lock acquisition/release and PID/runtime files
+- bot construction and `bot_loader.py` ownership
+- command registration and secondary command surface gating
+- Discord event registration and `on_ready()` ownership
+- startup gate/idempotency behaviour
+- cache warming and cache failure handling
+- persistent view and message rehydration
+- queue worker startup, channel queue ownership, and live queue rehydration
+- scheduler startup for Ark, MGE, calendar/events, reminders, subscriptions, maintenance, and UTC clock
+- task monitor / background task supervision
+- graceful shutdown, signal handling, cancellation, and logging flush order
+- restart markers, crash recovery, and admin startup/shutdown notifications
+- tests that currently cover startup, registration, scheduler startup, live queue persistence, and singleton locks
+
+Produce these Step 1 outputs:
+
+- Audit Summary
+- Current Startup / Lifecycle Map
+- Current Shutdown / Recovery Map
+- Task Supervision And Scheduler Map
+- Queue Worker / Live Queue Lifecycle Map
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6 Architecture Direction
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## 10. Architecture Targets
+
+| Concern | Target |
+|---|---|
+| Process entry, signal wiring, `bot.run()` | `DL_bot.py` or a small process-entry module after approval |
+| Bot construction singleton | `bot_loader.py` / `bot_instance.py` with one clear owner |
+| Startup sequencing | service/helper boundary with idempotency and task ownership explicit |
+| Event registration | one clear event-owner module; avoid duplicate registration paths |
+| Queue worker lifecycle | one boundary that starts workers, rehydrates live queue state, and documents ownership |
+| Task supervision | `TaskMonitor` or equivalent central lifecycle owner |
+| Shutdown | one coordinated path for cancellation, state flush, locks, markers, and logging shutdown |
+| Runtime files | `constants.py` paths plus focused helpers for atomic state writes |
+| Tests | focused lifecycle tests in `tests/`, plus smoke/import/registration validators |
+
+## 11. Likely Files
+
+### Review
+
+- `DL_bot.py`
+- `bot_instance.py`
+- `bot_loader.py`
+- `bot_startup_gate.py`
+- `boot_safety.py`
+- `startup_utils.py`
+- `singleton_lock.py`
+- `bot_helpers.py`
+- `utils.py`
+- `logging_setup.py`
+- `constants.py`
+- `Commands.py`
+- `command_regenerate.py`
+- `scripts/smoke_imports.py`
+- `scripts/validate_command_registration.py`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `tests/test_command_registration_smoke.py`
+- `tests/test_domain_registrars_no_legacy_register_commands.py`
+- `tests/test_mge_startup_hook_invoked.py`
+- `tests/test_mge_rehydrate_and_regression.py`
+- `tests/test_live_queue_persistence.py`
+- `tests/test_utils_live_queue.py`
+- `tests/test_singleton_lock_Version2.py`
+- `tests/test_maintenance_suite.py`
+
+### Modify
+
+To be decided after Step 1 approval.
+
+Likely first-slice candidates after audit:
+
+- `DL_bot.py`
+- `bot_instance.py`
+- one small lifecycle helper module if the audit proves a clean extraction
+- focused lifecycle tests
+- startup/shutdown runbook notes
+
+### Create
+
+To be decided after Step 1 approval.
+
+Possible candidates:
+
+- `core/lifecycle.py`
+- `core/startup_sequence.py`
+- `core/shutdown.py`
+- `tests/test_startup_lifecycle.py`
+
+Do not create new lifecycle modules until the ownership model is approved.
+
+## 12. Implementation Requirements
+
+- Preserve production startup, shutdown, and command registration behaviour unless an explicit
+  behaviour change is approved.
+- Keep upload-route behaviour unchanged.
+- Avoid moving large blocks without tests.
+- Make idempotency and duplicate-start prevention explicit.
+- Keep persistent/restart-sensitive state safe.
+- Use existing helpers before adding new ones.
+- Keep long-running or blocking cleanup bounded or offloaded.
+- Preserve logging and improve it only where the audit finds ambiguity.
+- Capture larger queue/lifecycle/task-supervision debt structurally if it exceeds the approved
+  first PR.
+
+## 13. Refactor Decisions
+
+Initial classification before audit:
+
+| Issue | Decision | Reason |
+|---|---|---|
+| Upload-route consolidation | not applicable | Phase 5 is complete; do not reopen routing in Phase 6. |
+| Process entry and singleton lock ownership | audit first | High-impact startup path; define target ownership before edits. |
+| Bot construction and event registration ownership | audit first | Current ownership is spread across `bot_loader.py`, `bot_instance.py`, and `DL_bot.py`. |
+| `on_ready()` / `full_startup_sequence()` size and responsibilities | audit first | Likely first implementation candidate, but requires careful map and tests. |
+| Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
+| Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
+| Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
+| SQL/importer contracts | not applicable unless discovered | Phase 6 should avoid SQL/importer contract changes. |
+
+Final decisions must be updated after Step 1 audit.
+
+## 14. Testing Requirements
+
+Consider and document:
+
+- happy path startup
+- repeated `on_ready()` / startup gate idempotency
+- command registration smoke
+- persistent view or scheduler startup paths touched
+- queue worker startup and live queue rehydration
+- shutdown/cancellation/state persistence where touched
+- singleton lock acquisition/release
+- smoke imports without runtime side effects
+- command-registration duplicate warnings
+- log-noise and production operational log boundaries when running broad tests
+
+Baseline audit/design-only commands:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+Implementation validation should be selected after scope approval. Likely commands include:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_command_registration_smoke.py tests\test_domain_registrars_no_legacy_register_commands.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_singleton_lock_Version2.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+## 15. Acceptance Criteria
+
+- [ ] Phase 6 audit/scope packet is completed before implementation.
+- [ ] Current startup, shutdown, task, queue, and persistence ownership is mapped.
+- [ ] Target lifecycle ownership model is approved before code changes.
+- [ ] First implementation slice is PR-sized and approved.
+- [ ] Upload-route behaviour remains unchanged.
+- [ ] Startup and shutdown remain idempotent and restart-safe.
+- [ ] Queue worker lifecycle and live queue persistence remain safe.
+- [ ] Command registration and duplicate-surface guardrails remain intact.
+- [ ] Tests are added/updated or clear skip reasons are documented.
+- [ ] Quality gates are run or documented.
+- [ ] Codex Security review is run before PR handoff for code changes, or skipped only for
+  documentation-only work with a reason.
+- [ ] Deferred optimisations are captured structurally.
+
+## 16. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. New Files
+4. Modified Files
+5. SQL Changes
+6. Helpers Reused
+7. Refactor Findings
+8. Test Plan
+9. AI Review Gates
+10. Deployment Steps
+11. Deferred Optimisations
+
+For Step 1 audit only, include:
+
+- Audit Summary
+- Current Startup / Lifecycle Map
+- Current Shutdown / Recovery Map
+- Task Supervision And Scheduler Map
+- Queue Worker / Live Queue Lifecycle Map
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6 Architecture Direction
+- Recommended First PR Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## 17. PR Summary Template
+
+```md
+## Summary
+
+- Audit and separate DL_bot startup/lifecycle ownership after Phase 5 upload-route completion.
+- Preserve runtime behaviour while moving only the approved lifecycle slice.
+
+## Changes
+
+- Map current startup, shutdown, task supervision, queue worker, and restart-state ownership.
+- Implement the approved PR-sized lifecycle boundary after audit approval.
+
+## Tests
+
+- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
+- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
+- `.\.venv\Scripts\python.exe scripts\select_tests.py`
+- focused lifecycle pytest commands selected during audit
+- broader repo gates as required by the approved implementation scope
+
+## AI Review Gates
+
+- Codex Security: run before PR handoff for code changes; skip only for docs-only work with reason.
+
+## Deferred Optimisations
+
+- None, or structured deferred items.
+
+## Risk / Rollback
+
+- Risk: medium-high; startup/lifecycle changes can affect bot availability, task duplication,
+  restart safety, and shutdown behaviour.
+- Rollback: revert the lifecycle PR and restart from the last known-good production branch.
+```
+
+## 18. Required Stop Point
+
+Stop after the Phase 6 audit/scope packet.
+
+Do not implement startup extraction, move event registration, alter singleton/runtime file
+ownership, change queue worker lifecycle, alter shutdown behaviour, or open a PR until the audit
+packet, target architecture, and first implementation scope have each been approved.

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md
@@ -23,6 +23,9 @@ We are starting Phase 5 of the DL_bot upload-routing optimisation programme afte
   and closed.
 - Phase 5C extracted Rally Forts ingest into `upload_routes/rally_forts_route.py`, was smoke
   tested successfully, merged, deployed to production, and pushed to production.
+- Phase 5D extracted main monitored-channel fallback queueing into
+  `upload_routes/fallback_queue_route.py`, was smoke tested successfully on 2026-05-26, closed,
+  pushed to production, and completed Phase 5 upload-routing consolidation.
 
 ## Completion Note
 
@@ -146,13 +149,77 @@ Validation evidence included:
 Observed final full-suite result after review fixes: `1528 passed, 2 skipped`. Pytest log-noise
 validation confirmed production operational logs were unchanged.
 
-Phase 5D is now the final upload-routing sub-phase for main monitored-channel fallback queueing.
-Starter packet:
+Phase 5D fallback queue route extraction was completed in PR 116. Its starter packet is retained
+for delivery history:
 `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
 
-Phase 5 is the remaining fast-path upload-route consolidation slice. It should use the proven
+## Phase 5D Completion Note
+
+Status: Phase 5D complete in PR 116 (`codex/dlbot-upload-routing-phase-5d`), smoke tested
+successfully on 2026-05-26 with a monitored-channel stats workbook upload, closed, pushed to
+production, and confirmed in production logs.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates main monitored-channel fallback queue handling through
+  `handle_fallback_queue_upload()`.
+- `upload_routes/fallback_queue_route.py` preserves route order after inventory, player location,
+  MGE results, PreKvK, Honor, weekly activity, Rally Forts, and KVK_ALL routes.
+- Fallback accepted attachment extensions remain `.xlsx`, `.xls`, and `.csv`.
+- Worker queue handoff through `channel_queues` is preserved, including current
+  enqueue-once-per-accepted-attachment behaviour.
+- `QueueFull` remains a logged drop with no user-facing Discord response.
+- Live queue bookkeeping, queue embed updates, command fall-through, and best-effort background
+  log-backup scheduling are preserved.
+- Review fixes kept synchronous log-backup awaitable construction failures non-fatal and switched
+  fallback live-queue appends to the shared `utils.live_queue_lock` async lock used by
+  `update_live_queue_embed()` and processing pipeline updates.
+- Worker ownership, `processing_pipeline.py`, importer execution, queue persistence semantics,
+  SQL/importer contracts, and startup/lifecycle ownership were not changed.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_processing_pipeline.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py tests\test_utils_live_queue.py tests\test_live_queue_persistence.py tests\test_processing_pipeline.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed full-suite result before final review fixes: `1539 passed, 2 skipped`. Pytest log-noise
+validation confirmed production operational logs were unchanged.
+
+Production smoke evidence confirmed a monitored-channel workbook upload was recognized by
+`upload_routes.fallback_queue_route`, enqueued for the worker, triggered a successful background
+log-backup request, and completed the downstream processing pipeline through Excel processing,
+archive, SQL procedure, export, ProcConfig import, cache refresh, and final success summary.
+
+## Phase 5 Completion Note
+
+Status: Phase 5 complete. The remaining upload fast paths after Phase 4 now delegate through
+focused `upload_routes` modules:
+
+- MGE results: `upload_routes/mge_results_route.py`
+- KVK Honor: `upload_routes/honor_route.py`
+- Inventory upload-first: `upload_routes/inventory_route.py`
+- Weekly activity: `upload_routes/weekly_activity_route.py`
+- Rally Forts: `upload_routes/rally_forts_route.py`
+- Main monitored-channel fallback queue: `upload_routes/fallback_queue_route.py`
+
+`DL_bot.py` now keeps upload listener/event plumbing and delegates upload-route behaviour. Phase 6
+is the next architecture batch and should audit startup/lifecycle ownership separately from upload
+routing.
+
+Phase 5 was the remaining fast-path upload-route consolidation slice. It used the proven
 `upload_routes` pattern to reduce `DL_bot.py` listener responsibilities while preserving production
-behaviour.
+behaviour. This section is retained as delivery history.
 
 ## Goal
 
@@ -161,10 +228,10 @@ modules or an approved shared upload-router boundary.
 
 The desired end state is:
 
-- `DL_bot.py` delegates remaining upload message handling and keeps only listener/event plumbing.
+- `DL_bot.py` delegates remaining upload message handling and keeps upload listener/event plumbing.
 - MGE results import, KVK Honour ingest, weekly activity ingest, inventory upload-first routing,
-  and Rally Forts ingest have clear route ownership after Phase 5C. Fallback monitored-channel
-  queueing remains to be extracted in Phase 5D.
+  Rally Forts ingest, and fallback monitored-channel queueing have clear route ownership after
+  Phase 5D.
 - Shared SQL preflight, offload dispatch, import embed rendering, and route-level structured
   logging are consolidated only where behaviour parity is safe and testable.
 - Current Discord output, importer contracts, accepted filenames/extensions, side effects, fallback
@@ -234,7 +301,7 @@ In scope for Step 1 audit:
 
 Likely remaining route candidate:
 
-- Main monitored-channel fallback queue route.
+- None. Phase 5D completed the final remaining fallback queue route.
 
 Out of scope until separately approved:
 

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5B Inventory and Weekly Activity Route Starter.md
@@ -37,8 +37,9 @@ Delivered behaviour:
 - Focused route tests and the full suite passed before PR handoff. Production smoke confirmed
   inventory and alliance weekly uploads after merge and production push.
 
-Phase 5C Rally Forts route extraction is now the next active slice. Phase 5D is expected to be
-required as the final upload-routing sub-phase for main monitored-channel fallback queueing.
+Phase 5C Rally Forts route extraction and Phase 5D fallback monitored-channel queue extraction
+have since completed, been smoke tested, and been pushed to production. Phase 5 upload-routing
+consolidation is complete.
 
 Phase 5B was the next small upload-routing slice. It kept using the proven `upload_routes`
 pattern and the new `upload_routes/common.py` helpers where the behaviour matched, without forcing

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5C Rally Forts Route Starter.md
@@ -44,7 +44,7 @@ Delivered behaviour:
 - Attachment names containing path separators are rejected before local save to prevent path
   traversal or directory-component staging.
 - `forts_ingest.py` and Rally SQL/importer contracts were not changed.
-- Phase 5D remains required as the final upload-routing sub-phase for main monitored-channel
+- Phase 5D has since completed as the final upload-routing sub-phase for main monitored-channel
   fallback queueing.
 
 Validation evidence included:
@@ -65,8 +65,11 @@ Validation evidence included:
 Observed final full-suite result after review fixes: `1528 passed, 2 skipped`. Pytest log-noise
 validation confirmed production operational logs were unchanged.
 
-The next starter packet is
+Phase 5D starter packet, retained for delivery history:
 `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`.
+
+Phase 5 upload-routing consolidation is now complete. Phase 6 startup/lifecycle separation is the
+next active architecture batch.
 
 ## Goal
 
@@ -217,8 +220,8 @@ Likely SQL repo objects to validate:
   way as the inline branch?
 - What route tests prove behaviour parity without adding live SQL or filesystem-heavy integration
   coverage?
-- Should Phase 5D be required? Current recommendation: yes. Phase 5D should be the final
-  upload-routing sub-phase and should focus only on the main monitored-channel fallback queue route.
+- Should Phase 5D be required? Historical answer: yes. Phase 5D completed the final
+  upload-routing sub-phase and focused only on the main monitored-channel fallback queue route.
 
 ## Step 1 Required Output
 
@@ -284,8 +287,8 @@ $env:RUN_DB_TESTS="1"
 - `upload_routes/common.py` is reused where behaviour parity is clear and covered.
 - Out-of-scope fallback queue, SQL, lifecycle, worker, or importer-internal findings are captured
   structurally.
-- The implementation packet explicitly states whether Phase 5D remains required. Current expected
-  answer: yes, Phase 5D is required for fallback monitored-channel queueing and should be the final
+- The implementation packet explicitly states whether Phase 5D remains required. Historical
+  answer: yes; Phase 5D later completed fallback monitored-channel queueing as the final
   upload-routing sub-phase.
 
 ## Explicit Stop Point

--- a/docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md
+++ b/docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md
@@ -25,9 +25,62 @@ We are starting Phase 5D of the DL_bot upload-routing optimisation programme aft
 - Phase 5C extracted Rally Forts ingest into `upload_routes/rally_forts_route.py`, was smoke
   tested successfully, merged, deployed to production, and pushed to production.
 
-Phase 5D is expected to be the final upload-routing sub-phase before Phase 6 startup/lifecycle
-separation. It is intentionally more sensitive than the previous upload-route slices because the
-remaining inline path owns queue handoff, live queue bookkeeping, and queue embed side effects.
+Phase 5D was the final upload-routing sub-phase before Phase 6 startup/lifecycle separation. It
+was intentionally more sensitive than the previous upload-route slices because the remaining inline
+path owned queue handoff, live queue bookkeeping, and queue embed side effects.
+
+## Completion Note
+
+Status: Phase 5D complete in PR 116 (`codex/dlbot-upload-routing-phase-5d`), smoke tested
+successfully on 2026-05-26 with a monitored-channel stats workbook upload, closed, pushed to
+production, and confirmed in production logs.
+
+Delivered behaviour:
+
+- `DL_bot.py` delegates main monitored-channel fallback queue handling through
+  `handle_fallback_queue_upload()`.
+- `upload_routes/fallback_queue_route.py` owns monitored-channel fallback matching, supported
+  attachment filtering, worker queue handoff, live queue job append, queue embed update, and
+  best-effort log-backup scheduling.
+- Route order and command fall-through are preserved after all specific fast-path upload routes.
+- Accepted fallback attachments remain `.xlsx`, `.xls`, and `.csv`.
+- Existing worker queue handoff through `channel_queues` is preserved.
+- Existing `QueueFull` behaviour is preserved as a logged drop with no user-facing Discord embed.
+- Existing `live_queue["jobs"]` bookkeeping and `update_live_queue_embed()` side effects are
+  preserved while using the shared `utils.live_queue_lock` async lock.
+- Existing best-effort log-backup scheduling for queued imports is preserved, including non-fatal
+  handling for both awaitable construction failures and task scheduling failures.
+- No worker-process, `processing_pipeline.py`, queue persistence, SQL/importer, or lifecycle
+  ownership changes were introduced.
+
+Validation evidence included:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_processing_pipeline.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_fallback_queue_route.py tests\test_utils_live_queue.py tests\test_live_queue_persistence.py tests\test_processing_pipeline.py
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Observed full-suite result before final review fixes: `1539 passed, 2 skipped`. Pytest log-noise
+validation confirmed production operational logs were unchanged.
+
+Production smoke evidence confirmed a monitored-channel workbook upload was recognized by
+`upload_routes.fallback_queue_route`, enqueued for the worker, triggered a successful background
+log-backup request, and completed the downstream processing pipeline through Excel processing,
+archive, SQL procedure, export, ProcConfig import, cache refresh, and final success summary.
+
+Phase 5 upload-routing consolidation is now complete. Phase 6 remains required for
+startup/lifecycle separation and should audit `DL_bot.py`, `bot_instance.py`, startup/shutdown
+runbooks, task supervision, singleton/runtime concerns, queue worker lifecycle, live queue
+rehydration, scheduler startup, and restart-safe state separately from upload routing.
 
 ## Goal
 
@@ -48,8 +101,7 @@ The desired end state is:
 - No worker-process, `processing_pipeline.py`, queue persistence, SQL/importer, or lifecycle
   ownership changes are introduced unless explicitly approved after the audit packet.
 
-Step 1 is an audit/design packet, not implementation. Stop before code changes until the Phase 5D
-route classification and implementation scope are approved.
+Step 1 was completed before implementation. This starter is retained for delivery history.
 
 ## Required Reading
 
@@ -203,18 +255,18 @@ Phase 5D Step 1 must produce:
 - Approval Questions
 - Explicit Stop Point
 
-Do not write bot code, tests, SQL, or deployment scripts during Step 1.
+Step 1 output was completed before implementation.
 
 ## Validation Requirements
 
-For audit/design-only work:
+For audit/design-only work, the expected checks were:
 
 ```powershell
 .\.venv\Scripts\python.exe scripts\validate_deferred_items.py
 .\.venv\Scripts\python.exe scripts\select_tests.py
 ```
 
-For implementation after approval, choose validation based on the approved Phase 5D route slice:
+For implementation after approval, validation was selected from:
 
 - focused new fallback queue route tests
 - relevant existing queue/live-queue tests
@@ -248,8 +300,6 @@ For implementation after approval, choose validation based on the approved Phase
 
 ## Explicit Stop Point
 
-Stop after the Phase 5D audit/design packet.
-
-Do not implement route extraction, alter queue ownership, change worker behaviour, change
-processing-pipeline behaviour, or open a PR until the audit packet, route classification, and first
-implementation scope have each been approved.
+Completed. Do not reopen Phase 5D. Use
+`docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` for startup/lifecycle
+separation and broader queue ownership audits.

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from core.startup_lifecycle import StartupPhase, run_startup_phases
+
+
+@pytest.mark.asyncio
+async def test_run_startup_phases_runs_in_order():
+    seen: list[str] = []
+
+    async def first():
+        seen.append("first")
+
+    async def second():
+        seen.append("second")
+
+    await run_startup_phases(
+        [
+            StartupPhase("first", first),
+            StartupPhase("second", second),
+        ]
+    )
+
+    assert seen == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_run_startup_phases_propagates_phase_failure():
+    async def boom():
+        raise RuntimeError("phase failed")
+
+    with pytest.raises(RuntimeError, match="phase failed"):
+        await run_startup_phases([StartupPhase("boom", boom)])
+
+
+def test_on_ready_uses_named_startup_lifecycle_boundary():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    on_ready = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "on_ready"
+    )
+
+    runner_call = next(
+        node
+        for node in ast.walk(on_ready)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_startup_phases"
+    )
+    phases_arg = runner_call.args[0]
+    assert isinstance(phases_arg, ast.List)
+
+    startup_phase_names = []
+    for phase_call in phases_arg.elts:
+        assert isinstance(phase_call, ast.Call)
+        assert isinstance(phase_call.func, ast.Name)
+        assert phase_call.func.id == "StartupPhase"
+        assert phase_call.args
+        assert isinstance(phase_call.args[0], ast.Constant)
+        assert isinstance(phase_call.args[0].value, str)
+        startup_phase_names.append(phase_call.args[0].value)
+
+    assert startup_phase_names == ["ready_runtime_bootstrap"]


### PR DESCRIPTION
## Summary

- Add a small `core.startup_lifecycle` module for named startup phases.
- Route the first `bot_instance.py:on_ready()` bootstrap step through the lifecycle boundary.
- Add focused tests for phase ordering, failure propagation, and the `on_ready()` lifecycle hook.
- Sync Phase 5 completion docs/backlog and add the Phase 6 startup lifecycle starter docs so the PR branch reflects the current programme state.

## Changes

- Keeps `DL_bot.py` as process entry.
- Preserves existing startup order and behavior for the first sub-phase.
- Does not change upload routing, queue worker lifecycle, shutdown behavior, command sync semantics, SQL/importer contracts, or deployment flow.
- Marks Phase 5D/fallback queue extraction complete in the active backlog and related task packs.
- Adds the Phase 6 audit starter and chat starter as the source material for remaining startup/lifecycle work.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_startup_lifecycle.py tests/test_mge_startup_hook_invoked.py` -> `5 passed`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py` -> passed with known disabled secondary duplicate warnings
- `./.venv/Scripts/python.exe -m pytest -q tests` -> `1543 passed, 2 skipped`
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py` -> production operational logs unchanged

## AI Review Gates

- Codex Security: not yet run; should run before PR handoff/merge because Phase 6 touches startup and restart-sensitive behavior.

## Risk / Rollback

- Risk: low for this sub-phase; the moved logic is behavior-preserving and limited to loop exception handler setup plus console-handler cleanup. Documentation changes are phase-history/backlog sync only.
- Rollback: revert this PR to return `on_ready()` bootstrap logic inline and remove the phase-sync docs from this branch.