### PR TITLE
[codex] Extract ready runtime services phase

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -1808,7 +1808,7 @@ async def _run_ready_runtime_services() -> None:
             health_dashboard_task.start()
             logger.info("[BOOT] Health dashboard task started")
     except Exception:
-        logger.error("[BOOT] Failed to start health_dashboard_task: {e}")
+        logger.exception("[BOOT] Failed to start health_dashboard_task")
 
     # Start offload monitor as a supervised TaskMonitor task if available
     try:

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -1538,119 +1538,9 @@ async def on_ready():
     await run_startup_phases(
         [
             StartupPhase("ready_runtime_bootstrap", _run_ready_runtime_bootstrap),
+            StartupPhase("ready_runtime_services", _run_ready_runtime_services),
         ]
     )
-
-    # Start heartbeat now that the loop is running
-
-    try:
-        os.makedirs(LOG_DIR, exist_ok=True)
-        task_monitor.create("heartbeat", heartbeat_loop)
-        logger.info("[BOOT] Heartbeat loop started; writing to %s/heartbeat.json", LOG_DIR)
-    except Exception:
-        logger.exception("[BOOT] Failed to start heartbeat loop")
-
-    try:
-        if not health_dashboard_task.is_running():
-            health_dashboard_task.start()
-            logger.info("[BOOT] Health dashboard task started")
-    except Exception:
-        logger.error("[BOOT] Failed to start health_dashboard_task: {e}")
-
-    # Start offload monitor as a supervised TaskMonitor task if available
-    try:
-        if monitor_loop_coro is not None:
-            # avoid duplicate creation if already scheduled
-            if not task_monitor.is_running("offload_monitor"):
-                # run with reasonable defaults; adjust via env or later config if needed
-                task_monitor.create(
-                    "offload_monitor",
-                    lambda: monitor_loop_coro(
-                        interval_seconds=int(os.getenv("OFFLOAD_MONITOR_INTERVAL", "300")),
-                        rotate_days=int(os.getenv("OFFLOAD_MONITOR_ROTATE_DAYS", "30")),
-                        max_entries=int(os.getenv("OFFLOAD_MONITOR_MAX_ENTRIES", "2000")),
-                    ),
-                )
-                logger.info("[BOOT] Offload monitor scheduled via TaskMonitor")
-            else:
-                logger.info("[BOOT] Offload monitor already running; skipping schedule")
-    except Exception:
-        logger.exception("[BOOT] Failed to schedule offload monitor")
-
-    # 🔒 Prevent accidental Image.show() calls that invoke tkinter
-    try:
-        from PIL import Image
-
-        def disabled_show(*args, **kwargs):
-            import warnings
-
-            warnings.warn("⚠️ Image.show() disabled to prevent tkinter-based crashes.")
-
-        Image.show = disabled_show
-        logger.info("[BOOT] PIL.Image.show() disabled at startup.")
-    except Exception as e:
-        logger.warning(f"[BOOT] Failed to patch Image.show(): {e}")
-
-    try:
-        clean_old_lock_files(LOG_DIR)
-        logger.info("[LOCK_FILES] Cleared old LOCK Files on Startup")
-    except Exception as e:
-        logger.warning(f"[LOCK_FILES] Failed to clean lock files: {e}")
-
-    # Make sure usage tracker is alive (idempotent)
-    try:
-        usage_tracker().start()
-        logger.info("[BOOT] Usage tracker started.")
-    except Exception:
-        logger.exception("[BOOT] Failed to start usage tracker.")
-
-    try:
-        if not daily_summary.is_running():
-            daily_summary.start()
-            logger.info("[BOOT] daily_summary loop started")
-    except Exception:
-        logger.exception("[BOOT] Failed to start daily_summary loop")
-
-    if ACTIVITY_TRACKING_ENABLED:
-        try:
-            await run_blocking(ensure_activity_schema)
-            register_activity_listeners(bot)
-            logger.info("[BOOT] Server activity tracking initialized")
-        except Exception:
-            logger.exception("[BOOT] Failed to initialize server activity tracking")
-
-    if SERVER_STATUS_ENABLED:
-        if UTC_CLOCK_CHANNEL_ID:
-            try:
-                if not task_monitor.is_running("utc_clock_channel"):
-                    task_monitor.create(
-                        "utc_clock_channel",
-                        lambda: run_utc_clock_channel_loop(bot),
-                        replace=False,
-                    )
-                    logger.info("[BOOT] UTC clock status channel loop started")
-            except Exception:
-                logger.exception("[BOOT] Failed to start UTC clock status channel loop")
-        else:
-            logger.debug(
-                "[BOOT] UTC clock status channel loop skipped – UTC_CLOCK_CHANNEL_ID not set"
-            )
-
-        if MEMBER_COUNT_CHANNEL_ID:
-            try:
-                if not task_monitor.is_running("member_count_channel"):
-                    task_monitor.create(
-                        "member_count_channel",
-                        lambda: run_member_count_channel_loop(bot),
-                        replace=False,
-                    )
-                    logger.info("[BOOT] Member count status channel loop started")
-            except Exception:
-                logger.exception("[BOOT] Failed to start member count status channel loop")
-        else:
-            logger.debug(
-                "[BOOT] Member count status channel loop skipped – MEMBER_COUNT_CHANNEL_ID not set"
-            )
 
     try:
         logger.info(f"✅ Bot is ready – logged in as {bot.user} (ID: {bot.user.id})")
