### PR TITLE
[codex] add queue lifecycle startup phase

### DIFF
--- a/bot_instance.py
+++ b/bot_instance.py
@@ -66,6 +66,7 @@ from core.event_rehydration_lifecycle import (
     wait_for_events,
 )
 from core.interaction_safety import get_operation_lock
+from core.queue_lifecycle import run_ready_queue_lifecycle
 from core.scheduler_lifecycle import (
     run_ready_calendar_scheduler_tasks,
     run_ready_domain_scheduler_tasks,
@@ -1676,6 +1677,20 @@ async def _run_ready_calendar_scheduler_tasks() -> None:
     )
 
 
+async def _run_ready_queue_lifecycle() -> None:
+    await run_ready_queue_lifecycle(
+        channel_ids=CHANNEL_IDS,
+        task_monitor_create=task_monitor.create,
+        queue_worker=queue_worker,
+        load_live_queue=load_live_queue,
+        update_live_queue_embed=update_live_queue_embed,
+        bot=bot,
+        notify_channel_id=NOTIFY_CHANNEL_ID,
+        queue_cleanup_loop=queue_cleanup_loop,
+        connection_watchdog=connection_watchdog,
+    )
+
+
 async def _run_ready_runtime_services() -> None:
     # Start heartbeat now that the loop is running
     try:
@@ -2037,17 +2052,9 @@ async def full_startup_sequence():
                         csv.writer(f).writerow(headers)
                         logger.info(f"[LOG INIT] Initialized headers for {log_file}")
 
-            for cid in CHANNEL_IDS:
-                task_monitor.create(f"queue_worker:{cid}", lambda cid=cid: queue_worker(cid))
-
-            load_live_queue()
-            try:
-                await update_live_queue_embed(bot, NOTIFY_CHANNEL_ID)
-            except Exception as e:
-                logger.error(f"💥 Failed to update queue embed: {e}")
-
-            task_monitor.create("queue_cleanup", queue_cleanup_loop)
-            task_monitor.create("connection_watchdog", lambda: connection_watchdog(bot))
+            await run_startup_phases(
+                [StartupPhase("ready_queue_lifecycle", _run_ready_queue_lifecycle)]
+            )
 
             # --- CrystalTech config load & validate at startup ---
             try:

--- a/core/queue_lifecycle.py
+++ b/core/queue_lifecycle.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+StartupCoroutine = Callable[[], Awaitable[Any]]
+TaskMonitorCreate = Callable[..., Any]
+
+
+async def run_ready_queue_lifecycle(
+    *,
+    channel_ids: Iterable[int],
+    task_monitor_create: TaskMonitorCreate,
+    queue_worker: Callable[[int], Awaitable[Any]],
+    load_live_queue: Callable[[], Any],
+    update_live_queue_embed: Callable[[Any, int], Awaitable[Any]],
+    bot: Any,
+    notify_channel_id: int,
+    queue_cleanup_loop: StartupCoroutine,
+    connection_watchdog: Callable[[Any], Awaitable[Any]],
+) -> None:
+    """Register queue workers and recover live queue state at the existing startup point."""
+    for channel_id in channel_ids:
+        task_monitor_create(
+            f"queue_worker:{channel_id}",
+            lambda channel_id=channel_id: queue_worker(channel_id),
+        )
+    logger.info("[QUEUE] Queue workers registered for monitored channels.")
+
+    load_live_queue()
+    logger.info("[QUEUE] Live queue state load requested.")
+
+    try:
+        await update_live_queue_embed(bot, notify_channel_id)
+        logger.info("[QUEUE] Live queue embed refresh completed.")
+    except Exception:
+        logger.exception("[QUEUE] Failed to update live queue embed during startup")
+
+    task_monitor_create("queue_cleanup", queue_cleanup_loop)
+    logger.info("[QUEUE] Queue cleanup task registered.")
+
+    task_monitor_create("connection_watchdog", lambda: connection_watchdog(bot))
+    logger.info("[QUEUE] Connection watchdog task registered.")

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -75,12 +75,27 @@ admin tooling convergence was completed in PR 122
 signature inventory, version display, cache update, and cache validation while preserving admin
 permissions, ephemeral responses, operation locking, embeds, timeout behaviour, and grouped command
 names. Production smoke confirmed both command execution and usage telemetry flushes, including a
