### PR TITLE
[codex] add Phase 6F event rehydration lifecycle boundary

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -52,7 +52,6 @@ from constants import (
     LAST_RESTART_INFO,
     LAST_SHUTDOWN_INFO,
     PASSWORD,
-    REMINDER_TRACKING_FILE,
     RESTART_LOG_FILE,
     SERVER,
     STATS_SHEET_ID,
@@ -60,24 +59,24 @@ from constants import (
     USERNAME,
 )
 from core.command_lifecycle import run_ready_command_sync
+from core.event_rehydration_lifecycle import (
+    run_ready_event_cache_rehydration,
+    run_ready_pinned_calendar_rehydration,
+    run_ready_tracked_view_rehydration,
+    wait_for_events,
+)
 from core.interaction_safety import get_operation_lock
 from core.startup_lifecycle import StartupPhase, run_startup_phases
 from crystaltech_di import init_crystaltech_service
 from daily_KVK_overview_embed import post_or_update_daily_KVK_overview
 from embed_utils import expire_old_event_embeds, send_summary_embed
-from event_cache import (
-    get_all_upcoming_events,
-    is_cache_stale,
-    load_event_cache,
-    refresh_event_cache,
-)
-from event_calendar.pinned_embed import rehydrate_pinned_calendar_view, update_calendar_embed
+from event_cache import refresh_event_cache
+from event_calendar.pinned_embed import update_calendar_embed
 from event_calendar.reminders import run_calendar_reminder_loop
 from event_calendar.service import get_calendar_service
 from event_embed_manager import rehydrate_live_event_views, update_live_event_embeds
 from event_scheduler import (
     cleanup_orphaned_reminders,
-    load_active_reminders,
     load_dm_scheduled_tracker,
     load_dm_sent_tracker,
     refresh_reminder_format,
@@ -100,7 +99,6 @@ from player_stats_cache import (  # optional, see note
 )
 from proc_config_import import run_proc_config_import, run_proc_config_import_offload
 from profile_cache import get_cache_stats, warm_cache as warm_profile_cache
-from rehydrate_views import rehydrate_tracked_views
 from server_activity import register_activity_listeners
 from server_activity.activity_store import ensure_activity_schema
 from server_status import run_member_count_channel_loop, run_utc_clock_channel_loop
@@ -186,19 +184,6 @@ async def _refresh_mge_caches_on_startup() -> None:
         )
     except Exception:
         logger.exception("[BOOT] MGE cache refresh failed")
-
-
-async def wait_for_events(timeout_seconds: int = 10) -> bool:
-    """Return True as soon as we have at least 1 upcoming event, else False after timeout."""
-    checks = int(max(1, timeout_seconds) * 10)
-    for _ in range(checks):
-        try:
-            if get_all_upcoming_events():  # non-empty list means ready
-                return True
-        except Exception:
-            pass
-        await asyncio.sleep(0.1)
-    return False
 
 
 def schedule_bg(name: str, timeout: float, coro_factory: Callable[[], Awaitable[Any]]):
@@ -356,7 +341,7 @@ async def _start_event_dependent_tasks():
         )
         logger.info("[BOOT] rehydrate_live_event_views complete")
     except Exception:
-        logger.error("[BOOT] Failed to start rehydrate_live_event_views: {e}")
+        logger.exception("[BOOT] Failed to start rehydrate_live_event_views")
 
     # Scheduled expiry
     try:
@@ -364,25 +349,6 @@ async def _start_event_dependent_tasks():
         logger.info("[BOOT] Event embed expiry task scheduled for 08:00 UTC daily")
     except Exception as e:
         logger.error(f"[BOOT] Failed to start event_embed_expiry task: {e}")
-
-
-async def _start_event_tasks_when_ready(max_wait_seconds: int = 300):
-    """
-    Block until the event cache has at least one upcoming event (or timeout),
-    then start all event-dependent background tasks exactly once.
-    """
-    try:
-        ready = await wait_for_events(timeout_seconds=max_wait_seconds)
-        if not ready:
-            logger.warning(
-                "[BOOT] Event cache still not ready after %ss; "
-                "skipping event-dependent task start for now.",
-                max_wait_seconds,
-            )
-            return
-        await _start_event_dependent_tasks()
-    except Exception as e:
-        logger.exception("[BOOT] _start_event_tasks_when_ready failed: %s", e)
 
 
 # wrap blockers
@@ -1524,6 +1490,9 @@ async def on_graceful_shutdown():
         logger.exception("[SHUTDOWN] on_graceful_shutdown failed.")
 
 
+_startup_loaded_reminder_ids: set[Any] = set()
+
+
 @bot.event
 async def on_ready():
     # Gate: only the first on_ready() does startup work
@@ -1542,38 +1511,9 @@ async def on_ready():
         logger.info(f"✅ Bot is ready – logged in as {bot.user} (ID: {bot.user.id})")
         await run_startup_phases([StartupPhase("ready_command_sync", _run_ready_command_sync)])
 
