### PR TITLE
[codex] coordinate shutdown recovery lifecycle

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -733,17 +733,24 @@ async def _write_shutdown_markers(exit_code: int = 0, reason: str = "signal"):
 
 async def _quiesce_background_tasks():
     """
-    Stop schedulers/registries before closing the Discord client.
+    Stop app-owned schedulers/registries before closing the Discord client.
     Must be safe/idempotent if called multiple times.
     """
-    # 1) Cancel registry/scheduler loops if present
+    try:
+        from bot_instance import run_graceful_teardown
+
+        await run_graceful_teardown()
+        return
+    except Exception:
+        logger.exception("[SHUTDOWN] bot_instance graceful teardown failed.")
+
+    # Fallback only: keep the previous narrow cleanup if the bot teardown import/path fails.
     try:
         from reminder_task_registry import TaskRegistry
 
         await TaskRegistry.cancel_all(timeout=5)
     except Exception:
-        logger.debug("[SHUTDOWN] TaskRegistry cancel skipped or failed.", exc_info=True)
-    # 2) Quiesce any per-module loops (no hard fails)
+        logger.debug("[SHUTDOWN] TaskRegistry fallback cancel skipped or failed.", exc_info=True)
     try:
         from bot_instance import quiesce_logging
 

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -35,6 +35,7 @@ from bot_config import (
     UTC_CLOCK_CHANNEL_ID,
 )
 from bot_helpers import (
+    channel_queues,
     connection_watchdog,
     prune_restart_log,
     queue_cleanup_loop,
@@ -112,7 +113,13 @@ from server_activity.activity_store import ensure_activity_schema
 from server_status import run_member_count_channel_loop, run_utc_clock_channel_loop
 from subscription_tracker import load_subscriptions
 from target_utils import warm_name_cache
-from utils import ensure_aware_utc, load_live_queue, update_live_queue_embed, utcnow
+from utils import (
+    ensure_aware_utc,
+    load_live_queue,
+    save_live_queue,
+    update_live_queue_embed,
+    utcnow,
+)
 
 # offload monitor integration
 try:
@@ -1401,6 +1408,54 @@ async def schedule_event_embed_expiry():
 
 # --- Graceful teardown ------------------
 _shutdown_once = asyncio.Event()
+_QUEUE_SHUTDOWN_DRAIN_SECONDS = 3.0
+_QUEUE_SHUTDOWN_SAVE_SECONDS = 5.0
+
+
+async def _drain_shutdown_queues(timeout_seconds: float = _QUEUE_SHUTDOWN_DRAIN_SECONDS) -> None:
+    """Briefly let queue workers finish pending channel queue items before cancellation."""
+    queues = list(channel_queues.items())
+    if not queues:
+        logger.info("[SHUTDOWN] No channel queues configured for drain.")
+        return
+
+    pending_before = {channel_id: queue.qsize() for channel_id, queue in queues}
+    total_pending = sum(pending_before.values())
+    if total_pending <= 0:
+        logger.info("[SHUTDOWN] Channel queues already empty before task cancellation.")
+        return
+
+    logger.info(
+        "[SHUTDOWN] Draining %d queued message(s) across %d channel queue(s) for up to %.1fs.",
+        total_pending,
+        len(queues),
+        timeout_seconds,
+    )
+    joins = [queue.join() for _channel_id, queue in queues]
+    try:
+        await asyncio.wait_for(asyncio.gather(*joins), timeout=timeout_seconds)
+        logger.info("[SHUTDOWN] Channel queues drained before task cancellation.")
+    except TimeoutError:
+        pending_after = {channel_id: queue.qsize() for channel_id, queue in queues}
+        logger.warning(
+            "[SHUTDOWN] Channel queue drain timed out; pending_before=%s pending_after=%s",
+            pending_before,
+            pending_after,
+        )
+
+
+async def _flush_live_queue_state(timeout_seconds: float = _QUEUE_SHUTDOWN_SAVE_SECONDS) -> None:
+    """Persist live queue state before logging and process resources shut down."""
+    try:
+        await asyncio.wait_for(asyncio.to_thread(save_live_queue), timeout=timeout_seconds)
+        logger.info("[SHUTDOWN] Live queue state persisted.")
+    except TimeoutError:
+        logger.warning(
+            "[SHUTDOWN] Timed out persisting live queue state after %.1fs.",
+            timeout_seconds,
+        )
+    except Exception:
+        logger.exception("[SHUTDOWN] Failed persisting live queue state.")
 
 
 async def _graceful_teardown():
@@ -1423,6 +1478,16 @@ async def _graceful_teardown():
             logger.info("[SHUTDOWN] Stopped refresh_event_cache_task loop.")
     except Exception:
         logger.exception("[SHUTDOWN] Failed stopping refresh_event_cache_task.")
+
+    try:
+        await _drain_shutdown_queues()
+    except Exception:
+        logger.exception("[SHUTDOWN] Queue drain failed.")
+
+    try:
+        await _flush_live_queue_state()
+    except Exception:
+        logger.exception("[SHUTDOWN] Live queue flush failed.")
 
     # Cancel supervised tasks
     try:
@@ -1490,10 +1555,14 @@ async def _graceful_teardown():
         pass
 
 
+async def run_graceful_teardown():
+    await _graceful_teardown()
+
+
 @bot.event
 async def on_graceful_shutdown():
     try:
-        await _graceful_teardown()
+        await run_graceful_teardown()
     except Exception:
         logger.exception("[SHUTDOWN] on_graceful_shutdown failed.")
 

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -1422,15 +1422,18 @@ async def _drain_shutdown_queues(timeout_seconds: float = _QUEUE_SHUTDOWN_DRAIN_
     pending_before = {channel_id: queue.qsize() for channel_id, queue in queues}
     total_pending = sum(pending_before.values())
     if total_pending <= 0:
-        logger.info("[SHUTDOWN] Channel queues already empty before task cancellation.")
-        return
-
-    logger.info(
-        "[SHUTDOWN] Draining %d queued message(s) across %d channel queue(s) for up to %.1fs.",
-        total_pending,
-        len(queues),
-        timeout_seconds,
-    )
+        logger.info(
+            "[SHUTDOWN] Channel queues have no pending items; waiting up to %.1fs for "
+            "any in-flight queue work to finish.",
+            timeout_seconds,
+        )
+    else:
+        logger.info(
+            "[SHUTDOWN] Draining %d queued message(s) across %d channel queue(s) for up to %.1fs.",
+            total_pending,
+            len(queues),
+            timeout_seconds,
+        )
     joins = [queue.join() for _channel_id, queue in queues]
     try:
         await asyncio.wait_for(asyncio.gather(*joins), timeout=timeout_seconds)

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -90,12 +90,15 @@ started in the expected order with no startup phase failure or `on_ready()` crit
 Phase 6H queue worker/live queue lifecycle moved queue worker registration, live queue recovery,
 best-effort queue embed refresh, queue cleanup startup, and connection watchdog startup into
 `core/queue_lifecycle.py` and the `ready_queue_lifecycle` startup phase while preserving the
-existing `full_startup_sequence()` ordering.
+existing `full_startup_sequence()` ordering. PR 125
+(`codex/dlbot-phase-6h-queue-lifecycle`) was merged, smoke tested cleanly, pushed to production,
+and confirmed the new queue lifecycle phase ran in order with queue workers, live queue recovery,
+queue cleanup, connection watchdog, and later startup phases continuing normally.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md`, with
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md`, with
 this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
@@ -168,16 +171,16 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 - Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. After Phase 6H, keep shutdown coordination and final process-entry/bot-construction cleanup in later approval-gated slices.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6H lifecycle slices are complete or in delivery; proceed with shutdown/recovery coordination before process-entry cleanup.
+- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6H lifecycle slices are complete, merged, production-pushed, and smoke tested; proceed with shutdown/recovery coordination before process-entry cleanup.
 
 ### Deferred Optimisation
 - Area: `utils.py`, `bot_helpers.py`, `core/queue_lifecycle.py`, queue runtime state
 - Type: refactor
-- Description: Phase 6H separated queue lifecycle startup, but broader queue persistence hardening remains out of scope. `load_live_queue()` is synchronous while scheduling an async state apply when an event loop is running, and queue draining/state flush semantics are still coupled to later shutdown behavior.
+- Description: Phase 6H separated queue lifecycle startup, but broader queue persistence hardening remains out of scope. `load_live_queue()` is synchronous while scheduling an async state apply when an event loop is running, and queue draining/state flush semantics are coupled to later shutdown behavior.
 - Suggested Fix: Add a dedicated queue persistence hardening slice after Phase 6I or fold it into Phase 6I only if shutdown work requires it. Make live queue load/apply explicitly awaitable where practical, preserve sync test compatibility or add a safe wrapper, verify atomic save behavior and stale metadata handling, and add restart/persistence tests for load-before-embed-refresh ordering and state flush after queue cancellation.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6H lifecycle extraction; coordinate with Phase 6I cooperative cancellation and queue draining/state flush design.
+- Dependencies: Phase 6H lifecycle extraction is complete and production-smoke-tested; coordinate with Phase 6I cooperative cancellation and queue draining/state flush design.
 
 ### Deferred Optimisation
 - Area: `bot_helpers.py`, `bot_instance.py`, `DL_bot.py` shutdown and queue task lifecycle

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -192,6 +192,15 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 - Dependencies: Phase 6H queue lifecycle extraction; keep process-entry and bot-construction cleanup for Phase 6J unless Phase 6I reveals a hard dependency.
 
 ### Deferred Optimisation
+- Area: `graceful_shutdown.py`, `run_bot.py`, `commands/admin_cmds.py`, shutdown operations
+- Type: architecture
+- Description: The existing weekly-machine-restart helper `graceful_shutdown.py` writes shutdown markers and externally terminates matching `DL_bot.py` processes, but it does not request the bot's in-process graceful teardown path first. This can preserve watchdog/recovery markers while bypassing cooperative queue drain, live queue state flush, `TaskMonitor` cancellation ordering, usage tracker stop, and logging shutdown order.
+- Suggested Fix: Scope a dedicated shutdown-operations hardening slice after Phase 6I. Preserve `/ops force_restart` as the break-glass restart path for stuck or looping bot states, add or document a separate graceful restart/shutdown path for cooperative drains, and update `graceful_shutdown.py` so scheduled machine restarts first request the in-process graceful teardown/restart path with a bounded timeout before falling back to external process termination. Add smoke instructions and focused tests where practical for marker writing, queue drain/flush, timeout fallback, and watchdog recovery.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 6I shutdown coordination PR; operator approval for any new `/ops graceful_restart` or shutdown command naming and behavior.
+
+### Deferred Optimisation
 - Area: `event_calendar/pinned_embed.py`
 - Type: refactor
 - Description: Pinned calendar tracker persistence currently uses direct `Path.write_text()` JSON writes in `_save_tracker()`, unlike other restart-sensitive tracker files that use atomic JSON helpers and clearer failure boundaries.

--- a/docs/reference/runbook_shutdown.md
+++ b/docs/reference/runbook_shutdown.md
@@ -56,3 +56,18 @@ Use existing atomic file helpers where possible.
 - Logs are flushed before logging shutdown.
 - Critical state is persisted atomically.
 - Tests cover lock release, task cancellation, or state persistence where practical.
+
+## Phase 6I Focus
+
+Phase 6I is the next approved-review slice after Phase 6H queue lifecycle extraction. It should
+audit and then fix cooperative cancellation, queue draining/state flush, and shutdown ordering
+without reopening upload routing, scheduler ownership, command lifecycle, or process-entry cleanup.
+
+Review these shutdown/recovery surfaces together before implementation:
+
+- signal/admin/watchdog shutdown entry points
+- `bot_instance.py` graceful teardown and `TaskMonitor` cancellation behavior
+- queue workers, queue cleanup, connection watchdog, and `QUEUE_CACHE_FILE` persistence
+- shutdown marker writing, singleton/PID cleanup, and logging flush order
+- whether queue persistence hardening belongs inside Phase 6I or should remain a separate
+  follow-up slice after shutdown ordering is settled

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -52,6 +52,7 @@ Purpose: describe the bot startup sequence, guardrails, logging setup, and commo
 - `singleton_lock.py`
 - `Commands.py`
 - `core/command_lifecycle.py`
+- `core/queue_lifecycle.py`
 - `core/scheduler_lifecycle.py`
 
 ## Startup Guards
@@ -113,9 +114,16 @@ before tracked view rehydration via `ready_event_cache_refresh_loop` and changed
 registration failures to `logger.exception()` for traceback parity. Production smoke confirmed all
 new scheduler phases, Ark/MGE scheduler ticks, `full_startup_sequence()`, reminder cleanup, pinned
 calendar rehydration, daily pinned refresh, and calendar reminder loop startup with no startup
-phase failure or `on_ready()` critical exception. Phase 6H moved queue worker/live queue startup
-into `core/queue_lifecycle.py` and the `ready_queue_lifecycle` phase while preserving the existing
-`full_startup_sequence()` ordering. Remaining lifecycle cleanup continues with shutdown
+phase failure or `on_ready()` critical exception. Phase 6H completed in PR 125
+(`codex/dlbot-phase-6h-queue-lifecycle`), was smoke tested cleanly, merged, and pushed to
+production: queue worker/live queue startup now runs through `core/queue_lifecycle.py` and the
+`ready_queue_lifecycle` phase while preserving the existing `full_startup_sequence()` ordering,
+`TaskMonitor` duplicate prevention, live queue recovery, best-effort queue embed refresh, queue
+cleanup startup, and connection watchdog startup. Production smoke confirmed the new queue phase
+ran after `ready_domain_scheduler_tasks`, started workers for configured monitored channels, loaded
+live queue state before embed refresh, started queue cleanup and connection watchdog once, and
+allowed `full_startup_sequence()`, reminder cleanup, pinned calendar rehydration, and calendar
+scheduler startup to continue normally. Remaining lifecycle cleanup continues with shutdown
 coordination and final process-entry/bot-construction cleanup.
 
 When changing startup, verify restart safety and avoid duplicate task creation.

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md
@@ -1,12 +1,24 @@
 # Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle
 
-Use this starter to continue Phase 6 after Phase 6G scheduler/task-supervision startup was
-merged, smoke-tested, pushed to production, and marked complete.
+Status: complete. PR 125 (`codex/dlbot-phase-6h-queue-lifecycle`) was merged, smoke-tested, and
+pushed to production on 2026-05-28. This starter is retained as historical context for Phase 6H.
 
-Status: implementation approved and in progress. The approved ownership model uses
-`core/queue_lifecycle.py` and the `ready_queue_lifecycle` phase for queue worker registration,
-live queue recovery, best-effort queue embed refresh, queue cleanup startup, connection watchdog
-startup, ordering, logging, and `TaskMonitor` duplicate-prevention preservation.
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md` for
+the next Phase 6 slice.
+
+Delivered outcome:
+
+- `core/queue_lifecycle.py` now owns queue worker registration, live queue recovery, best-effort
+  queue embed refresh, queue cleanup startup, connection watchdog startup, ordering, logging, and
+  `TaskMonitor` duplicate-prevention preservation.
+- `bot_instance.py:full_startup_sequence()` delegates queue startup through the named
+  `ready_queue_lifecycle` phase at the existing startup point.
+- Production smoke confirmed the new queue lifecycle phase ran after `ready_domain_scheduler_tasks`,
+  queue workers started for the configured monitored channels, live queue state loaded before
+  embed refresh, queue cleanup and connection watchdog started once, and later startup phases
+  continued normally.
+- No startup phase failure, `on_ready()` critical exception, queue embed refresh failure,
+  `queue_worker` monitor crash, `queue_cleanup` crash, or `connection_watchdog` crash was observed.
 
 Follow-up note: queue persistence hardening is intentionally not part of the Phase 6H lifecycle
 extraction. Track it as an optional slice after Phase 6I, or include it in Phase 6I only if
@@ -261,8 +273,8 @@ The wider command-surface migration/renaming programme remains separate from Pha
 ## Deferred Item Links
 
 This starter continues the DL_bot startup/lifecycle deferred optimisation in
-`docs/reference/deferred_optimisations.md` after Phase 6G completed scheduler/task-supervision
-boundary extraction.
+`docs/reference/deferred_optimisations.md` after Phase 6H completed queue worker/live queue
+lifecycle extraction.
 
 Carry forward, but do not implement unless separately approved:
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md
@@ -1,0 +1,286 @@
+# Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination
+
+Use this starter to continue Phase 6 after Phase 6H queue worker/live queue lifecycle was merged,
+smoke-tested, pushed to production, and marked complete.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6I:
+shutdown and recovery coordination.
+
+Phase 6A, 6B, 6C, 6D, 6E, 6F, 6G, and 6H are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged and pushed to production.
+- PR 123 (`codex/dlbot-phase-6f-event-rehydration`) was merged and pushed to production.
+- PR 124 (`codex/dlbot-phase-6g-scheduler-lifecycle`) was merged and pushed to production.
+- PR 125 (`codex/dlbot-phase-6h-queue-lifecycle`) was merged and pushed to production.
+- `core/startup_lifecycle.py` provides `StartupPhase` and `run_startup_phases()`.
+- `core/command_lifecycle.py` owns startup command signature/cache/sync mechanics and shared
+  `/ops` command lifecycle mechanics.
+- `core/event_rehydration_lifecycle.py` owns event cache, active reminder loading, tracked view
+  rehydration scheduling, and pinned calendar view rehydration scheduling.
+- `core/scheduler_lifecycle.py` owns scheduler/task registration ordering, event readiness
+  gating, `TaskMonitor` registration, duplicate-prevention checks, and best-effort failure
+  logging.
+- `core/queue_lifecycle.py` owns queue worker registration, live queue recovery, best-effort queue
+  embed refresh, queue cleanup startup, connection watchdog startup, ordering, logging, and
+  `TaskMonitor` duplicate-prevention preservation.
+- `bot_instance.py:on_ready()` delegates:
+  - initial loop/console bootstrap through `ready_runtime_bootstrap`
+  - runtime services/observability startup through `ready_runtime_services`
+  - startup command signature/cache/sync through `ready_command_sync`
+  - event cache/reminder/live-event readiness through `ready_event_cache_rehydration`
+  - event-dependent scheduler tasks through `ready_event_scheduler_tasks`
+  - long-running event cache refresh loop through `ready_event_cache_refresh_loop`
+  - tracked view rehydration through `ready_view_rehydration`
+  - Ark/MGE scheduler startup through `ready_domain_scheduler_tasks`
+  - queue worker/live queue startup through `ready_queue_lifecycle`
+  - pinned calendar rehydration through `ready_pinned_calendar_rehydration`
+  - calendar scheduler startup through `ready_calendar_scheduler_tasks`
+- Production smoke logs confirmed for Phase 6H:
+  - `ready_queue_lifecycle` ran after `ready_domain_scheduler_tasks`
+  - queue workers started for the configured monitored channels
+  - live queue state loaded before live queue embed refresh
+  - live queue embed refresh completed
+  - queue cleanup started once
+  - connection watchdog started once
+  - `full_startup_sequence()` completed
+  - reminder cleanup, pinned calendar rehydration, and calendar scheduler tasks continued normally
+  - no startup phase failure, `on_ready()` critical exception, queue embed refresh failure,
+    `queue_worker` monitor crash, `queue_cleanup` crash, or `connection_watchdog` crash was
+    observed
+
+This is review/scope first. Do not implement code changes until the Phase 6I scope, target
+ownership model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/reference/runbook_diagnostics.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md`
+
+## Phase 6I Objective
+
+Separate and harden shutdown/recovery coordination while preserving current operator behavior,
+restart safety, singleton/runtime file handling, queue state persistence, task supervision, and
+logging shutdown order.
+
+Explicit Phase 6I fix target:
+
+- Handle cooperative cancellation, queue draining/state flush, and shutdown ordering.
+
+The next cohesive slice after Phase 6H is the shutdown/recovery block currently spread across
+`DL_bot.py`, `bot_instance.py`, `TaskMonitor`, queue worker helpers, singleton/runtime files, and
+logging setup:
+
+- signal/admin/watchdog shutdown entry points
+- `on_graceful_shutdown()` and `_graceful_teardown()`
+- `TaskMonitor` cancellation/listing/restart behavior during shutdown
+- queue workers, queue cleanup loop, connection watchdog, and `QUEUE_CACHE_FILE` state flush
+- shutdown marker and restart marker handling, including `LAST_SHUTDOWN_INFO`,
+  `LAST_RESTART_INFO`, `RESTART_FLAG_PATH`, `EXIT_CODE_FILE`, and related runtime files
+- singleton lock and PID cleanup behavior
+- logging flush/quiesce/shutdown behavior
+- recovery verification through startup logs and persisted state
+
+Recommended target: keep process-entry behavior in place for this slice, but introduce or refine a
+narrow lifecycle helper/boundary only if the audit proves it makes shutdown ordering and tests
+clearer. Avoid a broad process-entry rewrite. Keep queue worker implementation logic in existing
+modules unless the audit proves a small extraction is necessary for cooperative cancellation or
+state flush.
+
+## In Scope
+
+- Audit the relationship between:
+  - `DL_bot.py` signal handling and graceful shutdown helpers
+  - `bot_instance.py:on_graceful_shutdown()`
+  - `bot_instance.py:_graceful_teardown()`
+  - `TaskMonitor` task listing, active flag, cancellation, and restart behavior
+  - queue lifecycle tasks: `queue_worker:{cid}`, `queue_cleanup`, `connection_watchdog`
+  - `queue_worker(cid)`, `queue_cleanup_loop`, `connection_watchdog(bot)`
+  - shared queue state and locking through `utils.live_queue_lock`
+  - `QUEUE_CACHE_FILE`, `save_live_queue()`, and live queue recovery expectations
+  - shutdown/restart marker files such as `LAST_SHUTDOWN_INFO`, `LAST_RESTART_INFO`,
+    `RESTART_FLAG_PATH`, `EXIT_CODE_FILE`, `SHUTDOWN_MARKER_FILE`, and `BOT_LOCK_PATH`
+  - `logging_setup.flush_logs()`, `quiesce_logging()`, and `shutdown_logging()`
+  - watchdog and bot-machine restart behavior
+- Define the exact shutdown ordering that must be preserved or intentionally corrected.
+- Decide whether shutdown coordination should be one helper/boundary or multiple smaller helpers.
+- Preserve restart safety, idempotency, and duplicate-shutdown prevention.
+- Preserve existing operator-facing restart/shutdown notifications unless explicitly approved.
+- Add or update focused tests for cooperative task cancellation, queue state flush, shutdown marker
+  writing, idempotency, and continued clean restart behavior where practical.
+- Decide whether queue persistence hardening is required inside Phase 6I or should remain a
+  separate follow-up slice after shutdown ordering is settled.
+- Capture process-entry and broader bot-construction cleanup findings as Phase 6J work unless
+  explicitly approved for this slice.
+
+## Out Of Scope
+
+- Broad `DL_bot.py` process-entry rewrite or bot construction cleanup.
+- Upload-route behavior changes, including fallback queue routing behavior.
+- Queue worker processing behavior changes beyond what is needed for cooperative cancellation,
+  queue draining, or state flush.
+- Scheduler ownership changes already completed in Phase 6G.
+- Queue startup ownership changes already completed in Phase 6H.
+- Event cache load/refresh ownership changes already completed in Phase 6F and 6G.
+- Command lifecycle, command sync, command cache, slash-command renaming, grouping, or retirement.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes unless unexpectedly required by
+  shutdown validation.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `DL_bot.py`
+- `bot_instance.py`
+- `core/startup_lifecycle.py`
+- `core/scheduler_lifecycle.py`
+- `core/queue_lifecycle.py`
+- `bot_helpers.py`
+- `utils.py`
+- `constants.py`
+- `logging_setup.py`
+- `singleton_lock.py`
+- `bot_startup_gate.py`
+- `boot_safety.py`
+- `startup_utils.py`
+- `run_bot.py`
+- `tests/test_singleton_lock_Version2.py`
+- `tests/test_live_queue_persistence.py`
+- `tests/test_utils_live_queue.py`
+- `tests/test_queue_lifecycle.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_process_utils.py`
+- `tests/test_file_utils_lockinfo.py`
+- `tests/test_file_utils.py`
+- `tests/test_command_registration_smoke.py`
+
+Likely modify after approval:
+
+- `bot_instance.py`
+- `DL_bot.py` only if the audit proves a narrow shutdown hook change is required
+- one focused shutdown lifecycle helper if the audit proves a clean extraction
+- focused shutdown/queue persistence tests
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Do not create a broad process-entry or bot-construction module in Phase 6I.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Shutdown / Recovery Lifecycle Map
+- Current Phase 6A-H Startup Lifecycle Boundary Map
+- Proposed Phase 6I Ownership Model
+- Shutdown Ordering And Idempotency Checklist
+- TaskMonitor Cancellation And Duplicate-Prevention Map
+- Queue Draining And State Flush Map
+- Runtime State, Marker, Lock, And Persistence Map
+- Logging Flush / Quiesce / Shutdown Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6I Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_queue_lifecycle.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_singleton_lock_Version2.py tests\test_process_utils.py tests\test_file_utils_lockinfo.py tests\test_file_utils.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6I touches
+shutdown, file-backed runtime state, queue recovery, task cancellation, singleton locks, logging,
+watchdog/restart behavior, and restart-sensitive persistence.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- normal startup still shows all Phase 6A-H startup phases
+- graceful shutdown or `/ops force_restart` writes expected restart/shutdown markers
+- queue workers cancel cooperatively or drain according to the approved design
+- live queue state is flushed before shutdown completes
+- `QUEUE_CACHE_FILE` remains readable and startup can reload it
+- singleton lock/PID state is cleaned or preserved according to existing watchdog expectations
+- logs are flushed before logging shutdown/quiesce prevents late handler failures
+- restart returns through the expected startup notification path
+- repeated shutdown requests remain idempotent
+- repeated `on_ready()` still skips startup work and no duplicate background tasks are observed
+
+The smoke test should not show:
+
+```text
+[CRITICAL] Exception during on_ready
+[STARTUP] phase failed
+[SHUTDOWN] on_graceful_shutdown failed
+[SHUTDOWN] Failed writing shutdown heartbeat
+[QUEUE] Failed to save
+[MONITOR] Task queue_worker
+[MONITOR] Task queue_cleanup crashed
+[MONITOR] Task connection_watchdog crashed
+```
+
+Known best-effort warnings may be acceptable only when intentionally induced or otherwise
+understood, and only when shutdown/restart still continues cleanly.
+
+## Remaining Phase 6 Slices
+
+Recommended order after Phase 6H:
+
+1. Phase 6I shutdown and recovery coordination, including cooperative cancellation, queue
+   draining/state flush, and shutdown ordering.
+2. Optional queue persistence hardening slice after Phase 6I, unless Phase 6I requires it directly.
+3. Phase 6J process-entry and bot-construction cleanup.
+
+The wider command-surface migration/renaming programme remains separate from Phase 6.
+
+## Deferred Item Links
+
+This starter continues the DL_bot startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6H completed queue worker/live queue
+lifecycle extraction.
+
+Carry forward, but do not implement unless separately approved:
+
+- process-entry and bot-construction cleanup
+- queue persistence hardening after Phase 6I, unless required directly by Phase 6I shutdown work
+- pinned calendar tracker persistence hardening in `event_calendar/pinned_embed.py`

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-28`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F/6G startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F/6G/6H startup lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -25,13 +25,13 @@ Before implementation, read the current repository instructions and indexed core
 - `docs/reference/runbook_startup.md`
 - `docs/reference/runbook_shutdown.md`
 - `docs/reference/singleton_lock.md`
+- `docs/reference/runbook_diagnostics.md`
 - `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
-- `docs/task_packs/DL_bot Upload Routing - Phase 5 Remaining Upload Fast Paths Starter.md`
-- `docs/task_packs/DL_bot Upload Routing - Phase 5D Fallback Queue Route Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md`
 
-Use `docs/reference/runbook_diagnostics.md` if the audit needs deeper diagnostics, telemetry,
-offload registry, queue recovery, watchdog, or log-backup context. Use `docs/reference/ENV_REFERENCE.md`
-if environment-variable ownership or runtime configuration validation becomes part of the design.
+Use `docs/reference/ENV_REFERENCE.md` if environment-variable ownership or runtime configuration
+validation becomes part of the design.
 
 SQL validation is not expected for the first Phase 6 audit unless the review unexpectedly reaches
 SQL-backed cache, import, export, report, or ProcConfig contracts. If it does, validate relevant
@@ -158,8 +158,28 @@ Phase 6G scheduler and task-supervision boundary is complete:
 - No startup phase failure, `on_ready()` critical exception, scheduler registration failure,
   pinned-calendar scheduling failure, or calendar reminder loop failure was observed.
 - The PR was merged and pushed to production.
-- Queue worker lifecycle, shutdown coordination, and process-entry cleanup remain later Phase 6
-  slices.
+
+Phase 6H queue worker/live queue lifecycle is complete:
+
+- PR 125 (`codex/dlbot-phase-6h-queue-lifecycle`) added `core/queue_lifecycle.py`.
+- `core/queue_lifecycle.py` owns queue worker registration, live queue recovery, best-effort queue
+  embed refresh, queue cleanup startup, connection watchdog startup, ordering, logging, and
+  `TaskMonitor` duplicate-prevention preservation.
+- `bot_instance.py:full_startup_sequence()` delegates queue startup through the named
+  `ready_queue_lifecycle` phase at the existing point after restart/log initialization and before
+  CrystalTech startup.
+- Focused tests cover worker registration ordering, live queue load before embed refresh,
+  best-effort embed refresh failure behavior, and duplicate-prevention delegation through
+  `TaskMonitor.create()`.
+- Production smoke testing on 2026-05-28 confirmed the queue lifecycle phase ran after
+  `ready_domain_scheduler_tasks`, queue workers started for the configured monitored channels, live
+  queue state loaded before embed refresh, queue cleanup and connection watchdog started once,
+  `full_startup_sequence()` completed, reminder cleanup started, pinned calendar rehydration
+  completed, and calendar scheduler tasks armed.
+- No startup phase failure, `on_ready()` critical exception, queue embed refresh failure,
+  `queue_worker` monitor crash, `queue_cleanup` crash, or `connection_watchdog` crash was observed.
+- The PR was merged and pushed to production.
+- Shutdown coordination and process-entry cleanup remain later Phase 6 slices.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -374,7 +394,7 @@ Initial classification before audit:
 | Event cache, reminder loading, and rehydration boundary | complete | Phase 6F separated event cache load/refresh, active reminder loading, event-dependent view rehydration, tracked view rehydration, and pinned calendar view rehydration from the remaining `on_ready()` body with explicit ordering and startup phase logs. Scheduler ownership inside the existing event-dependent bundle was deliberately deferred to Phase 6G. |
 | Scheduler and task-supervision boundary | complete | Phase 6G separated scheduler/task registration from the remaining `on_ready()` body and the previous event-dependent bundle while preserving startup order, readiness gates, best-effort behavior, and `TaskMonitor` duplicate prevention. |
 | `on_ready()` / `full_startup_sequence()` remaining responsibilities | audit first | Continue extracting in small slices; do not move cache warming, startup notifications, shutdown, and process entry together. |
-| Queue worker startup and live queue rehydration | complete | Phase 6H extracted queue worker registration, live queue recovery, best-effort queue embed refresh, queue cleanup startup, and connection watchdog startup into `core/queue_lifecycle.py` and `ready_queue_lifecycle` while preserving ordering and `TaskMonitor` duplicate prevention. |
+| Queue worker startup and live queue rehydration | complete | Phase 6H extracted queue worker registration, live queue recovery, best-effort queue embed refresh, queue cleanup startup, and connection watchdog startup into `core/queue_lifecycle.py` and `ready_queue_lifecycle` while preserving ordering and `TaskMonitor` duplicate prevention. PR 125 was smoke tested, merged, and pushed to production. |
 | Task monitor/scheduler startup | audit first | Multiple subsystems depend on startup order and duplicate prevention. |
 | Graceful shutdown and signal handling | audit first | High blast radius; may be separate PR from startup extraction. |
 | SQL/importer contracts | not applicable unless discovered | Phase 6 should avoid SQL/importer contract changes. |

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -176,3 +176,71 @@ def test_queue_lifecycle_uses_dedicated_helper():
     assert not _calls_name(full_startup, "update_live_queue_embed")
     assert not _creates_task_monitor_task(full_startup, "queue_cleanup")
     assert not _creates_task_monitor_task(full_startup, "connection_watchdog")
+
+
+def _call_order(node: ast.AST, names: set[str]) -> list[str]:
+    ordered: list[tuple[int, str]] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        name: str | None = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name in names:
+            ordered.append((getattr(child, "lineno", 0), name))
+    return [name for _lineno, name in sorted(ordered)]
+
+
+def _task_monitor_stop_line(node: ast.AST) -> int:
+    for child in ast.walk(node):
+        if not (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "stop"
+            and isinstance(child.func.value, ast.Name)
+            and child.func.value.id == "task_monitor"
+        ):
+            continue
+        return getattr(child, "lineno", 0)
+    raise AssertionError("task_monitor.stop() call not found")
+
+
+def _first_call_line(node: ast.AST, name: str) -> int:
+    lines = [
+        getattr(child, "lineno", 0)
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == name
+    ]
+    if not lines:
+        raise AssertionError(f"{name}() call not found")
+    return min(lines)
+
+
+def test_graceful_teardown_drains_and_flushes_queue_before_task_monitor_stop():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    teardown = _async_function(tree, "_graceful_teardown")
+    task_monitor_stop_line = _task_monitor_stop_line(teardown)
+
+    assert _first_call_line(teardown, "_drain_shutdown_queues") < task_monitor_stop_line
+    assert _first_call_line(teardown, "_flush_live_queue_state") < task_monitor_stop_line
+
+
+def test_dl_bot_signal_shutdown_calls_bot_instance_teardown_before_bot_close():
+    src = Path("DL_bot.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    shutdown = _async_function(tree, "_graceful_shutdown")
+    order = _call_order(shutdown, {"_quiesce_background_tasks", "close", "_shutdown_logging"})
+
+    assert order.index("_quiesce_background_tasks") < order.index("close")
+    assert order.index("close") < order.index("_shutdown_logging")
+
+    quiesce = _async_function(tree, "_quiesce_background_tasks")
+    assert _calls_name(quiesce, "run_graceful_teardown")

--- a/tests/test_startup_lifecycle.py
+++ b/tests/test_startup_lifecycle.py
@@ -232,6 +232,25 @@ def test_graceful_teardown_drains_and_flushes_queue_before_task_monitor_stop():
     assert _first_call_line(teardown, "_flush_live_queue_state") < task_monitor_stop_line
 
 
+def test_queue_shutdown_drain_waits_even_when_qsize_is_zero():
+    src = Path("bot_instance.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    drain = _async_function(tree, "_drain_shutdown_queues")
+    total_pending_branch = next(
+        node
+        for node in ast.walk(drain)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "total_pending"
+    )
+
+    assert not any(isinstance(child, ast.Return) for child in ast.walk(total_pending_branch))
+    assert "gather" in _call_order(drain, {"gather", "wait_for"})
+    assert "wait_for" in _call_order(drain, {"gather", "wait_for"})
+
+
 def test_dl_bot_signal_shutdown_calls_bot_instance_teardown_before_bot_close():
     src = Path("DL_bot.py").read_text(encoding="utf-8")
     tree = ast.parse(src)


### PR DESCRIPTION
## Summary

- Route signal/admin shutdown through the bot-side graceful teardown before closing the Discord client.
- Add bounded queue draining plus live queue state persistence before supervised task cancellation.
- Update Phase 6I shutdown/recovery docs and task-pack context, while carrying queue persistence hardening as a follow-up phase.

## Changes

- `DL_bot.py` now calls `bot_instance.run_graceful_teardown()` from the signal shutdown path before `bot.close()`.
- `bot_instance.py` drains pending `channel_queues` briefly, persists `live_queue` state via `save_live_queue()`, then stops `TaskMonitor`.
- `tests/test_startup_lifecycle.py` asserts the shutdown ordering contracts.
- Docs/task packs now include Phase 6I shutdown/recovery scope and follow-up notes.

## Tests

- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_queue_lifecycle.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_singleton_lock_Version2.py tests\test_process_utils.py tests\test_file_utils_lockinfo.py tests\test_file_utils.py`
- `.\.venv\Scripts\python.exe -m pre_commit run -a`
- `.\.venv\Scripts\python.exe -m pytest -q tests` (`1577 passed, 2 skipped`)
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`

## AI Review Gates

- Codex Security diff review: no plausible security findings in the shutdown coordination patch.

## Deferred Optimisations

- Full queue persistence hardening remains a later phase after Phase 6I, unless separately approved.
- Phase 6J process-entry and bot-construction cleanup remains separate.

## Risk / Rollback

- Risk: medium-high because shutdown/recovery touches restart-sensitive task cancellation, runtime files, queue recovery, and logging order.
- Rollback: revert this PR and restart from the previous production branch.