-successful manual command resync.
+successful manual command resync. Phase 6F event cache/reminder/view rehydration was completed in
+PR 123 (`codex/dlbot-phase-6f-event-rehydration`), merged, smoke tested, and pushed to production
+on 2026-05-28. Phase 6G scheduler/task-supervision startup was completed in PR 124
+(`codex/dlbot-phase-6g-scheduler-lifecycle`), merged, smoke tested, and pushed to production on
+2026-05-28: `core/scheduler_lifecycle.py` now owns scheduler/task registration ordering, event
+readiness gating, `TaskMonitor` registration, duplicate-prevention checks, and best-effort logging;
+`bot_instance.py:on_ready()` delegates through `ready_event_scheduler_tasks`,
+`ready_event_cache_refresh_loop`, `ready_domain_scheduler_tasks`, and
+`ready_calendar_scheduler_tasks`. Production smoke confirmed event-dependent schedulers,
+`refresh_event_cache_task`, tracked view rehydration, Ark/MGE schedulers, `full_startup_sequence()`,
+reminder cleanup, pinned calendar rehydration, daily pinned refresh, and calendar reminder loop all
+started in the expected order with no startup phase failure or `on_ready()` critical exception.
+Phase 6H queue worker/live queue lifecycle moved queue worker registration, live queue recovery,
+best-effort queue embed refresh, queue cleanup startup, and connection watchdog startup into
+`core/queue_lifecycle.py` and the `ready_queue_lifecycle` startup phase while preserving the
+existing `full_startup_sequence()` ordering.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md`, with
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md`, with
 this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -149,20 +164,29 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, queue worker startup, live queue rehydration, cache warming, startup notifications, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner, Phase 6F extracted event cache, reminder loading, tracked view rehydration, and pinned calendar view rehydration behind named lifecycle boundaries, and Phase 6G extracted scheduler/task-supervision startup into `core/scheduler_lifecycle.py`. Remaining `on_ready()` work still mixes cache warming, queue worker startup, startup notifications, and later shutdown coordination.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. After Phase 6G, keep queue worker lifecycle, shutdown coordination, and final process-entry/bot-construction cleanup in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, cache warming, startup notifications, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner, Phase 6F extracted event cache, reminder loading, tracked view rehydration, and pinned calendar view rehydration behind named lifecycle boundaries, Phase 6G extracted scheduler/task-supervision startup into `core/scheduler_lifecycle.py`, and Phase 6H extracted queue worker/live queue startup into `core/queue_lifecycle.py`. Remaining `on_ready()` work still mixes cache warming, startup notifications, shutdown coordination, and process-entry/bot-construction cleanup.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. After Phase 6H, keep shutdown coordination and final process-entry/bot-construction cleanup in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6F lifecycle slices are complete, merged, production-pushed, and smoke tested; Phase 6G is the current scheduler/task-supervision implementation slice and should be smoke tested before marking complete.
+- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6H lifecycle slices are complete or in delivery; proceed with shutdown/recovery coordination before process-entry cleanup.
 
 ### Deferred Optimisation
-- Area: `bot_instance.py:_start_event_dependent_tasks`
-- Type: architecture
-- Description: Phase 6G moved the event-dependent scheduler bundle and later Ark/MGE/calendar scheduler registrations out of `bot_instance.py:on_ready()` and the event cache/rehydration boundary into `core/scheduler_lifecycle.py`, while preserving readiness gating, startup order, `TaskMonitor` duplicate prevention, and existing production logging.
-- Suggested Fix: After Phase 6G production smoke, remove this item from the active backlog or move it to resolved history. Keep any remaining queue-worker, shutdown, process-entry, and pinned-calendar persistence work as separate deferred items.
+- Area: `utils.py`, `bot_helpers.py`, `core/queue_lifecycle.py`, queue runtime state
+- Type: refactor
+- Description: Phase 6H separated queue lifecycle startup, but broader queue persistence hardening remains out of scope. `load_live_queue()` is synchronous while scheduling an async state apply when an event loop is running, and queue draining/state flush semantics are still coupled to later shutdown behavior.
+- Suggested Fix: Add a dedicated queue persistence hardening slice after Phase 6I or fold it into Phase 6I only if shutdown work requires it. Make live queue load/apply explicitly awaitable where practical, preserve sync test compatibility or add a safe wrapper, verify atomic save behavior and stale metadata handling, and add restart/persistence tests for load-before-embed-refresh ordering and state flush after queue cancellation.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6F boundary extraction completed in PR 123 (`codex/dlbot-phase-6f-event-rehydration`), smoke tested cleanly, merged, and pushed to production; scheduler ownership was explicitly deferred to Phase 6G.
+- Dependencies: Phase 6H lifecycle extraction; coordinate with Phase 6I cooperative cancellation and queue draining/state flush design.
+
+### Deferred Optimisation
+- Area: `bot_helpers.py`, `bot_instance.py`, `DL_bot.py` shutdown and queue task lifecycle
+- Type: architecture
+- Description: Queue workers, queue cleanup, connection watchdog, and other background tasks still lack a single approved shutdown/recovery coordination boundary for cooperative cancellation, queue draining, state flush, singleton/PID markers, and logging shutdown order.
+- Suggested Fix: Phase 6I should fix cooperative cancellation, queue draining/state flush, and shutdown ordering. Audit signal/admin shutdown paths, `TaskMonitor` cancellation behavior, queue worker cancellation, `QUEUE_CACHE_FILE` persistence, `LAST_SHUTDOWN_INFO` writing, singleton/PID cleanup, and logging flush order before implementation.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 6H queue lifecycle extraction; keep process-entry and bot-construction cleanup for Phase 6J unless Phase 6I reveals a hard dependency.
 
 ### Deferred Optimisation
 - Area: `event_calendar/pinned_embed.py`

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -31,6 +31,9 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
    - `ready_view_rehydration` schedules tracked persistent view rehydration.
    - `ready_domain_scheduler_tasks` starts the Ark lifecycle scheduler, MGE cache warm, and MGE
      lifecycle scheduler.
