### PR TITLE
[codex] add Phase 6D command sync lifecycle phase

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -35,20 +35,14 @@ from bot_config import (
     UTC_CLOCK_CHANNEL_ID,
 )
 from bot_helpers import (
-    commands_changed,
     connection_watchdog,
-    get_command_signature,
-    load_command_signatures,
     prune_restart_log,
     queue_cleanup_loop,
     queue_worker,
-    save_command_signatures,
 )
 from bot_loader import bot
 from bot_startup_gate import claim_startup_once
-from commands.command_inventory import flatten_application_commands
 from constants import (
-    COMMAND_CACHE_FILE,
     CREDENTIALS_FILE,
     CSV_LOG,
     DATABASE,
@@ -65,6 +59,7 @@ from constants import (
     SUMMARY_LOG,
     USERNAME,
 )
+from core.command_lifecycle import run_ready_command_sync
 from core.interaction_safety import get_operation_lock
 from core.startup_lifecycle import StartupPhase, run_startup_phases
 from crystaltech_di import init_crystaltech_service
@@ -1545,70 +1540,7 @@ async def on_ready():
 
     try:
         logger.info(f"✅ Bot is ready – logged in as {bot.user} (ID: {bot.user.id})")
-
-        commands = list(bot.application_commands)
-        signature_commands = list(flatten_application_commands(commands))
-        current_signatures = [
-            sig
-            for name, cmd in signature_commands
-            if (sig := get_command_signature(cmd, name=name)) is not None
-        ]
-
-        logger.info("🧪 Reading command cache file...")
-        saved_signatures = load_command_signatures(filepath=COMMAND_CACHE_FILE)
-        logger.info("✅ Command cache loaded")
-
-        try:
-            result = commands_changed(current_signatures, saved_signatures)
-            logger.info(f"✅ commands_changed result: {result}")
-        except Exception:
-            logger.exception("💥 Exception in commands_changed")
-            result = False
-
-        if bool(result):
-            logger.info(
-                f"[DEBUG] Slash commands changed — syncing to GUILD_ID={os.getenv('GUILD_ID')}"
-            )
-            gid_env = os.getenv("GUILD_ID")
-            try:
-                if gid_env:
-                    gid = int(gid_env)
-                    try:
-                        await asyncio.wait_for(bot.sync_commands(guild_ids=[gid]), timeout=10.0)
-                        logger.info("[DEBUG] Commands synced successfully")
-                    except TimeoutError:
-                        logger.warning("[WARN] Command sync timed out — skipping for now.")
-                        try:
-                            emit_telemetry_event(
-                                {
-                                    "event": "command_sync",
-                                    "status": "timeout",
-                                    "guild_id": gid,
-                                    "orphaned_offload_possible": False,
-                                }
-                            )
-                        except Exception:
-                            logger.debug(
-                                "[TELEMETRY] Failed to emit command_sync timeout telemetry",
-                                exc_info=True,
-                            )
-                    except Exception as e:
-                        logger.warning(f"[WARN] Command sync failed: {e}")
-                else:
-                    logger.warning("[WARN] GUILD_ID not set; skipping scoped sync.")
-            except ValueError:
-                logger.warning("[WARN] GUILD_ID is not an integer; skipping scoped sync.")
-            except Exception as e:
-                logger.warning(f"[WARN] Command sync failed: {e}")
-
-            save_command_signatures(current_signatures, filepath=COMMAND_CACHE_FILE)
-            logger.warning("🔁 Slash commands changed — updated cache")
-        else:
-            logger.warning("⏩ Slash commands unchanged — skipping sync and update.")
-
-        logger.warning("📋 Loaded slash commands:")
-        for name, cmd in signature_commands:
-            logger.warning(f" - /{name} – {cmd.description}")
+        await run_startup_phases([StartupPhase("ready_command_sync", _run_ready_command_sync)])
 
         logger.info(f"[REMINDER_CACHE] Attempting to load from {REMINDER_TRACKING_FILE}")
         loaded_ids = await load_active_reminders(bot)
@@ -1793,6 +1725,10 @@ async def _run_ready_runtime_bootstrap() -> None:
         _drop_console_handlers_once()
     except Exception:
         pass
+
+
+async def _run_ready_command_sync() -> None:
+    await run_ready_command_sync(bot)
 
 
 async def _run_ready_runtime_services() -> None:

--- a/core/command_lifecycle.py
+++ b/core/command_lifecycle.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+import logging
+import os
+from typing import Any
+
+from bot_helpers import (
+    commands_changed,
+    get_command_signature,
+    load_command_signatures,
+    save_command_signatures,
+)
+from commands.command_inventory import flatten_application_commands
+from constants import COMMAND_CACHE_FILE
+from file_utils import emit_telemetry_event
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommandSyncLifecycleResult:
+    changed: bool
+    signatures: list[dict[str, Any]]
+    loaded_commands: Sequence[tuple[str, Any]]
+    sync_attempted: bool = False
+    sync_succeeded: bool = False
+    sync_timed_out: bool = False
+    sync_skipped_reason: str | None = None
+
+
+def build_command_signatures(commands: Sequence[Any]) -> tuple[list[dict[str, Any]], list[tuple[str, Any]]]:
+    signature_commands = list(flatten_application_commands(commands))
+    current_signatures = [
+        sig
+        for name, cmd in signature_commands
+        if (sig := get_command_signature(cmd, name=name)) is not None
+    ]
+    return current_signatures, signature_commands
+
+
+def log_loaded_slash_commands(signature_commands: Sequence[tuple[str, Any]]) -> None:
+    logger.warning("📋 Loaded slash commands:")
+    for name, cmd in signature_commands:
+        logger.warning(f" - /{name} – {cmd.description}")
+
+
+async def run_ready_command_sync(
+    bot: Any,
+    *,
+    cache_file: str = COMMAND_CACHE_FILE,
+    guild_id_env: str | None = None,
+    sync_timeout_seconds: float = 10.0,
+    telemetry_emit: Callable[[dict[str, Any]], Any] = emit_telemetry_event,
+) -> CommandSyncLifecycleResult:
+    commands = list(bot.application_commands)
+    current_signatures, signature_commands = build_command_signatures(commands)
+
+    logger.info("🧪 Reading command cache file...")
+    saved_signatures = load_command_signatures(filepath=cache_file)
+    logger.info("✅ Command cache loaded")
+
+    try:
+        result = commands_changed(current_signatures, saved_signatures)
+        logger.info(f"✅ commands_changed result: {result}")
+    except Exception:
+        logger.exception("💥 Exception in commands_changed")
+        result = False
+
+    changed = bool(result)
+    sync_attempted = False
+    sync_succeeded = False
+    sync_timed_out = False
+    sync_skipped_reason = None
+
+    if changed:
+        gid_env = guild_id_env if guild_id_env is not None else os.getenv("GUILD_ID")
+        logger.info(f"[DEBUG] Slash commands changed — syncing to GUILD_ID={gid_env}")
+        try:
+            if gid_env:
+                gid = int(gid_env)
+                sync_attempted = True
+                try:
+                    await asyncio.wait_for(
+                        bot.sync_commands(guild_ids=[gid]),
+                        timeout=sync_timeout_seconds,
+                    )
+                    sync_succeeded = True
+                    logger.info("[DEBUG] Commands synced successfully")
+                except TimeoutError:
+                    sync_timed_out = True
+                    logger.warning("[WARN] Command sync timed out — skipping for now.")
+                    try:
+                        telemetry_emit(
+                            {
+                                "event": "command_sync",
+                                "status": "timeout",
+                                "guild_id": gid,
+                                "orphaned_offload_possible": False,
+                            }
+                        )
+                    except Exception:
+                        logger.debug(
+                            "[TELEMETRY] Failed to emit command_sync timeout telemetry",
+                            exc_info=True,
+                        )
+                except Exception as e:
+                    logger.warning(f"[WARN] Command sync failed: {e}")
+            else:
+                sync_skipped_reason = "missing_guild_id"
+                logger.warning("[WARN] GUILD_ID not set; skipping scoped sync.")
+        except ValueError:
+            sync_skipped_reason = "invalid_guild_id"
+            logger.warning("[WARN] GUILD_ID is not an integer; skipping scoped sync.")
+        except Exception as e:
+            logger.warning(f"[WARN] Command sync failed: {e}")
+
+        save_command_signatures(current_signatures, filepath=cache_file)
+        logger.warning("🔁 Slash commands changed — updated cache")
+    else:
+        logger.warning("⏩ Slash commands unchanged — skipping sync and update.")
+
+    log_loaded_slash_commands(signature_commands)
+    return CommandSyncLifecycleResult(
+        changed=changed,
+        signatures=current_signatures,
+        loaded_commands=signature_commands,
+        sync_attempted=sync_attempted,
+        sync_succeeded=sync_succeeded,
+        sync_timed_out=sync_timed_out,
+        sync_skipped_reason=sync_skipped_reason,
+    )

--- a/core/command_lifecycle.py
+++ b/core/command_lifecycle.py
@@ -31,7 +31,9 @@ class CommandSyncLifecycleResult:
     sync_skipped_reason: str | None = None
 
 
-def build_command_signatures(commands: Sequence[Any]) -> tuple[list[dict[str, Any]], list[tuple[str, Any]]]:
+def build_command_signatures(
+    commands: Sequence[Any],
+) -> tuple[list[dict[str, Any]], list[tuple[str, Any]]]:
     signature_commands = list(flatten_application_commands(commands))
     current_signatures = [
         sig

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -67,6 +67,7 @@ singleton and moved usage JSONL prune startup into `ready_runtime_services`, lea
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`, with this backlog and
 the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -136,7 +137,25 @@ the current `K98-bot-mirror` GitHub issues list as supporting context.
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
 - Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, and Phase 6C consolidated usage tracker lifecycle ownership. Remaining `on_ready()` work still mixes command sync/cache handling, event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice should audit a coherent remaining startup responsibility such as command sync/cache handling or event cache/rehydration boundaries while preserving startup order, idempotency, and production smoke log expectations. Keep queue worker lifecycle and shutdown coordination in later approval-gated slices.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and `docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`. The next PR-sized slice should audit and extract command signature/cache/sync handling into an explicit lifecycle owner while preserving command registration, cache update, sync timeout, and loaded-command logging behaviour. Keep event cache/rehydration, scheduler startup, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
 - Impact: medium
 - Risk: medium
 - Dependencies: Phase 5 upload routing, Phase 6A startup lifecycle boundary, Phase 6B runtime services extraction, and Phase 6C usage tracker ownership consolidation are complete in code; proceed with audit/design before each remaining implementation slice.
+
+### Deferred Optimisation
+- Area: `core/command_lifecycle.py`, `commands/admin_cmds.py`, command cache admin tooling
+- Type: architecture
+- Description: Phase 6D establishes a startup command lifecycle owner, but admin command tooling still has separate cache and sync handling in `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`. Those flows intentionally remain out of the conservative startup slice because they include Discord embed UX, permission-gated admin interaction behaviour, and different timeout/output expectations.
+- Suggested Fix: Add a later Phase 6 command-lifecycle slice that reuses `core/command_lifecycle.py` for admin resync, cache validation, and command-version inventory while preserving existing admin-only permissions, ephemeral responses, embed output, timeout behaviour, and operator-facing summaries. Add focused tests for shared startup/admin signature parity, manual resync cache writes, validation output, timeout handling, and command registration smoke coverage.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 6D startup command lifecycle extraction is merged and smoke tested; keep slash-command renaming and command-surface consolidation out of this slice.
+
+### Deferred Optimisation
+- Area: `commands/`, command documentation, `scripts/validate_command_registration.py`
+- Type: architecture
+- Description: The wider command-surface end state remains separate from startup lifecycle ownership. Grouping or retiring slash-command surfaces can reduce Discord's 100-command sync risk, but it affects public/operator command paths, documentation, tests, and rollout communication.
+- Suggested Fix: Scope a standalone command-surface optimisation programme after the Phase 6 lifecycle slices. Group or retire command paths by domain only with operator-approved UX rules, update docs and tests for renamed paths, preserve permissions and autocomplete behaviour, and keep `scripts/validate_command_registration.py` enforcing command-count guardrails. Treat this as a separate wider task, not a startup lifecycle PR.
+- Impact: high
+- Risk: medium
+- Dependencies: Operator approval for command path changes; command lifecycle admin tooling convergence can happen first but is not required for command-surface grouping.

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -17,6 +17,8 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
    - `ready_runtime_services` starts heartbeat, health dashboard, offload monitor, image-show
      safety patching, legacy lock cleanup, the shared usage tracker and usage JSONL prune loop,
      daily summary, activity tracking, and server status channel loops.
+   - `ready_command_sync` owns slash-command signature inventory, command-cache comparison,
+     scoped command sync when signatures change, timeout telemetry, and loaded-command logging.
 9. Caches, rehydration, background tasks, heartbeat, and admin notification start.
 
 ## Main Files
@@ -30,6 +32,7 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
 - `logging_setup.py`
 - `singleton_lock.py`
 - `Commands.py`
+- `core/command_lifecycle.py`
 
 ## Startup Guards
 
@@ -74,8 +77,10 @@ runtime services/observability startup. Phase 6C consolidated usage tracking ont
 `usage_tracker.py` singleton, with tracker startup and usage JSONL pruning owned by
 `ready_runtime_services`. The unified tracker intentionally uses the previous command/decorator
 cadence of a 5-second flush interval or 20-event batch size for command, component, metric, and
-alert usage events. Remaining lifecycle cleanup includes command/cache extraction, rehydration and
-scheduler boundaries, queue worker lifecycle, and shutdown coordination.
+alert usage events. Phase 6D moved startup command signature/cache/sync handling behind
+`ready_command_sync` and `core/command_lifecycle.py`. Remaining lifecycle cleanup after that
+includes rehydration and scheduler boundaries, queue worker lifecycle, command lifecycle admin
+tooling convergence, and shutdown coordination.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle.md
@@ -1,10 +1,11 @@
 # Codex Chat Starter - DL_bot Phase 6 Startup Lifecycle
 
 Use this starter for historical Phase 6 kickoff context. Phase 6A was completed in PR 117
-(`codex/dlbot-phase-6-startup-lifecycle-1`), and Phase 6B was completed in PR 119
-(`codex/dlbot-phase-6b-runtime-services`). Both were smoke-tested on 2026-05-27, merged, and
-pushed to production. For the next active slice, use
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`.
+(`codex/dlbot-phase-6-startup-lifecycle-1`), Phase 6B was completed in PR 119
+(`codex/dlbot-phase-6b-runtime-services`), and Phase 6C was completed in PR 120
+(`codex/dlbot-phase-6c-usage-tracker`). These slices were smoke-tested, merged, and pushed to
+production. For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`.
 
 This original starter began Phase 6 after Phase 5 upload-routing consolidation was closed,
 smoke-tested, pushed to production, and marked complete.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6B Runtime Services.md
@@ -4,8 +4,9 @@ Use this starter for historical Phase 6B context. Phase 6B was completed in PR 1
 (`codex/dlbot-phase-6b-runtime-services`), smoke-tested on 2026-05-27, merged, and pushed to
 production.
 
-For the next active slice, use
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`.
+Phase 6C was completed in PR 120 (`codex/dlbot-phase-6c-usage-tracker`), smoke-tested, merged,
+and pushed to production. For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`.
 
 This original starter continued Phase 6 after Phase 6A startup lifecycle boundary was merged,
 smoke-tested, pushed to production, and marked complete.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md
@@ -1,6 +1,12 @@
 # Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership
 
-Use this starter to continue Phase 6 after Phase 6B runtime services extraction was merged,
+Use this starter for historical Phase 6C context. Phase 6C was completed in PR 120
+(`codex/dlbot-phase-6c-usage-tracker`), smoke-tested, merged, and pushed to production.
+
+For the next active slice, use
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`.
+
+This original starter continued Phase 6 after Phase 6B runtime services extraction was merged,
 smoke-tested, pushed to production, and marked complete.
 
 ## Copy/Paste Starter
@@ -184,7 +190,7 @@ This starter continues the usage tracker ownership deferred optimisation in
 
 ## Phase 6C Is Complete
 
-**Status**: Merged via PR codex/dlbot-phase-6c-usage-tracker (commit d39f5b0) and pushed to production.
+**Status**: Merged via PR 120 (`codex/dlbot-phase-6c-usage-tracker`), smoke-tested, and pushed to production.
 
 **What Changed**:
 
@@ -205,4 +211,5 @@ This starter continues the usage tracker ownership deferred optimisation in
 
 **Next Steps**:
 
-Continue with the next Phase 6 task when identified, or proceed to other architectural optimisation work as prioritized.
+Continue with Phase 6D command signature/cache/sync lifecycle ownership:
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md
@@ -1,0 +1,220 @@
+# Codex Chat Starter - DL_bot Phase 6D Command Sync Cache
+
+Use this starter to continue Phase 6 after Phase 6C usage tracker lifecycle ownership was merged,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6D:
+command signature/cache/sync lifecycle ownership.
+
+Phase 6A, 6B, and 6C are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `bot_instance.py:on_ready()` now delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+- `ready_runtime_services` owns heartbeat, health dashboard, offload monitor, image-show safety,
+  lock cleanup, shared usage tracker startup, usage JSONL pruning, daily summary, activity
+  tracking, and server status channel loops.
+- Production smoke logs confirmed:
+  - `[STARTUP] phase started: ready_runtime_bootstrap`
+  - `[STARTUP] phase completed: ready_runtime_bootstrap`
+  - `[STARTUP] phase started: ready_runtime_services`
+  - `[BOOT] Usage tracker started.`
+  - `[MONITOR] Task started: usage_jsonl_prune`
+  - `[BOOT] Usage JSONL prune loop started (retention=30 days).`
+  - `[STARTUP] phase completed: ready_runtime_services`
+  - command cache, event cache, rehydration, schedulers, queue workers, and
+    `full_startup_sequence()` continued afterward.
+
+This is review/scope first. Do not implement code changes until the Phase 6D scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+## Phase 6D Objective
+
+Audit and extract command signature/cache/sync handling from the remaining `on_ready()` body into
+an explicit lifecycle owner.
+
+The current production-smoke-tested behaviour must be preserved:
+
+- build the current flattened slash-command signature list
+- load `COMMAND_CACHE_FILE`
+- compare command signatures with `commands_changed()`
+- when changed, perform scoped `bot.sync_commands(guild_ids=[GUILD_ID])` with the current timeout
+  behaviour and telemetry on timeout
+- save command signatures only after the changed-command path
+- skip sync when signatures are unchanged
+- log loaded slash commands in the same order/shape currently used for operator visibility
+
+Recommended target: a named startup phase or helper that owns command cache/sync behaviour without
+mixing it with event cache refresh, reminder loading, rehydration, schedulers, queue workers, or
+`full_startup_sequence()`.
+
+## In Scope
+
+- Audit the relationship between:
+  - `bot_instance.py:on_ready()`
+  - `bot_helpers.commands_changed()`
+  - `bot_helpers.load_command_signatures()`
+  - `bot_helpers.save_command_signatures()`
+  - `commands.command_inventory.flatten_application_commands()`
+  - `bot_instance.py:get_command_signature()`
+  - `COMMAND_CACHE_FILE`
+  - `bot.sync_commands()`
+  - command sync timeout telemetry via `emit_telemetry_event()`
+- Decide whether command signature/cache/sync should become:
+  - a dedicated named startup phase such as `ready_command_sync`
+  - a focused helper called by `on_ready()` after `ready_runtime_services`
+  - or another explicit ownership model that preserves startup order.
+- Preserve command registration and command-cache behaviour.
+- Preserve command-sync timeout/error behaviour and logs.
+- Preserve startup order enough that event cache and later tasks do not begin until command cache
+  handling has completed or intentionally skipped sync.
+- Add or update focused lifecycle tests.
+- Capture broader command-surface consolidation or validator output cleanup as deferred work.
+
+## Out Of Scope
+
+- Command surface consolidation or slash-command renaming.
+- Event cache refresh, reminder loading, view rehydration, scheduler registration, and MGE/Ark
+  lifecycle extraction.
+- Queue worker startup, live queue rehydration, or queue persistence changes.
+- Usage tracker lifecycle changes beyond preserving Phase 6C behaviour.
+- Shutdown redesign.
+- `DL_bot.py` process-entry changes.
+- Upload-route behaviour changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `bot_helpers.py`
+- `commands/command_inventory.py`
+- `constants.py`
+- `core/startup_lifecycle.py`
+- `scripts/validate_command_registration.py`
+- `scripts/smoke_imports.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_command_registration_smoke.py`
+- `tests/test_domain_registrars_no_legacy_register_commands.py`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- `tests/test_startup_lifecycle.py`
+- possibly a focused helper module only if the audit proves `bot_instance.py` is no longer the
+  right owner for command cache/sync orchestration.
+
+Do not create a new command lifecycle module unless the audit finds a clear boundary that
+`core/startup_lifecycle.py` and a local helper cannot cover.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Command Sync / Cache Lifecycle Map
+- Current Phase 6A/6B/6C Boundary Map
+- Proposed Phase 6D Ownership Model
+- Behaviour Preservation Checklist
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6D Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_command_registration_smoke.py tests\test_domain_registrars_no_legacy_register_commands.py tests\test_mge_startup_hook_invoked.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6 touches
+startup, Discord command registration/sync behaviour, runtime config, telemetry, and
+restart-sensitive lifecycle.
+
+## Expected Smoke Log Signals
+
+After implementation and deployment, expected startup logs should still include:
+
+```text
+[STARTUP] phase started: ready_runtime_bootstrap
+[STARTUP] phase completed: ready_runtime_bootstrap
+[STARTUP] phase started: ready_runtime_services
+[BOOT] Usage tracker started.
+[BOOT] Usage JSONL prune loop started (retention=30 days).
+[STARTUP] phase completed: ready_runtime_services
+[STARTUP] phase started: ready_command_sync
+[STARTUP] phase completed: ready_command_sync
+```
+
+If the implementation uses a helper rather than a new named phase, smoke expectations should still
+include the existing command-cache and command-sync lines:
+
+```text
+Bot is ready
+Reading command cache file
+Command cache loaded
+commands_changed result: False
+Slash commands unchanged - skipping sync and update.
+Loaded slash commands:
+```
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+[WARN] Command sync timed out
+[WARN] Command sync failed
+GUILD_ID not set; skipping scoped sync
+GUILD_ID is not an integer; skipping scoped sync
+```
+
+Warnings about command sync should be investigated if they are new; they may be expected only when
+the environment or command signatures intentionally force that path.
+
+## Deferred Item Link
+
+This starter continues the startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6C completed usage tracker ownership.

--- a/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
+++ b/docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md
@@ -337,10 +337,13 @@ Phase breakdown:
      (`codex/dlbot-phase-6b-runtime-services`), routing heartbeat, health dashboard, offload
      monitor, lock cleanup, usage tracker startup, daily summary, activity tracking, and status
      channel loops through `ready_runtime_services`.
-   - Remaining work: usage tracker lifecycle ownership, command sync/cache extraction, event cache
-     and rehydration boundaries, scheduler/task ownership, queue worker lifecycle, shutdown, and
-     restart-safe state coordination.
-   - Current starter packet: `docs/task_packs/Codex Chat Starter - DL_bot Phase 6C Usage Tracker Ownership.md`
+   - Phase 6C completed usage tracker lifecycle ownership in PR 120
+     (`codex/dlbot-phase-6c-usage-tracker`), consolidating command/component/metric/alert usage
+     logging onto the shared `usage_tracker.py` singleton and moving usage JSONL prune startup
+     into `ready_runtime_services`.
+   - Remaining work: command sync/cache extraction, event cache and rehydration boundaries,
+     scheduler/task ownership, queue worker lifecycle, shutdown, and restart-safe state coordination.
+   - Current starter packet: `docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`
 
 Phase 2A delivery notes:
 

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-27`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -80,8 +80,19 @@ Phase 6B runtime services extraction is complete:
   started the runtime services, completed, and then allowed command cache, event cache,
   rehydration, schedulers, queue workers, and `full_startup_sequence()` to continue.
 - The PR was merged and pushed to production.
-- Usage tracker ownership remains a deliberate follow-up because usage tracking is started in the
-  runtime services phase and later startup/prune-loop behaviour remains in `full_startup_sequence()`.
+- Usage tracker ownership remained a deliberate follow-up because usage tracking was started in the
+  runtime services phase and later startup/prune-loop behaviour remained in `full_startup_sequence()`.
+
+Phase 6C usage tracker lifecycle ownership is complete:
+
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) consolidated command, component, metric, and alert
+  usage logging onto the shared `usage_tracker.py` singleton.
+- `_run_ready_runtime_services()` now owns usage tracker startup and `usage_jsonl_prune` TaskMonitor
+  registration.
+- `full_startup_sequence()` no longer owns usage observability startup.
+- Production smoke testing on 2026-05-27 confirmed usage tracker startup, prune-loop scheduling,
+  command/component SQL flushes, and startup sequence continuity.
+- The PR was merged and pushed to production.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -290,7 +301,8 @@ Initial classification before audit:
 | Bot construction and event registration ownership | audit first | Current ownership is spread across `bot_loader.py`, `bot_instance.py`, and `DL_bot.py`. |
 | Initial `on_ready()` runtime bootstrap boundary | complete | Phase 6A moved loop exception handler setup and console-handler cleanup behind `ready_runtime_bootstrap`, preserving startup order and adding named phase logs. |
 | Runtime services/observability startup | complete | Phase 6B moved heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops behind `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
-| Usage tracker lifecycle ownership | next recommended slice | Usage tracking now has clearer phase attribution but still has split ownership between `ready_runtime_services`, `full_startup_sequence()`, and shutdown. Audit and consolidate this before broader `full_startup_sequence()` extraction. |
+| Usage tracker lifecycle ownership | complete | Phase 6C consolidated command/component/metric/alert usage logging onto the shared `usage_tracker.py` singleton and moved usage JSONL pruning into `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
+| Command signature/cache/sync ownership | next recommended slice | This is the next contiguous `on_ready()` block after named startup phases. Audit and extract command signature generation, command-cache load/compare/save, scoped sync, timeout telemetry, and loaded-command logging before event cache or scheduler work. |
 | `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |

--- a/tests/test_command_lifecycle.py
+++ b/tests/test_command_lifecycle.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from core.command_lifecycle import build_command_signatures, run_ready_command_sync
+
+
+def _command(name: str, *, description: str = "desc", version: str = "v1.0"):
+    def callback():
+        return None
+
+    callback.__version__ = version
+    return SimpleNamespace(name=name, description=description, callback=callback, subcommands=[])
+
+
+class FakeBot:
+    def __init__(self, commands):
+        self.application_commands = commands
+        self.sync_calls: list[list[int]] = []
+
+    async def sync_commands(self, *, guild_ids):
+        self.sync_calls.append(guild_ids)
+
+
+def test_build_command_signatures_uses_flattened_inventory_names():
+    subcommand = _command("status", description="Show status", version="v2.0")
+    group = SimpleNamespace(name="ops", subcommands=[subcommand])
+
+    signatures, signature_commands = build_command_signatures([group])
+
+    assert signature_commands == [("ops status", subcommand)]
+    assert signatures == [
+        {
+            "name": "ops status",
+            "description": "Show status",
+            "version": "v2.0",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_ready_command_sync_skips_unchanged_signatures(tmp_path):
+    command = _command("ping", description="Ping", version="v1.0")
+    cache_file = tmp_path / "command_cache.json"
+    cache_file.write_text(
+        json.dumps([{"name": "ping", "description": "Ping", "version": "v1.0"}]),
+        encoding="utf-8",
+    )
+    bot = FakeBot([command])
+
+    result = await run_ready_command_sync(bot, cache_file=str(cache_file), guild_id_env="123")
+
+    assert result.changed is False
+    assert result.sync_attempted is False
+    assert bot.sync_calls == []
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == result.signatures
+
+
+@pytest.mark.asyncio
+async def test_run_ready_command_sync_syncs_and_saves_changed_signatures(tmp_path):
+    command = _command("ping", description="Ping", version="v2.0")
+    cache_file = tmp_path / "command_cache.json"
+    cache_file.write_text(
+        json.dumps([{"name": "ping", "description": "Ping", "version": "v1.0"}]),
+        encoding="utf-8",
+    )
+    bot = FakeBot([command])
+
+    result = await run_ready_command_sync(bot, cache_file=str(cache_file), guild_id_env="123")
+
+    assert result.changed is True
+    assert result.sync_attempted is True
+    assert result.sync_succeeded is True
+    assert bot.sync_calls == [[123]]
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == result.signatures
+
+
+@pytest.mark.asyncio
+async def test_run_ready_command_sync_timeout_emits_telemetry_and_saves_cache(tmp_path):
+    class TimeoutBot(FakeBot):
+        async def sync_commands(self, *, guild_ids):
+            self.sync_calls.append(guild_ids)
+            raise TimeoutError
+
+    command = _command("ping", description="Ping", version="v2.0")
+    cache_file = tmp_path / "command_cache.json"
+    cache_file.write_text("[]", encoding="utf-8")
+    telemetry_events = []
+    bot = TimeoutBot([command])
+
+    result = await run_ready_command_sync(
+        bot,
+        cache_file=str(cache_file),
+        guild_id_env="123",
+        telemetry_emit=telemetry_events.append,
+    )
+
+    assert result.changed is True
+    assert result.sync_attempted is True
+    assert result.sync_timed_out is True
+    assert bot.sync_calls == [[123]]
+    assert telemetry_events == [
+        {
+            "event": "command_sync",
+            "status": "timeout",
+            "guild_id": 123,
+            "orphaned_offload_possible": False,
+        }
+    ]
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == result.signatures
+
+
+@pytest.mark.asyncio
+async def test_run_ready_command_sync_invalid_guild_id_skips_sync_but_saves_cache(tmp_path):
+    command = _command("ping", description="Ping", version="v2.0")
+    cache_file = tmp_path / "command_cache.json"
+    cache_file.write_text("[]", encoding="utf-8")
+    bot = FakeBot([command])
+
+    result = await run_ready_command_sync(bot, cache_file=str(cache_file), guild_id_env="abc")
+
+    assert result.changed is True
+    assert result.sync_attempted is False
+    assert result.sync_skipped_reason == "invalid_guild_id"
+    assert bot.sync_calls == []
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == result.signatures

--- a/tests/test_command_signature_inventory.py
+++ b/tests/test_command_signature_inventory.py
@@ -24,9 +24,11 @@ def test_get_command_signature_uses_grouped_inventory_name():
 
 
 def test_bot_startup_uses_flattened_command_inventory_for_signatures():
-    source = open("bot_instance.py", encoding="utf-8").read()
+    lifecycle_source = open("core/command_lifecycle.py", encoding="utf-8").read()
+    startup_source = open("bot_instance.py", encoding="utf-8").read()
 
-    assert "from commands.command_inventory import flatten_application_commands" in source
-    assert "signature_commands = list(flatten_application_commands(commands))" in source
-    assert "get_command_signature(cmd, name=name)" in source
-    assert "for name, cmd in signature_commands:" in source
+    assert "from commands.command_inventory import flatten_application_commands" in lifecycle_source
+    assert "signature_commands = list(flatten_application_commands(commands))" in lifecycle_source
+    assert "get_command_signature(cmd, name=name)" in lifecycle_source
+    assert "for name, cmd in signature_commands:" in lifecycle_source
+    assert 'StartupPhase("ready_command_sync", _run_ready_command_sync)' in startup_source

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -56,6 +56,7 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         and node.func.id == "run_startup_phases"
     ]
     assert runner_calls
+    runner_calls.sort(key=lambda node: getattr(node, "lineno", 0))
 
     for runner_call in runner_calls:
         phases_arg = runner_call.args[0]

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -47,27 +47,45 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "on_ready"
     )
 
-    runner_call = next(
+    startup_phase_names = []
+    runner_calls = [
         node
         for node in ast.walk(on_ready)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "run_startup_phases"
-    )
-    phases_arg = runner_call.args[0]
-    assert isinstance(phases_arg, ast.List)
+    ]
+    assert runner_calls
 
-    startup_phase_names = []
-    for phase_call in phases_arg.elts:
-        assert isinstance(phase_call, ast.Call)
-        assert isinstance(phase_call.func, ast.Name)
-        assert phase_call.func.id == "StartupPhase"
-        assert phase_call.args
-        assert isinstance(phase_call.args[0], ast.Constant)
-        assert isinstance(phase_call.args[0].value, str)
-        startup_phase_names.append(phase_call.args[0].value)
+    for runner_call in runner_calls:
+        phases_arg = runner_call.args[0]
+        assert isinstance(phases_arg, ast.List)
+        for phase_call in phases_arg.elts:
+            assert isinstance(phase_call, ast.Call)
+            assert isinstance(phase_call.func, ast.Name)
+            assert phase_call.func.id == "StartupPhase"
+            assert phase_call.args
+            assert isinstance(phase_call.args[0], ast.Constant)
+            assert isinstance(phase_call.args[0].value, str)
+            startup_phase_names.append(phase_call.args[0].value)
 
-    assert startup_phase_names == ["ready_runtime_bootstrap", "ready_runtime_services"]
+    assert startup_phase_names == [
+        "ready_runtime_bootstrap",
+        "ready_runtime_services",
+        "ready_command_sync",
+    ]
+
+
+def test_on_ready_command_sync_lifecycle_uses_dedicated_helper():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    command_sync = _async_function(tree, "_run_ready_command_sync")
+    on_ready = _async_function(tree, "on_ready")
+
+    assert _calls_name(command_sync, "run_ready_command_sync")
+    assert not _calls_name(on_ready, "commands_changed")
+    assert not _calls_name(on_ready, "save_command_signatures")
 
 
 def _async_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:


### PR DESCRIPTION
## Summary

- Add `core/command_lifecycle.py` as the dedicated owner for startup command signature/cache/sync handling.
- Route `bot_instance.on_ready()` through a named `ready_command_sync` lifecycle phase while preserving existing startup order before reminder/event/cache/rehydration/scheduler work.
- Add focused tests for unchanged signatures, changed-command sync/cache save, timeout telemetry, invalid guild handling, and lifecycle ownership.
- Update the startup runbook and deferred backlog to split follow-up command lifecycle admin tooling from the wider command-surface optimisation programme.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_command_lifecycle.py tests\test_startup_lifecycle.py tests\test_command_inventory.py tests\test_command_signature_inventory.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests`
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe -m pre_commit run -a`
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`

## Notes

- No SQL changes.
- Existing unstaged task-pack edits were intentionally left out of this PR.
- Codex Security review should run before merge handoff because this touches Discord startup/command lifecycle behaviour.