### PR TITLE
[codex] Add DL_bot Phase 6G scheduler lifecycle boundary

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -66,6 +66,13 @@ from core.event_rehydration_lifecycle import (
     wait_for_events,
 )
 from core.interaction_safety import get_operation_lock
+from core.scheduler_lifecycle import (
+    run_ready_calendar_scheduler_tasks,
+    run_ready_domain_scheduler_tasks,
+    run_ready_event_scheduler_tasks,
+    start_event_cache_refresh_loop,
+    start_legacy_reminder_cleanup,
+)
 from core.startup_lifecycle import StartupPhase, run_startup_phases
 from crystaltech_di import init_crystaltech_service
 from daily_KVK_overview_embed import post_or_update_daily_KVK_overview
@@ -298,7 +305,7 @@ async def calendar_reminder_task():
     await run_calendar_reminder_loop(bot)
 
 
-async def _start_event_dependent_tasks():
+async def _start_event_scheduler_tasks():
     """Start tasks that require a ready event cache."""
     # Live embeds
     task_monitor.create("periodic_live_embed_update", periodic_live_embed_update)
@@ -1514,6 +1521,9 @@ async def on_ready():
         await run_startup_phases(
             [StartupPhase("ready_event_cache_rehydration", _run_ready_event_cache_rehydration)]
         )
+        await run_startup_phases(
+            [StartupPhase("ready_event_scheduler_tasks", _run_ready_event_scheduler_tasks)]
+        )
 
         try:
             schedule_bg("warm_name_cache", 8.0, lambda: warm_name_cache())
@@ -1561,60 +1571,26 @@ async def on_ready():
         except Exception:
             logger.exception("[SUBSCRIPTIONS] Failed to load at startup")
 
-        try:
-            if not refresh_event_cache_task.is_running():
-                refresh_event_cache_task.start()
-            else:
-                logger.info("[BOOT] refresh_event_cache_task already running; skipping start.")
-        except Exception:
-            logger.exception("[BOOT] Failed to start refresh_event_cache_task")
+        await run_startup_phases(
+            [StartupPhase("ready_event_cache_refresh_loop", _run_ready_event_cache_refresh_loop)]
+        )
 
         await run_startup_phases(
             [StartupPhase("ready_view_rehydration", _run_ready_view_rehydration)]
         )
-
-        try:
-            task_monitor.create("ark_scheduler", lambda: schedule_ark_lifecycle(bot))
-            logger.info("[BOOT] Ark scheduler started")
-        except Exception as e:
-            logger.error(f"[BOOT] Failed to start Ark scheduler: {e}")
-
-        try:
-            if not task_monitor.is_running("refresh_mge_caches_on_startup"):
-                task_monitor.create(
-                    "refresh_mge_caches_on_startup",
-                    _refresh_mge_caches_on_startup,
-                    replace=False,
-                )
-                logger.info("[BOOT] MGE cache refresh scheduled")
-            else:
-                logger.info("[BOOT] MGE cache refresh already running")
-        except Exception:
-            logger.exception("[BOOT] Failed to schedule MGE cache refresh")
-
-        try:
-            if not task_monitor.is_running("mge_lifecycle"):
-                task_monitor.create(
-                    "mge_lifecycle",
-                    lambda: schedule_mge_lifecycle(bot),
-                    replace=False,
-                )
-                logger.info("[BOOT] MGE scheduler started")
-            else:
-                logger.info("[BOOT] MGE scheduler already running")
-        except Exception:
-            logger.exception("[BOOT] Failed to start MGE scheduler")
+        await run_startup_phases(
+            [StartupPhase("ready_domain_scheduler_tasks", _run_ready_domain_scheduler_tasks)]
+        )
 
         logger.info("[DEBUG] Calling full_startup_sequence...")
         try:
             await full_startup_sequence()
         except Exception:
             logger.exception("[STARTUP] ❌ full_startup_sequence failed")
-        try:
-            task_monitor.create("reminder_cleanup", reminder_cleanup_loop)
-            logger.info("[BOOT] Reminder cleanup task started")
-        except Exception:
-            logger.exception("[BOOT] Failed to start reminder_cleanup_loop")
+        await start_legacy_reminder_cleanup(
+            task_monitor_create=task_monitor.create,
+            reminder_cleanup_loop=reminder_cleanup_loop,
+        )
 
         await run_startup_phases(
             [
@@ -1625,26 +1601,9 @@ async def on_ready():
             ]
         )
 
-        try:
-            task_monitor.create(
-                "daily_pinned_calendar_refresh", schedule_daily_pinned_calendar_refresh
-            )
-            logger.info("[BOOT] daily pinned calendar refresh started")
-        except Exception:
-            logger.exception("[BOOT] failed to start daily pinned calendar refresh")
-
-        try:
-            if not task_monitor.is_running("calendar_reminder_loop"):
-                task_monitor.create(
-                    "calendar_reminder_loop",
-                    calendar_reminder_task,
-                    replace=False,
-                )
-                logger.info("[CALENDAR][REMINDER] reminder loop armed")
-            else:
-                logger.info("[CALENDAR][REMINDER] reminder loop already running; skipping")
-        except Exception:
-            logger.exception("[BOOT] failed to start calendar reminder loop")
+        await run_startup_phases(
+            [StartupPhase("ready_calendar_scheduler_tasks", _run_ready_calendar_scheduler_tasks)]
+        )
 
     except Exception:
         logger.exception("[CRITICAL] Exception during on_ready")
@@ -1675,8 +1634,14 @@ async def _run_ready_event_cache_rehydration() -> None:
     _startup_loaded_reminder_ids = await run_ready_event_cache_rehydration(
         bot=bot,
         schedule_bg=schedule_bg,
+    )
+
+
+async def _run_ready_event_scheduler_tasks() -> None:
+    await run_ready_event_scheduler_tasks(
+        start_event_scheduler_tasks=_start_event_scheduler_tasks,
+        wait_for_events=wait_for_events,
         task_monitor_create=task_monitor.create,
-        start_event_dependent_tasks=_start_event_dependent_tasks,
     )
 
 
@@ -1684,8 +1649,31 @@ async def _run_ready_view_rehydration() -> None:
     await run_ready_tracked_view_rehydration(bot=bot, schedule_bg=schedule_bg)
 
 
+async def _run_ready_event_cache_refresh_loop() -> None:
+    await start_event_cache_refresh_loop(refresh_event_cache_task=refresh_event_cache_task)
+
+
+async def _run_ready_domain_scheduler_tasks() -> None:
+    await run_ready_domain_scheduler_tasks(
+        task_monitor_create=task_monitor.create,
+        task_monitor_is_running=task_monitor.is_running,
+        schedule_ark_lifecycle=lambda: schedule_ark_lifecycle(bot),
+        refresh_mge_caches_on_startup=_refresh_mge_caches_on_startup,
+        schedule_mge_lifecycle=lambda: schedule_mge_lifecycle(bot),
+    )
+
+
 async def _run_ready_pinned_calendar_rehydration() -> None:
     await run_ready_pinned_calendar_rehydration(bot=bot, schedule_bg=schedule_bg)