@@ -1902,6 +1792,118 @@ async def _run_ready_runtime_bootstrap() -> None:
         _drop_console_handlers_once()
     except Exception:
         pass
+
+
+async def _run_ready_runtime_services() -> None:
+    # Start heartbeat now that the loop is running
+    try:
+        os.makedirs(LOG_DIR, exist_ok=True)
+        task_monitor.create("heartbeat", heartbeat_loop)
+        logger.info("[BOOT] Heartbeat loop started; writing to %s/heartbeat.json", LOG_DIR)
+    except Exception:
+        logger.exception("[BOOT] Failed to start heartbeat loop")
+
+    try:
+        if not health_dashboard_task.is_running():
+            health_dashboard_task.start()
+            logger.info("[BOOT] Health dashboard task started")
+    except Exception:
+        logger.error("[BOOT] Failed to start health_dashboard_task: {e}")
+
+    # Start offload monitor as a supervised TaskMonitor task if available
+    try:
+        if monitor_loop_coro is not None:
+            # avoid duplicate creation if already scheduled
+            if not task_monitor.is_running("offload_monitor"):
+                # run with reasonable defaults; adjust via env or later config if needed
+                task_monitor.create(
+                    "offload_monitor",
+                    lambda: monitor_loop_coro(
+                        interval_seconds=int(os.getenv("OFFLOAD_MONITOR_INTERVAL", "300")),
+                        rotate_days=int(os.getenv("OFFLOAD_MONITOR_ROTATE_DAYS", "30")),
+                        max_entries=int(os.getenv("OFFLOAD_MONITOR_MAX_ENTRIES", "2000")),
+                    ),
+                )
+                logger.info("[BOOT] Offload monitor scheduled via TaskMonitor")
+            else:
+                logger.info("[BOOT] Offload monitor already running; skipping schedule")
+    except Exception:
+        logger.exception("[BOOT] Failed to schedule offload monitor")
+
+    # 🔒 Prevent accidental Image.show() calls that invoke tkinter
+    try:
+        from PIL import Image
+
+        def disabled_show(*args, **kwargs):
+            import warnings
+
+            warnings.warn("⚠️ Image.show() disabled to prevent tkinter-based crashes.")
+
+        Image.show = disabled_show
+        logger.info("[BOOT] PIL.Image.show() disabled at startup.")
+    except Exception as e:
+        logger.warning(f"[BOOT] Failed to patch Image.show(): {e}")
+
+    try:
+        clean_old_lock_files(LOG_DIR)
+        logger.info("[LOCK_FILES] Cleared old LOCK Files on Startup")
+    except Exception as e:
+        logger.warning(f"[LOCK_FILES] Failed to clean lock files: {e}")
+
+    # Make sure usage tracker is alive (idempotent)
+    try:
+        usage_tracker().start()
+        logger.info("[BOOT] Usage tracker started.")
+    except Exception:
+        logger.exception("[BOOT] Failed to start usage tracker.")
+
+    try:
+        if not daily_summary.is_running():
+            daily_summary.start()
+            logger.info("[BOOT] daily_summary loop started")
+    except Exception:
+        logger.exception("[BOOT] Failed to start daily_summary loop")
+
+    if ACTIVITY_TRACKING_ENABLED:
+        try:
+            await run_blocking(ensure_activity_schema)
+            register_activity_listeners(bot)
+            logger.info("[BOOT] Server activity tracking initialized")
+        except Exception:
+            logger.exception("[BOOT] Failed to initialize server activity tracking")
+
+    if SERVER_STATUS_ENABLED:
+        if UTC_CLOCK_CHANNEL_ID:
+            try:
+                if not task_monitor.is_running("utc_clock_channel"):
+                    task_monitor.create(
+                        "utc_clock_channel",
+                        lambda: run_utc_clock_channel_loop(bot),
+                        replace=False,
+                    )
+                    logger.info("[BOOT] UTC clock status channel loop started")
+            except Exception:
+                logger.exception("[BOOT] Failed to start UTC clock status channel loop")
+        else:
+            logger.debug(
+                "[BOOT] UTC clock status channel loop skipped – UTC_CLOCK_CHANNEL_ID not set"
+            )
+
+        if MEMBER_COUNT_CHANNEL_ID:
+            try:
+                if not task_monitor.is_running("member_count_channel"):
+                    task_monitor.create(
+                        "member_count_channel",
+                        lambda: run_member_count_channel_loop(bot),
+                        replace=False,
+                    )
+                    logger.info("[BOOT] Member count status channel loop started")
+            except Exception:
+                logger.exception("[BOOT] Failed to start member count status channel loop")
+        else:
+            logger.debug(
+                "[BOOT] Member count status channel loop skipped – MEMBER_COUNT_CHANNEL_ID not set"
+            )
 
 
 @bot.event

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -49,12 +49,18 @@ pushed to production: `DL_bot.py` now delegates the monitored-channel fallback q
 attachment handling, worker queue handoff, `QueueFull` drop behaviour, live queue bookkeeping,
 queue embed updates, shared `utils.live_queue_lock` usage, command fall-through, and best-effort
 log-backup scheduling. Phase 5 upload-routing consolidation is complete. Phase 6 startup/lifecycle
