### PR TITLE
[codex] consolidate usage tracker lifecycle

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -128,6 +128,7 @@ telemetry_logger = logging.getLogger("telemetry")
 
 # Usage tracker (for component + autocomplete logging)
 from decoraters import usage_tracker  # lazy singleton; safe to import here
+from usage_tracker import start_usage_tracker, usage_jsonl_prune_loop
 
 
 def _aware(dt: datetime) -> datetime:
@@ -1850,12 +1851,21 @@ async def _run_ready_runtime_services() -> None:
     except Exception as e:
         logger.warning(f"[LOCK_FILES] Failed to clean lock files: {e}")
 
-    # Make sure usage tracker is alive (idempotent)
+    # Make sure usage tracking and retention pruning are alive (idempotent)
     try:
-        usage_tracker().start()
+        start_usage_tracker()
         logger.info("[BOOT] Usage tracker started.")
     except Exception:
         logger.exception("[BOOT] Failed to start usage tracker.")
+
+    try:
+        task_monitor.create("usage_jsonl_prune", usage_jsonl_prune_loop)
+        logger.info(
+            "[BOOT] Usage JSONL prune loop started (retention=%s days).",
+            os.getenv("USAGE_JSONL_RETENTION_DAYS", "30"),
+        )
+    except Exception:
+        logger.exception("[BOOT] Failed to start usage JSONL prune loop.")
 
     try:
         if not daily_summary.is_running():
@@ -1939,16 +1949,6 @@ async def full_startup_sequence():
         try:
             logger.warning(f"🤖 Logged in as {bot.user} (ID: {bot.user.id})")
             logger.warning("✅ Bot is ready.")
-
-            from usage_tracker import start_usage_tracker, usage_jsonl_prune_loop
-
-            start_usage_tracker()
-            logger.info("[STARTUP] Usage tracker started.")
-            task_monitor.create("usage_jsonl_prune", usage_jsonl_prune_loop)
-            logger.info(
-                "[STARTUP] Usage JSONL prune loop started (retention=%s days).",
-                os.getenv("USAGE_JSONL_RETENTION_DAYS", "30"),
-            )
 
             notify_channel = bot.get_channel(NOTIFY_CHANNEL_ID)
             if not notify_channel:

--- a/decoraters.py
+++ b/decoraters.py
@@ -18,7 +18,7 @@ from bot_config import (
     LEADERSHIP_ROLE_NAMES,
     NOTIFY_CHANNEL_ID,
 )
-from usage_tracker import AsyncUsageTracker
+from usage_tracker import AsyncUsageTracker, get_usage_tracker
 
 # Use timezone.utc for broad Python compatibility (works on Py 3.8+).
 UTC = UTC