+
+
+async def _run_ready_calendar_scheduler_tasks() -> None:
+    await run_ready_calendar_scheduler_tasks(
+        task_monitor_create=task_monitor.create,
+        task_monitor_is_running=task_monitor.is_running,
+        schedule_daily_pinned_calendar_refresh=schedule_daily_pinned_calendar_refresh,
+        calendar_reminder_task=calendar_reminder_task,
+    )
 
 
 async def _run_ready_runtime_services() -> None:

--- a/core/event_rehydration_lifecycle.py
+++ b/core/event_rehydration_lifecycle.py
@@ -19,8 +19,6 @@ from rehydrate_views import rehydrate_tracked_views
 logger = logging.getLogger(__name__)
 
 ScheduleBackground = Callable[[str, float, Callable[[], Awaitable[Any]]], Any]
-TaskMonitorCreate = Callable[[str, Callable[[], Awaitable[Any]]], Any]
-StartupCoroutine = Callable[[], Awaitable[Any]]
 
 
 async def wait_for_events(timeout_seconds: int = 10) -> bool:
@@ -36,33 +34,12 @@ async def wait_for_events(timeout_seconds: int = 10) -> bool:
     return False
 
 
-async def _start_event_tasks_when_ready(
-    *,
-    start_event_dependent_tasks: StartupCoroutine,
-    max_wait_seconds: int,
-) -> None:
-    try:
-        ready = await wait_for_events(timeout_seconds=max_wait_seconds)
-        if not ready:
-            logger.warning(
-                "[BOOT] Event cache still not ready after %ss; "
-                "skipping event-dependent task start for now.",
-                max_wait_seconds,
-            )
-            return
-        await start_event_dependent_tasks()
-    except Exception:
-        logger.exception("[BOOT] event_tasks_when_ready failed")
-
-
 async def run_ready_event_cache_rehydration(
     *,
     bot: Any,
     schedule_bg: ScheduleBackground,
-    task_monitor_create: TaskMonitorCreate,
-    start_event_dependent_tasks: StartupCoroutine,
 ) -> set[Any]:
-    """Load reminder/cache state and start the existing event-ready startup bundle."""
+    """Load reminder/cache state and schedule the one-shot cache refresh."""
     logger.info("[REMINDER_CACHE] Attempting to load from %s", REMINDER_TRACKING_FILE)
     loaded_ids = await load_active_reminders(bot)
 