-separation is now the next DL_bot architecture batch.
+separation is now the active DL_bot architecture batch. Phase 6A startup lifecycle boundary work
+was completed in PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`), smoke tested successfully on
+2026-05-27, merged, and pushed to production: `bot_instance.py:on_ready()` now routes its initial
+runtime bootstrap through `core.startup_lifecycle.run_startup_phases()` with a named
+`ready_runtime_bootstrap` phase, preserving startup order while adding phase start/completion and
+failure attribution logs.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
-startup/lifecycle ownership, not as a continuation of upload routing. Start that task with a new
-audit/scope pass and review `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`,
-this backlog, and the current `K98-bot-mirror` GitHub issues list.
+startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
+`docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`, with this backlog and
+the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
 - Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
@@ -122,8 +128,8 @@ this backlog, and the current `K98-bot-mirror` GitHub issues list.
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, so lifecycle ownership can now be audited independently.
-- Suggested Fix: Start Phase 6 from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. Audit `DL_bot.py`, `bot_instance.py`, `bot_loader.py`, `bot_startup_gate.py`, `boot_safety.py`, `startup_utils.py`, `singleton_lock.py`, `bot_helpers.py`, `utils.py`, and startup/shutdown runbooks before proposing any implementation. Define a target ownership model for process entry, bot construction, command registration, event registration, startup sequencing, task supervision, queue worker lifecycle, graceful shutdown, singleton/runtime files, and restart-safe state. Stop for approval before code changes.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, and Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap. Remaining `on_ready()` work still mixes runtime service startup, command sync/cache handling, event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and `docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`. The next PR-sized slice should extract the `on_ready()` runtime services/observability block after `ready_runtime_bootstrap` into a named lifecycle phase while preserving order and behaviour. Keep command sync/cache, event rehydration, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing is complete, smoke tested, closed, and production-pushed; proceed with audit/design before implementation.
+- Dependencies: Phase 5 upload routing and Phase 6A startup lifecycle boundary are complete, smoke tested, merged, and production-pushed; proceed with audit/design before each remaining implementation slice.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
@@ -1,6 +1,11 @@
 # Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle
 
-Use this starter to begin Phase 6 after Phase 5 upload-routing consolidation was closed,
+Use this starter for historical Phase 6 kickoff context. Phase 6A was completed in PR 117
+(`codex/dlbot-phase-6-startup-lifecycle-1`), smoke-tested on 2026-05-27, merged, and pushed to
+production. For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`.
+
+This original starter began Phase 6 after Phase 5 upload-routing consolidation was closed,
 smoke-tested, pushed to production, and marked complete.
 
 ## Copy/Paste Starter

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
@@ -1,0 +1,167 @@
+# Codex Chat Starter - DL_bot Phase 6B Runtime Services
+
+Use this starter to continue Phase 6 after Phase 6A startup lifecycle boundary was merged,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6B:
+`on_ready()` runtime services and observability startup extraction.
+
+Phase 6A is complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- `core/startup_lifecycle.py` now provides `StartupPhase` and `run_startup_phases()`.
+- `bot_instance.py:on_ready()` now delegates the initial loop/console bootstrap through the
+  named `ready_runtime_bootstrap` phase.
+- Production smoke logs confirmed:
+  - `[STARTUP] phase started: ready_runtime_bootstrap`
+  - `[BOOT] Global asyncio exception handler installed on running loop.`
+  - `[STARTUP] phase completed: ready_runtime_bootstrap`
+  - normal heartbeat, health dashboard, command-cache, scheduler, queue worker, rehydration, and
+    full startup logs continued afterward.
+
+This is review/scope first. Do not implement code changes until the Phase 6B scope, target
+phase boundary, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+## Phase 6B Objective
+
+Extract the next contiguous `bot_instance.py:on_ready()` startup block into a named lifecycle phase
+using the Phase 6A `core.startup_lifecycle` pattern.
+
+Recommended target phase:
+
+`ready_runtime_services`
+
+This phase should cover only the runtime services and observability startup block that currently
+follows `ready_runtime_bootstrap`, including:
+
+- heartbeat task startup
+- health dashboard task startup
+- offload monitor startup
+- `PIL.Image.show()` safety patch
+- old lock-file cleanup
+- usage tracker startup
+- daily summary loop startup
+- activity schema/listener startup when activity tracking is enabled
+- UTC clock status channel loop startup
+- member-count status channel loop startup
+
+The implementation should preserve startup order and behaviour.
+
+## Out Of Scope
+
+- `DL_bot.py` process-entry changes.
+- Upload-route behaviour changes.
+- Command sync/cache extraction.
+- Command-surface consolidation.
+- Event cache refresh, reminder loading, view rehydration, scheduler registration, and MGE/Ark
+  lifecycle extraction.
+- Queue worker startup, live queue rehydration, or queue persistence changes.
+- Shutdown, signal handling, singleton lock, PID, marker, or logging-shutdown changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `core/startup_lifecycle.py`
+- `tests/test_startup_lifecycle.py`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- `tests/test_startup_lifecycle.py`
+
+Do not create a new lifecycle module unless the audit finds `core/startup_lifecycle.py` is no
+longer sufficient.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Phase 6A Boundary Map
+- Proposed Phase 6B Runtime Services Map
+- Behaviour Preservation Checklist
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6B Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_mge_startup_hook_invoked.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6 touches
+startup, file handling, network calls, Discord runtime behaviour, and restart-sensitive
+persistence.
+
+## Expected Smoke Log Signals
+
+After implementation and deployment, expected startup logs should include:
+
+```text
+[STARTUP] phase started: ready_runtime_bootstrap
+[STARTUP] phase completed: ready_runtime_bootstrap
+[STARTUP] phase started: ready_runtime_services
+[BOOT] Heartbeat loop started
+[BOOT] Health dashboard task started
+[BOOT] Offload monitor scheduled via TaskMonitor
+[BOOT] Usage tracker started.
+[BOOT] daily_summary loop started
+[BOOT] Server activity tracking initialized
+[BOOT] UTC clock status channel loop started
+[BOOT] Member count status channel loop started
+[STARTUP] phase completed: ready_runtime_services
+```
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed: ready_runtime_services
+[CRITICAL] Exception during on_ready
+```
+
+## Deferred Item Link
+
+This starter continues the startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md`.

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -4,7 +4,8 @@
 
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and pushed to production`
+- Last updated: `2026-05-27`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A startup lifecycle boundary was pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -56,6 +57,17 @@ Phase 5 upload-routing consolidation is complete:
 - Phase 5B extracted inventory upload-first and weekly activity routes.
 - Phase 5C extracted Rally Forts routing.
 - Phase 5D extracted main monitored-channel fallback queueing.
+
+Phase 6A startup lifecycle boundary is complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) added `core/startup_lifecycle.py`.
+- `bot_instance.py:on_ready()` now delegates the initial loop/console bootstrap through
+  `run_startup_phases([StartupPhase("ready_runtime_bootstrap", ...)])`.
+- Smoke testing on 2026-05-27 confirmed the expected `ready_runtime_bootstrap` phase started,
+  installed the global asyncio exception handler, completed, and then allowed normal heartbeat,
+  health dashboard, command-cache, scheduler, queue worker, rehydration, and full startup logs to
+  continue.
+- The PR was merged and pushed to production.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -262,13 +274,15 @@ Initial classification before audit:
 | Upload-route consolidation | not applicable | Phase 5 is complete; do not reopen routing in Phase 6. |
 | Process entry and singleton lock ownership | audit first | High-impact startup path; define target ownership before edits. |
 | Bot construction and event registration ownership | audit first | Current ownership is spread across `bot_loader.py`, `bot_instance.py`, and `DL_bot.py`. |
-| `on_ready()` / `full_startup_sequence()` size and responsibilities | audit first | Likely first implementation candidate, but requires careful map and tests. |
+| Initial `on_ready()` runtime bootstrap boundary | complete | Phase 6A moved loop exception handler setup and console-handler cleanup behind `ready_runtime_bootstrap`, preserving startup order and adding named phase logs. |
+| Runtime services/observability startup | next recommended slice | The next contiguous `on_ready()` block starts heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops. It is a coherent PR-sized slice before command sync/cache work. |
+| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
 | SQL/importer contracts | not applicable unless discovered | Phase 6 should avoid SQL/importer contract changes. |
 
-Final decisions must be updated after Step 1 audit.
+Final decisions should be updated after each Phase 6 sub-phase.
 
 ## 14. Testing Requirements
 

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -67,4 +67,4 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         assert isinstance(phase_call.args[0].value, str)
         startup_phase_names.append(phase_call.args[0].value)
 
-    assert startup_phase_names == ["ready_runtime_bootstrap"]
+    assert startup_phase_names == ["ready_runtime_bootstrap", "ready_runtime_services"]


### PR DESCRIPTION
## Summary

- Extract the next contiguous `bot_instance.py:on_ready()` runtime services block into a named `ready_runtime_services` startup phase.
- Preserve the existing startup order and runtime behavior for heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity tracking, UTC clock, and member-count loops.
- Update Phase 6 docs/task packs to mark Phase 6A complete and introduce the Phase 6B runtime services starter.

## Changes

- `bot_instance.py` now runs `ready_runtime_bootstrap` followed by `ready_runtime_services` through `run_startup_phases()`.
- The runtime services block was moved mechanically into `_run_ready_runtime_services()` without changing its internal guards or task names.
- `tests/test_startup_lifecycle.py` now asserts the two-phase startup order.
- Phase 6 docs/backlog now point to the Phase 6B starter and describe the next lifecycle slice.

## Tests

- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_mge_startup_hook_invoked.py` (`5 passed`)
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `\.\.venv\Scripts\python.exe scripts\select_tests.py`
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests` (`1543 passed, 2 skipped`)
- `\.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`
- `\.\.venv\Scripts\python.exe -m pre_commit run -a`

## Security Review

- Codex Security diff review performed for the startup/runtime lifecycle change.
- Threat model: Discord bot startup/runtime services, file/log handling, background tasks, and restart-sensitive observability.
- Finding discovery: no plausible new attacker-controlled source, privilege boundary change, or dangerous sink introduced; this patch wraps existing startup calls in a named phase and preserves existing guards/order.
- Validation and attack-path analysis: not applicable because discovery produced no candidates.

## Deferred Optimisations

- Keep usage tracker lifecycle ownership in view for a later Phase 6 slice. Startup currently invokes usage tracker behavior in the new runtime services phase and later `full_startup_sequence()`; this remains idempotent, but ownership should be consolidated in a follow-up lifecycle extraction.

## Risk / Rollback

- Risk: medium. This touches startup sequencing, but the code movement is mechanical and guarded by lifecycle tests plus full-suite validation.
- Rollback: revert this PR to return `on_ready()` to the prior inline runtime services block.