@@ -310,17 +310,8 @@ def channel_only(
     return decorator
 
 
-# lazy singleton to avoid circular imports
-_tracker: AsyncUsageTracker | None = None
-
-
 def usage_tracker() -> AsyncUsageTracker:
-    global _tracker
-    if _tracker is None:
-        # Flush every 5s or every 20 events while testing
-        _tracker = AsyncUsageTracker(flush_interval_sec=5, batch_size=20)
-        # .start() is called from bot_instance.full_startup_sequence() after the event loop is running.
-    return _tracker
+    return get_usage_tracker()
 
 
 # add near _safe_args_shape

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -54,12 +54,19 @@ was completed in PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`), smoke teste
 2026-05-27, merged, and pushed to production: `bot_instance.py:on_ready()` now routes its initial
 runtime bootstrap through `core.startup_lifecycle.run_startup_phases()` with a named
 `ready_runtime_bootstrap` phase, preserving startup order while adding phase start/completion and
-failure attribution logs.
+failure attribution logs. Phase 6B runtime services extraction was completed in PR 119
+(`codex/dlbot-phase-6b-runtime-services`), smoke tested successfully on 2026-05-27, merged, and
+pushed to production: `bot_instance.py:on_ready()` now routes heartbeat, health dashboard, offload
+monitor, PIL safety patch, lock-file cleanup, usage tracker startup, daily summary, activity
+tracking, UTC clock, and member-count status loops through the named `ready_runtime_services`
+phase while preserving startup order and behaviour. Phase 6C usage tracker lifecycle ownership
+then consolidated command/component/metric usage logging onto the shared `usage_tracker.py`
+singleton and moved usage JSONL prune startup into `ready_runtime_services`, leaving
+`full_startup_sequence()` free of usage observability startup.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`, with this backlog and
 the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -128,8 +135,8 @@ the current `K98-bot-mirror` GitHub issues list as supporting context.
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, and Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap. Remaining `on_ready()` work still mixes runtime service startup, command sync/cache handling, event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and `docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`. The next PR-sized slice should extract the `on_ready()` runtime services/observability block after `ready_runtime_bootstrap` into a named lifecycle phase while preserving order and behaviour. Keep command sync/cache, event rehydration, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, and Phase 6C consolidated usage tracker lifecycle ownership. Remaining `on_ready()` work still mixes command sync/cache handling, event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice should audit a coherent remaining startup responsibility such as command sync/cache handling or event cache/rehydration boundaries while preserving startup order, idempotency, and production smoke log expectations. Keep queue worker lifecycle and shutdown coordination in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing and Phase 6A startup lifecycle boundary are complete, smoke tested, merged, and production-pushed; proceed with audit/design before each remaining implementation slice.
+- Dependencies: Phase 5 upload routing, Phase 6A startup lifecycle boundary, Phase 6B runtime services extraction, and Phase 6C usage tracker ownership consolidation are complete in code; proceed with audit/design before each remaining implementation slice.

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -12,6 +12,11 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
 6. Commands are registered locally.
 7. Discord client starts.
 8. `bot_instance.on_ready()` runs the full startup sequence.
+   - `ready_runtime_bootstrap` installs the running-loop exception handler and final console
+     handler cleanup.
+   - `ready_runtime_services` starts heartbeat, health dashboard, offload monitor, image-show
+     safety patching, legacy lock cleanup, the shared usage tracker and usage JSONL prune loop,
+     daily summary, activity tracking, and server status channel loops.
 9. Caches, rehydration, background tasks, heartbeat, and admin notification start.
 
 ## Main Files
@@ -55,6 +60,7 @@ Important checks include:
 
 Startup may rehydrate or start:
 
+- named lifecycle phases from `core/startup_lifecycle.py`
 - command signature cache
 - live queue state
 - event views
@@ -62,6 +68,14 @@ Startup may rehydrate or start:
 - subscription reminder tasks
 - maintenance/health tasks
 - heartbeat file updates
+
+Phase 6A and 6B introduced named `on_ready()` startup phases for initial runtime bootstrap and
+runtime services/observability startup. Phase 6C consolidated usage tracking onto the shared
+`usage_tracker.py` singleton, with tracker startup and usage JSONL pruning owned by
+`ready_runtime_services`. The unified tracker intentionally uses the previous command/decorator
+cadence of a 5-second flush interval or 20-event batch size for command, component, metric, and
+alert usage events. Remaining lifecycle cleanup includes command/cache extraction, rehydration and
+scheduler boundaries, queue worker lifecycle, and shutdown coordination.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
@@ -1,9 +1,10 @@
 # Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle
 
 Use this starter for historical Phase 6 kickoff context. Phase 6A was completed in PR 117
-(`codex/dlbot-phase-6-startup-lifecycle-1`), smoke-tested on 2026-05-27, merged, and pushed to
-production. For the next active slice, use
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md`.
+(`codex/dlbot-phase-6-startup-lifecycle-1`), and Phase 6B was completed in PR 119
+(`codex/dlbot-phase-6b-runtime-services`). Both were smoke-tested on 2026-05-27, merged, and
+pushed to production. For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`.
 
 This original starter began Phase 6 after Phase 5 upload-routing consolidation was closed,
 smoke-tested, pushed to production, and marked complete.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
@@ -1,6 +1,13 @@
 # Codex Chat Starter - DL_bot Phase 6B Runtime Services
 
-Use this starter to continue Phase 6 after Phase 6A startup lifecycle boundary was merged,
+Use this starter for historical Phase 6B context. Phase 6B was completed in PR 119
+(`codex/dlbot-phase-6b-runtime-services`), smoke-tested on 2026-05-27, merged, and pushed to
+production.
+
+For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`.
+
+This original starter continued Phase 6 after Phase 6A startup lifecycle boundary was merged,
 smoke-tested, pushed to production, and marked complete.
 
 ## Copy/Paste Starter
@@ -20,6 +27,28 @@ Phase 6A is complete:
   - `[STARTUP] phase completed: ready_runtime_bootstrap`
   - normal heartbeat, health dashboard, command-cache, scheduler, queue worker, rehydration, and
     full startup logs continued afterward.
+
+Phase 6B is complete:
+
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- `bot_instance.py:on_ready()` now delegates runtime services and observability startup through
+  the named `ready_runtime_services` phase.
+- Production smoke logs confirmed:
+  - `[STARTUP] phase started: ready_runtime_services`
+  - `[BOOT] Heartbeat loop started`
+  - `[BOOT] Health dashboard task started`
+  - `[BOOT] Offload monitor scheduled via TaskMonitor`
+  - `[BOOT] Usage tracker started.`
+  - `[BOOT] daily_summary loop started`
+  - `[BOOT] Server activity tracking initialized`
+  - `[BOOT] UTC clock status channel loop started`
+  - `[BOOT] Member count status channel loop started`
+  - `[STARTUP] phase completed: ready_runtime_services`
+  - command cache, event cache, rehydration, schedulers, queue workers, and
+    `full_startup_sequence()` continued afterward.
+- Follow-up note: usage tracker ownership remains intentionally visible for a later Phase 6 slice
+  because the runtime services phase starts usage tracking and `full_startup_sequence()` later
+  starts usage tracking/prune-loop behaviour through a second ownership path.
 
 This is review/scope first. Do not implement code changes until the Phase 6B scope, target
 phase boundary, and first PR-sized implementation plan have each been approved.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
@@ -179,3 +179,30 @@ The smoke test should not show:
 
 This starter continues the usage tracker ownership deferred optimisation in
 `docs/reference/deferred_optimisations.md`.
+
+---
+
+## Phase 6C Is Complete
+
+**Status**: Merged via PR codex/dlbot-phase-6c-usage-tracker (commit d39f5b0) and pushed to production.
+
+**What Changed**:
+
+- `decoraters.usage_tracker()` now delegates to the shared `usage_tracker.get_usage_tracker()` singleton.
+- `usage_tracker.py` owns the shared tracker singleton with unified flush cadence (`5s` / `20` events) for commands, components, metrics, and alerts.
+- `_run_ready_runtime_services()` now owns both usage tracker startup (`start_usage_tracker()`) and usage JSONL prune-loop registration (`task_monitor.create("usage_jsonl_prune", ...)`).
+- Usage observability startup removed from `full_startup_sequence()`.
+- Focused lifecycle tests added to assert shared singleton, preserved flush settings, and runtime-services ownership boundary.
+- Startup runbook and Phase 6 task-pack/deferred optimisation docs updated to reflect Phase 6C status.
+
+**Validation**:
+
+- All tests pass (1546 passed, 2 skipped).
+- All validation scripts pass (architecture boundaries, deferred items, select tests, smoke imports, command registration).
+- Pre-commit hooks pass.
+- Codex Security diff review completed (no findings).
+- Production smoke logs confirmed usage tracker startup in `ready_runtime_services` phase.
+
+**Next Steps**:
+
+Continue with the next Phase 6 task when identified, or proceed to other architectural optimisation work as prioritized.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
@@ -1,0 +1,181 @@
+# Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership
+
+Use this starter to continue Phase 6 after Phase 6B runtime services extraction was merged,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6C:
+usage tracker lifecycle ownership and `full_startup_sequence()` observability cleanup.
+
+Phase 6A and 6B are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `bot_instance.py:on_ready()` now delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+- Production smoke logs confirmed:
+  - `[STARTUP] phase started: ready_runtime_bootstrap`
+  - `[STARTUP] phase completed: ready_runtime_bootstrap`
+  - `[STARTUP] phase started: ready_runtime_services`
+  - heartbeat, health dashboard, offload monitor, usage tracker, daily summary, activity tracking,
+    UTC clock, and member-count status loops started
+  - `[STARTUP] phase completed: ready_runtime_services`
+  - command cache, event cache, rehydration, schedulers, queue workers, and
+    `full_startup_sequence()` continued afterward.
+
+This is review/scope first. Do not implement code changes until the Phase 6C scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+## Phase 6C Objective
+
+Audit and consolidate usage tracker lifecycle ownership now that Phase 6B made the runtime services
+phase explicit.
+
+The current production-smoke-tested behaviour is intentionally preserved, but ownership remains
+split:
+
+- `_run_ready_runtime_services()` starts the decorator-level `usage_tracker()` singleton.
+- `full_startup_sequence()` later calls `start_usage_tracker()` and starts the
+  `usage_jsonl_prune` TaskMonitor task.
+- `on_graceful_shutdown()` stops the decorator-level `usage_tracker()` singleton.
+
+Recommended target: one explicit startup lifecycle owner for usage tracking and usage JSONL prune
+startup, with shutdown ownership documented and preserved.
+
+## In Scope
+
+- Audit the relationship between:
+  - `decoraters.usage_tracker()`
+  - `usage_tracker.start_usage_tracker()`
+  - `usage_tracker.usage_jsonl_prune_loop`
+  - `bot_instance.py:_run_ready_runtime_services()`
+  - `bot_instance.py:full_startup_sequence()`
+  - `bot_instance.py:on_graceful_shutdown()`
+- Decide whether usage tracker startup and prune-loop startup should remain in
+  `ready_runtime_services`, move into a dedicated named phase, or be otherwise made explicit.
+- Preserve usage event capture for commands, components, autocomplete, denied-command logging, SQL
+  flush behaviour, JSONL writes, and JSONL retention pruning.
+- Preserve startup order enough that command/interactions do not lose usage logging after ready.
+- Preserve shutdown flushing/stopping behaviour.
+- Add or update focused lifecycle tests.
+- Capture any broader `full_startup_sequence()` cleanup that exceeds this slice.
+
+## Out Of Scope
+
+- Command sync/cache extraction.
+- Event cache refresh, reminder loading, view rehydration, scheduler registration, and MGE/Ark
+  lifecycle extraction.
+- Queue worker startup, live queue rehydration, or queue persistence changes.
+- Shutdown redesign beyond preserving usage tracker stop/flush behaviour.
+- `DL_bot.py` process-entry changes.
+- Upload-route behaviour changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `decoraters.py`
+- `usage_tracker.py`
+- `core/startup_lifecycle.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_usage_tracker.py`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- `tests/test_startup_lifecycle.py`
+- possibly `tests/test_usage_tracker.py`
+
+Do not create a new lifecycle module unless the audit finds `core/startup_lifecycle.py` is no
+longer sufficient.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Usage Tracker Lifecycle Map
+- Current Phase 6A/6B Boundary Map
+- Proposed Phase 6C Ownership Model
+- Behaviour Preservation Checklist
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6C Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_usage_tracker.py tests\test_mge_startup_hook_invoked.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6 touches
+startup, file handling, network calls, Discord runtime behaviour, usage telemetry, and
+restart-sensitive persistence.
+
+## Expected Smoke Log Signals
+
+After implementation and deployment, expected startup logs should still include:
+
+```text
+[STARTUP] phase started: ready_runtime_bootstrap
+[STARTUP] phase completed: ready_runtime_bootstrap
+[STARTUP] phase started: ready_runtime_services
+[BOOT] Usage tracker started.
+[STARTUP] phase completed: ready_runtime_services
+```
+
+If the implementation introduces a dedicated usage phase, the smoke expectations should include
+the new phase start/completion lines and should still show usage JSONL prune startup once.
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+[BOOT] Failed to start usage tracker.
+```
+
+## Deferred Item Link
+
+This starter continues the usage tracker ownership deferred optimisation in
+`docs/reference/deferred_optimisations.md`.

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -329,13 +329,18 @@ Phase breakdown:
      modules.
    - Starter packet: `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
 8. **Phase 6 - Startup/lifecycle separation**
-   - Next active architecture batch after Phase 5 completion.
-   - Audit and optimise `DL_bot.py` lifecycle/startup responsibilities alongside a full
-     `bot_instance.py` review.
-   - Define the target ownership model for bot construction, startup checks, lifecycle wiring,
-     singleton/runtime concerns, event registration, task supervision, queue worker lifecycle,
-     shutdown, and restart-safe state separately from upload-route behaviour.
-   - Starter packet: `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+   - Active architecture batch after Phase 5 completion.
+   - Phase 6A completed the first named startup lifecycle boundary in PR 117
+     (`codex/dlbot-phase-6-startup-lifecycle-1`), routing initial `on_ready()` runtime bootstrap
+     through `ready_runtime_bootstrap`.
+   - Phase 6B completed runtime services extraction in PR 119
+     (`codex/dlbot-phase-6b-runtime-services`), routing heartbeat, health dashboard, offload
+     monitor, lock cleanup, usage tracker startup, daily summary, activity tracking, and status
+     channel loops through `ready_runtime_services`.
+   - Remaining work: usage tracker lifecycle ownership, command sync/cache extraction, event cache
+     and rehydration boundaries, scheduler/task ownership, queue worker lifecycle, shutdown, and
+     restart-safe state coordination.
+   - Current starter packet: `docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`
 
 Phase 2A delivery notes:
 

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-27`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A startup lifecycle boundary was pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -68,6 +68,20 @@ Phase 6A startup lifecycle boundary is complete:
   health dashboard, command-cache, scheduler, queue worker, rehydration, and full startup logs to
   continue.
 - The PR was merged and pushed to production.
+
+Phase 6B runtime services extraction is complete:
+
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) added the named
+  `ready_runtime_services` phase after `ready_runtime_bootstrap`.
+- `bot_instance.py:on_ready()` now delegates heartbeat, health dashboard, offload monitor,
+  `PIL.Image.show()` safety patch, lock-file cleanup, usage tracker startup, daily summary,
+  activity tracking, UTC clock, and member-count status loops through `run_startup_phases()`.
+- Smoke testing on 2026-05-27 confirmed the expected `ready_runtime_services` phase started,
+  started the runtime services, completed, and then allowed command cache, event cache,
+  rehydration, schedulers, queue workers, and `full_startup_sequence()` to continue.
+- The PR was merged and pushed to production.
+- Usage tracker ownership remains a deliberate follow-up because usage tracking is started in the
+  runtime services phase and later startup/prune-loop behaviour remains in `full_startup_sequence()`.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -275,8 +289,9 @@ Initial classification before audit:
 | Process entry and singleton lock ownership | audit first | High-impact startup path; define target ownership before edits. |
 | Bot construction and event registration ownership | audit first | Current ownership is spread across `bot_loader.py`, `bot_instance.py`, and `DL_bot.py`. |
 | Initial `on_ready()` runtime bootstrap boundary | complete | Phase 6A moved loop exception handler setup and console-handler cleanup behind `ready_runtime_bootstrap`, preserving startup order and adding named phase logs. |
-| Runtime services/observability startup | next recommended slice | The next contiguous `on_ready()` block starts heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops. It is a coherent PR-sized slice before command sync/cache work. |
-| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, and shutdown together. |
+| Runtime services/observability startup | complete | Phase 6B moved heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops behind `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
+| Usage tracker lifecycle ownership | next recommended slice | Usage tracking now has clearer phase attribution but still has split ownership between `ready_runtime_services`, `full_startup_sequence()`, and shutdown. Audit and consolidate this before broader `full_startup_sequence()` extraction. |
+| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -68,3 +68,49 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         startup_phase_names.append(phase_call.args[0].value)
 
     assert startup_phase_names == ["ready_runtime_bootstrap", "ready_runtime_services"]
+
+
+def _async_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name
+    )
+
+
+def _calls_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == name
+        for child in ast.walk(node)
+    )
+
+
+def _creates_task_monitor_task(node: ast.AST, task_name: str) -> bool:
+    for child in ast.walk(node):
+        if not (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "create"
+            and isinstance(child.func.value, ast.Name)
+            and child.func.value.id == "task_monitor"
+            and child.args
+            and isinstance(child.args[0], ast.Constant)
+        ):
+            continue
+        if child.args[0].value == task_name:
+            return True
+    return False
+
+
+def test_usage_tracking_lifecycle_owned_by_runtime_services_phase():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    runtime_services = _async_function(tree, "_run_ready_runtime_services")
+    full_startup = _async_function(tree, "full_startup_sequence")
+
+    assert _calls_name(runtime_services, "start_usage_tracker")
+    assert _creates_task_monitor_task(runtime_services, "usage_jsonl_prune")
+
+    assert not _calls_name(full_startup, "start_usage_tracker")
+    assert not _creates_task_monitor_task(full_startup, "usage_jsonl_prune")

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -13,8 +13,15 @@ import tempfile
 
 import pytest
 