+   - `ready_queue_lifecycle` starts queue workers, loads persisted live queue state, refreshes the
+     live queue embed best-effort, and starts queue cleanup/watchdog tasks at the existing
+     `full_startup_sequence()` point.
    - `ready_pinned_calendar_rehydration` schedules pinned calendar view rehydration at the
      existing later startup point after `full_startup_sequence()`.
    - `ready_calendar_scheduler_tasks` starts the daily pinned calendar refresh and calendar
@@ -101,11 +104,19 @@ smoke on 2026-05-28 confirmed those commands loaded, executed, flushed usage tel
 scoped command resync completed successfully. Phase 6F completed in PR 123
 (`codex/dlbot-phase-6f-event-rehydration`), was smoke tested cleanly, merged, and pushed to
 production: event cache, reminder loading, tracked view rehydration, and pinned calendar
-rehydration now have explicit startup lifecycle boundaries. Phase 6G then separated scheduler and
-task-supervision startup into `core/scheduler_lifecycle.py` while preserving event readiness
-gating, task names, duplicate prevention, and the existing Ark/MGE/calendar ordering. Remaining
-lifecycle cleanup continues with queue worker lifecycle, shutdown coordination, and final
-process-entry/bot-construction cleanup.
+rehydration now have explicit startup lifecycle boundaries. Phase 6G completed in PR 124
+(`codex/dlbot-phase-6g-scheduler-lifecycle`), was smoke tested cleanly, merged, and pushed to
+production: scheduler and task-supervision startup now runs through `core/scheduler_lifecycle.py`
+while preserving event readiness gating, task names, duplicate prevention, and the existing
+Ark/MGE/calendar ordering. Review follow-up kept `refresh_event_cache_task` at its prior point
+before tracked view rehydration via `ready_event_cache_refresh_loop` and changed Ark scheduler
+registration failures to `logger.exception()` for traceback parity. Production smoke confirmed all
+new scheduler phases, Ark/MGE scheduler ticks, `full_startup_sequence()`, reminder cleanup, pinned
+calendar rehydration, daily pinned refresh, and calendar reminder loop startup with no startup
+phase failure or `on_ready()` critical exception. Phase 6H moved queue worker/live queue startup
+into `core/queue_lifecycle.py` and the `ready_queue_lifecycle` phase while preserving the existing
+`full_startup_sequence()` ordering. Remaining lifecycle cleanup continues with shutdown
+coordination and final process-entry/bot-construction cleanup.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md
@@ -1,14 +1,31 @@
 # Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary
 
-Use this starter to continue Phase 6 after Phase 6F event cache, reminder loading, and
-rehydration boundary was merged, smoke-tested, pushed to production, and marked complete.
+Status: complete. PR 124 (`codex/dlbot-phase-6g-scheduler-lifecycle`) was merged,
+smoke-tested, and pushed to production on 2026-05-28. This starter is retained as historical
+context for Phase 6G.
 