-        logger.info(f"[REMINDER_CACHE] Attempting to load from {REMINDER_TRACKING_FILE}")
-        loaded_ids = await load_active_reminders(bot)
-
-        try:
-            load_event_cache()
-            logger.info("[EVENT_CACHE] Loaded cache from disk")
-            if is_cache_stale() or not get_all_upcoming_events():
-                logger.info("[EVENT_CACHE] Cache was stale or empty — refreshing from GSheet")
-                await refresh_event_cache()
-
-            # Log a definitive post-refresh count so we can see what the bot is working with
-            try:
-                count = len(get_all_upcoming_events() or [])
-                logger.info(f"[EVENT_CACHE] Ready with {count} upcoming events.")
-            except Exception:
-                logger.info("[EVENT_CACHE] Ready; but could not count events.")
-        except Exception as e:
-            logger.error(f"[STARTUP] Failed to load or refresh event cache: {e}")
-
-        schedule_bg("refresh_event_cache_once", 10.0, lambda: refresh_event_cache())
-
-        ready = await wait_for_events(10)
-        if ready:
-            await _start_event_dependent_tasks()
-        else:
-            logger.warning(
-                "[BOOT] Event cache not ready; will wait in background and start event-dependent tasks when populated."
-            )
-            task_monitor.create(
-                "event_tasks_when_ready",
-                lambda: _start_event_tasks_when_ready(max_wait_seconds=300),
-            )
+        await run_startup_phases(
+            [StartupPhase("ready_event_cache_rehydration", _run_ready_event_cache_rehydration)]
+        )
 
         try:
             schedule_bg("warm_name_cache", 8.0, lambda: warm_name_cache())
@@ -1604,7 +1544,7 @@ async def on_ready():
         except Exception as e:
             logger.warning(f"[CACHE] Failed to schedule last-KVK cache build: {e}")
 
-        await cleanup_orphaned_reminders(loaded_ids)
+        await cleanup_orphaned_reminders(_startup_loaded_reminder_ids)
 
         try:
             load_dm_sent_tracker()
@@ -1619,7 +1559,7 @@ async def on_ready():
             load_subscriptions()
             logger.info("[SUBSCRIPTIONS] Subscription file loaded successfully.")
         except Exception:
-            logger.error("[SUBSCRIPTIONS] Failed to load at startup: {e}")
+            logger.exception("[SUBSCRIPTIONS] Failed to load at startup")
 
         try:
             if not refresh_event_cache_task.is_running():
@@ -1627,13 +1567,11 @@ async def on_ready():
             else:
                 logger.info("[BOOT] refresh_event_cache_task already running; skipping start.")
         except Exception:
-            logger.error("[BOOT] Failed to start refresh_event_cache_task: {e}")
+            logger.exception("[BOOT] Failed to start refresh_event_cache_task")
 
-        try:
-            schedule_bg("rehydrate_tracked_views", 10.0, lambda: rehydrate_tracked_views(bot))
-            logger.info("[BOOT] View tracker rehydration scheduled")
-        except Exception:
-            logger.error("[BOOT] Failed to start rehydrate_tracked_views: {e}")
+        await run_startup_phases(
+            [StartupPhase("ready_view_rehydration", _run_ready_view_rehydration)]
+        )
 
         try:
             task_monitor.create("ark_scheduler", lambda: schedule_ark_lifecycle(bot))
@@ -1676,15 +1614,16 @@ async def on_ready():
             task_monitor.create("reminder_cleanup", reminder_cleanup_loop)
             logger.info("[BOOT] Reminder cleanup task started")
         except Exception:
-            logger.error("[BOOT] Failed to start reminder_cleanup_loop: {e}")
+            logger.exception("[BOOT] Failed to start reminder_cleanup_loop")
 