+import decoraters
 from telemetry.dal.command_usage_dal import _coerce_ts
-from usage_tracker import AsyncUsageTracker, prune_usage_jsonl_files, start_usage_tracker
+import usage_tracker as usage_tracker_module
+from usage_tracker import (
+    AsyncUsageTracker,
+    get_usage_tracker,
+    prune_usage_jsonl_files,
+    start_usage_tracker,
+)
 
 # ---------------------------------------------------------------------------
 # Lifecycle tests
@@ -27,13 +34,32 @@ def test_tracker_not_started_before_start_called():
     assert tracker._task is None
 
 
-def test_start_usage_tracker_creates_task():
+def test_global_usage_tracker_preserves_decorator_flush_settings(monkeypatch):
+    """The shared tracker keeps the previous decorator-level flush cadence."""
+    monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)
+
+    tracker = get_usage_tracker()
+
+    assert tracker.flush_interval_sec == 5
+    assert tracker.batch_size == 20
+
+
+def test_decorater_usage_tracker_uses_shared_global_tracker(monkeypatch):
+    """Decorators and startup use the same tracker instance."""
+    monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)
+
+    assert decoraters.usage_tracker() is get_usage_tracker()
+
+
+def test_start_usage_tracker_creates_task(monkeypatch):
     """start_usage_tracker() returns a tracker with a running task."""