-Status: implementation approved and in progress. The approved ownership model uses
-`core/scheduler_lifecycle.py` for scheduler/task registration ordering, `TaskMonitor`
-registration, duplicate prevention, readiness gating, and best-effort logging. Scheduler
-implementation behavior remains in the existing domain modules.
-The long-running `refresh_event_cache_task` loop keeps its prior startup position before tracked
-view rehydration through the dedicated `ready_event_cache_refresh_loop` phase.
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md` for the next
+Phase 6 slice.
+
+Delivered outcome:
+
+- `core/scheduler_lifecycle.py` now owns scheduler/task registration ordering, readiness gating,
+  `TaskMonitor` registration, duplicate-prevention checks, and best-effort failure logging.
+- `bot_instance.py:on_ready()` delegates event-dependent schedulers through
+  `ready_event_scheduler_tasks`, the long-running event cache refresh loop through
+  `ready_event_cache_refresh_loop`, Ark/MGE schedulers through `ready_domain_scheduler_tasks`, and
+  calendar schedulers through `ready_calendar_scheduler_tasks`.
+- Review feedback restored `refresh_event_cache_task.start()` to its prior ordering before tracked
+  view rehydration by giving it the dedicated `ready_event_cache_refresh_loop` phase.
+- Review feedback also changed Ark scheduler registration failure logging to `logger.exception()`
+  so it retains tracebacks like the other scheduler registration paths.
+- Production smoke confirmed all new scheduler lifecycle phases ran in order, event readiness
+  gating succeeded, event-dependent schedulers started, the event cache refresh loop was armed
+  before tracked view rehydration, Ark and MGE schedulers ticked, `full_startup_sequence()`
+  completed, reminder cleanup started, pinned calendar rehydration completed, daily pinned
+  calendar refresh started, and the calendar reminder loop armed.
+- No startup phase failure, `on_ready()` critical exception, scheduler registration failure,
+  pinned-calendar scheduling failure, or calendar reminder loop failure was observed.
 
 ## Copy/Paste Starter
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md
@@ -1,0 +1,272 @@
+# Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle
+
+Use this starter to continue Phase 6 after Phase 6G scheduler/task-supervision startup was
+merged, smoke-tested, pushed to production, and marked complete.
+
+Status: implementation approved and in progress. The approved ownership model uses
+`core/queue_lifecycle.py` and the `ready_queue_lifecycle` phase for queue worker registration,
+live queue recovery, best-effort queue embed refresh, queue cleanup startup, connection watchdog
+startup, ordering, logging, and `TaskMonitor` duplicate-prevention preservation.
+
+Follow-up note: queue persistence hardening is intentionally not part of the Phase 6H lifecycle
+extraction. Track it as an optional slice after Phase 6I, or include it in Phase 6I only if
+shutdown work requires awaitable load/apply semantics or explicit queue state flush changes.
+Phase 6I should fix cooperative cancellation, queue draining/state flush, and shutdown ordering.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6H:
+queue worker and live queue lifecycle.
+
+Phase 6A, 6B, 6C, 6D, 6E, 6F, and 6G are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged and pushed to production.
+- PR 123 (`codex/dlbot-phase-6f-event-rehydration`) was merged and pushed to production.
+- PR 124 (`codex/dlbot-phase-6g-scheduler-lifecycle`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `core/command_lifecycle.py` owns startup command signature/cache/sync mechanics and shared
+  `/ops` command lifecycle mechanics.
+- `core/event_rehydration_lifecycle.py` owns event cache, active reminder loading, tracked view
+  rehydration scheduling, and pinned calendar view rehydration scheduling.
+- `core/scheduler_lifecycle.py` owns scheduler/task registration ordering, event readiness
+  gating, `TaskMonitor` registration, duplicate-prevention checks, and best-effort failure
+  logging.
+- `bot_instance.py:on_ready()` delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+  - startup command signature/cache/sync through `ready_command_sync`
+  - event cache/reminder/live-event readiness through `ready_event_cache_rehydration`
+  - event-dependent scheduler tasks through `ready_event_scheduler_tasks`
+  - long-running event cache refresh loop through `ready_event_cache_refresh_loop`
+  - tracked view rehydration through `ready_view_rehydration`
+  - Ark/MGE scheduler startup through `ready_domain_scheduler_tasks`
+  - pinned calendar rehydration through `ready_pinned_calendar_rehydration`
+  - calendar scheduler startup through `ready_calendar_scheduler_tasks`
+- Production smoke logs confirmed for Phase 6G:
+  - all new scheduler lifecycle phases ran in the expected order
+  - event-dependent scheduler tasks started after event readiness
+  - `refresh_event_cache_task` was armed before tracked view rehydration
+  - Ark scheduler started and ticked
+  - MGE cache warm completed and MGE scheduler ticked
+  - `full_startup_sequence()` completed
+  - reminder cleanup started
+  - pinned calendar rehydration completed
+  - daily pinned calendar refresh started
+  - calendar reminder loop armed
+  - no startup phase failure, `on_ready()` critical exception, scheduler registration failure,
+    pinned-calendar scheduling failure, or calendar reminder loop failure was observed
+
+This is review/scope first. Do not implement code changes until the Phase 6H scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/reference/runbook_diagnostics.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6G Scheduler Task Supervision Boundary.md`
+
+## Phase 6H Objective
+
+Separate queue worker and live queue lifecycle responsibilities from `bot_instance.py:on_ready()`
+and `full_startup_sequence()` while preserving worker startup order, live queue recovery, queue
+embed refresh behavior, restart safety, and duplicate-task prevention.
+
+The next cohesive slice after Phase 6G is the queue/live-queue block currently inside
+`full_startup_sequence()`:
+
+- queue worker startup for each `CHANNEL_IDS` entry through `queue_worker(cid)`
+- `TaskMonitor.create(f"queue_worker:{cid}", ...)` task names and duplicate prevention behavior
+- live queue recovery through `load_live_queue()`
+- live queue embed refresh through `update_live_queue_embed(bot, NOTIFY_CHANNEL_ID)`
+- queue cleanup startup through `queue_cleanup_loop`
+- connection watchdog startup through `connection_watchdog(bot)`
+- relationship to fallback upload queueing in `upload_routes/fallback_queue_route.py`
+- shared queue state and locking through `utils.live_queue_lock`
+- queue runtime state paths such as `QUEUE_CACHE_FILE`
+
+Recommended target: keep a non-Discord lifecycle helper in `core/` or a narrowly scoped startup
+module responsible for ordering, idempotency, logging, `TaskMonitor` registration, live queue
+recovery outcome reporting, and best-effort queue embed refresh. Keep queue worker implementation
+logic in existing modules such as `bot_helpers.py`, `utils.py`, and upload route modules unless
+the audit proves a small extraction is necessary.
+
+## In Scope
+
+- Audit the relationship between:
+  - `bot_instance.py:on_ready()`
+  - `full_startup_sequence()`
+  - `TaskMonitor.create()` and task names for `queue_worker:{cid}`, `queue_cleanup`, and
+    `connection_watchdog`
+  - `CHANNEL_IDS`
+  - `queue_worker(cid)`
+  - `queue_cleanup_loop`
+  - `connection_watchdog(bot)`
+  - `load_live_queue()`
+  - `update_live_queue_embed(bot, NOTIFY_CHANNEL_ID)`
+  - `utils.live_queue_lock`
+  - `upload_routes/fallback_queue_route.py`
+  - `QUEUE_CACHE_FILE` and related live queue persistence constants
+- Define the exact startup ordering that must be preserved.
+- Decide whether queue worker registration, live queue recovery, and queue cleanup/watchdog should
+  be one named startup phase or split into smaller phases.
+- Preserve restart safety and duplicate-task prevention.
+- Preserve best-effort behavior for queue embed refresh failures.
+- Add or update focused tests for worker registration, skipped duplicate registration where
+  practical, live queue load/update ordering, best-effort embed refresh failure logging, and
+  continued startup behavior.
+- Capture shutdown/cancellation, process-entry, and broader queue persistence hardening findings
+  as later work unless explicitly approved for this slice.
+
+## Out Of Scope
+
+- Shutdown redesign, signal handling, singleton/PID cleanup, logging shutdown order, or
+  cooperative cancellation changes.
+- `DL_bot.py` process-entry changes.
+- Upload-route behavior changes, including fallback queue routing behavior.
+- Scheduler ownership changes already completed in Phase 6G.
+- Event cache load/refresh ownership changes already completed in Phase 6F and 6G.
+- Command lifecycle, command sync, command cache, slash-command renaming, grouping, or retirement.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes unless unexpectedly required by
+  queue validation.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `bot_instance.py`
+- `core/startup_lifecycle.py`
+- `core/scheduler_lifecycle.py`
+- `bot_helpers.py`
+- `utils.py`
+- `upload_routes/fallback_queue_route.py`
+- `constants.py`
+- `tests/test_live_queue_persistence.py`
+- `tests/test_utils_live_queue.py`
+- `tests/test_fallback_queue_route.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_command_registration_smoke.py`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- one focused lifecycle helper module if the audit proves a clean extraction
+- focused queue/startup lifecycle tests
+- `docs/reference/runbook_startup.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Do not create a broad lifecycle orchestration module that also owns shutdown or process entry in
+Phase 6H.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Queue Worker / Live Queue Lifecycle Map
+- Current Phase 6A-G Startup Lifecycle Boundary Map
+- Proposed Phase 6H Ownership Model
+- Startup Ordering And Idempotency Checklist
+- TaskMonitor Key And Duplicate Prevention Map
+- Runtime State And Persistence Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6H Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_fallback_queue_route.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6H touches
+Discord-facing upload queue processing, file-backed runtime state, restart-sensitive queue
+recovery, and duplicate worker prevention.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- normal startup still shows all Phase 6A-G startup phases
+- new queue worker/live queue phase logs appear in the expected order
+- queue workers start for each monitored channel in `CHANNEL_IDS`
+- live queue state loads before the live queue embed refresh
+- live queue embed refresh still runs best-effort and does not block later startup on failure
+- queue cleanup starts once
+- connection watchdog starts once
+- `full_startup_sequence()` still sends startup notification and completes
+- repeated `on_ready()` still skips startup work and no duplicate `queue_worker:{cid}`,
+  `queue_cleanup`, or `connection_watchdog` background tasks are observed
+
+The smoke test should not show:
+
+```text
+[STARTUP] phase failed
+[CRITICAL] Exception during on_ready
+Failed to update queue embed
+[MONITOR] Task queue_worker
+[MONITOR] Task queue_cleanup crashed
+[MONITOR] Task connection_watchdog crashed
+```
+
+Known best-effort live queue embed warnings may be acceptable only when later startup still
+continues and the failure is intentionally induced or otherwise understood.
+
+## Remaining Phase 6 Slices
+
+Recommended order after Phase 6H:
+
+1. Phase 6I shutdown and recovery coordination, including cooperative cancellation, queue
+   draining/state flush, and shutdown ordering.
+2. Optional queue persistence hardening slice after Phase 6I, unless Phase 6I requires it directly.
+3. Phase 6J process-entry and bot-construction cleanup.
+
+The wider command-surface migration/renaming programme remains separate from Phase 6.
+
+## Deferred Item Links
+
+This starter continues the DL_bot startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6G completed scheduler/task-supervision
+boundary extraction.
+
+Carry forward, but do not implement unless separately approved:
+
+- shutdown and task cancellation coordination
+- process-entry and bot-construction cleanup
+- queue persistence hardening after Phase 6I, unless required directly by Phase 6I shutdown work
+- pinned calendar tracker persistence hardening in `event_calendar/pinned_embed.py`

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-28`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F/6G startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -136,8 +136,9 @@ Phase 6F event cache, reminder loading, and rehydration boundary is complete:
   scheduling failure, or `on_ready()` critical exception was observed.
 - The PR was merged and pushed to production.
 
