### PR TITLE
[codex] converge command lifecycle admin tooling

### DIFF
--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -28,7 +28,6 @@ from bot_config import (
 )
 from core.interaction_safety import get_operation_lock, safe_command, safe_defer
 from discord.ext import commands as ext_commands
-from commands.command_inventory import flatten_application_commands
 from commands.crystaltech_flow import run_crystaltech_flow
 from commands.telemetry_cmds import (
     _pick_log_source,
@@ -38,7 +37,7 @@ from commands.telemetry_cmds import (
 
 from embed_utils import FailuresView, HistoryView, generate_summary_embed
 from event_calendar.service import get_calendar_service
-from file_utils import append_csv_line, atomic_json_write, read_json_safe, read_summary_log_rows
+from file_utils import append_csv_line, read_json_safe, read_summary_log_rows
 from gsheet_module import check_basic_gsheets_access, run_all_exports
 from logging_setup import CRASH_LOG_PATH, ERROR_LOG_PATH, FULL_LOG_PATH, flush_logs
 from proc_config_import import run_proc_config_import_offload
@@ -722,15 +721,17 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @is_admin_and_notify_channel()
     @track_usage()
     async def resync_commands(ctx):
+        from core.command_lifecycle import command_cache_update, sync_commands_for_guild
+
         async with get_operation_lock("resync"):
             await safe_defer(ctx, ephemeral=True)
 
             # === Sync commands with timeout
-            try:
-                await asyncio.wait_for(bot.sync_commands(guild_ids=[GUILD_ID]), timeout=5.0)
+            sync_result = await sync_commands_for_guild(bot, guild_id=GUILD_ID, timeout_seconds=5.0)
+            if sync_result.ok:
                 logger.info("[COMMAND SYNC] Slash commands successfully resynced.")
-            except TimeoutError:
-                logger.exception("[COMMAND SYNC] Timed out during sync — skipping.")
+            elif sync_result.timed_out:
+                logger.warning("[COMMAND SYNC] Timed out during sync — skipping.")
                 await ctx.interaction.edit_original_response(
                     embed=discord.Embed(
                         title="⚠️ Sync Timed Out",
@@ -739,8 +740,12 @@ def register_admin(bot: ext_commands.Bot) -> None:
                     )
                 )
                 return
-            except Exception as e:
-                logger.exception("[COMMAND SYNC] Resync failed")
+            else:
+                e = sync_result.error or RuntimeError("Unknown command sync failure")
+                logger.error(
+                    "[COMMAND SYNC] Resync failed",
+                    exc_info=(type(e), e, e.__traceback__),
+                )
                 await ctx.interaction.edit_original_response(
                     embed=discord.Embed(
                         title="❌ Sync Failed",
@@ -755,40 +760,28 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 # Load existing cache (if present)
                 try:
                     with open(COMMAND_CACHE_FILE, encoding="utf-8") as f:
-                        old_cache = {cmd["name"]: cmd for cmd in json.load(f)}
+                        old_cache = json.load(f)
                 except FileNotFoundError:
-                    old_cache = {}
+                    old_cache = []
                 except Exception as e:
                     logger.warning(
                         "[COMMAND SYNC] Could not read existing command cache %s: %s",
                         COMMAND_CACHE_FILE,
                         e,
                     )
-                    old_cache = {}
+                    old_cache = []
 
-                new_cache = []
-                updated = []
+                update_result = command_cache_update(
+                    list(bot.application_commands),
+                    existing_signatures=old_cache,
+                    cache_file=COMMAND_CACHE_FILE,
+                )
 
-                for name, command in flatten_application_commands(bot.application_commands):
-                    version = getattr(command.callback, "__version__", "N/A")
-                    description = command.description or ""
-                    cached_version = old_cache.get(name, {}).get("version")
-
-                    entry = {
-                        "name": name,
-                        "version": version,
-                        "description": description,
-                        "admin_only": True,  # keep as-is; refine later if we introspect decorators
-                    }
-                    new_cache.append(entry)
-
-                    if cached_version != version:
-                        updated.append(f"/{name} → `{cached_version}` ➜ `{version}`")
-
-                # Write atomically
-                atomic_json_write(COMMAND_CACHE_FILE, new_cache)
-
-                summary = "\n".join(updated) if updated else "✅ No changes to cached versions."
+                summary = (
+                    "\n".join(update_result.updated_lines)
+                    if update_result.updated_lines
+                    else "✅ No changes to cached versions."
+                )
                 # Keep under embed description limit
                 if len(summary) > 4000:
                     summary = summary[:3990] + "…"
@@ -821,15 +814,13 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @is_admin_and_notify_channel()
     @track_usage()
     async def show_command_versions(ctx):
+        from core.command_lifecycle import command_version_lines, sorted_command_signatures
 
         await safe_defer(ctx, ephemeral=True)
 
         try:
             # Sort for stable output
-            cmds = sorted(
-                flatten_application_commands(bot.application_commands),
-                key=lambda item: item[0].lower(),
-            )
+            signatures = sorted_command_signatures(list(bot.application_commands))
 
             embed = discord.Embed(
                 title="📦 Loaded Slash Command Versions",
@@ -838,17 +829,15 @@ def register_admin(bot: ext_commands.Bot) -> None:
             )
 
             # Discord embeds allow max 25 fields. If we have more, use a description list.
-            if len(cmds) <= 25:
-                for command_name, command in cmds:
-                    version = getattr(command.callback, "__version__", "N/A")
+            if len(signatures) <= 25:
+                for signature in signatures:
+                    command_name = signature["name"]
+                    version = signature.get("version", "N/A")
                     embed.add_field(
                         name=f"/{command_name}", value=f"Version: `{version}`", inline=False
                     )
             else:
-                lines = []
-                for command_name, command in cmds:
-                    version = getattr(command.callback, "__version__", "N/A")
-                    lines.append(f"/{command_name} — `{version}`")
+                lines = command_version_lines(list(bot.application_commands))
                 text = "\n".join(lines)
                 # Keep under embed description limits (~4096 chars)
                 if len(text) > 3900:
@@ -874,6 +863,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @is_admin_and_notify_channel()
     @track_usage()
     async def validate_command_cache(ctx):
+        from core.command_lifecycle import validate_command_cache as build_command_cache_validation
 
         await safe_defer(ctx, ephemeral=True)
 
@@ -881,7 +871,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
         try:
             with open(COMMAND_CACHE_FILE, encoding="utf-8") as f:
                 raw = json.load(f)
-                cache = {entry["name"]: entry.get("version", "N/A") for entry in raw}
         except Exception as e:
             logger.exception("[COMMAND] /validate_command_cache load failed")
             await ctx.interaction.edit_original_response(
@@ -894,28 +883,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
             return
 
         # Build checks
-        loaded_cmds = sorted(
-            flatten_application_commands(bot.application_commands),
-            key=lambda item: item[0].lower(),
-        )
-        loaded_names = {name for name, _command in loaded_cmds}
-        cache_names = set(cache.keys())
-
-        issues = []
-
-        # Missing or mismatched
-        for name, command in loaded_cmds:
-            version = getattr(command.callback, "__version__", "N/A")
-            cached = cache.get(name)
-            if cached is None:
-                issues.append(f"➕ `/{name}` is **missing** from cache (code=`{version}`)")
-            elif cached != version:
-                issues.append(f"🔁 `/{name}` version mismatch: cache=`{cached}`, code=`{version}`")
-
-        # Stale entries (in cache but not loaded anymore)
-        stale = sorted(cache_names - loaded_names)
-        for name in stale:
-            issues.append(f"➖ `/{name}` is in cache but not currently loaded")
+        validation = build_command_cache_validation(list(bot.application_commands), raw)
+        issues = validation.issues
 
         # Build response
         if issues:

--- a/core/command_lifecycle.py
+++ b/core/command_lifecycle.py
@@ -15,7 +15,7 @@ from bot_helpers import (
 )
 from commands.command_inventory import flatten_application_commands
 from constants import COMMAND_CACHE_FILE
-from file_utils import emit_telemetry_event
+from file_utils import atomic_json_write, emit_telemetry_event
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,29 @@ class CommandSyncLifecycleResult:
     sync_skipped_reason: str | None = None
 
 
+@dataclass(frozen=True)
+class ManualCommandSyncResult:
+    guild_id: int
+    timed_out: bool = False
+    error: Exception | None = None
+
+    @property
+    def ok(self) -> bool:
+        return not self.timed_out and self.error is None
+
+
+@dataclass(frozen=True)
+class CommandCacheUpdateResult:
+    signatures: list[dict[str, Any]]
+    updated_lines: list[str]
+
+
+@dataclass(frozen=True)
+class CommandCacheValidationResult:
+    issues: list[str]
+    signatures: list[dict[str, Any]]
+
+
 def build_command_signatures(
     commands: Sequence[Any],
 ) -> tuple[list[dict[str, Any]], list[tuple[str, Any]]]:
@@ -41,6 +64,87 @@ def build_command_signatures(
         if (sig := get_command_signature(cmd, name=name)) is not None
     ]
     return current_signatures, signature_commands
+
+
+def sorted_command_signatures(commands: Sequence[Any]) -> list[dict[str, Any]]:
+    signatures, _signature_commands = build_command_signatures(commands)
+    return sorted(signatures, key=lambda sig: str(sig.get("name", "")).lower())
+
+
+def command_version_lines(commands: Sequence[Any]) -> list[str]:
+    return [
+        f"/{signature['name']} — `{signature.get('version', 'N/A')}`"
+        for signature in sorted_command_signatures(commands)
+    ]
+
+
+def command_cache_update(
+    commands: Sequence[Any],
+    *,
+    existing_signatures: Sequence[dict[str, Any]] | None = None,
+    cache_file: str = COMMAND_CACHE_FILE,
+    writer: Callable[[str, list[dict[str, Any]]], Any] = atomic_json_write,
+) -> CommandCacheUpdateResult:
+    old_cache = {
+        str(cmd.get("name", "")): cmd
+        for cmd in (existing_signatures or [])
+        if isinstance(cmd, dict) and cmd.get("name")
+    }
+    signatures = sorted_command_signatures(commands)
+    updated_lines = []
+    for signature in signatures:
+        name = str(signature.get("name", ""))
+        version = signature.get("version", "N/A")
+        cached_version = old_cache.get(name, {}).get("version")
+        if cached_version != version:
+            updated_lines.append(f"/{name} → `{cached_version}` ➜ `{version}`")
+
+    writer(cache_file, signatures)
+    return CommandCacheUpdateResult(signatures=signatures, updated_lines=updated_lines)
+
+
+def validate_command_cache(
+    commands: Sequence[Any],
+    cached_signatures: Sequence[dict[str, Any]],
+) -> CommandCacheValidationResult:
+    signatures = sorted_command_signatures(commands)
+    cache = {
+        str(entry.get("name", "")): entry.get("version", "N/A")
+        for entry in cached_signatures
+        if isinstance(entry, dict) and entry.get("name")
+    }
+    loaded_names = {str(signature.get("name", "")) for signature in signatures}
+    cache_names = set(cache)
+    issues = []
+
+    for signature in signatures:
+        name = str(signature.get("name", ""))
+        version = signature.get("version", "N/A")
+        cached = cache.get(name)
+        if cached is None:
+            issues.append(f"➕ `/{name}` is **missing** from cache (code=`{version}`)")
+        elif cached != version:
+            issues.append(f"🔁 `/{name}` version mismatch: cache=`{cached}`, code=`{version}`")
+
+    for name in sorted(cache_names - loaded_names):
+        issues.append(f"➖ `/{name}` is in cache but not currently loaded")
+
+    return CommandCacheValidationResult(issues=issues, signatures=signatures)
+
+
+async def sync_commands_for_guild(
+    bot: Any,
+    *,
+    guild_id: int,
+    timeout_seconds: float,
+) -> ManualCommandSyncResult:
+    try:
+        await asyncio.wait_for(bot.sync_commands(guild_ids=[guild_id]), timeout=timeout_seconds)
+        return ManualCommandSyncResult(guild_id=guild_id)
+    except TimeoutError:
+        return ManualCommandSyncResult(guild_id=guild_id, timed_out=True)
+    except Exception as exc:
+        return ManualCommandSyncResult(guild_id=guild_id, error=exc)
 
 
 def log_loaded_slash_commands(signature_commands: Sequence[tuple[str, Any]]) -> None:

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -62,13 +62,18 @@ tracking, UTC clock, and member-count status loops through the named `ready_runt
 phase while preserving startup order and behaviour. Phase 6C usage tracker lifecycle ownership
 then consolidated command/component/metric usage logging onto the shared `usage_tracker.py`
 singleton and moved usage JSONL prune startup into `ready_runtime_services`, leaving
-`full_startup_sequence()` free of usage observability startup.
+`full_startup_sequence()` free of usage observability startup. Phase 6D command sync lifecycle
+ownership was completed in PR 121 (`codex/dlbot-phase-6d-command-lifecycle`), smoke tested with
+unchanged, changed, and post-cache-update restart paths, merged, and pushed to production:
+`bot_instance.py:on_ready()` now delegates startup command signature/cache/sync handling through
+`core/command_lifecycle.py` and the named `ready_command_sync` phase while preserving scoped sync,
+timeout telemetry, command-cache writes, and loaded-command logging.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`, with this backlog and
-the current `K98-bot-mirror` GitHub issues list as supporting context.
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`, with
+this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
 - Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
@@ -136,17 +141,17 @@ the current `K98-bot-mirror` GitHub issues list as supporting context.
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, and Phase 6C consolidated usage tracker lifecycle ownership. Remaining `on_ready()` work still mixes command sync/cache handling, event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and `docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`. The next PR-sized slice should audit and extract command signature/cache/sync handling into an explicit lifecycle owner while preserving command registration, cache update, sync timeout, and loaded-command logging behaviour. Keep event cache/rehydration, scheduler startup, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, and Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`. Remaining `on_ready()` work still mixes event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice is command lifecycle admin tooling convergence from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`; after that, keep event cache/rehydration, scheduler startup, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing, Phase 6A startup lifecycle boundary, Phase 6B runtime services extraction, and Phase 6C usage tracker ownership consolidation are complete in code; proceed with audit/design before each remaining implementation slice.
+- Dependencies: Phase 5 upload routing, Phase 6A startup lifecycle boundary, Phase 6B runtime services extraction, Phase 6C usage tracker ownership consolidation, and Phase 6D command sync lifecycle extraction are complete in code and production smoke tested; proceed with audit/design before each remaining implementation slice.
 
 ### Deferred Optimisation
 - Area: `core/command_lifecycle.py`, `commands/admin_cmds.py`, command cache admin tooling
 - Type: architecture
 - Description: Phase 6D establishes a startup command lifecycle owner, but admin command tooling still has separate cache and sync handling in `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`. Those flows intentionally remain out of the conservative startup slice because they include Discord embed UX, permission-gated admin interaction behaviour, and different timeout/output expectations.
-- Suggested Fix: Add a later Phase 6 command-lifecycle slice that reuses `core/command_lifecycle.py` for admin resync, cache validation, and command-version inventory while preserving existing admin-only permissions, ephemeral responses, embed output, timeout behaviour, and operator-facing summaries. Add focused tests for shared startup/admin signature parity, manual resync cache writes, validation output, timeout handling, and command registration smoke coverage.
+- Suggested Fix: Execute Phase 6E from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`: reuse `core/command_lifecycle.py` for admin resync, cache validation, and command-version inventory while preserving existing admin-only permissions, ephemeral responses, embed output, timeout behaviour, and operator-facing summaries. Add focused tests for shared startup/admin signature parity, manual resync cache writes, validation output, timeout handling, and command registration smoke coverage.
 - Impact: medium
 - Risk: medium
 - Dependencies: Phase 6D startup command lifecycle extraction is merged and smoke tested; keep slash-command renaming and command-surface consolidation out of this slice.

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -79,8 +79,8 @@ runtime services/observability startup. Phase 6C consolidated usage tracking ont
 cadence of a 5-second flush interval or 20-event batch size for command, component, metric, and
 alert usage events. Phase 6D moved startup command signature/cache/sync handling behind
 `ready_command_sync` and `core/command_lifecycle.py`. Remaining lifecycle cleanup after that
-includes rehydration and scheduler boundaries, queue worker lifecycle, command lifecycle admin
-tooling convergence, and shutdown coordination.
+starts with command lifecycle admin tooling convergence, then continues into rehydration and
+scheduler boundaries, queue worker lifecycle, and shutdown coordination.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md
@@ -1,7 +1,10 @@
 # Codex Chat Starter - DL_bot Phase 6D Command Sync Cache
 
-Use this starter to continue Phase 6 after Phase 6C usage tracker lifecycle ownership was merged,
-smoke-tested, pushed to production, and marked complete.
+Status: complete. PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged, smoke-tested, and
+pushed to production on 2026-05-27. This starter is retained as historical context for Phase 6D.
+
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md` for
+the next Phase 6 slice.
 
 ## Copy/Paste Starter
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md
@@ -1,0 +1,208 @@
+# Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling
+
+Use this starter to continue Phase 6 after Phase 6D command sync lifecycle ownership was merged,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6E:
+command lifecycle admin tooling convergence.
+
+Phase 6A, 6B, 6C, and 6D are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `core/command_lifecycle.py` now owns startup command signature/cache/sync mechanics.
+- `bot_instance.py:on_ready()` delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+  - startup command signature/cache/sync through `ready_command_sync`
+- Production smoke logs confirmed for Phase 6D:
+  - unchanged-command startup loaded the command cache and skipped sync
+  - changed-command startup detected `/summary` version `v1.04` to `v1.05`
+  - scoped guild sync completed successfully
+  - command cache updated after the changed path
+  - the next restart returned to `commands_changed result: False`
+  - reminder cache, event cache, rehydration, and scheduler startup continued afterward
+
+This is review/scope first. Do not implement code changes until the Phase 6E scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6D Command Sync Cache.md`
+
+## Phase 6E Objective
+
+Converge admin command lifecycle tooling onto the Phase 6D command lifecycle owner while preserving
+operator-facing Discord behaviour.
+
+The startup path is already owned by `core/command_lifecycle.py`; Phase 6E should audit and, after
+approval, reuse that lifecycle layer from:
+
+- `/ops resync_commands`
+- `/ops validate_command_cache`
+- `/ops show_command_versions`
+
+The current production-smoke-tested behaviour must be preserved:
+
+- `/ops resync_commands` remains admin/notify-channel gated.
+- `safe_defer(ctx, ephemeral=True)` remains in place.
+- the resync operation lock remains in place.
+- manual resync performs scoped `bot.sync_commands(guild_ids=[GUILD_ID])` with the existing admin
+  timeout behaviour unless a different timeout is explicitly approved.
+- command cache writes remain atomic for admin-triggered writes.
+- admin embeds keep their existing success, timeout, failure, and validation semantics.
+- command-version display keeps flattened grouped command names such as `/ops run_sql_proc` and
+  `/mge leadership_board`.
+
+Recommended target: keep `core/command_lifecycle.py` as the non-Discord owner of command inventory,
+signature, cache, comparison, and sync mechanics. Keep `commands/admin_cmds.py` responsible for
+permissions, deferral, operation lock, Discord embeds, and admin UX.
+
+## In Scope
+
+- Audit the relationship between:
+  - `core/command_lifecycle.py`
+  - `commands/admin_cmds.py:/ops resync_commands`
+  - `commands/admin_cmds.py:/ops validate_command_cache`
+  - `commands/admin_cmds.py:/ops show_command_versions`
+  - `commands.command_inventory.flatten_application_commands()`
+  - `bot_helpers.get_command_signature()`
+  - `COMMAND_CACHE_FILE`
+  - `file_utils.atomic_json_write()`
+  - `bot.sync_commands()`
+- Decide which reusable helpers belong in `core/command_lifecycle.py`.
+- Preserve admin command presentation and permissions in `commands/admin_cmds.py`.
+- Add or update focused tests proving startup and admin tooling use the same signature model.
+- Capture broader command-surface consolidation as deferred work, not Phase 6E implementation.
+
+## Out Of Scope
+
+- Slash-command renaming, grouping, or retirement.
+- Ark, stats, registry, inventory, calendar, or subscription command-surface migrations.
+- Event cache refresh, reminder loading, view rehydration, scheduler registration, and MGE/Ark
+  lifecycle extraction.
+- Queue worker startup, live queue rehydration, or queue persistence changes.
+- Startup command sync behaviour changes beyond preserving Phase 6D behaviour.
+- Shutdown redesign.
+- `DL_bot.py` process-entry changes.
+- Upload-route behaviour changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `core/command_lifecycle.py`
+- `commands/admin_cmds.py`
+- `bot_helpers.py`
+- `commands/command_inventory.py`
+- `constants.py`
+- `file_utils.py`
+- `tests/test_command_lifecycle.py`
+- `tests/test_admin_command_cache_paths.py`
+- `tests/test_command_signature_inventory.py`
+- `tests/test_command_inventory.py`
+- `tests/test_command_registration_smoke.py`
+- `scripts/validate_command_registration.py`
+- `docs/reference/deferred_optimisations.md`
+
+Likely modify after approval:
+
+- `core/command_lifecycle.py`
+- `commands/admin_cmds.py`
+- `tests/test_command_lifecycle.py`
+- `tests/test_admin_command_cache_paths.py`
+- possibly a focused admin command lifecycle test file if AST/source-shape tests are not enough
+
+Do not create a new command-surface migration module in Phase 6E.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Admin Command Cache / Sync Tooling Map
+- Current Phase 6D Command Lifecycle Boundary Map
+- Proposed Phase 6E Ownership Model
+- Behaviour Preservation Checklist
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6E Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_command_lifecycle.py tests\test_admin_command_cache_paths.py tests\test_command_signature_inventory.py tests\test_command_inventory.py tests\test_command_registration_smoke.py tests\test_domain_registrars_no_legacy_register_commands.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6E touches
+Discord admin commands, command sync behaviour, command cache files, runtime config, and
+operator-triggered lifecycle actions.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- normal startup still shows `ready_command_sync` and `commands_changed result: False` when command
+  signatures are unchanged
+- `/ops show_command_versions` still lists flattened grouped commands with versions
+- `/ops validate_command_cache` still reports cache mismatches and missing/stale entries clearly
+- `/ops resync_commands` still syncs scoped guild commands and updates the cache
+- admin commands remain ephemeral and permission-gated
+- no command-surface names changed
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+[COMMAND SYNC] Resync failed
+[COMMAND SYNC] Timed out during sync
+[WARN] Command sync timed out
+[WARN] Command sync failed
+```
+
+Warnings about command sync should be investigated if they are new; timeout/failure paths may be
+expected only when deliberately testing those paths.
+
+## Deferred Item Link
+
+This starter continues the command lifecycle admin tooling deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6D completed startup command sync lifecycle
+ownership.

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-27`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -92,6 +92,18 @@ Phase 6C usage tracker lifecycle ownership is complete:
 - `full_startup_sequence()` no longer owns usage observability startup.
 - Production smoke testing on 2026-05-27 confirmed usage tracker startup, prune-loop scheduling,
   command/component SQL flushes, and startup sequence continuity.
+- The PR was merged and pushed to production.
+
+Phase 6D command sync lifecycle ownership is complete:
+
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) added `core/command_lifecycle.py` and the
+  named `ready_command_sync` phase.
+- `bot_instance.py:on_ready()` now delegates startup command signature inventory, command-cache
+  load/compare/save, scoped sync, timeout telemetry, and loaded-command logging through
+  `core.command_lifecycle.run_ready_command_sync()`.
+- Production smoke testing on 2026-05-27 confirmed the unchanged-command path, a changed-command
+  `/summary` version bump path with successful scoped guild sync and cache update, and a follow-up
+  restart returning to `commands_changed result: False`.
 - The PR was merged and pushed to production.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
@@ -302,7 +314,8 @@ Initial classification before audit:
 | Initial `on_ready()` runtime bootstrap boundary | complete | Phase 6A moved loop exception handler setup and console-handler cleanup behind `ready_runtime_bootstrap`, preserving startup order and adding named phase logs. |
 | Runtime services/observability startup | complete | Phase 6B moved heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops behind `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
 | Usage tracker lifecycle ownership | complete | Phase 6C consolidated command/component/metric/alert usage logging onto the shared `usage_tracker.py` singleton and moved usage JSONL pruning into `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
-| Command signature/cache/sync ownership | next recommended slice | This is the next contiguous `on_ready()` block after named startup phases. Audit and extract command signature generation, command-cache load/compare/save, scoped sync, timeout telemetry, and loaded-command logging before event cache or scheduler work. |
+| Command signature/cache/sync ownership | complete | Phase 6D moved startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, preserving cache, scoped sync, timeout telemetry, and loaded-command logging behaviour. |
+| Command lifecycle admin tooling convergence | next recommended slice | Phase 6E should reuse `core/command_lifecycle.py` from `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while preserving admin permissions, embeds, timeout behaviour, and operator-facing summaries. |
 | `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
@@ -310,6 +323,28 @@ Initial classification before audit:
 | SQL/importer contracts | not applicable unless discovered | Phase 6 should avoid SQL/importer contract changes. |
 
 Final decisions should be updated after each Phase 6 sub-phase.
+
+## 13.1 Remaining Phase 6 Slices
+
+Current recommended order after Phase 6D:
+
+1. Phase 6E command lifecycle admin tooling convergence: reuse `core/command_lifecycle.py` from
+   `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while
+   preserving admin UX and keeping command-surface consolidation out of scope.
+2. Event cache, reminder loading, and rehydration boundary: separate event cache refresh,
+   reminder state loading, tracked view rehydration, and calendar pinned view rehydration from the
+   remaining `on_ready()` body with explicit startup ordering.
+3. Scheduler and task-supervision boundary: extract Ark, MGE, event reminder, calendar reminder,
+   daily pinned refresh, and related TaskMonitor registrations into named lifecycle ownership.
+4. Queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
+   queue embed refresh, and queue persistence/recovery concerns.
+5. Shutdown and recovery coordination: audit graceful teardown, signal handling, task
+   cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order.
+6. Process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
+   stable, review whether `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final
+   ownership split.
+
+The wider command-surface migration/renaming programme is deliberately separate from Phase 6.
 
 ## 14. Testing Requirements
 

--- a/tests/test_admin_command_cache_paths.py
+++ b/tests/test_admin_command_cache_paths.py
@@ -19,4 +19,6 @@ def test_admin_command_cache_handlers_use_canonical_cache_path():
     combined = "\n".join(functions.values())
     assert "COMMAND_CACHE_FILE" in combined
     assert '"command_cache.json"' not in combined
-    assert "atomic_json_write(COMMAND_CACHE_FILE" in functions["resync_commands"]
+    assert "command_cache_update(" in functions["resync_commands"]
+    assert "build_command_cache_validation(" in functions["validate_command_cache"]
+    assert "flatten_application_commands" not in combined

--- a/tests/test_command_lifecycle.py
+++ b/tests/test_command_lifecycle.py
@@ -5,7 +5,14 @@ from types import SimpleNamespace
 
 import pytest
 
-from core.command_lifecycle import build_command_signatures, run_ready_command_sync
+from core.command_lifecycle import (
+    build_command_signatures,
+    command_cache_update,
+    command_version_lines,
+    run_ready_command_sync,
+    sync_commands_for_guild,
+    validate_command_cache,
+)
 
 
 def _command(name: str, *, description: str = "desc", version: str = "v1.0"):
@@ -39,6 +46,82 @@ def test_build_command_signatures_uses_flattened_inventory_names():
             "version": "v2.0",
         }
     ]
+
+
+def test_command_cache_update_writes_startup_signature_shape_atomically():
+    command = _command("ping", description="Ping", version="v2.0")
+    writes = []
+
+    result = command_cache_update(
+        [command],
+        existing_signatures=[
+            {
+                "name": "ping",
+                "description": "Ping",
+                "version": "v1.0",
+                "admin_only": True,
+            }
+        ],
+        cache_file="cache.json",
+        writer=lambda path, data: writes.append((path, data)),
+    )
+
+    assert result.updated_lines == ["/ping → `v1.0` ➜ `v2.0`"]
+    assert result.signatures == [{"name": "ping", "description": "Ping", "version": "v2.0"}]
+    assert writes == [("cache.json", result.signatures)]
+
+
+def test_validate_command_cache_uses_shared_signature_model():
+    command = _command("ping", description="Ping", version="v2.0")
+    stale = {"name": "old", "description": "Old", "version": "v1.0"}
+
+    result = validate_command_cache(
+        [command],
+        [
+            {"name": "ping", "description": "Ping", "version": "v1.0"},
+            stale,
+        ],
+    )
+
+    assert result.issues == [
+        "🔁 `/ping` version mismatch: cache=`v1.0`, code=`v2.0`",
+        "➖ `/old` is in cache but not currently loaded",
+    ]
+
+
+def test_command_version_lines_use_flattened_group_names():
+    subcommand = _command("run_sql_proc", description="Run SQL", version="v1.03")
+    group = SimpleNamespace(name="ops", subcommands=[subcommand])
+
+    assert command_version_lines([group]) == ["/ops run_sql_proc — `v1.03`"]
+
+
+@pytest.mark.asyncio
+async def test_sync_commands_for_guild_reports_success():
+    bot = FakeBot([])
+
+    result = await sync_commands_for_guild(bot, guild_id=123, timeout_seconds=5.0)
+
+    assert result.ok is True
+    assert result.guild_id == 123
+    assert bot.sync_calls == [[123]]
+
+
+@pytest.mark.asyncio
+async def test_sync_commands_for_guild_reports_timeout():
+    class TimeoutBot(FakeBot):
+        async def sync_commands(self, *, guild_ids):
+            self.sync_calls.append(guild_ids)
+            raise TimeoutError
+
+    bot = TimeoutBot([])
+
+    result = await sync_commands_for_guild(bot, guild_id=123, timeout_seconds=5.0)
+
+    assert result.ok is False
+    assert result.timed_out is True
+    assert result.error is None
+    assert bot.sync_calls == [[123]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Converge `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` onto the shared Phase 6D command lifecycle owner.
- Keep Discord admin UX, permissions, ephemeral responses, operation locking, scoped guild sync, and existing embed semantics in `commands/admin_cmds.py`.
- Update Phase 6 docs/task packs to mark Phase 6D complete and introduce Phase 6E as the next lifecycle slice.

## Changes

- Added reusable command lifecycle helpers for manual scoped sync, sorted command signatures, version lines, command-cache updates, and command-cache validation.
- Replaced local admin command inventory/cache comparison logic with calls into `core.command_lifecycle`.
- Preserved atomic admin-triggered command cache writes while aligning the cache shape with startup signatures (`name`, `description`, `version`).
- Added focused tests for shared startup/admin signature behavior, manual sync result handling, cache validation, and source-shape guardrails.

## Tests

- `./.venv/Scripts/python.exe -m pytest -q tests/test_command_lifecycle.py tests/test_admin_command_cache_paths.py tests/test_command_signature_inventory.py tests/test_command_inventory.py`
- `./.venv/Scripts/python.exe -m py_compile core/command_lifecycle.py commands/admin_cmds.py`
- `./.venv/Scripts/python.exe scripts/validate_architecture_boundaries.py`
- `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- `./.venv/Scripts/python.exe scripts/select_tests.py`
- `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- `./.venv/Scripts/python.exe -m pytest -q tests/test_command_lifecycle.py tests/test_admin_command_cache_paths.py tests/test_command_signature_inventory.py tests/test_command_inventory.py tests/test_command_registration_smoke.py tests/test_domain_registrars_no_legacy_register_commands.py`
- `./.venv/Scripts/python.exe -m pytest -q tests` (`1557 passed, 2 skipped`)
- `./.venv/Scripts/python.exe -m pre_commit run -a`
- `./.venv/Scripts/python.exe scripts/analyse_pytest_log_noise.py`

## AI Review Gates

- Codex Security review still recommended before merge because this touches Discord admin commands, command sync behavior, command cache file handling, and operator-triggered lifecycle actions.

## Risk / Rollback

- Risk: medium; command lifecycle admin tooling affects operator sync/cache workflows but should not alter slash command paths or startup behavior.
- Rollback: revert this PR and restart from the Phase 6D command lifecycle baseline.