+    monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)
 
     async def _inner():
         tracker = start_usage_tracker()
         try:
             assert tracker._task is not None
+            assert tracker is get_usage_tracker()
         finally:
             # Cancel the background task so the test loop can exit cleanly
             tracker._task.cancel()

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -44,7 +44,7 @@ def test_global_usage_tracker_preserves_decorator_flush_settings(monkeypatch):
     assert tracker.batch_size == 20
 
 
-def test_decorater_usage_tracker_uses_shared_global_tracker(monkeypatch):
+def test_decorator_usage_tracker_uses_shared_global_tracker(monkeypatch):
     """Decorators and startup use the same tracker instance."""
     monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)
 

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -197,24 +197,29 @@ class AsyncUsageTracker:
 # -------------------------
 _GLOBAL_TRACKER: Optional[AsyncUsageTracker] = None
 _GLOBAL_LOCK = threading.Lock()
+_DEFAULT_FLUSH_INTERVAL_SEC = 5
+_DEFAULT_BATCH_SIZE = 20
 
 
-def _ensure_global_tracker() -> AsyncUsageTracker:
+def get_usage_tracker() -> AsyncUsageTracker:
     # NOTE: caller must call start_usage_tracker() after the event loop is running.
     global _GLOBAL_TRACKER
     with _GLOBAL_LOCK:
         if _GLOBAL_TRACKER is None:
-            _GLOBAL_TRACKER = AsyncUsageTracker()
+            _GLOBAL_TRACKER = AsyncUsageTracker(
+                flush_interval_sec=_DEFAULT_FLUSH_INTERVAL_SEC,
+                batch_size=_DEFAULT_BATCH_SIZE,
+            )
             log.debug("[USAGE] Global tracker created; awaiting start_usage_tracker() call")
         return _GLOBAL_TRACKER
 
 
 def start_usage_tracker() -> "AsyncUsageTracker":
     """
-    Start the global usage tracker. Call this from bot startup (full_startup_sequence)
+    Start the global usage tracker. Call this from bot startup
     after the event loop is running. Safe to call multiple times.
     """
-    tracker = _ensure_global_tracker()
+    tracker = get_usage_tracker()
     tracker.start()
     return tracker
 
@@ -358,7 +363,7 @@ def _emit_alert(name: str, count: int, window: int) -> None:
         log.exception("[USAGE] Could not persist alert JSONL")
     # Attempt to enqueue an alert event into the usage tracker so it gets flushed to SQL
     try:
-        tracker = _ensure_global_tracker()
+        tracker = get_usage_tracker()
         # Build a compact usage event payload
         evt = {
             "executed_at_utc": utcnow(),
@@ -462,7 +467,7 @@ def usage_event(name: str, value: int = 1, metadata: Optional[dict] = None) -> N
 
     # Attempt to enqueue to AsyncUsageTracker (best-effort, non-blocking)
     try:
-        tracker = _ensure_global_tracker()
+        tracker = get_usage_tracker()
         # lightweight usage-entry for SQL flush
         evt = {
             "executed_at_utc": ts,
@@ -517,6 +522,7 @@ def set_alert_thresholds(threshold: int, window_s: int, suppress_s: int = 300) -
 # so they can call usage_tracker.usage_event(...) to record metrics
 __all__ = [
     "AsyncUsageTracker",
+    "get_usage_tracker",
     "metrics_window_count",
     "prune_usage_jsonl_files",
     "set_alert_callback",


### PR DESCRIPTION
## Summary

- Consolidate Phase 6C usage tracking onto the shared `usage_tracker.py` singleton while preserving the existing decorator-level flush cadence (`5s` / `20` events).
- Move usage tracker startup and usage JSONL prune-loop ownership into the `ready_runtime_services` lifecycle phase.
- Remove usage observability startup from `full_startup_sequence()` and update Phase 6 lifecycle docs/task starters.

## Changes

- `decoraters.usage_tracker()` now delegates to `usage_tracker.get_usage_tracker()`.
- `usage_tracker.py` owns the shared tracker singleton used by commands, components, metrics, and alerts.
- The unified tracker intentionally applies the previous command/decorator cadence (`5s` flush interval or `20` event batch) to metric and alert events as well as command/component events.
- `_run_ready_runtime_services()` starts the shared tracker and schedules `usage_jsonl_prune` via `TaskMonitor`.
- Focused lifecycle tests assert the shared singleton, preserved flush settings, and runtime-services ownership boundary.
- Startup runbook and Phase 6 task-pack/deferred optimisation docs now reflect Phase 6B/6C status.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_startup_lifecycle.py tests/test_usage_tracker.py tests/test_mge_startup_hook_invoked.py` -> `19 passed`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_usage_tracker.py tests/test_startup_lifecycle.py` -> `17 passed` after review feedback fixes
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pytest -q tests` -> `1546 passed, 2 skipped`
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py` -> production operational logs unchanged

## AI Review Gates

- Codex Security diff review: no plausible security findings found; validation/attack-path phases skipped because discovery produced no candidates.

## Risk / Rollback

- Risk: medium. This touches startup lifecycle and usage telemetry ownership, but preserves the existing command usage flush cadence and keeps the change scoped to usage tracking.
- Rollback: revert this PR to restore the prior split startup behavior between `ready_runtime_services` and `full_startup_sequence()`.