-        try:
-            schedule_bg(
-                "rehydrate_pinned_calendar_view", 8.0, lambda: rehydrate_pinned_calendar_view(bot)
-            )
-            logger.info("[BOOT] pinned calendar view rehydration scheduled")
-        except Exception:
-            logger.exception("[BOOT] failed to schedule pinned calendar rehydration")
+        await run_startup_phases(
+            [
+                StartupPhase(
+                    "ready_pinned_calendar_rehydration",
+                    _run_ready_pinned_calendar_rehydration,
+                )
+            ]
+        )
 
         try:
             task_monitor.create(
@@ -1707,8 +1646,8 @@ async def on_ready():
         except Exception:
             logger.exception("[BOOT] failed to start calendar reminder loop")
 
-    except Exception as e:
-        logger.exception(f"[CRITICAL] Exception during on_ready: {e}")
+    except Exception:
+        logger.exception("[CRITICAL] Exception during on_ready")
 
 
 async def _run_ready_runtime_bootstrap() -> None:
@@ -1729,6 +1668,24 @@ async def _run_ready_runtime_bootstrap() -> None:
 
 async def _run_ready_command_sync() -> None:
     await run_ready_command_sync(bot)
+
+
+async def _run_ready_event_cache_rehydration() -> None:
+    global _startup_loaded_reminder_ids
+    _startup_loaded_reminder_ids = await run_ready_event_cache_rehydration(
+        bot=bot,
+        schedule_bg=schedule_bg,
+        task_monitor_create=task_monitor.create,
+        start_event_dependent_tasks=_start_event_dependent_tasks,
+    )
+
+
+async def _run_ready_view_rehydration() -> None:
+    await run_ready_tracked_view_rehydration(bot=bot, schedule_bg=schedule_bg)
+
+
+async def _run_ready_pinned_calendar_rehydration() -> None:
+    await run_ready_pinned_calendar_rehydration(bot=bot, schedule_bg=schedule_bg)
 
 
 async def _run_ready_runtime_services() -> None:

--- a/core/event_rehydration_lifecycle.py
+++ b/core/event_rehydration_lifecycle.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import logging
+from typing import Any
+
+from constants import REMINDER_TRACKING_FILE
+from event_cache import (
+    get_all_upcoming_events,
+    is_cache_stale,
+    load_event_cache,
+    refresh_event_cache,
+)
+from event_calendar.pinned_embed import rehydrate_pinned_calendar_view
+from event_scheduler import load_active_reminders
+from rehydrate_views import rehydrate_tracked_views
+
+logger = logging.getLogger(__name__)
+
+ScheduleBackground = Callable[[str, float, Callable[[], Awaitable[Any]]], Any]
+TaskMonitorCreate = Callable[[str, Callable[[], Awaitable[Any]]], Any]
+StartupCoroutine = Callable[[], Awaitable[Any]]
+
+
+async def wait_for_events(timeout_seconds: int = 10) -> bool:
+    """Return True once the event cache has upcoming events, otherwise False on timeout."""
+    checks = int(max(1, timeout_seconds) * 10)
+    for _ in range(checks):
+        try:
+            if get_all_upcoming_events():
+                return True
+        except Exception:
+            logger.debug("[EVENT_CACHE] Upcoming-event readiness check failed", exc_info=True)
+        await asyncio.sleep(0.1)
+    return False
+
+
+async def _start_event_tasks_when_ready(
+    *,
+    start_event_dependent_tasks: StartupCoroutine,
+    max_wait_seconds: int,
+) -> None:
+    try:
+        ready = await wait_for_events(timeout_seconds=max_wait_seconds)
+        if not ready:
+            logger.warning(
+                "[BOOT] Event cache still not ready after %ss; "
+                "skipping event-dependent task start for now.",
+                max_wait_seconds,
+            )
+            return
+        await start_event_dependent_tasks()
+    except Exception:
+        logger.exception("[BOOT] event_tasks_when_ready failed")
+
+
+async def run_ready_event_cache_rehydration(
+    *,
+    bot: Any,
+    schedule_bg: ScheduleBackground,
+    task_monitor_create: TaskMonitorCreate,
+    start_event_dependent_tasks: StartupCoroutine,
+) -> set[Any]:
+    """Load reminder/cache state and start the existing event-ready startup bundle."""
+    logger.info("[REMINDER_CACHE] Attempting to load from %s", REMINDER_TRACKING_FILE)
+    loaded_ids = await load_active_reminders(bot)
+
+    try:
+        load_event_cache()
+        logger.info("[EVENT_CACHE] Loaded cache from disk")
+        if is_cache_stale() or not get_all_upcoming_events():
+            logger.info("[EVENT_CACHE] Cache was stale or empty; refreshing from GSheet")
+            await refresh_event_cache()
+
+        try:
+            count = len(get_all_upcoming_events() or [])
+            logger.info("[EVENT_CACHE] Ready with %s upcoming events.", count)
+        except Exception:
+            logger.info("[EVENT_CACHE] Ready; but could not count events.")
+    except Exception:
+        logger.exception("[STARTUP] Failed to load or refresh event cache")
+
+    schedule_bg("refresh_event_cache_once", 10.0, lambda: refresh_event_cache())
+
+    ready = await wait_for_events(10)
+    if ready:
+        logger.info(
+            "[BOOT] Starting current event-dependent task bundle; scheduler ownership "
+            "split is deferred to Phase 6G."
+        )
+        await start_event_dependent_tasks()
+    else:
+        logger.warning(
+            "[BOOT] Event cache not ready; will wait in background and start "
+            "event-dependent tasks when populated."
+        )
+        task_monitor_create(
+            "event_tasks_when_ready",
+            lambda: _start_event_tasks_when_ready(
+                start_event_dependent_tasks=start_event_dependent_tasks,
+                max_wait_seconds=300,
+            ),
+        )
+
+    return set(loaded_ids or set())
+
+
+async def run_ready_tracked_view_rehydration(
+    *,
+    bot: Any,
+    schedule_bg: ScheduleBackground,
+) -> None:
+    try:
+        schedule_bg("rehydrate_tracked_views", 10.0, lambda: rehydrate_tracked_views(bot))
+        logger.info("[BOOT] View tracker rehydration scheduled")
+    except Exception:
+        logger.exception("[BOOT] Failed to start rehydrate_tracked_views")
+
+
+async def run_ready_pinned_calendar_rehydration(
+    *,
+    bot: Any,
+    schedule_bg: ScheduleBackground,
+) -> None:
+    try:
+        schedule_bg(
+            "rehydrate_pinned_calendar_view",
+            8.0,
+            lambda: rehydrate_pinned_calendar_view(bot),
+        )
+        logger.info("[BOOT] pinned calendar view rehydration scheduled")
+    except Exception:
+        logger.exception("[BOOT] failed to schedule pinned calendar rehydration")

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -67,12 +67,20 @@ ownership was completed in PR 121 (`codex/dlbot-phase-6d-command-lifecycle`), sm
 unchanged, changed, and post-cache-update restart paths, merged, and pushed to production:
 `bot_instance.py:on_ready()` now delegates startup command signature/cache/sync handling through
 `core/command_lifecycle.py` and the named `ready_command_sync` phase while preserving scoped sync,
-timeout telemetry, command-cache writes, and loaded-command logging.
+timeout telemetry, command-cache writes, and loaded-command logging. Phase 6E command lifecycle
+admin tooling convergence was completed in PR 122
+(`codex/dlbot-phase-6e-command-admin-tooling`), merged, smoke tested, and pushed to production on
+2026-05-28: `/ops resync_commands`, `/ops validate_command_cache`, and
+`/ops show_command_versions` now reuse `core/command_lifecycle.py` for manual scoped sync,
+signature inventory, version display, cache update, and cache validation while preserving admin
+permissions, ephemeral responses, operation locking, embeds, timeout behaviour, and grouped command
+names. Production smoke confirmed both command execution and usage telemetry flushes, including a
+successful manual command resync.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`, with
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md`, with
 this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -141,20 +149,29 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, and Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`. Remaining `on_ready()` work still mixes event cache and rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice is command lifecycle admin tooling convergence from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`; after that, keep event cache/rehydration, scheduler startup, queue worker lifecycle, and shutdown coordination in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, and Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner. Remaining `on_ready()` work still mixes event cache refresh, reminder state loading, tracked/live view rehydration, pinned calendar rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice is event cache, reminder loading, and rehydration boundary extraction from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md`; after that, keep scheduler/task supervision, queue worker lifecycle, shutdown coordination, and final process-entry/bot-construction cleanup in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing, Phase 6A startup lifecycle boundary, Phase 6B runtime services extraction, Phase 6C usage tracker ownership consolidation, and Phase 6D command sync lifecycle extraction are complete in code and production smoke tested; proceed with audit/design before each remaining implementation slice.
+- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6E lifecycle slices are complete, merged, production-pushed, and smoke tested; proceed with audit/design before each remaining implementation slice.
 
 ### Deferred Optimisation
-- Area: `core/command_lifecycle.py`, `commands/admin_cmds.py`, command cache admin tooling
+- Area: `bot_instance.py:_start_event_dependent_tasks`
 - Type: architecture
-- Description: Phase 6D establishes a startup command lifecycle owner, but admin command tooling still has separate cache and sync handling in `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`. Those flows intentionally remain out of the conservative startup slice because they include Discord embed UX, permission-gated admin interaction behaviour, and different timeout/output expectations.
-- Suggested Fix: Execute Phase 6E from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`: reuse `core/command_lifecycle.py` for admin resync, cache validation, and command-version inventory while preserving existing admin-only permissions, ephemeral responses, embed output, timeout behaviour, and operator-facing summaries. Add focused tests for shared startup/admin signature parity, manual resync cache writes, validation output, timeout handling, and command registration smoke coverage.
+- Description: The Phase 6F event cache and rehydration boundary deliberately preserves the existing event-dependent startup bundle, which still mixes readiness-bound live view rehydration with scheduler/task-supervision concerns such as periodic live embed updates, daily KVK overview updates, legacy event reminder scheduling, and event embed expiry.
+- Suggested Fix: In Phase 6G, split scheduler and task-supervision ownership out of the event cache/rehydration boundary into a focused lifecycle owner while preserving readiness gating, startup order, `TaskMonitor` duplicate prevention, and existing production logging.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6D startup command lifecycle extraction is merged and smoke tested; keep slash-command renaming and command-surface consolidation out of this slice.
+- Dependencies: Phase 6F boundary extraction approved with scheduler ownership explicitly deferred to Phase 6G.
+
+### Deferred Optimisation
+- Area: `event_calendar/pinned_embed.py`
+- Type: refactor
+- Description: Pinned calendar tracker persistence currently uses direct `Path.write_text()` JSON writes in `_save_tracker()`, unlike other restart-sensitive tracker files that use atomic JSON helpers and clearer failure boundaries.
+- Suggested Fix: Move pinned calendar tracker persistence to the established atomic JSON helper pattern, preserve tracker shape and missing-message recovery behavior, and add focused tests for successful save, failed/partial write protection, missing tracker, and rehydration after restart.
+- Impact: medium
+- Risk: low
+- Dependencies: Keep this separate from Phase 6F unless a later pinned-calendar persistence task is approved.
 
 ### Deferred Optimisation
 - Area: `commands/`, command documentation, `scripts/validate_command_registration.py`

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -19,6 +19,14 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
      daily summary, activity tracking, and server status channel loops.
    - `ready_command_sync` owns slash-command signature inventory, command-cache comparison,
      scoped command sync when signatures change, timeout telemetry, and loaded-command logging.
+     Phase 6E also converged `/ops` command lifecycle admin tooling onto the same command
+     lifecycle helpers while keeping Discord admin UX in `commands/admin_cmds.py`.
+   - `ready_event_cache_rehydration` owns active reminder loading, event cache disk load,
+     stale/empty cache refresh, one-shot refresh scheduling, and the current event-dependent
+     startup bundle. Scheduler ownership inside that bundle remains deferred to Phase 6G.
+   - `ready_view_rehydration` schedules tracked persistent view rehydration.
+   - `ready_pinned_calendar_rehydration` schedules pinned calendar view rehydration at the
+     existing later startup point after `full_startup_sequence()`.
 9. Caches, rehydration, background tasks, heartbeat, and admin notification start.
 
 ## Main Files
@@ -78,9 +86,14 @@ runtime services/observability startup. Phase 6C consolidated usage tracking ont
 `ready_runtime_services`. The unified tracker intentionally uses the previous command/decorator
 cadence of a 5-second flush interval or 20-event batch size for command, component, metric, and
 alert usage events. Phase 6D moved startup command signature/cache/sync handling behind
-`ready_command_sync` and `core/command_lifecycle.py`. Remaining lifecycle cleanup after that
-starts with command lifecycle admin tooling convergence, then continues into rehydration and
-scheduler boundaries, queue worker lifecycle, and shutdown coordination.
+`ready_command_sync` and `core/command_lifecycle.py`. Phase 6E reused that lifecycle owner from
+`/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`; production
+smoke on 2026-05-28 confirmed those commands loaded, executed, flushed usage telemetry, and manual
+scoped command resync completed successfully. Phase 6F added explicit boundaries for event cache,
+reminder loading, tracked view rehydration, and pinned calendar rehydration while preserving the
+existing event-dependent scheduler bundle for Phase 6G. Remaining lifecycle cleanup continues with
+scheduler/task supervision, queue worker lifecycle, shutdown coordination, and final
+process-entry/bot-construction cleanup.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md
@@ -1,7 +1,20 @@
 # Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling
 
-Use this starter to continue Phase 6 after Phase 6D command sync lifecycle ownership was merged,
-smoke-tested, pushed to production, and marked complete.
+Status: complete. PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged, smoke-tested,
+and pushed to production on 2026-05-28. This starter is retained as historical context for Phase
+6E.
+
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md` for
+the next Phase 6 slice.
+
+Delivered outcome:
+
+- `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` now reuse
+  `core/command_lifecycle.py` for lifecycle mechanics.
+- `commands/admin_cmds.py` continues to own Discord admin UX, permissions, ephemeral responses,
+  operation locking, and embeds.
+- Production smoke confirmed the three `/ops` commands loaded and executed, command usage telemetry
+  flushed normally, and manual scoped resync logged success.
 
 ## Copy/Paste Starter
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md
@@ -1,0 +1,241 @@
+# Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary
+
+Use this starter to continue Phase 6 after Phase 6E command lifecycle admin tooling convergence
+was merged, smoke-tested, pushed to production, and marked complete.
+
+Approved Phase 6F scope decision: extract event cache, reminder loading, tracked view rehydration,
+and pinned calendar rehydration behind explicit startup lifecycle boundaries. Preserve the current
+event-dependent scheduler bundle as a compatibility path and defer scheduler/task-supervision
+ownership to Phase 6G so that work is not lost.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6F:
+event cache, reminder loading, and rehydration boundary.
+
+Phase 6A, 6B, 6C, 6D, and 6E are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `core/command_lifecycle.py` owns startup command signature/cache/sync mechanics and the shared
+  command lifecycle mechanics used by `/ops` admin tooling.
+- `bot_instance.py:on_ready()` delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+  - startup command signature/cache/sync through `ready_command_sync`
+- Production smoke logs confirmed for Phase 6E:
+  - `/ops show_command_versions` loaded and executed
+  - `/ops validate_command_cache` loaded and executed
+  - `/ops resync_commands` completed scoped sync successfully
+  - command usage telemetry flushed normally for all three commands
+  - no command sync timeout, failure, startup phase failure, or `on_ready()` critical exception was
+    observed
+
+This is review/scope first. Do not implement code changes until the Phase 6F scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/reference/events_and_dm_reminders.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6E Command Lifecycle Admin Tooling.md`
+
+## Phase 6F Objective
+
+Separate the event cache, reminder loading, and rehydration portion of `bot_instance.py:on_ready()`
+behind an explicit startup lifecycle boundary while preserving current startup order and runtime
+behaviour.
+
+The next cohesive slice is the block after `ready_command_sync` and before scheduler/task
+supervision cleanup. Phase 6F should audit and, after approval, extract ownership for:
+
+- active reminder state loading through `load_active_reminders(bot)`
+- event cache load/stale/empty handling through `load_event_cache()`, `is_cache_stale()`,
+  `get_all_upcoming_events()`, and `refresh_event_cache()`
+- background one-shot event cache refresh scheduling
+- event cache readiness gating through `wait_for_events(10)`
+- event-dependent startup work currently grouped under `_start_event_dependent_tasks()`
+- tracked view rehydration through `rehydrate_tracked_views(bot)`
+- pinned calendar view rehydration through `rehydrate_pinned_calendar_view(bot)`
+
+Recommended target: keep a non-Discord lifecycle helper in `core/` or a narrowly scoped startup
+module responsible for ordering, logging, timeouts, and outcome reporting. Keep Discord-specific
+view/event helpers in their existing modules, and keep actual scheduler ownership for a later
+Phase 6G slice.
+
+## In Scope
+
+- Audit the relationship between:
+  - `bot_instance.py:on_ready()`
+  - `_start_event_dependent_tasks()`
+  - `schedule_bg()`
+  - `_with_timeout()`
+  - `event_cache.py`
+  - `event_scheduler.load_active_reminders()`
+  - `event_scheduler.refresh_reminder_format()`
+  - `event_embed_manager.rehydrate_live_event_views()`
+  - `rehydrate_views.rehydrate_tracked_views()`
+  - `event_calendar.pinned_embed.rehydrate_pinned_calendar_view()`
+  - `event_calendar.pinned_embed.update_calendar_embed()`
+  - `REMINDER_TRACKING_FILE`
+  - event/reminder/view tracker persisted state files
+- Define the exact startup ordering that must be preserved.
+- Decide whether this should be one named startup phase or two smaller phases.
+- Preserve restart safety and duplicate-task prevention.
+- Add or update focused tests for success, stale/empty cache handling, failure logging, and
+  idempotent/safe scheduling where practical.
+- Capture scheduler/task-supervision, queue-worker, shutdown, and process-entry findings as later
+  Phase 6 work.
+
+## Out Of Scope
+
+- Ark, MGE, event reminder, calendar reminder, subscription, maintenance, or daily pinned refresh
+  scheduler ownership changes.
+- Queue worker startup, live queue rehydration, queue embed refresh, or queue persistence changes.
+- Shutdown redesign, signal handling, singleton/PID cleanup, or logging shutdown order.
+- `DL_bot.py` process-entry changes.
+- Command lifecycle, command sync, command cache, slash-command renaming, grouping, or retirement.
+- Upload-route behaviour changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes unless unexpectedly required by
+  event/reminder state validation.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `core/startup_lifecycle.py`
+- `event_cache.py`
+- `event_scheduler.py`
+- `event_embed_manager.py`
+- `rehydrate_views.py`
+- `event_calendar/pinned_embed.py`
+- `event_calendar/reminders.py`
+- `constants.py`
+- `tests/test_mge_startup_hook_invoked.py`
+- `tests/test_mge_rehydrate_and_regression.py`
+- `tests/test_rehydrate_views.py`
+- `tests/test_rehydrate_views_and_localtime.py`
+- `tests/test_rehydrate_sanitize_and_fileio.py`
+- `tests/test_event_cache.py`
+- `tests/test_calendar_pinned_embed.py`
+- `tests/test_calendar_reminders.py`
+- `tests/test_calendar_reminders_dispatch.py`
+- `tests/test_command_registration_smoke.py`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- one focused lifecycle helper module if the audit proves a clean extraction
+- focused startup/rehydration tests
+- `docs/reference/runbook_startup.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Do not create a broad lifecycle orchestration module that also owns schedulers, queue workers, or
+shutdown in Phase 6F.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Event Cache / Reminder / Rehydration Map
+- Current Phase 6A-E Startup Lifecycle Boundary Map
+- Proposed Phase 6F Ownership Model
+- Startup Ordering And Idempotency Checklist
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6F Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_event_cache.py tests\test_rehydrate_views.py tests\test_rehydrate_views_and_localtime.py tests\test_rehydrate_sanitize_and_fileio.py tests\test_calendar_pinned_embed.py tests\test_calendar_reminders.py tests\test_calendar_reminders_dispatch.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6F touches
+Discord event/view rehydration, user-facing reminder state, file-backed runtime state, and
+restart-sensitive persistence.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- normal startup still shows `ready_runtime_bootstrap`, `ready_runtime_services`, and
+  `ready_command_sync`
+- event reminder state loads from `REMINDER_TRACKING_FILE`
+- event cache loads from disk or refreshes when stale/empty
+- event cache ready count is logged
+- event-dependent live views rehydrate successfully
+- tracked views are scheduled for rehydration
+- pinned calendar view rehydration is scheduled
+- later schedulers still start after the rehydration boundary
+- no duplicate background task starts are observed after a repeated `on_ready()` call
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+[STARTUP] Failed to load or refresh event cache
+[BOOT] Failed to start rehydrate_live_event_views
+[BOOT] Failed to start rehydrate_tracked_views
+[BOOT] failed to schedule pinned calendar rehydration
+```
+
+Warnings around stale or empty event cache may be expected only when followed by a successful
+refresh and ready event count.
+
+## Remaining Phase 6 Slices
+
+Recommended order after Phase 6E:
+
+1. Phase 6F event cache, reminder loading, and rehydration boundary.
+2. Phase 6G scheduler and task-supervision boundary.
+3. Phase 6H queue worker and live queue lifecycle.
+4. Phase 6I shutdown and recovery coordination.
+5. Phase 6J process-entry and bot-construction cleanup.
+
+The wider command-surface migration/renaming programme remains separate from Phase 6.
+
+## Deferred Item Link
+
+This starter continues the DL_bot startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6E completed command lifecycle admin tooling
+convergence.

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -4,8 +4,8 @@
 
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
-- Last updated: `2026-05-27`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D startup lifecycle boundaries were pushed to production`
+- Last updated: `2026-05-28`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -104,6 +104,19 @@ Phase 6D command sync lifecycle ownership is complete:
 - Production smoke testing on 2026-05-27 confirmed the unchanged-command path, a changed-command
   `/summary` version bump path with successful scoped guild sync and cache update, and a follow-up
   restart returning to `commands_changed result: False`.
+- The PR was merged and pushed to production.
+
+Phase 6E command lifecycle admin tooling convergence is complete:
+
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) reused `core/command_lifecycle.py` from
+  `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`.
+- `commands/admin_cmds.py` still owns admin permissions, notify-channel gating, ephemeral deferral,
+  operation locking, and Discord embeds.
+- `core.command_lifecycle` now owns shared command signature sorting, version-line rendering,
+  manual scoped sync result handling, atomic command-cache updates, and cache validation logic.
+- Production smoke testing on 2026-05-28 confirmed `show_command_versions`,
+  `validate_command_cache`, and `resync_commands` loaded and executed, usage telemetry flushed
+  normally, and manual command sync logged `[COMMAND SYNC] Slash commands successfully resynced.`
 - The PR was merged and pushed to production.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
@@ -315,8 +328,9 @@ Initial classification before audit:
 | Runtime services/observability startup | complete | Phase 6B moved heartbeat, health dashboard, offload monitor, PIL safety patch, lock cleanup, usage tracker, daily summary, activity listeners, and status-channel loops behind `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
 | Usage tracker lifecycle ownership | complete | Phase 6C consolidated command/component/metric/alert usage logging onto the shared `usage_tracker.py` singleton and moved usage JSONL pruning into `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
 | Command signature/cache/sync ownership | complete | Phase 6D moved startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, preserving cache, scoped sync, timeout telemetry, and loaded-command logging behaviour. |
-| Command lifecycle admin tooling convergence | next recommended slice | Phase 6E should reuse `core/command_lifecycle.py` from `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while preserving admin permissions, embeds, timeout behaviour, and operator-facing summaries. |
-| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move command sync, event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
+| Command lifecycle admin tooling convergence | complete | Phase 6E reused `core/command_lifecycle.py` from `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while preserving admin permissions, embeds, timeout behaviour, and operator-facing summaries. |
+| Event cache, reminder loading, and rehydration boundary | approved/current slice | Phase 6F separates event cache load/refresh, active reminder loading, event-dependent view rehydration, tracked view rehydration, and pinned calendar view rehydration from the remaining `on_ready()` body with explicit ordering and startup phase logs. Scheduler ownership inside the existing event-dependent bundle is deliberately deferred to Phase 6G. |
+| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
@@ -326,21 +340,20 @@ Final decisions should be updated after each Phase 6 sub-phase.
 
 ## 13.1 Remaining Phase 6 Slices
 
-Current recommended order after Phase 6D:
+Current recommended order after Phase 6E:
 
-1. Phase 6E command lifecycle admin tooling convergence: reuse `core/command_lifecycle.py` from
-   `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while
-   preserving admin UX and keeping command-surface consolidation out of scope.
-2. Event cache, reminder loading, and rehydration boundary: separate event cache refresh,
+1. Phase 6F event cache, reminder loading, and rehydration boundary: separate event cache refresh,
    reminder state loading, tracked view rehydration, and calendar pinned view rehydration from the
-   remaining `on_ready()` body with explicit startup ordering.
-3. Scheduler and task-supervision boundary: extract Ark, MGE, event reminder, calendar reminder,
+   remaining `on_ready()` body with explicit startup ordering. Preserve the current event-dependent
+   scheduler bundle as a compatibility path and carry the scheduler/task-supervision split into
+   Phase 6G.
+2. Phase 6G scheduler and task-supervision boundary: extract Ark, MGE, event reminder, calendar reminder,
    daily pinned refresh, and related TaskMonitor registrations into named lifecycle ownership.
-4. Queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
+3. Phase 6H queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
    queue embed refresh, and queue persistence/recovery concerns.
-5. Shutdown and recovery coordination: audit graceful teardown, signal handling, task
+4. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
    cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order.
-6. Process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
+5. Phase 6J process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
    stable, review whether `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final
    ownership split.
 

--- a/tests/test_event_rehydration_lifecycle.py
+++ b/tests/test_event_rehydration_lifecycle.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core import event_rehydration_lifecycle as lifecycle
+
+
+@pytest.mark.asyncio
+async def test_ready_event_cache_rehydration_refreshes_and_starts_event_bundle(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_load_active_reminders(_bot):
+        calls.append("load_active_reminders")
+        return {"event-1"}
+
+    async def fake_refresh_event_cache():
+        calls.append("refresh_event_cache")
+        return 1
+
+    async def fake_start_event_dependent_tasks():
+        calls.append("start_event_dependent_tasks")
+
+    def fake_schedule_bg(name, timeout, coro_factory):
+        calls.append(f"schedule_bg:{name}:{timeout}")
+        assert callable(coro_factory)
+
+    def fake_task_monitor_create(name, factory):
+        calls.append(f"task_monitor:{name}")
+
+    monkeypatch.setattr(lifecycle, "load_active_reminders", fake_load_active_reminders)
+    monkeypatch.setattr(lifecycle, "load_event_cache", lambda: calls.append("load_event_cache"))
+    monkeypatch.setattr(lifecycle, "is_cache_stale", lambda: True)
+    monkeypatch.setattr(lifecycle, "get_all_upcoming_events", lambda: [{"name": "Ready"}])
+    monkeypatch.setattr(lifecycle, "refresh_event_cache", fake_refresh_event_cache)
+    monkeypatch.setattr(lifecycle, "wait_for_events", AsyncMock(return_value=True))
+
+    loaded = await lifecycle.run_ready_event_cache_rehydration(
+        bot=object(),
+        schedule_bg=fake_schedule_bg,
+        task_monitor_create=fake_task_monitor_create,
+        start_event_dependent_tasks=fake_start_event_dependent_tasks,
+    )
+
+    assert loaded == {"event-1"}
+    assert calls == [
+        "load_active_reminders",
+        "load_event_cache",
+        "refresh_event_cache",
+        "schedule_bg:refresh_event_cache_once:10.0",
+        "start_event_dependent_tasks",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ready_event_cache_rehydration_defers_event_bundle_until_ready(monkeypatch):
+    calls: list[str] = []
+    scheduled: dict[str, object] = {}
+
+    async def fake_load_active_reminders(_bot):
+        return set()
+
+    async def fake_start_event_dependent_tasks():
+        calls.append("start_event_dependent_tasks")
+
+    def fake_schedule_bg(name, timeout, coro_factory):
+        calls.append(f"schedule_bg:{name}:{timeout}")
+
+    def fake_task_monitor_create(name, factory):
+        scheduled["name"] = name
+        scheduled["factory"] = factory
+        calls.append(f"task_monitor:{name}")
+
+    monkeypatch.setattr(lifecycle, "load_active_reminders", fake_load_active_reminders)
+    monkeypatch.setattr(lifecycle, "load_event_cache", lambda: None)
+    monkeypatch.setattr(lifecycle, "is_cache_stale", lambda: False)
+    monkeypatch.setattr(lifecycle, "get_all_upcoming_events", lambda: [])
+
+    async def fake_refresh_event_cache():
+        calls.append("refresh_event_cache")
+        return 0
+
+    monkeypatch.setattr(lifecycle, "refresh_event_cache", fake_refresh_event_cache)
+    monkeypatch.setattr(lifecycle, "wait_for_events", AsyncMock(return_value=False))
+
+    loaded = await lifecycle.run_ready_event_cache_rehydration(
+        bot=object(),
+        schedule_bg=fake_schedule_bg,
+        task_monitor_create=fake_task_monitor_create,
+        start_event_dependent_tasks=fake_start_event_dependent_tasks,
+    )
+
+    assert loaded == set()
+    assert calls == [
+        "refresh_event_cache",
+        "schedule_bg:refresh_event_cache_once:10.0",
+        "task_monitor:event_tasks_when_ready",
+    ]
+    assert scheduled["name"] == "event_tasks_when_ready"
+    assert callable(scheduled["factory"])
+
+
+@pytest.mark.asyncio
+async def test_ready_view_rehydration_helpers_schedule_expected_tasks(monkeypatch):
+    calls: list[tuple[str, float]] = []
+
+    def fake_schedule_bg(name, timeout, coro_factory):
+        calls.append((name, timeout))
+        assert callable(coro_factory)
+
+    await lifecycle.run_ready_tracked_view_rehydration(bot=object(), schedule_bg=fake_schedule_bg)
+    await lifecycle.run_ready_pinned_calendar_rehydration(
+        bot=object(), schedule_bg=fake_schedule_bg
+    )
+
+    assert calls == [
+        ("rehydrate_tracked_views", 10.0),
+        ("rehydrate_pinned_calendar_view", 8.0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tracked_view_rehydration_schedule_failure_is_best_effort(caplog):
+    def fail_schedule_bg(name, timeout, coro_factory):
+        raise RuntimeError("scheduler unavailable")
+
+    await lifecycle.run_ready_tracked_view_rehydration(
+        bot=object(),
+        schedule_bg=fail_schedule_bg,
+    )
+
+    assert "Failed to start rehydrate_tracked_views" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_pinned_calendar_rehydration_schedule_failure_is_best_effort(caplog):
+    def fail_schedule_bg(name, timeout, coro_factory):
+        raise RuntimeError("scheduler unavailable")
+
+    await lifecycle.run_ready_pinned_calendar_rehydration(
+        bot=object(),
+        schedule_bg=fail_schedule_bg,
+    )
+
+    assert "failed to schedule pinned calendar rehydration" in caplog.text

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -74,6 +74,9 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         "ready_runtime_bootstrap",
         "ready_runtime_services",
         "ready_command_sync",
+        "ready_event_cache_rehydration",
+        "ready_view_rehydration",
+        "ready_pinned_calendar_rehydration",
     ]
 
 
@@ -133,3 +136,22 @@ def test_usage_tracking_lifecycle_owned_by_runtime_services_phase():
 
     assert not _calls_name(full_startup, "start_usage_tracker")
     assert not _creates_task_monitor_task(full_startup, "usage_jsonl_prune")
+
+
+def test_event_rehydration_lifecycle_uses_dedicated_helpers():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    event_cache = _async_function(tree, "_run_ready_event_cache_rehydration")
+    tracked_views = _async_function(tree, "_run_ready_view_rehydration")
+    pinned_calendar = _async_function(tree, "_run_ready_pinned_calendar_rehydration")
+    on_ready = _async_function(tree, "on_ready")
+
+    assert _calls_name(event_cache, "run_ready_event_cache_rehydration")
+    assert _calls_name(tracked_views, "run_ready_tracked_view_rehydration")
+    assert _calls_name(pinned_calendar, "run_ready_pinned_calendar_rehydration")
+
+    assert not _calls_name(on_ready, "load_event_cache")
+    assert not _calls_name(on_ready, "load_active_reminders")
+    assert not _calls_name(on_ready, "rehydrate_tracked_views")
+    assert not _calls_name(on_ready, "rehydrate_pinned_calendar_view")


### PR DESCRIPTION
## Summary

- Add a focused `core.event_rehydration_lifecycle` helper for Phase 6F event cache, active reminder loading, event readiness gating, tracked view rehydration, and pinned calendar rehydration scheduling.
- Route `bot_instance.py:on_ready()` through named startup phases: `ready_event_cache_rehydration`, `ready_view_rehydration`, and `ready_pinned_calendar_rehydration`.
- Preserve the current event-dependent startup bundle and explicitly defer scheduler/task-supervision ownership to Phase 6G.
- Preserve tracked-view and pinned-calendar rehydration scheduling as best-effort so scheduling failures do not block later startup phases.
- Include startup runbook, deferred optimisation, and Phase 6 task-pack updates, including the pinned calendar tracker atomic persistence follow-up.

## Validation

- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_event_cache.py tests\test_rehydrate_views.py tests\test_rehydrate_views_and_localtime.py tests\test_rehydrate_sanitize_and_fileio.py tests\test_calendar_pinned_embed.py tests\test_calendar_reminders.py tests\test_calendar_reminders_dispatch.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py tests\test_event_rehydration_lifecycle.py tests\test_startup_lifecycle.py` (`44 passed`)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1561 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` (`1561 passed, 2 skipped`; production operational logs unchanged)
- `git diff --check`

## Security Review

Diff-scoped security review found no new issue. The change moves startup orchestration around existing reminder/cache/view functions without introducing new user input parsing, SQL, permissions, persistence formats, or external network surfaces. Restart-sensitive scheduler ownership remains unchanged and is captured for Phase 6G.

## Deferred Optimisations

- Phase 6G: split scheduler/task-supervision ownership out of the current event-dependent startup bundle.
- Pinned calendar tracker persistence: replace raw `Path.write_text()` JSON writes with the established atomic JSON helper pattern in a later focused task.

## Risk / Rollback

Risk: medium, because startup and Discord rehydration ordering is touched. Behavior is intended to be order-preserving and covered by focused startup/rehydration tests plus the full suite.

Rollback: revert this PR and restart from the previous production-tested Phase 6E startup path.