-Phase 6G scheduler and task-supervision boundary is the current implementation slice:
+Phase 6G scheduler and task-supervision boundary is complete:
 
+- PR 124 (`codex/dlbot-phase-6g-scheduler-lifecycle`) added `core/scheduler_lifecycle.py`.
 - `core/scheduler_lifecycle.py` owns scheduler/task registration ordering, readiness gating,
   `TaskMonitor` registration, duplicate-prevention checks, and best-effort logging.
 - `bot_instance.py:on_ready()` delegates event-dependent schedulers through
@@ -146,6 +147,17 @@ Phase 6G scheduler and task-supervision boundary is the current implementation s
   calendar schedulers through `ready_calendar_scheduler_tasks`.
 - `reminder_cleanup` deliberately remains at its existing point after `full_startup_sequence()` and
   before pinned calendar rehydration.
+- Review feedback restored `refresh_event_cache_task.start()` to its previous position before
+  tracked view rehydration via the dedicated `ready_event_cache_refresh_loop` phase and changed Ark
+  scheduler registration failure logging to `logger.exception()` for traceback parity.
+- Production smoke testing on 2026-05-28 confirmed all Phase 6G lifecycle phases ran in order,
+  event-dependent schedulers started after event readiness, `refresh_event_cache_task` armed before
+  tracked view rehydration, Ark and MGE schedulers started and ticked, `full_startup_sequence()`
+  completed, reminder cleanup started, pinned calendar rehydration completed, daily pinned calendar
+  refresh started, and the calendar reminder loop armed.
+- No startup phase failure, `on_ready()` critical exception, scheduler registration failure,
+  pinned-calendar scheduling failure, or calendar reminder loop failure was observed.
+- The PR was merged and pushed to production.
 - Queue worker lifecycle, shutdown coordination, and process-entry cleanup remain later Phase 6
   slices.
 