@@ -82,26 +59,6 @@ async def run_ready_event_cache_rehydration(
         logger.exception("[STARTUP] Failed to load or refresh event cache")
 
     schedule_bg("refresh_event_cache_once", 10.0, lambda: refresh_event_cache())
-
-    ready = await wait_for_events(10)
-    if ready:
-        logger.info(
-            "[BOOT] Starting current event-dependent task bundle; scheduler ownership "
-            "split is deferred to Phase 6G."
-        )
-        await start_event_dependent_tasks()
-    else:
-        logger.warning(
-            "[BOOT] Event cache not ready; will wait in background and start "
-            "event-dependent tasks when populated."
-        )
-        task_monitor_create(
-            "event_tasks_when_ready",
-            lambda: _start_event_tasks_when_ready(
-                start_event_dependent_tasks=start_event_dependent_tasks,
-                max_wait_seconds=300,
-            ),
-        )
 
     return set(loaded_ids or set())
 

--- a/core/scheduler_lifecycle.py
+++ b/core/scheduler_lifecycle.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+StartupCoroutine = Callable[[], Awaitable[Any]]
+TaskMonitorCreate = Callable[..., Any]
+TaskMonitorIsRunning = Callable[[str], bool]
+
+
+async def _start_event_tasks_when_ready(
+    *,
+    start_event_scheduler_tasks: StartupCoroutine,
+    wait_for_events: Callable[[int], Awaitable[bool]],
+    max_wait_seconds: int,
+) -> None:
+    try:
+        ready = await wait_for_events(max_wait_seconds)
+        if not ready:
+            logger.warning(
+                "[BOOT] Event cache still not ready after %ss; "
+                "skipping event-dependent scheduler start for now.",
+                max_wait_seconds,
+            )
+            return
+        await start_event_scheduler_tasks()
+    except Exception:
+        logger.exception("[BOOT] event_tasks_when_ready failed")
+
+
+async def run_ready_event_scheduler_tasks(
+    *,
+    start_event_scheduler_tasks: StartupCoroutine,
+    wait_for_events: Callable[[int], Awaitable[bool]],
+    task_monitor_create: TaskMonitorCreate,
+    ready_wait_seconds: int = 10,
+    deferred_wait_seconds: int = 300,
+) -> None:
+    """Start event-cache-dependent scheduler tasks after event readiness."""
+    ready = await wait_for_events(ready_wait_seconds)
+    if ready:
+        logger.info("[BOOT] Starting event-dependent scheduler task bundle.")
+        await start_event_scheduler_tasks()
+        return
+
+    logger.warning(
+        "[BOOT] Event cache not ready; will wait in background and start "
+        "event-dependent scheduler tasks when populated."
+    )
+    task_monitor_create(
+        "event_tasks_when_ready",
+        lambda: _start_event_tasks_when_ready(
+            start_event_scheduler_tasks=start_event_scheduler_tasks,
+            wait_for_events=wait_for_events,
+            max_wait_seconds=deferred_wait_seconds,
+        ),
+    )
+
+
+async def run_ready_domain_scheduler_tasks(
+    *,
+    task_monitor_create: TaskMonitorCreate,
+    task_monitor_is_running: TaskMonitorIsRunning,
+    schedule_ark_lifecycle: StartupCoroutine,
+    refresh_mge_caches_on_startup: StartupCoroutine,
+    schedule_mge_lifecycle: StartupCoroutine,
+) -> None:
+    """Register domain scheduler tasks that run after event/view readiness."""
+    try:
+        task_monitor_create("ark_scheduler", schedule_ark_lifecycle)
+        logger.info("[BOOT] Ark scheduler started")
+    except Exception:
+        logger.exception("[BOOT] Failed to start Ark scheduler")
+
+    try:
+        if not task_monitor_is_running("refresh_mge_caches_on_startup"):
+            task_monitor_create(
+                "refresh_mge_caches_on_startup",
+                refresh_mge_caches_on_startup,
+                replace=False,
+            )
+            logger.info("[BOOT] MGE cache refresh scheduled")
+        else:
+            logger.info("[BOOT] MGE cache refresh already running")
+    except Exception:
+        logger.exception("[BOOT] Failed to schedule MGE cache refresh")
+
+    try:
+        if not task_monitor_is_running("mge_lifecycle"):
+            task_monitor_create(
+                "mge_lifecycle",
+                schedule_mge_lifecycle,
+                replace=False,
+            )
+            logger.info("[BOOT] MGE scheduler started")
+        else:
+            logger.info("[BOOT] MGE scheduler already running")
+    except Exception:
+        logger.exception("[BOOT] Failed to start MGE scheduler")
+
+
+async def start_event_cache_refresh_loop(*, refresh_event_cache_task: Any) -> None:
+    """Start the long-running event cache refresh loop at its existing startup point."""
+    try:
+        if not refresh_event_cache_task.is_running():
+            refresh_event_cache_task.start()
+        else:
+            logger.info("[BOOT] refresh_event_cache_task already running; skipping start.")
+    except Exception:
+        logger.exception("[BOOT] Failed to start refresh_event_cache_task")
+
+
+async def start_legacy_reminder_cleanup(
+    *,
+    task_monitor_create: TaskMonitorCreate,
+    reminder_cleanup_loop: StartupCoroutine,
+) -> None:
+    """Register the legacy reminder cleanup loop at its existing startup point."""
+    try:
+        task_monitor_create("reminder_cleanup", reminder_cleanup_loop)
+        logger.info("[BOOT] Reminder cleanup task started")
+    except Exception:
+        logger.exception("[BOOT] Failed to start reminder_cleanup_loop")
+
+
+async def run_ready_calendar_scheduler_tasks(
+    *,
+    task_monitor_create: TaskMonitorCreate,
+    task_monitor_is_running: TaskMonitorIsRunning,
+    schedule_daily_pinned_calendar_refresh: StartupCoroutine,
+    calendar_reminder_task: StartupCoroutine,
+) -> None:
+    """Register calendar scheduler tasks that run after pinned calendar rehydration."""
+    try:
+        task_monitor_create(
+            "daily_pinned_calendar_refresh",
+            schedule_daily_pinned_calendar_refresh,
+        )
+        logger.info("[BOOT] daily pinned calendar refresh started")
+    except Exception:
+        logger.exception("[BOOT] failed to start daily pinned calendar refresh")
+
+    try:
+        if not task_monitor_is_running("calendar_reminder_loop"):
+            task_monitor_create(
+                "calendar_reminder_loop",
+                calendar_reminder_task,
+                replace=False,
+            )
+            logger.info("[CALENDAR][REMINDER] reminder loop armed")
+        else:
+            logger.info("[CALENDAR][REMINDER] reminder loop already running; skipping")
+    except Exception:
+        logger.exception("[BOOT] failed to start calendar reminder loop")

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -80,7 +80,7 @@ successful manual command resync.
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md`, with
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md`, with
 this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -149,20 +149,20 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, task supervision, queue worker startup, live queue rehydration, cache warming, scheduler startup, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, and Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner. Remaining `on_ready()` work still mixes event cache refresh, reminder state loading, tracked/live view rehydration, pinned calendar rehydration, scheduler registration, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. The next PR-sized slice is event cache, reminder loading, and rehydration boundary extraction from `docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md`; after that, keep scheduler/task supervision, queue worker lifecycle, shutdown coordination, and final process-entry/bot-construction cleanup in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, queue worker startup, live queue rehydration, cache warming, startup notifications, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner, Phase 6F extracted event cache, reminder loading, tracked view rehydration, and pinned calendar view rehydration behind named lifecycle boundaries, and Phase 6G extracted scheduler/task-supervision startup into `core/scheduler_lifecycle.py`. Remaining `on_ready()` work still mixes cache warming, queue worker startup, startup notifications, and later shutdown coordination.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. After Phase 6G, keep queue worker lifecycle, shutdown coordination, and final process-entry/bot-construction cleanup in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6E lifecycle slices are complete, merged, production-pushed, and smoke tested; proceed with audit/design before each remaining implementation slice.
+- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6F lifecycle slices are complete, merged, production-pushed, and smoke tested; Phase 6G is the current scheduler/task-supervision implementation slice and should be smoke tested before marking complete.
 
 ### Deferred Optimisation
 - Area: `bot_instance.py:_start_event_dependent_tasks`
 - Type: architecture
-- Description: The Phase 6F event cache and rehydration boundary deliberately preserves the existing event-dependent startup bundle, which still mixes readiness-bound live view rehydration with scheduler/task-supervision concerns such as periodic live embed updates, daily KVK overview updates, legacy event reminder scheduling, and event embed expiry.
-- Suggested Fix: In Phase 6G, split scheduler and task-supervision ownership out of the event cache/rehydration boundary into a focused lifecycle owner while preserving readiness gating, startup order, `TaskMonitor` duplicate prevention, and existing production logging.
+- Description: Phase 6G moved the event-dependent scheduler bundle and later Ark/MGE/calendar scheduler registrations out of `bot_instance.py:on_ready()` and the event cache/rehydration boundary into `core/scheduler_lifecycle.py`, while preserving readiness gating, startup order, `TaskMonitor` duplicate prevention, and existing production logging.
+- Suggested Fix: After Phase 6G production smoke, remove this item from the active backlog or move it to resolved history. Keep any remaining queue-worker, shutdown, process-entry, and pinned-calendar persistence work as separate deferred items.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6F boundary extraction approved with scheduler ownership explicitly deferred to Phase 6G.
+- Dependencies: Phase 6F boundary extraction completed in PR 123 (`codex/dlbot-phase-6f-event-rehydration`), smoke tested cleanly, merged, and pushed to production; scheduler ownership was explicitly deferred to Phase 6G.
 
 ### Deferred Optimisation
 - Area: `event_calendar/pinned_embed.py`

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -22,11 +22,19 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
      Phase 6E also converged `/ops` command lifecycle admin tooling onto the same command
      lifecycle helpers while keeping Discord admin UX in `commands/admin_cmds.py`.
    - `ready_event_cache_rehydration` owns active reminder loading, event cache disk load,
-     stale/empty cache refresh, one-shot refresh scheduling, and the current event-dependent
-     startup bundle. Scheduler ownership inside that bundle remains deferred to Phase 6G.
+     stale/empty cache refresh, and one-shot refresh scheduling.
+   - `ready_event_scheduler_tasks` owns event-readiness-gated startup for live event embed
+     updates, daily KVK overview updates, event reminders, reminder format refresh,
+     live-event view rehydration, and event embed expiry.
+   - `ready_event_cache_refresh_loop` starts the long-running event cache refresh loop at the
+     existing point before tracked view rehydration.
    - `ready_view_rehydration` schedules tracked persistent view rehydration.
+   - `ready_domain_scheduler_tasks` starts the Ark lifecycle scheduler, MGE cache warm, and MGE
+     lifecycle scheduler.
    - `ready_pinned_calendar_rehydration` schedules pinned calendar view rehydration at the
      existing later startup point after `full_startup_sequence()`.
+   - `ready_calendar_scheduler_tasks` starts the daily pinned calendar refresh and calendar
+     reminder loop after pinned calendar rehydration.
 9. Caches, rehydration, background tasks, heartbeat, and admin notification start.
 
 ## Main Files
@@ -41,6 +49,7 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
 - `singleton_lock.py`
 - `Commands.py`
 - `core/command_lifecycle.py`
+- `core/scheduler_lifecycle.py`
 
 ## Startup Guards
 
@@ -89,10 +98,13 @@ alert usage events. Phase 6D moved startup command signature/cache/sync handling
 `ready_command_sync` and `core/command_lifecycle.py`. Phase 6E reused that lifecycle owner from
 `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions`; production
 smoke on 2026-05-28 confirmed those commands loaded, executed, flushed usage telemetry, and manual
-scoped command resync completed successfully. Phase 6F added explicit boundaries for event cache,
-reminder loading, tracked view rehydration, and pinned calendar rehydration while preserving the
-existing event-dependent scheduler bundle for Phase 6G. Remaining lifecycle cleanup continues with
-scheduler/task supervision, queue worker lifecycle, shutdown coordination, and final
+scoped command resync completed successfully. Phase 6F completed in PR 123
+(`codex/dlbot-phase-6f-event-rehydration`), was smoke tested cleanly, merged, and pushed to
+production: event cache, reminder loading, tracked view rehydration, and pinned calendar
+rehydration now have explicit startup lifecycle boundaries. Phase 6G then separated scheduler and
+task-supervision startup into `core/scheduler_lifecycle.py` while preserving event readiness
+gating, task names, duplicate prevention, and the existing Ark/MGE/calendar ordering. Remaining
+lifecycle cleanup continues with queue worker lifecycle, shutdown coordination, and final
 process-entry/bot-construction cleanup.
 
 When changing startup, verify restart safety and avoid duplicate task creation.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md
@@ -1,7 +1,22 @@
 # Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary
 
-Use this starter to continue Phase 6 after Phase 6E command lifecycle admin tooling convergence
-was merged, smoke-tested, pushed to production, and marked complete.
+Status: complete. PR 123 (`codex/dlbot-phase-6f-event-rehydration`) was merged, smoke-tested,
+and pushed to production on 2026-05-28. This starter is retained as historical context for Phase
+6F.
+
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md`
+for the next Phase 6 slice.
+
+Delivered outcome:
+
+- `core/event_rehydration_lifecycle.py` now owns event cache/reminder/view rehydration startup
+  ordering, readiness gating, and best-effort scheduling boundaries.
+- `bot_instance.py:on_ready()` delegates through `ready_event_cache_rehydration`,
+  `ready_view_rehydration`, and `ready_pinned_calendar_rehydration`.
+- The current event-dependent scheduler bundle was deliberately preserved and deferred to Phase 6G.
+- Production smoke confirmed clean startup phases, event cache ready count, active reminder
+  rehydration, tracked view scheduling, pinned calendar rehydration scheduling, later scheduler
+  continuation, full startup completion, and no Phase 6F error signatures.
 
 Approved Phase 6F scope decision: extract event cache, reminder loading, tracked view rehydration,
 and pinned calendar rehydration behind explicit startup lifecycle boundaries. Preserve the current

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md
@@ -1,0 +1,280 @@
+# Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary
+
+Use this starter to continue Phase 6 after Phase 6F event cache, reminder loading, and
+rehydration boundary was merged, smoke-tested, pushed to production, and marked complete.
+
+Status: implementation approved and in progress. The approved ownership model uses
+`core/scheduler_lifecycle.py` for scheduler/task registration ordering, `TaskMonitor`
+registration, duplicate prevention, readiness gating, and best-effort logging. Scheduler
+implementation behavior remains in the existing domain modules.
+The long-running `refresh_event_cache_task` loop keeps its prior startup position before tracked
+view rehydration through the dedicated `ready_event_cache_refresh_loop` phase.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6G:
+scheduler and task-supervision boundary.
+
+Phase 6A, 6B, 6C, 6D, 6E, and 6F are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged and pushed to production.
+- PR 123 (`codex/dlbot-phase-6f-event-rehydration`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `core/command_lifecycle.py` owns startup command signature/cache/sync mechanics and shared
+  `/ops` command lifecycle mechanics.
+- `core/event_rehydration_lifecycle.py` owns event cache, active reminder loading, event readiness
+  gating, tracked view rehydration scheduling, and pinned calendar view rehydration scheduling.
+- `bot_instance.py:on_ready()` delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+  - startup command signature/cache/sync through `ready_command_sync`
+  - event cache/reminder/live-event readiness through `ready_event_cache_rehydration`
+  - tracked view rehydration through `ready_view_rehydration`
+  - pinned calendar rehydration through `ready_pinned_calendar_rehydration`
+- Production smoke logs confirmed for Phase 6F:
+  - event reminder state loaded from `REMINDER_TRACKING_FILE`
+  - event cache loaded from disk and one-shot refresh completed
+  - event cache ready count was logged
+  - event-dependent live views rehydrated
+  - tracked view rehydration was scheduled
+  - pinned calendar view rehydration was scheduled and completed
+  - Ark/MGE schedulers, `full_startup_sequence()`, reminder cleanup, daily pinned calendar refresh,
+    and calendar reminder loop still started afterward
+  - no startup phase failure, event cache failure, tracked-view scheduling failure,
+    pinned-calendar scheduling failure, or `on_ready()` critical exception was observed
+
+This is review/scope first. Do not implement code changes until the Phase 6G scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/reference/events_and_dm_reminders.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6F Event Cache Rehydration Boundary.md`
+
+## Phase 6G Objective
+
+Separate scheduler and task-supervision startup responsibilities from `bot_instance.py:on_ready()`
+and from the current event-dependent compatibility bundle while preserving startup order,
+readiness gating, best-effort failure boundaries, and duplicate-task prevention.
+
+The next cohesive slice is scheduler/task registration after Phase 6F:
+
+- event-dependent scheduler bundle currently grouped in `_start_event_dependent_tasks()`
+- long-running event cache refresh loop startup through `refresh_event_cache_task`
+- Ark lifecycle scheduler startup through `schedule_ark_lifecycle(bot)`
+- MGE cache warm and lifecycle scheduler startup through `_refresh_mge_caches_on_startup()` and
+  `schedule_mge_lifecycle(bot)`
+- legacy reminder cleanup loop startup through `reminder_cleanup_loop`
+- daily pinned calendar refresh startup through `schedule_daily_pinned_calendar_refresh`
+- calendar reminder loop startup through `calendar_reminder_task()` and `run_calendar_reminder_loop(bot)`
+- related `TaskMonitor.create()` keys, `replace=False` behavior, and `is_running()` checks
+
+Recommended target: keep a non-Discord lifecycle helper in `core/` or a narrowly scoped startup
+module responsible for ordering, idempotency, logging, `TaskMonitor` registration, and outcome
+reporting. Keep scheduler implementation logic in existing domain modules such as `ark/`,
+`mge/`, `event_scheduler.py`, and `event_calendar/`.
+
+## In Scope
+
+- Audit the relationship between:
+  - `bot_instance.py:on_ready()`
+  - `_start_event_dependent_tasks()`
+  - `schedule_bg()`
+  - `_with_timeout()`
+  - `TaskMonitor.create()`, `TaskMonitor.is_running()`, and task names
+  - `refresh_event_cache_task`
+  - `periodic_live_embed_update()`
+  - `schedule_daily_KVK_overview()`
+  - `schedule_event_reminders()`
+  - `refresh_reminder_format()`
+  - `rehydrate_live_event_views()`
+  - `schedule_event_embed_expiry()`
+  - `schedule_ark_lifecycle(bot)`
+  - `_refresh_mge_caches_on_startup()`
+  - `schedule_mge_lifecycle(bot)`
+  - `reminder_cleanup_loop`
+  - `schedule_daily_pinned_calendar_refresh()`
+  - `calendar_reminder_task()`
+  - `run_calendar_reminder_loop(bot)`
+- Define the exact startup ordering that must be preserved.
+- Decide whether this should be one named startup phase or two smaller scheduler phases.
+- Preserve event readiness gating from Phase 6F.
+- Preserve restart safety and duplicate-task prevention.
+- Preserve best-effort behavior for non-critical scheduler registration failures.
+- Add or update focused tests for successful registration, skipped duplicate registration,
+  best-effort failure logging, and continued startup behavior where practical.
+- Capture queue-worker, shutdown, process-entry, and pinned-calendar persistence findings as later
+  work unless explicitly approved for this slice.
+
+## Out Of Scope
+
+- Queue worker startup, live queue rehydration, queue embed refresh, or queue persistence changes.
+- Shutdown redesign, signal handling, singleton/PID cleanup, or logging shutdown order.
+- `DL_bot.py` process-entry changes.
+- Command lifecycle, command sync, command cache, slash-command renaming, grouping, or retirement.
+- Event cache load/refresh ownership changes already completed in Phase 6F.
+- View rehydration ownership changes already completed in Phase 6F.
+- Scheduler implementation behavior changes inside Ark, MGE, legacy reminders, or event calendar
+  modules unless needed to preserve current startup behavior.
+- Pinned calendar tracker persistence hardening. This remains a deferred optimisation:
+  `event_calendar/pinned_embed.py` should later replace raw `Path.write_text()` tracker writes with
+  established atomic JSON helper usage.
+- Upload-route behaviour changes.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes unless unexpectedly required by
+  scheduler validation.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `core/startup_lifecycle.py`
+- `core/event_rehydration_lifecycle.py`
+- `ark/ark_scheduler.py`
+- `mge/mge_scheduler.py`
+- `mge/mge_cache.py`
+- `event_scheduler.py`
+- `event_embed_manager.py`
+- `event_calendar/reminders.py`
+- `event_calendar/pinned_embed.py`
+- `event_calendar/scheduler.py`
+- `constants.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_event_rehydration_lifecycle.py`
+- `tests/test_mge_startup_hook_invoked.py`
+- `tests/test_mge_rehydrate_and_regression.py`
+- `tests/test_calendar_pinned_embed.py`
+- `tests/test_calendar_reminders.py`
+- `tests/test_calendar_reminders_dispatch.py`
+- `tests/test_calendar_scheduler.py`
+- `tests/test_ark_scheduler.py`
+- `tests/test_ark_scheduler_post_start.py`
+- `tests/test_command_registration_smoke.py`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- one focused lifecycle helper module if the audit proves a clean extraction
+- focused scheduler/startup lifecycle tests
+- `docs/reference/runbook_startup.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Do not create a broad lifecycle orchestration module that also owns queue workers, shutdown, or
+process entry in Phase 6G.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Scheduler / Task Supervision Map
+- Current Phase 6A-F Startup Lifecycle Boundary Map
+- Proposed Phase 6G Ownership Model
+- Startup Ordering And Idempotency Checklist
+- TaskMonitor Key And Duplicate Prevention Map
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6G Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_event_rehydration_lifecycle.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py tests\test_calendar_pinned_embed.py tests\test_calendar_reminders.py tests\test_calendar_reminders_dispatch.py tests\test_calendar_scheduler.py tests\test_ark_scheduler.py tests\test_ark_scheduler_post_start.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6G touches
+Discord-facing schedulers, reminder state, restart-sensitive task supervision, file-backed runtime
+state, and duplicate-action prevention.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- normal startup still shows all Phase 6A-F startup phases
+- new scheduler/task-supervision phase logs appear in the expected order
+- event-dependent scheduler tasks still start only after event readiness
+- live embed update, daily KVK overview, event reminders, reminder format refresh, live event view
+  rehydration, and event embed expiry still start or complete as before
+- Ark scheduler still starts
+- MGE cache warm and MGE lifecycle scheduler still start
+- `full_startup_sequence()` still runs after scheduler startup
+- reminder cleanup still starts
+- daily pinned calendar refresh still starts after pinned calendar rehydration
+- calendar reminder loop still starts once
+- repeated `on_ready()` still skips startup work and no duplicate background tasks are observed
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+[BOOT] Failed to start schedule_event_reminders
+[BOOT] Failed to start event_embed_expiry task
+[BOOT] Failed to start Ark scheduler
+[BOOT] Failed to start MGE scheduler
+[BOOT] failed to start daily pinned calendar refresh
+[BOOT] failed to start calendar reminder loop
+```
+
+Known best-effort scheduler warnings may be acceptable only when later startup still continues and
+the failure is intentionally induced or otherwise understood.
+
+## Remaining Phase 6 Slices
+
+Recommended order after Phase 6F:
+
+1. Phase 6G scheduler and task-supervision boundary.
+2. Phase 6H queue worker and live queue lifecycle.
+3. Phase 6I shutdown and recovery coordination.
+4. Phase 6J process-entry and bot-construction cleanup.
+
+The wider command-surface migration/renaming programme remains separate from Phase 6.
+
+## Deferred Item Links
+
+This starter continues the DL_bot startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6F completed event cache/reminder/view
+rehydration boundary extraction.
+
+Carry forward, but do not implement unless separately approved:
+
+- scheduler/task-supervision split from the current `_start_event_dependent_tasks()` bundle
+- pinned calendar tracker persistence hardening in `event_calendar/pinned_embed.py`

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-28`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -118,6 +118,36 @@ Phase 6E command lifecycle admin tooling convergence is complete:
   `validate_command_cache`, and `resync_commands` loaded and executed, usage telemetry flushed
   normally, and manual command sync logged `[COMMAND SYNC] Slash commands successfully resynced.`
 - The PR was merged and pushed to production.
+
+Phase 6F event cache, reminder loading, and rehydration boundary is complete:
+
+- PR 123 (`codex/dlbot-phase-6f-event-rehydration`) added
+  `core/event_rehydration_lifecycle.py`.
+- `bot_instance.py:on_ready()` now routes event cache/reminder/view rehydration through
+  `ready_event_cache_rehydration`, `ready_view_rehydration`, and
+  `ready_pinned_calendar_rehydration`.
+- The current event-dependent scheduler bundle was deliberately preserved as a compatibility path
+  and deferred to Phase 6G for scheduler/task-supervision ownership.
+- Production smoke testing on 2026-05-28 confirmed clean startup phase logs, active reminder
+  rehydration, event cache load/refresh, tracked view rehydration scheduling, pinned calendar
+  rehydration scheduling, Ark/MGE scheduler continuation, `full_startup_sequence()` completion,
+  reminder cleanup, daily pinned calendar refresh startup, and calendar reminder loop startup.
+- No startup phase failure, event cache failure, tracked-view scheduling failure, pinned-calendar
+  scheduling failure, or `on_ready()` critical exception was observed.
+- The PR was merged and pushed to production.
+
+Phase 6G scheduler and task-supervision boundary is the current implementation slice:
+
+- `core/scheduler_lifecycle.py` owns scheduler/task registration ordering, readiness gating,
+  `TaskMonitor` registration, duplicate-prevention checks, and best-effort logging.
+- `bot_instance.py:on_ready()` delegates event-dependent schedulers through
+  `ready_event_scheduler_tasks`, the long-running event cache refresh loop through
+  `ready_event_cache_refresh_loop`, Ark/MGE schedulers through `ready_domain_scheduler_tasks`, and
+  calendar schedulers through `ready_calendar_scheduler_tasks`.
+- `reminder_cleanup` deliberately remains at its existing point after `full_startup_sequence()` and
+  before pinned calendar rehydration.
+- Queue worker lifecycle, shutdown coordination, and process-entry cleanup remain later Phase 6
+  slices.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -329,8 +359,9 @@ Initial classification before audit:
 | Usage tracker lifecycle ownership | complete | Phase 6C consolidated command/component/metric/alert usage logging onto the shared `usage_tracker.py` singleton and moved usage JSONL pruning into `ready_runtime_services`, preserving startup order and smoke-tested behaviour. |
 | Command signature/cache/sync ownership | complete | Phase 6D moved startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, preserving cache, scoped sync, timeout telemetry, and loaded-command logging behaviour. |
 | Command lifecycle admin tooling convergence | complete | Phase 6E reused `core/command_lifecycle.py` from `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while preserving admin permissions, embeds, timeout behaviour, and operator-facing summaries. |
-| Event cache, reminder loading, and rehydration boundary | approved/current slice | Phase 6F separates event cache load/refresh, active reminder loading, event-dependent view rehydration, tracked view rehydration, and pinned calendar view rehydration from the remaining `on_ready()` body with explicit ordering and startup phase logs. Scheduler ownership inside the existing event-dependent bundle is deliberately deferred to Phase 6G. |
-| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move event rehydration, schedulers, queue workers, startup notifications, and shutdown together. |
+| Event cache, reminder loading, and rehydration boundary | complete | Phase 6F separated event cache load/refresh, active reminder loading, event-dependent view rehydration, tracked view rehydration, and pinned calendar view rehydration from the remaining `on_ready()` body with explicit ordering and startup phase logs. Scheduler ownership inside the existing event-dependent bundle was deliberately deferred to Phase 6G. |
+| Scheduler and task-supervision boundary | current slice | Phase 6G separates scheduler/task registration from the remaining `on_ready()` body and the current event-dependent bundle while preserving startup order, readiness gates, best-effort behavior, and `TaskMonitor` duplicate prevention. |
+| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move cache warming, queue workers, startup notifications, and shutdown together. |
 | Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
@@ -340,20 +371,13 @@ Final decisions should be updated after each Phase 6 sub-phase.
 
 ## 13.1 Remaining Phase 6 Slices
 
-Current recommended order after Phase 6E:
+Current recommended order after Phase 6G:
 
-1. Phase 6F event cache, reminder loading, and rehydration boundary: separate event cache refresh,
-   reminder state loading, tracked view rehydration, and calendar pinned view rehydration from the
-   remaining `on_ready()` body with explicit startup ordering. Preserve the current event-dependent
-   scheduler bundle as a compatibility path and carry the scheduler/task-supervision split into
-   Phase 6G.
-2. Phase 6G scheduler and task-supervision boundary: extract Ark, MGE, event reminder, calendar reminder,
-   daily pinned refresh, and related TaskMonitor registrations into named lifecycle ownership.
-3. Phase 6H queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
+1. Phase 6H queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
    queue embed refresh, and queue persistence/recovery concerns.
-4. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
+2. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
    cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order.
-5. Phase 6J process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
+3. Phase 6J process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
    stable, review whether `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final
    ownership split.
 

--- a/tests/test_event_rehydration_lifecycle.py
+++ b/tests/test_event_rehydration_lifecycle.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from core import event_rehydration_lifecycle as lifecycle
 
 
 @pytest.mark.asyncio
-async def test_ready_event_cache_rehydration_refreshes_and_starts_event_bundle(monkeypatch):
+async def test_ready_event_cache_rehydration_refreshes_and_schedules_one_shot(monkeypatch):
     calls: list[str] = []
 
     async def fake_load_active_reminders(_bot):
@@ -19,28 +17,19 @@ async def test_ready_event_cache_rehydration_refreshes_and_starts_event_bundle(m
         calls.append("refresh_event_cache")
         return 1
 
-    async def fake_start_event_dependent_tasks():
-        calls.append("start_event_dependent_tasks")
-
     def fake_schedule_bg(name, timeout, coro_factory):
         calls.append(f"schedule_bg:{name}:{timeout}")
         assert callable(coro_factory)
-
-    def fake_task_monitor_create(name, factory):
-        calls.append(f"task_monitor:{name}")
 
     monkeypatch.setattr(lifecycle, "load_active_reminders", fake_load_active_reminders)
     monkeypatch.setattr(lifecycle, "load_event_cache", lambda: calls.append("load_event_cache"))
     monkeypatch.setattr(lifecycle, "is_cache_stale", lambda: True)
     monkeypatch.setattr(lifecycle, "get_all_upcoming_events", lambda: [{"name": "Ready"}])
     monkeypatch.setattr(lifecycle, "refresh_event_cache", fake_refresh_event_cache)
-    monkeypatch.setattr(lifecycle, "wait_for_events", AsyncMock(return_value=True))
 
     loaded = await lifecycle.run_ready_event_cache_rehydration(
         bot=object(),
         schedule_bg=fake_schedule_bg,
-        task_monitor_create=fake_task_monitor_create,
-        start_event_dependent_tasks=fake_start_event_dependent_tasks,
     )
 
     assert loaded == {"event-1"}
@@ -49,28 +38,18 @@ async def test_ready_event_cache_rehydration_refreshes_and_starts_event_bundle(m
         "load_event_cache",
         "refresh_event_cache",
         "schedule_bg:refresh_event_cache_once:10.0",
-        "start_event_dependent_tasks",
     ]
 
 
 @pytest.mark.asyncio
-async def test_ready_event_cache_rehydration_defers_event_bundle_until_ready(monkeypatch):
+async def test_ready_event_cache_rehydration_schedules_one_shot_when_empty(monkeypatch):
     calls: list[str] = []
-    scheduled: dict[str, object] = {}
 
     async def fake_load_active_reminders(_bot):
         return set()
 
-    async def fake_start_event_dependent_tasks():
-        calls.append("start_event_dependent_tasks")
-
     def fake_schedule_bg(name, timeout, coro_factory):
         calls.append(f"schedule_bg:{name}:{timeout}")
-
-    def fake_task_monitor_create(name, factory):
-        scheduled["name"] = name
-        scheduled["factory"] = factory
-        calls.append(f"task_monitor:{name}")
 
     monkeypatch.setattr(lifecycle, "load_active_reminders", fake_load_active_reminders)
     monkeypatch.setattr(lifecycle, "load_event_cache", lambda: None)
@@ -82,23 +61,17 @@ async def test_ready_event_cache_rehydration_defers_event_bundle_until_ready(mon
         return 0
 
     monkeypatch.setattr(lifecycle, "refresh_event_cache", fake_refresh_event_cache)
-    monkeypatch.setattr(lifecycle, "wait_for_events", AsyncMock(return_value=False))
 
     loaded = await lifecycle.run_ready_event_cache_rehydration(
         bot=object(),
         schedule_bg=fake_schedule_bg,
-        task_monitor_create=fake_task_monitor_create,
-        start_event_dependent_tasks=fake_start_event_dependent_tasks,
     )
 
     assert loaded == set()
     assert calls == [
         "refresh_event_cache",
         "schedule_bg:refresh_event_cache_once:10.0",
-        "task_monitor:event_tasks_when_ready",
     ]
-    assert scheduled["name"] == "event_tasks_when_ready"
-    assert callable(scheduled["factory"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler_lifecycle.py
+++ b/tests/test_scheduler_lifecycle.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+
+from core import scheduler_lifecycle as lifecycle
+
+
+class _LoopTask:
+    def __init__(self, *, running: bool = False) -> None:
+        self.running = running
+        self.started = 0
+
+    def is_running(self) -> bool:
+        return self.running
+
+    def start(self) -> None:
+        self.started += 1
+        self.running = True
+
+
+@pytest.mark.asyncio
+async def test_event_scheduler_tasks_start_when_events_are_ready():
+    calls: list[str] = []
+
+    async def wait_for_events(seconds: int) -> bool:
+        calls.append(f"wait:{seconds}")
+        return True
+
+    async def start_tasks() -> None:
+        calls.append("start")
+
+    def create(*_args, **_kwargs):
+        calls.append("create")
+
+    await lifecycle.run_ready_event_scheduler_tasks(
+        start_event_scheduler_tasks=start_tasks,
+        wait_for_events=wait_for_events,
+        task_monitor_create=create,
+    )
+
+    assert calls == ["wait:10", "start"]
+
+
+@pytest.mark.asyncio
+async def test_event_scheduler_tasks_defer_until_ready_when_cache_is_empty():
+    calls: list[str] = []
+    scheduled = {}
+
+    async def wait_for_events(seconds: int) -> bool:
+        calls.append(f"wait:{seconds}")
+        return False
+
+    async def start_tasks() -> None:
+        calls.append("start")
+
+    def create(name, factory, **_kwargs):
+        scheduled["name"] = name
+        scheduled["factory"] = factory
+        calls.append(f"create:{name}")
+
+    await lifecycle.run_ready_event_scheduler_tasks(
+        start_event_scheduler_tasks=start_tasks,
+        wait_for_events=wait_for_events,
+        task_monitor_create=create,
+    )
+
+    assert calls == ["wait:10", "create:event_tasks_when_ready"]
+    assert scheduled["name"] == "event_tasks_when_ready"
+    assert callable(scheduled["factory"])
+
+
+@pytest.mark.asyncio
+async def test_domain_scheduler_tasks_register_in_existing_order():
+    calls: list[str] = []
+
+    def create(name, factory, **kwargs):
+        calls.append(f"create:{name}:{kwargs.get('replace')}")
+        assert callable(factory)
+
+    def is_running(name: str) -> bool:
+        calls.append(f"is_running:{name}")
+        return False
+
+    async def ark() -> None:
+        return None
+
+    async def mge_cache() -> None:
+        return None
+
+    async def mge() -> None:
+        return None
+
+    await lifecycle.run_ready_domain_scheduler_tasks(
+        task_monitor_create=create,
+        task_monitor_is_running=is_running,
+        schedule_ark_lifecycle=ark,
+        refresh_mge_caches_on_startup=mge_cache,
+        schedule_mge_lifecycle=mge,
+    )
+
+    assert calls == [
+        "create:ark_scheduler:None",
+        "is_running:refresh_mge_caches_on_startup",
+        "create:refresh_mge_caches_on_startup:False",
+        "is_running:mge_lifecycle",
+        "create:mge_lifecycle:False",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_domain_scheduler_tasks_skip_duplicate_mge_tasks():
+    calls: list[str] = []
+
+    def create(name, factory, **kwargs):
+        calls.append(f"create:{name}:{kwargs.get('replace')}")
+
+    def is_running(name: str) -> bool:
+        calls.append(f"is_running:{name}")
+        return name in {"refresh_mge_caches_on_startup", "mge_lifecycle"}
+
+    async def noop() -> None:
+        return None
+
+    await lifecycle.run_ready_domain_scheduler_tasks(
+        task_monitor_create=create,
+        task_monitor_is_running=is_running,
+        schedule_ark_lifecycle=noop,
+        refresh_mge_caches_on_startup=noop,
+        schedule_mge_lifecycle=noop,
+    )
+
+    assert calls == [
+        "create:ark_scheduler:None",
+        "is_running:refresh_mge_caches_on_startup",
+        "is_running:mge_lifecycle",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_calendar_scheduler_tasks_register_and_skip_duplicate_loop():
+    calls: list[str] = []
+
+    def create(name, factory, **kwargs):
+        calls.append(f"create:{name}:{kwargs.get('replace')}")
+        assert callable(factory)
+
+    def is_running(name: str) -> bool:
+        calls.append(f"is_running:{name}")
+        return False
+
+    async def noop() -> None:
+        return None
+
+    await lifecycle.run_ready_calendar_scheduler_tasks(
+        task_monitor_create=create,
+        task_monitor_is_running=is_running,
+        schedule_daily_pinned_calendar_refresh=noop,
+        calendar_reminder_task=noop,
+    )
+
+    assert calls == [
+        "create:daily_pinned_calendar_refresh:None",
+        "is_running:calendar_reminder_loop",
+        "create:calendar_reminder_loop:False",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_registration_failures_are_best_effort(caplog):
+    def create(_name, _factory, **_kwargs):
+        raise RuntimeError("monitor unavailable")
+
+    async def noop() -> None:
+        return None
+
+    await lifecycle.run_ready_domain_scheduler_tasks(
+        task_monitor_create=create,
+        task_monitor_is_running=lambda _name: False,
+        schedule_ark_lifecycle=noop,
+        refresh_mge_caches_on_startup=noop,
+        schedule_mge_lifecycle=noop,
+    )
+
+    assert "Failed to start Ark scheduler" in caplog.text
+    assert "Failed to schedule MGE cache refresh" in caplog.text
+    assert "Failed to start MGE scheduler" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_event_cache_refresh_loop_starts_at_dedicated_boundary():
+    refresh_loop = _LoopTask()
+
+    await lifecycle.start_event_cache_refresh_loop(refresh_event_cache_task=refresh_loop)
+
+    assert refresh_loop.started == 1
+
+
+@pytest.mark.asyncio
+async def test_event_cache_refresh_loop_skips_when_already_running():
+    refresh_loop = _LoopTask(running=True)
+
+    await lifecycle.start_event_cache_refresh_loop(refresh_event_cache_task=refresh_loop)
+
+    assert refresh_loop.started == 0

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -75,8 +75,12 @@ def test_on_ready_uses_named_startup_lifecycle_boundary():
         "ready_runtime_services",
         "ready_command_sync",
         "ready_event_cache_rehydration",
+        "ready_event_scheduler_tasks",
+        "ready_event_cache_refresh_loop",
         "ready_view_rehydration",
+        "ready_domain_scheduler_tasks",
         "ready_pinned_calendar_rehydration",
+        "ready_calendar_scheduler_tasks",
     ]
 
 


### PR DESCRIPTION
## Summary

- Add `core/scheduler_lifecycle.py` as the Phase 6G owner for scheduler/task-supervision startup registration.
- Move event-dependent scheduler startup, the long-running event cache refresh loop, Ark/MGE scheduler startup, and calendar scheduler startup behind named lifecycle phases while preserving ordering and task keys.
- Update Phase 6 startup docs/task packs and focused lifecycle tests.

## Changes

- `bot_instance.py` now delegates through `ready_event_scheduler_tasks`, `ready_event_cache_refresh_loop`, `ready_domain_scheduler_tasks`, and `ready_calendar_scheduler_tasks`.
- `ready_event_cache_refresh_loop` preserves the previous `refresh_event_cache_task.start()` ordering before tracked view rehydration.
- `core/event_rehydration_lifecycle.py` now owns event cache/reminder loading and the one-shot event cache refresh only; scheduler readiness deferral moved to `core/scheduler_lifecycle.py`.
- `reminder_cleanup` deliberately remains at its existing point after `full_startup_sequence()` and before pinned calendar rehydration.
- Added scheduler lifecycle tests for successful registration, delayed event readiness, duplicate skip behavior, best-effort failure logging, and event cache refresh loop idempotency.

## Review Follow-up

- Restored the long-running event cache refresh loop to its prior startup position before `ready_view_rehydration` by splitting it into `ready_event_cache_refresh_loop`.
- Changed Ark scheduler registration failure logging to `logger.exception()` so failures retain tracebacks like the other scheduler registration paths.

## Validation

- `\.\.venv\Scripts\python.exe -m py_compile core\scheduler_lifecycle.py core\event_rehydration_lifecycle.py bot_instance.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_event_rehydration_lifecycle.py tests\test_scheduler_lifecycle.py tests\test_mge_startup_hook_invoked.py tests\test_calendar_scheduler.py` -> 27 passed after review follow-up
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_event_rehydration_lifecycle.py tests\test_scheduler_lifecycle.py tests\test_mge_startup_hook_invoked.py tests\test_mge_rehydrate_and_regression.py tests\test_calendar_pinned_embed.py tests\test_calendar_reminders.py tests\test_calendar_reminders_dispatch.py tests\test_calendar_scheduler.py tests\test_ark_scheduler.py tests\test_ark_scheduler_post_start.py` -> 51 passed after review follow-up
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `\.\.venv\Scripts\python.exe scripts\select_tests.py`
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `\.\.venv\Scripts\python.exe -m pre_commit run -a`
- `\.\.venv\Scripts\python.exe -m pytest -q tests` -> 1569 passed, 2 skipped before review follow-up
- `\.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py` -> 1569 passed, 2 skipped; production operational logs unchanged before review follow-up

## Security Review

- Diff-scoped Codex Security review completed before PR handoff.
- No findings: this PR moves existing scheduler registration behind injected lifecycle helpers, preserves existing `TaskMonitor` task keys/readiness gates, and does not add new user input, file path, network, secrets/config, SQL, permission, or Discord interaction surfaces.

## Risk / Rollback

- Risk: medium; startup lifecycle changes can affect task registration order or duplicate-task prevention.
- Rollback: revert this PR and restart from the previous Phase 6F startup layout.

## Smoke Expectations

After deployment, verify the new scheduler phase logs appear in order, event-dependent scheduler tasks still wait for event readiness, the event cache refresh loop still starts before tracked view rehydration, Ark/MGE/calendar scheduler logs still appear, `full_startup_sequence()` still runs after domain scheduler startup, and repeated `on_ready()` does not create duplicate background tasks.