@@ -360,9 +372,9 @@ Initial classification before audit:
 | Command signature/cache/sync ownership | complete | Phase 6D moved startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, preserving cache, scoped sync, timeout telemetry, and loaded-command logging behaviour. |
 | Command lifecycle admin tooling convergence | complete | Phase 6E reused `core/command_lifecycle.py` from `/ops resync_commands`, `/ops validate_command_cache`, and `/ops show_command_versions` while preserving admin permissions, embeds, timeout behaviour, and operator-facing summaries. |
 | Event cache, reminder loading, and rehydration boundary | complete | Phase 6F separated event cache load/refresh, active reminder loading, event-dependent view rehydration, tracked view rehydration, and pinned calendar view rehydration from the remaining `on_ready()` body with explicit ordering and startup phase logs. Scheduler ownership inside the existing event-dependent bundle was deliberately deferred to Phase 6G. |
-| Scheduler and task-supervision boundary | current slice | Phase 6G separates scheduler/task registration from the remaining `on_ready()` body and the current event-dependent bundle while preserving startup order, readiness gates, best-effort behavior, and `TaskMonitor` duplicate prevention. |
-| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move cache warming, queue workers, startup notifications, and shutdown together. |
-| Queue worker startup and live queue rehydration | audit first | Restart-sensitive; must preserve worker handoff and live queue persistence. |
+| Scheduler and task-supervision boundary | complete | Phase 6G separated scheduler/task registration from the remaining `on_ready()` body and the previous event-dependent bundle while preserving startup order, readiness gates, best-effort behavior, and `TaskMonitor` duplicate prevention. |
+| `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move cache warming, startup notifications, shutdown, and process entry together. |
+| Queue worker startup and live queue rehydration | complete | Phase 6H extracted queue worker registration, live queue recovery, best-effort queue embed refresh, queue cleanup startup, and connection watchdog startup into `core/queue_lifecycle.py` and `ready_queue_lifecycle` while preserving ordering and `TaskMonitor` duplicate prevention. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
 | SQL/importer contracts | not applicable unless discovered | Phase 6 should avoid SQL/importer contract changes. |
@@ -371,12 +383,14 @@ Final decisions should be updated after each Phase 6 sub-phase.
 
 ## 13.1 Remaining Phase 6 Slices
 
-Current recommended order after Phase 6G:
+Current recommended order after Phase 6H:
 
-1. Phase 6H queue worker and live queue lifecycle: isolate queue worker startup, live queue rehydration,
-   queue embed refresh, and queue persistence/recovery concerns.
-2. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
-   cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order.
+1. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
+   cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order. Fix:
+   handle cooperative cancellation, queue draining/state flush, and shutdown ordering.
+2. Optional queue persistence hardening slice: after Phase 6I, or inside Phase 6I only if shutdown
+   work requires it, harden live queue load/apply semantics, atomic save verification, stale
+   metadata handling, and restart/state-flush tests.
 3. Phase 6J process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
    stable, review whether `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final
    ownership split.

--- a/tests/test_queue_lifecycle.py
+++ b/tests/test_queue_lifecycle.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from core.queue_lifecycle import run_ready_queue_lifecycle
+
+
+@pytest.mark.asyncio
+async def test_queue_lifecycle_registers_workers_loads_queue_and_starts_loops():
+    calls: list[str] = []
+    bot = object()
+
+    def create(name, factory, **_kwargs):
+        calls.append(f"create:{name}")
+        assert callable(factory)
+
+    async def queue_worker(channel_id: int) -> None:
+        calls.append(f"worker:{channel_id}")
+
+    def load_live_queue() -> None:
+        calls.append("load")
+
+    async def update_live_queue_embed(_bot, notify_channel_id: int) -> None:
+        assert _bot is bot
+        calls.append(f"embed:{notify_channel_id}")
+
+    async def queue_cleanup_loop() -> None:
+        calls.append("cleanup")
+
+    async def connection_watchdog(_bot) -> None:
+        assert _bot is bot
+        calls.append("watchdog")
+
+    await run_ready_queue_lifecycle(
+        channel_ids=[10, 20],
+        task_monitor_create=create,
+        queue_worker=queue_worker,
+        load_live_queue=load_live_queue,
+        update_live_queue_embed=update_live_queue_embed,
+        bot=bot,
+        notify_channel_id=99,
+        queue_cleanup_loop=queue_cleanup_loop,
+        connection_watchdog=connection_watchdog,
+    )
+
+    assert calls == [
+        "create:queue_worker:10",
+        "create:queue_worker:20",
+        "load",
+        "embed:99",
+        "create:queue_cleanup",
+        "create:connection_watchdog",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_queue_lifecycle_embed_refresh_failure_is_best_effort(caplog):
+    caplog.set_level("ERROR", logger="core.queue_lifecycle")
+    calls: list[str] = []
+
+    def create(name, factory, **_kwargs):
+        calls.append(f"create:{name}")
+
+    async def queue_worker(_channel_id: int) -> None:
+        return None
+
+    def load_live_queue() -> None:
+        calls.append("load")
+
+    async def update_live_queue_embed(_bot, _notify_channel_id: int) -> None:
+        calls.append("embed")
+        raise RuntimeError("discord unavailable")
+
+    async def queue_cleanup_loop() -> None:
+        return None
+
+    async def connection_watchdog(_bot) -> None:
+        return None
+
+    await run_ready_queue_lifecycle(
+        channel_ids=[10],
+        task_monitor_create=create,
+        queue_worker=queue_worker,
+        load_live_queue=load_live_queue,
+        update_live_queue_embed=update_live_queue_embed,
+        bot=object(),
+        notify_channel_id=99,
+        queue_cleanup_loop=queue_cleanup_loop,
+        connection_watchdog=connection_watchdog,
+    )
+
+    assert calls == [
+        "create:queue_worker:10",
+        "load",
+        "embed",
+        "create:queue_cleanup",
+        "create:connection_watchdog",
+    ]
+    assert "Failed to update live queue embed during startup" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_queue_lifecycle_preserves_task_monitor_duplicate_prevention_contract():
+    created: list[str] = []
+    skipped: list[str] = []
+    running = {"queue_worker:10", "queue_cleanup", "connection_watchdog"}
+
+    def create(name, factory, **_kwargs):
+        if name in running:
+            skipped.append(name)
+            return object()
+        created.append(name)
+        return factory
+
+    async def noop_worker(_channel_id: int) -> None:
+        return None
+
+    async def noop() -> None:
+        return None
+
+    await run_ready_queue_lifecycle(
+        channel_ids=[10, 20],
+        task_monitor_create=create,
+        queue_worker=noop_worker,
+        load_live_queue=lambda: None,
+        update_live_queue_embed=lambda _bot, _notify_channel_id: noop(),
+        bot=object(),
+        notify_channel_id=99,
+        queue_cleanup_loop=noop,
+        connection_watchdog=lambda _bot: noop(),
+    )
+
+    assert skipped == ["queue_worker:10", "queue_cleanup", "connection_watchdog"]
+    assert created == ["queue_worker:20"]

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -159,3 +159,20 @@ def test_event_rehydration_lifecycle_uses_dedicated_helpers():
     assert not _calls_name(on_ready, "load_active_reminders")
     assert not _calls_name(on_ready, "rehydrate_tracked_views")
     assert not _calls_name(on_ready, "rehydrate_pinned_calendar_view")
+
+
+def test_queue_lifecycle_uses_dedicated_helper():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    queue_lifecycle = _async_function(tree, "_run_ready_queue_lifecycle")
+    full_startup = _async_function(tree, "full_startup_sequence")
+
+    assert _calls_name(queue_lifecycle, "run_ready_queue_lifecycle")
+    assert _calls_name(full_startup, "run_startup_phases")
+
+    assert not _calls_name(full_startup, "queue_worker")
+    assert not _calls_name(full_startup, "load_live_queue")
+    assert not _calls_name(full_startup, "update_live_queue_embed")
+    assert not _creates_task_monitor_task(full_startup, "queue_cleanup")
+    assert not _creates_task_monitor_task(full_startup, "connection_watchdog")


### PR DESCRIPTION
## Summary

- Add `core/queue_lifecycle.py` to own Phase 6H queue worker/live queue startup orchestration.
- Delegate the existing `full_startup_sequence()` queue block through the named `ready_queue_lifecycle` startup phase while preserving ordering.
- Include updated Phase 6 docs/task-pack notes, including queue persistence hardening and Phase 6I shutdown follow-up scope.

## Changes

- Register `queue_worker:{cid}` tasks for each monitored channel via the new lifecycle helper.
- Load live queue state before best-effort live queue embed refresh.
- Register `queue_cleanup` and `connection_watchdog` through the same helper, preserving `TaskMonitor` duplicate-prevention behavior.
- Add focused tests for queue lifecycle ordering, best-effort embed refresh failure, and duplicate-prevention delegation.
- Update startup runbook, deferred optimisation notes, Phase 6 audit starter, and Phase 6G/6H task-pack docs.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q tests\test_queue_lifecycle.py tests\test_startup_lifecycle.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_fallback_queue_route.py` (`25 passed`)
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_queue_lifecycle.py tests\test_startup_lifecycle.py` (`10 passed`)
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1575 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py` (known secondary duplicate command notices)
- `.\.venv\Scripts\python.exe -m pre_commit run -a`
- `.\.venv\Scripts\python.exe -m pre_commit run --files core/queue_lifecycle.py tests/test_queue_lifecycle.py "docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md"`
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`
- `git diff --check`

## AI Review Gates

- Codex Security diff review: no plausible security findings; validation/attack-path phases skipped because discovery found no candidates.

## Deferred Follow-Up

- Queue persistence hardening is logged as a later optional slice after Phase 6I, or inside Phase 6I only if shutdown work requires it.
- Phase 6I notes explicitly include cooperative cancellation, queue draining/state flush, and shutdown ordering.