### PR TITLE
[codex] Add graceful restart operations

### DIFF
--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -10,7 +10,6 @@ import json
 import os
 import re
 import signal
-import sys
 from collections import deque
 from datetime import datetime, timezone
 from math import ceil
@@ -34,6 +33,7 @@ from commands.telemetry_cmds import (
     _usage_detail_value_ac,
     start_bot_time,
 )
+from core.restart_operations import run_cooperative_restart, write_restart_request
 
 from embed_utils import FailuresView, HistoryView, generate_summary_embed
 from event_calendar.service import get_calendar_service
@@ -44,7 +44,7 @@ from proc_config_import import run_proc_config_import_offload
 from stats_alerts.interface import send_stats_update_embed
 from stats_alerts.kvk_meta import is_currently_kvk
 from stats_module import run_stats_copy_archive
-from ui.views.admin_views import ConfirmRestartView, LogTailView
+from ui.views.admin_views import LogTailView
 from utils import utcnow
 from versioning import versioned
 
@@ -63,11 +63,9 @@ from constants import (
     CSV_LOG,
     DATABASE,
     COMMAND_CACHE_FILE,
-    EXIT_CODE_FILE,
     FAILED_LOG,
     PASSWORD,
     RESTART_EXIT_CODE,
-    RESTART_FLAG_PATH,
     SERVER,
     SHEET_ID,
     SUMMARY_LOG,
@@ -513,127 +511,59 @@ def register_admin(bot: ext_commands.Bot) -> None:
         await ctx.interaction.edit_original_response(content=None, embed=embed)
 
     @ops_group.command(
-        name="restart_bot",
-        description="Forcefully restart the bot",
+        name="graceful_restart",
+        description="Safely drain work and restart the bot via the watchdog.",
     )
-    @versioned("v1.06")
+    @versioned("v1.00")
     @safe_command
     @is_admin_and_notify_channel()
+    @ext_commands.has_permissions(administrator=True)
     @track_usage()
-    async def restart_bot_command(ctx):
-        view = ConfirmRestartView(ctx, bot=bot, notify_channel_id=NOTIFY_CHANNEL_ID)
-        await ctx.respond("⚠️ Are you sure you want to restart the bot?", view=view, ephemeral=True)
+    async def graceful_restart(ctx):
+        logger.info("[COMMAND] /graceful_restart invoked by %s", ctx.user)
 
-        # Cache the original ephemeral message so the view can disable itself
         try:
-            view.message = await ctx.interaction.original_response()
+            await safe_defer(ctx, ephemeral=True)
         except Exception:
             pass
 
         try:
-            await asyncio.wait_for(view.confirmed.wait(), timeout=30)
-        except TimeoutError:
-            # Use followup after initial respond
-            await view._try_disable_ui()
-            await ctx.followup.send(
-                "⏱️ Restart cancelled – no confirmation received.", ephemeral=True
+            await ctx.interaction.edit_original_response(
+                content="Restarting safely: draining queues and saving runtime state..."
             )
-            return
+        except Exception:
+            pass
 
-        if view.cancelled:
-            await ctx.followup.send("✅ Restart request cancelled.", ephemeral=True)
-            return
-
-        logger.info("[RESTART] Confirmation received – proceeding with restart.")
-        await asyncio.sleep(2)
-
-        restart_data = {
-            "timestamp": datetime.utcnow().isoformat(),
-            "user_id": ctx.user.id,
-            "reason": "slash_restart",
-        }
-
-        try:
-            with open(RESTART_FLAG_PATH, "w", encoding="utf-8") as f:
-                json.dump(restart_data, f)
-                f.flush()
-                os.fsync(f.fileno())
-            logger.info("[RESTART] Restart flag file written")
-
+        async def _do_graceful_restart():
             try:
-                with open(RESTART_FLAG_PATH, encoding="utf-8") as f:
-                    contents = f.read().strip()
-                logger.info(f"[RESTART] Restart flag content: {contents}")
-            except Exception as e:
-                logger.exception(f"[RESTART] Failed to read back restart flag: {e}")
+                from bot_instance import run_graceful_teardown
 
-            ws_code, ws_reason, ws_time = "", "", ""
-            if os.path.exists(".last_disconnect_reason"):
-                try:
-                    with open(".last_disconnect_reason", encoding="utf-8") as f:
-                        ws_info = json.load(f)
-                        ws_code = str(ws_info.get("code", ""))
-                        ws_reason = ws_info.get("reason", "")
-                        ws_time = ws_info.get("timestamp", "")
-                except Exception as e:
-                    logger.exception(
-                        f"[RESTART] Failed to read .last_disconnect_reason for CSV: {e}"
-                    )
-
-            await append_csv_line(
-                "restart_log.csv",
-                [
-                    restart_data["timestamp"],
-                    restart_data["reason"],
-                    restart_data["user_id"],
-                    "success",
-                    ws_code,
-                    ws_reason,
-                    ws_time,
-                ],
-            )
-
-        except Exception as e:
-            logger.exception(f"[RESTART] Failed to write restart flag or log: {e}")
-
-        try:
-            logger.info("[RESTART] Restarting bot via slash command.")
-            logger.info(f"[RESTART] sys.executable = {sys.executable}")
-            logger.info(f"[RESTART] sys.argv = {sys.argv}")
-
-            # Followup (not respond) after the initial message
-            await ctx.followup.send(
-                "✅ Restarting now... This may take a few seconds.", ephemeral=True
-            )
-            await asyncio.sleep(3)
-
-            flush_logs()
-
-            with open(EXIT_CODE_FILE, "w", encoding="utf-8") as f:
-                f.write(str(RESTART_EXIT_CODE))
-
-            flush_logs()
-            await asyncio.sleep(1)
-            print("[RESTART] Restart flag written – sleeping before SIGTERM")
-            print("[RESTART] Sending SIGTERM to self now.")
-            os.kill(os.getpid(), signal.SIGTERM)
-
-        except Exception as e:
-            logger.exception(f"[RESTART ERROR] Restart attempt failed: {e}")
-            try:
-                await ctx.followup.send(
-                    # architecture-check: allow
-                    embed=discord.Embed(
-                        title="❌ Restart Failed",
-                        description=f"Bot restart failed: `{type(e).__name__}: {e}`",
-                        color=0xE74C3C,
-                    ),
-                    ephemeral=True,
+                await run_cooperative_restart(
+                    reason="slash_graceful_restart",
+                    user_id=str(ctx.user.id),
+                    append_csv_line=append_csv_line,
+                    graceful_teardown=run_graceful_teardown,
+                    close_bot=bot.close,
+                    flush_logs=flush_logs,
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.exception("[RESTART ERROR] Graceful restart attempt failed: %s", e)
+                try:
+                    await ctx.followup.send(
+                        # architecture-check: allow
+                        embed=discord.Embed(
+                            title="Graceful Restart Failed",
+                            description=f"Bot restart failed: `{type(e).__name__}: {e}`",
+                            color=0xE74C3C,
+                        ),
+                        ephemeral=True,
+                    )
+                except Exception:
+                    pass
 
-    # Commands.py — replace the whole function body of force_restart with this slimmer flow
+        asyncio.create_task(_do_graceful_restart())
+        return
+
     @ops_group.command(
         name="force_restart",
         description="Force a restart via the watchdog mechanism (admin only).",
@@ -661,41 +591,12 @@ def register_admin(bot: ext_commands.Bot) -> None:
         # 3) Schedule the actual restart; DO NOT await long-running work here
         async def _do_restart():
             try:
-                # Write restart flag + audit quickly
-                restart_flag = {
-                    "timestamp": datetime.utcnow().isoformat(),
-                    "reason": "slash_force_restart",
-                    "user_id": str(ctx.user.id),
-                }
-                with open(RESTART_FLAG_PATH, "w", encoding="utf-8") as f:
-                    json.dump(restart_flag, f)
-                    f.flush()
-                    os.fsync(f.fileno())
+                await write_restart_request(
+                    reason="slash_force_restart",
+                    user_id=str(ctx.user.id),
+                    append_csv_line=append_csv_line,
+                )
                 logger.info("[RESTART] Flag written")
-
-                # Optional CSV audit (best-effort)
-                try:
-                    await append_csv_line(
-                        "restart_log.csv",
-                        [
-                            restart_flag["timestamp"],
-                            restart_flag["reason"],
-                            restart_flag["user_id"],
-                            "success",
-                            "",
-                            "",
-                            "",
-                        ],
-                    )
-                except Exception:
-                    pass
-
-                # Exit code file for watchdog
-                try:
-                    with open(EXIT_CODE_FILE, "w", encoding="utf-8") as f:
-                        f.write(str(RESTART_EXIT_CODE))
-                except Exception:
-                    pass
 
                 # Small delay to let the response leave the socket
                 await asyncio.sleep(0.25)

--- a/core/restart_operations.py
+++ b/core/restart_operations.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+import json
+import logging
+import os
+from typing import Any
+
+from constants import EXIT_CODE_FILE, RESTART_EXIT_CODE, RESTART_FLAG_PATH
+
+logger = logging.getLogger(__name__)
+
+RestartAuditWriter = Callable[[str, list[Any]], Awaitable[Any]]
+AsyncStep = Callable[[], Awaitable[Any]]
+FlushLogs = Callable[[], Any]
+DEFAULT_BOT_CLOSE_TIMEOUT_SECONDS = 10.0
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _fsync_json(path: str, payload: dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def _write_exit_code(path: str, exit_code: int) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(str(exit_code))
+        f.flush()
+        os.fsync(f.fileno())
+
+
+async def write_restart_request(
+    *,
+    reason: str,
+    user_id: str,
+    append_csv_line: RestartAuditWriter | None = None,
+    restart_flag_path: str = RESTART_FLAG_PATH,
+    exit_code_file: str = EXIT_CODE_FILE,
+    exit_code: int = RESTART_EXIT_CODE,
+    timestamp: str | None = None,
+) -> dict[str, str]:
+    restart_flag = {
+        "timestamp": timestamp or _utcnow_iso(),
+        "reason": reason,
+        "user_id": str(user_id),
+    }
+    _fsync_json(restart_flag_path, restart_flag)
+    _write_exit_code(exit_code_file, exit_code)
+
+    if append_csv_line is not None:
+        try:
+            await append_csv_line(
+                "restart_log.csv",
+                [
+                    restart_flag["timestamp"],
+                    restart_flag["reason"],
+                    restart_flag["user_id"],
+                    "success",
+                    "",
+                    "",
+                    "",
+                ],
+            )
+        except Exception:
+            logger.exception("[RESTART] Failed to append restart audit log.")
+
+    return restart_flag
+
+
+async def run_cooperative_restart(
+    *,
+    reason: str,
+    user_id: str,
+    append_csv_line: RestartAuditWriter | None,
+    graceful_teardown: AsyncStep,
+    close_bot: AsyncStep,
+    flush_logs: FlushLogs | None = None,
+    response_delay_seconds: float = 0.25,
+    close_timeout_seconds: float = DEFAULT_BOT_CLOSE_TIMEOUT_SECONDS,
+) -> dict[str, str]:
+    restart_flag = await write_restart_request(
+        reason=reason,
+        user_id=user_id,
+        append_csv_line=append_csv_line,
+    )
+    if response_delay_seconds > 0:
+        await asyncio.sleep(response_delay_seconds)
+    await graceful_teardown()
+    if flush_logs is not None:
+        flush_logs()
+    try:
+        await asyncio.wait_for(close_bot(), timeout=close_timeout_seconds)
+    except TimeoutError:
+        logger.warning("[RESTART] bot.close() timed out after %.1fs", close_timeout_seconds)
+    return restart_flag

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -1,6 +1,6 @@
 # Command Surface Audit
 
-Last updated: 2026-05-19
+Last updated: 2026-05-28
 
 ## Current Registration Summary
 
@@ -29,7 +29,8 @@ application-command limit. The validator warns at 90+ and fails above 100.
 |---|---|
 | `/run_sql_proc` | `/ops run_sql_proc` |
 | `/run_gsheets_export` | `/ops run_gsheets_export` |
-| `/restart_bot` | `/ops restart_bot` |
+| `/restart_bot` | retired in favour of `/ops graceful_restart` |
+| n/a | `/ops graceful_restart` |
 | `/force_restart` | `/ops force_restart` |
 | `/resync_commands` | `/ops resync_commands` |
 | `/show_command_versions` | `/ops show_command_versions` |

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -93,13 +93,25 @@ best-effort queue embed refresh, queue cleanup startup, and connection watchdog 
 existing `full_startup_sequence()` ordering. PR 125
 (`codex/dlbot-phase-6h-queue-lifecycle`) was merged, smoke tested cleanly, pushed to production,
 and confirmed the new queue lifecycle phase ran in order with queue workers, live queue recovery,
-queue cleanup, connection watchdog, and later startup phases continuing normally.
+queue cleanup, connection watchdog, and later startup phases continuing normally. Phase 6I shutdown
+and recovery coordination was completed in PR 126
+(`codex/dlbot-phase-6i-shutdown-recovery`), merged, and pushed to production: signal shutdown now
+routes through bot-side graceful teardown before `bot.close()`, `bot_instance.py` briefly waits for
+configured `channel_queues` including in-flight `queue.join()` work, persists `QUEUE_CACHE_FILE`
+through `save_live_queue()`, then cancels supervised tasks and stops usage tracking. Validation
+passed locally, and production `/ops force_restart` smoke confirmed restart recovery and all
+Phase 6A-H startup phases continued normally. Because `/ops force_restart` intentionally remains a
+break-glass path and Windows/process termination did not expose a reliable in-process graceful
+shutdown log trail, Phase 6I is closed with residual smoke risk. Phase 6J now owns the approved
+two-route operator model: retire `/ops restart_bot`, add `/ops graceful_restart` as the safe
+cooperative restart path, preserve `/ops force_restart` as break-glass, and harden
+`graceful_shutdown.py` with a configurable cooperative fallback timeout.
 
 The next coherent major architecture batch should be scoped as fresh work around `DL_bot.py`
 startup/lifecycle ownership, not as a continuation of upload routing. Continue that task from
 `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md` and
-`docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md`, with
-this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
+`docs/task_packs/Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations.md`,
+with this backlog and the current `K98-bot-mirror` GitHub issues list as supporting context.
 
 ### Deferred Optimisation
 - Area: `tests/test_ark_preference_service.py`, `tests/test_ark_bans_enforcement.py`, `tests/test_lock_timeout.py`, `tests/test_calendar_service.py`, `tests/test_calendar_pipeline.py`, remaining slow full-suite pytest paths
@@ -167,29 +179,38 @@ this backlog and the current `K98-bot-mirror` GitHub issues list as supporting c
 ### Deferred Optimisation
 - Area: `DL_bot.py`, `bot_instance.py` startup and lifecycle
 - Type: architecture
-- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, cache warming, startup notifications, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner, Phase 6F extracted event cache, reminder loading, tracked view rehydration, and pinned calendar view rehydration behind named lifecycle boundaries, Phase 6G extracted scheduler/task-supervision startup into `core/scheduler_lifecycle.py`, and Phase 6H extracted queue worker/live queue startup into `core/queue_lifecycle.py`. Remaining `on_ready()` work still mixes cache warming, startup notifications, shutdown coordination, and process-entry/bot-construction cleanup.
-- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. After Phase 6H, keep shutdown coordination and final process-entry/bot-construction cleanup in later approval-gated slices.
+- Description: Startup and lifecycle responsibilities remain spread across `DL_bot.py` and `bot_instance.py`, including interpreter/startup checks, bot construction/import wiring, event registration, singleton/runtime concerns, signal/shutdown handling, cache warming, startup notifications, and lifecycle coordination for the wider bot. Phase 5 completed upload-route separation, Phase 6A introduced the first named startup lifecycle boundary for the initial `on_ready()` runtime bootstrap, Phase 6B extracted runtime services/observability startup into `ready_runtime_services`, Phase 6C consolidated usage tracker lifecycle ownership, Phase 6D extracted startup command signature/cache/sync handling into `core/command_lifecycle.py` and `ready_command_sync`, Phase 6E converged command lifecycle admin tooling onto the same lifecycle owner, Phase 6F extracted event cache, reminder loading, tracked view rehydration, and pinned calendar view rehydration behind named lifecycle boundaries, Phase 6G extracted scheduler/task-supervision startup into `core/scheduler_lifecycle.py`, Phase 6H extracted queue worker/live queue startup into `core/queue_lifecycle.py`, Phase 6I added bot-side graceful teardown coordination for queue drain/state flush before supervised task cancellation, and Phase 6J now scopes cooperative restart/shutdown operations. Remaining lifecycle work after Phase 6J should address process-entry/bot-construction cleanup.
+- Suggested Fix: Continue Phase 6 incrementally from `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`. Complete Phase 6J graceful restart/shutdown operations hardening, then keep final process-entry and bot-construction cleanup for a later approval-gated slice.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6H lifecycle slices are complete, merged, production-pushed, and smoke tested; proceed with shutdown/recovery coordination before process-entry cleanup.
+- Dependencies: Phase 5 upload routing and Phase 6A through Phase 6I lifecycle slices are complete, merged, production-pushed, and locally validated; Phase 6I production smoke confirmed restart recovery but not a reliable in-process graceful shutdown log trail, so Phase 6J should prove that path before process-entry cleanup.
 
 ### Deferred Optimisation
 - Area: `utils.py`, `bot_helpers.py`, `core/queue_lifecycle.py`, queue runtime state
 - Type: refactor
 - Description: Phase 6H separated queue lifecycle startup, but broader queue persistence hardening remains out of scope. `load_live_queue()` is synchronous while scheduling an async state apply when an event loop is running, and queue draining/state flush semantics are coupled to later shutdown behavior.
-- Suggested Fix: Add a dedicated queue persistence hardening slice after Phase 6I or fold it into Phase 6I only if shutdown work requires it. Make live queue load/apply explicitly awaitable where practical, preserve sync test compatibility or add a safe wrapper, verify atomic save behavior and stale metadata handling, and add restart/persistence tests for load-before-embed-refresh ordering and state flush after queue cancellation.
+- Suggested Fix: Add a dedicated queue persistence hardening slice after Phase 6J or fold it into Phase 6J only if graceful restart/shutdown work requires it. Make live queue load/apply explicitly awaitable where practical, preserve sync test compatibility or add a safe wrapper, verify atomic save behavior and stale metadata handling, and add restart/persistence tests for load-before-embed-refresh ordering and state flush after queue cancellation.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6H lifecycle extraction is complete and production-smoke-tested; coordinate with Phase 6I cooperative cancellation and queue draining/state flush design.
+- Dependencies: Phase 6H lifecycle extraction and Phase 6I shutdown coordination are complete and production-pushed; coordinate with Phase 6J graceful restart/shutdown operations before starting broader queue persistence hardening.
 
 ### Deferred Optimisation
 - Area: `bot_helpers.py`, `bot_instance.py`, `DL_bot.py` shutdown and queue task lifecycle
 - Type: architecture
-- Description: Queue workers, queue cleanup, connection watchdog, and other background tasks still lack a single approved shutdown/recovery coordination boundary for cooperative cancellation, queue draining, state flush, singleton/PID markers, and logging shutdown order.
-- Suggested Fix: Phase 6I should fix cooperative cancellation, queue draining/state flush, and shutdown ordering. Audit signal/admin shutdown paths, `TaskMonitor` cancellation behavior, queue worker cancellation, `QUEUE_CACHE_FILE` persistence, `LAST_SHUTDOWN_INFO` writing, singleton/PID cleanup, and logging flush order before implementation.
+- Description: Phase 6I added a single approved shutdown/recovery coordination boundary for cooperative cancellation, queue draining/state flush, and logging order, but the available production `/ops force_restart` smoke path is intentionally break-glass and did not reliably exercise in-process graceful teardown logs. Phase 6J introduces the cooperative restart entry point needed to verify those logs.
+- Suggested Fix: Treat Phase 6I as delivered but smoke-limited until Phase 6J is deployed and smoke-tested. In Phase 6J, add `/ops graceful_restart`, retire `/ops restart_bot`, keep `/ops force_restart` as the break-glass path, and update smoke guidance so queue drain/live queue flush/TaskMonitor cancellation can be proven through logs.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 6H queue lifecycle extraction; keep process-entry and bot-construction cleanup for Phase 6J unless Phase 6I reveals a hard dependency.
+- Dependencies: Phase 6I shutdown coordination is merged and production-pushed; preserve operator access to force restart for stuck or looping states.
+
+### Deferred Optimisation
+- Area: `graceful_shutdown.py`, `run_bot.py`, `commands/admin_cmds.py`, shutdown operations
+- Type: architecture
+- Description: The existing weekly-machine-restart helper `graceful_shutdown.py` writes shutdown markers and externally terminates matching `DL_bot.py` processes, but it needs an explicit cooperative-first timeout/fallback model so logs prove whether in-process teardown completed or fell back to kill.
+- Suggested Fix: Prioritise this as Phase 6J. Preserve `/ops force_restart` as the break-glass restart path for stuck or looping bot states, add `/ops graceful_restart` for cooperative drains, retire `/ops restart_bot`, and update `graceful_shutdown.py` so scheduled machine restarts first request the in-process graceful teardown/restart path with a configurable timeout defaulting to 15 seconds before falling back to external process termination. Add smoke instructions and focused tests where practical for marker writing, queue drain/flush, timeout fallback, and watchdog recovery.
+- Impact: medium
+- Risk: medium
+- Dependencies: Phase 6I shutdown coordination PR; operator approval for any new `/ops graceful_restart` or shutdown command naming and behavior.
 
 ### Deferred Optimisation
 - Area: `event_calendar/pinned_embed.py`

--- a/docs/reference/runbook_shutdown.md
+++ b/docs/reference/runbook_shutdown.md
@@ -57,17 +57,47 @@ Use existing atomic file helpers where possible.
 - Critical state is persisted atomically.
 - Tests cover lock release, task cancellation, or state persistence where practical.
 
-## Phase 6I Focus
+## Phase 6I Outcome
 
-Phase 6I is the next approved-review slice after Phase 6H queue lifecycle extraction. It should
-audit and then fix cooperative cancellation, queue draining/state flush, and shutdown ordering
-without reopening upload routing, scheduler ownership, command lifecycle, or process-entry cleanup.
+Phase 6I was completed in PR 126 (`codex/dlbot-phase-6i-shutdown-recovery`), merged, and pushed
+to production. It routes signal shutdown through bot-side graceful teardown before `bot.close()`,
+briefly waits for configured `channel_queues` including in-flight `queue.join()` work, persists
+`QUEUE_CACHE_FILE` with `save_live_queue()`, then cancels supervised `TaskMonitor` tasks and stops
+usage tracking.
 
-Review these shutdown/recovery surfaces together before implementation:
+Production `/ops force_restart` smoke confirmed restart recovery and normal Phase 6A-H startup
+continuation, but it did not provide a reliable in-process graceful shutdown log trail because
+`force_restart` remains a break-glass restart path. Phase 6I is therefore closed with residual
+smoke risk: the in-process teardown path may need rework if Phase 6J exposes an issue while adding
+a cooperative smoke-testable restart path.
 
-- signal/admin/watchdog shutdown entry points
-- `bot_instance.py` graceful teardown and `TaskMonitor` cancellation behavior
-- queue workers, queue cleanup, connection watchdog, and `QUEUE_CACHE_FILE` persistence
-- shutdown marker writing, singleton/PID cleanup, and logging flush order
-- whether queue persistence hardening belongs inside Phase 6I or should remain a separate
-  follow-up slice after shutdown ordering is settled
+Expected Phase 6I shutdown log markers when the in-process graceful path is exercised:
+
+- `[SHUTDOWN] Graceful teardown initiated.`
+- `[SHUTDOWN] Channel queues have no pending items; waiting up to ... for any in-flight queue work to finish.`
+- `[SHUTDOWN] Draining ... queued message(s) across ... channel queue(s) for up to ...`
+- `[SHUTDOWN] Channel queues drained before task cancellation.`
+- `[SHUTDOWN] Live queue state persisted.`
+- `[MONITOR] Stop requested; tasks cancelled where applicable.`
+- `[SHUTDOWN] Usage tracker stopped.`
+
+## Phase 6J Focus
+
+Phase 6J should make the Phase 6I shutdown path categorically smoke-testable without weakening
+the current break-glass restart behavior.
+
+Approved operator model:
+
+- `/ops graceful_restart` is the preferred safe restart path. It writes the restart marker and
+  watchdog exit-code file, enters the bot-side graceful teardown path, drains queues briefly,
+  persists live queue state, stops supervised tasks and usage tracking, flushes logs, then closes
+  the bot so the watchdog restarts it.
+- `/ops force_restart` remains the emergency break-glass path for stuck, looping, or unresponsive
+  states.
+- The old `/ops restart_bot` path is retired instead of kept as a compatibility alias.
+- `graceful_shutdown.py` should request cooperative process teardown first and wait up to
+  `GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS` seconds, defaulting to `15`, before falling back to process
+  kill.
+
+Queue persistence hardening and process-entry cleanup remain follow-up slices unless Phase 6J
+smoke testing proves they are required for safe cooperative restart behavior.

--- a/docs/reference/runbook_startup.md
+++ b/docs/reference/runbook_startup.md
@@ -123,8 +123,18 @@ cleanup startup, and connection watchdog startup. Production smoke confirmed the
 ran after `ready_domain_scheduler_tasks`, started workers for configured monitored channels, loaded
 live queue state before embed refresh, started queue cleanup and connection watchdog once, and
 allowed `full_startup_sequence()`, reminder cleanup, pinned calendar rehydration, and calendar
-scheduler startup to continue normally. Remaining lifecycle cleanup continues with shutdown
-coordination and final process-entry/bot-construction cleanup.
+scheduler startup to continue normally. Phase 6I completed in PR 126
+(`codex/dlbot-phase-6i-shutdown-recovery`), was merged and pushed to production: shutdown now
+routes through bot-side graceful teardown before `bot.close()`, briefly drains configured
+`channel_queues`, persists live queue state, cancels supervised tasks, and stops usage tracking.
+Production `/ops force_restart` smoke confirmed restart recovery and startup continuity, but it did
+not prove the in-process graceful shutdown log trail because `force_restart` remains a break-glass
+path. The next Phase 6 slice should add `/ops graceful_restart` and harden
+`graceful_shutdown.py` so Phase 6I shutdown behavior can be categorically smoke-tested before final
+process-entry/bot-construction cleanup. The approved Phase 6J operator model retires the old
+`/ops restart_bot` command, makes `/ops graceful_restart` the preferred safe restart path, keeps
+`/ops force_restart` as the emergency path, and gives `graceful_shutdown.py` a configurable
+cooperative fallback timeout that defaults to 15 seconds.
 
 When changing startup, verify restart safety and avoid duplicate task creation.
 

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md
@@ -1,7 +1,21 @@
 # Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination
 
-Use this starter to continue Phase 6 after Phase 6H queue worker/live queue lifecycle was merged,
-smoke-tested, pushed to production, and marked complete.
+Status: complete. Phase 6I was delivered in PR 126
+(`codex/dlbot-phase-6i-shutdown-recovery`), merged, and pushed to production.
+
+Phase 6I added bot-side graceful teardown coordination before `bot.close()`, brief channel queue
+drain handling including in-flight `queue.join()` work, live queue snapshot persistence, supervised
+task cancellation ordering, shutdown heartbeat writing, usage tracker stop, and logging
+quiesce/shutdown ordering. Production `/ops force_restart` smoke confirmed restart recovery and
+startup continuity, but it did not provide a reliable in-process graceful shutdown log trail because
+`/ops force_restart` remains the break-glass restart path.
+
+Use `docs/task_packs/Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations.md`
+for the next Phase 6 slice. Phase 6J should add a smoke-testable cooperative `/ops graceful_restart`
+path, preserve `/ops force_restart` for stuck/looping states, and update `graceful_shutdown.py` so
+scheduled machine restarts can exercise the Phase 6I graceful teardown path before bounded fallback.
+
+Historical starter retained below.
 
 ## Copy/Paste Starter
 
@@ -128,7 +142,7 @@ state flush.
   writing, idempotency, and continued clean restart behavior where practical.
 - Decide whether queue persistence hardening is required inside Phase 6I or should remain a
   separate follow-up slice after shutdown ordering is settled.
-- Capture process-entry and broader bot-construction cleanup findings as Phase 6J work unless
+- Capture process-entry and broader bot-construction cleanup findings as Phase 6K work unless
   explicitly approved for this slice.
 
 ## Out Of Scope
@@ -264,12 +278,15 @@ understood, and only when shutdown/restart still continues cleanly.
 
 ## Remaining Phase 6 Slices
 
-Recommended order after Phase 6H:
+Recommended order after Phase 6I:
 
-1. Phase 6I shutdown and recovery coordination, including cooperative cancellation, queue
-   draining/state flush, and shutdown ordering.
-2. Optional queue persistence hardening slice after Phase 6I, unless Phase 6I requires it directly.
-3. Phase 6J process-entry and bot-construction cleanup.
+1. Phase 6J graceful restart/shutdown operations:
+   - add `/ops graceful_restart`
+   - preserve `/ops force_restart` as break-glass
+   - update `graceful_shutdown.py`
+   - prove the Phase 6I graceful teardown path with production smoke logs
+2. Optional queue persistence hardening slice after Phase 6J, unless Phase 6J requires it directly.
+3. Phase 6K process-entry and bot-construction cleanup.
 
 The wider command-surface migration/renaming programme remains separate from Phase 6.
 
@@ -281,6 +298,6 @@ lifecycle extraction.
 
 Carry forward, but do not implement unless separately approved:
 
-- process-entry and bot-construction cleanup
-- queue persistence hardening after Phase 6I, unless required directly by Phase 6I shutdown work
+- process-entry and bot-construction cleanup as Phase 6K
+- queue persistence hardening after Phase 6J, unless required directly by Phase 6J shutdown work
 - pinned calendar tracker persistence hardening in `event_calendar/pinned_embed.py`

--- a/docs/task_packs/Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations.md
+++ b/docs/task_packs/Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations.md
@@ -1,0 +1,287 @@
+# Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations
+
+Use this starter to continue Phase 6 after Phase 6I shutdown/recovery coordination was merged,
+pushed to production, and closed with a known smoke-test gap.
+
+## Copy/Paste Starter
+
+Codex, continue Phase 6 of the DL_bot architecture optimisation programme with Phase 6J:
+graceful restart and shutdown operations.
+
+Phase 6A through Phase 6I are complete:
+
+- PR 117 (`codex/dlbot-phase-6-startup-lifecycle-1`) was merged and pushed to production.
+- PR 119 (`codex/dlbot-phase-6b-runtime-services`) was merged and pushed to production.
+- PR 120 (`codex/dlbot-phase-6c-usage-tracker`) was merged and pushed to production.
+- PR 121 (`codex/dlbot-phase-6d-command-lifecycle`) was merged and pushed to production.
+- PR 122 (`codex/dlbot-phase-6e-command-admin-tooling`) was merged and pushed to production.
+- PR 123 (`codex/dlbot-phase-6f-event-rehydration`) was merged and pushed to production.
+- PR 124 (`codex/dlbot-phase-6g-scheduler-lifecycle`) was merged and pushed to production.
+- PR 125 (`codex/dlbot-phase-6h-queue-lifecycle`) was merged and pushed to production.
+- PR 126 (`codex/dlbot-phase-6i-shutdown-recovery`) was merged and pushed to production.
+- `bot_instance.py:on_ready()` delegates startup to the Phase 6 lifecycle boundaries for runtime
+  services, command sync, event rehydration, scheduler registration, queue lifecycle, pinned
+  calendar rehydration, and calendar scheduler tasks.
+- Phase 6I routed `DL_bot.py` signal shutdown through bot-side graceful teardown before
+  `bot.close()`.
+- Phase 6I waits briefly for configured `channel_queues`, including in-flight `queue.join()` work,
+  before supervised task cancellation.
+- Phase 6I snapshots and persists current live queue state before teardown continues.
+- Phase 6I preserves restart/shutdown markers, shutdown heartbeat, `TaskMonitor` shutdown ordering,
+  usage tracker stop, logging quiesce, and logging shutdown behavior.
+
+Phase 6I production smoke note:
+
+- `/ops force_restart` confirmed restart recovery and normal Phase 6A-I startup continuity.
+- `/ops force_restart` did not produce a reliable in-process graceful shutdown log trail because it
+  remains the break-glass restart path for stuck queues, looping workers, or other unhealthy bot
+  states.
+- Phase 6I is closed with the residual risk that some shutdown coordination may need rework after a
+  cooperative restart/shutdown path can categorically smoke-test the new behavior.
+
+This is review/scope first. Do not implement code changes until the Phase 6J scope, target
+operator model, and first PR-sized implementation plan have each been approved.
+
+Before implementation, read and follow:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/singleton_lock.md`
+- `docs/reference/runbook_diagnostics.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md`
+
+## Phase 6J Objective
+
+Add an operator-facing cooperative restart/shutdown path that proves the Phase 6I graceful teardown
+contract in production while preserving the existing break-glass restart behavior.
+
+Explicit Phase 6J targets:
+
+- Add `/ops graceful_restart` as the normal cooperative restart path.
+- Preserve `/ops force_restart` as the emergency path for stuck, looping, or unresponsive bot states.
+- Remove `/ops restart_bot` instead of keeping it as an alias, leaving one preferred safe path and
+  one break-glass path.
+- Review and update `graceful_shutdown.py` so weekly bot-machine restarts first request cooperative
+  in-process teardown with a configurable timeout defaulting to 15 seconds, then fall back to
+  external process termination.
+- Produce a clear smoke-test log trail for queue drain, live queue persistence, supervised task
+  cancellation, shutdown markers, logging shutdown, watchdog recovery, and startup return.
+
+## In Scope
+
+- Audit the current relationship between:
+  - `/ops force_restart`
+  - retired `/ops restart_bot` behavior
+  - any admin restart buttons or shared command lifecycle helpers
+  - `DL_bot.py` signal handling
+  - `bot_instance.py:on_graceful_shutdown()`
+  - `bot_instance.py:_graceful_teardown()` and related wrappers
+  - `graceful_shutdown.py`
+  - `run_bot.py` watchdog/restart behavior
+  - restart/shutdown marker files, including `RESTART_FLAG_PATH`, `EXIT_CODE_FILE`,
+    `LAST_RESTART_INFO`, `LAST_SHUTDOWN_INFO`, `SHUTDOWN_MARKER_FILE`, and `BOT_LOCK_PATH`
+  - `TaskMonitor` cancellation and duplicate-prevention behavior
+  - queue workers, `channel_queues`, `live_queue`, `QUEUE_CACHE_FILE`, and `save_live_queue()`
+  - logging flush, quiesce, and shutdown ordering
+- Define operator semantics for `/ops graceful_restart` versus `/ops force_restart`.
+- Remove `/ops restart_bot`; do not route it as a compatibility alias.
+- Add or refine a narrow helper only if it keeps marker writing, teardown invocation, timeout
+  fallback, or command tests clear.
+- Keep `/ops force_restart` available for recovery when graceful teardown cannot be trusted.
+- Update `graceful_shutdown.py` to prefer cooperative shutdown/restart with bounded fallback.
+- Add focused tests for command routing, graceful teardown invocation, force fallback preservation,
+  marker handling, and timeout/fallback behavior where practical.
+- Update runbooks, deferred optimisation docs, and task-pack references.
+- Capture any process-entry, bot construction, or queue persistence hardening findings as later
+  slices unless directly required for the cooperative restart path.
+
+## Out Of Scope
+
+- Broad `DL_bot.py` process-entry rewrite or bot construction cleanup.
+- Removing or weakening `/ops force_restart`.
+- Upload-route behavior changes, including fallback queue routing behavior.
+- Queue worker processing behavior changes beyond what is required to prove graceful restart/shutdown.
+- Full queue persistence hardening unless the audit proves it is required for Phase 6J.
+- Scheduler ownership changes already completed in Phase 6G.
+- Queue startup ownership changes already completed in Phase 6H.
+- Shutdown coordination already completed in Phase 6I except where Phase 6J smoke testing proves a
+  defect.
+- SQL/importer/workbook/Google Sheets/ProcConfig contract changes unless unexpectedly required by
+  validation.
+- Production promotion or bot-machine deployment without `k98-promotion-check`.
+
+## Likely Files
+
+Review:
+
+- `commands/admin_cmds.py`
+- `core/restart_operations.py`
+- `core/command_lifecycle.py`
+- `bot_instance.py`
+- `DL_bot.py`
+- `graceful_shutdown.py`
+- `run_bot.py`
+- `constants.py`
+- `logging_setup.py`
+- `singleton_lock.py`
+- `bot_startup_gate.py`
+- `boot_safety.py`
+- `startup_utils.py`
+- `bot_helpers.py`
+- `utils.py`
+- `tests/test_startup_lifecycle.py`
+- `tests/test_queue_lifecycle.py`
+- `tests/test_live_queue_persistence.py`
+- `tests/test_utils_live_queue.py`
+- `tests/test_singleton_lock_Version2.py`
+- `tests/test_process_utils.py`
+- `tests/test_file_utils_lockinfo.py`
+- `tests/test_file_utils.py`
+- `tests/test_command_registration_smoke.py`
+
+Likely modify after approval:
+
+- `commands/admin_cmds.py`
+- one narrow restart/shutdown helper
+- `bot_instance.py`
+- `graceful_shutdown.py`
+- `DL_bot.py` only if the audit proves a narrow shutdown hook change is required
+- one narrow restart/shutdown helper only if the audit proves it is clearer than local wiring
+- focused command, shutdown, queue persistence, or process utility tests
+- `docs/reference/runbook_shutdown.md`
+- `docs/reference/runbook_startup.md`
+- `docs/reference/deferred_optimisations.md`
+- `docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md`
+
+Do not create a broad process-entry or bot-construction module in Phase 6J.
+
+## Step 1 Required Output
+
+- Audit Summary
+- Current Restart And Shutdown Command Map
+- Current `graceful_shutdown.py` Machine Restart Map
+- Phase 6I Shutdown Boundary Map
+- Proposed Phase 6J Operator Model
+- `/ops graceful_restart` Versus `/ops force_restart` Semantics
+- Shutdown Marker, Restart Marker, Exit Code, Lock, And Watchdog Map
+- Queue Drain And Live Queue Persistence Smoke Map
+- TaskMonitor Cancellation And Timeout/Fallback Map
+- Logging Flush / Quiesce / Shutdown Smoke Map
+- Ownership Problems And Refactor Triggers
+- Recommended Phase 6J Implementation Scope
+- Test And Validation Strategy
+- Deferred Optimisation Findings
+- Approval Questions
+- Explicit Stop Point
+
+## Audit / Design-Only Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+## Likely Implementation Validation After Approval
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_startup_lifecycle.py tests\test_queue_lifecycle.py tests\test_live_queue_persistence.py tests\test_utils_live_queue.py tests\test_singleton_lock_Version2.py tests\test_process_utils.py tests\test_file_utils_lockinfo.py tests\test_file_utils.py tests\test_command_registration_smoke.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review should be run before PR handoff for code changes because Phase 6J touches
+Discord admin commands, restart-sensitive persistence, file-backed runtime state, process shutdown,
+watchdog behavior, queue draining, and logging shutdown.
+
+## Expected Smoke / Manual Verification
+
+After implementation and deployment, manually verify:
+
+- `/ops graceful_restart` writes the expected restart marker and enters the bot-side graceful
+  teardown path.
+- `/ops restart_bot` is no longer registered.
+- shutdown logs show queue drain/join handling before supervised task cancellation.
+- live queue state is persisted before shutdown completes.
+- usage tracking is stopped and flushed before process exit.
+- logging is flushed before quiesce/shutdown prevents late handler failures.
+- watchdog restarts the bot and startup returns through the expected Phase 6A-I phase logs.
+- repeated `/ops graceful_restart` requests remain idempotent.
+- `/ops force_restart` remains available and suitable for stuck or looping states.
+- `graceful_shutdown.py` weekly machine restart flow requests cooperative teardown first and falls
+  back within the approved timeout if the bot is unresponsive.
+
+The graceful restart smoke test should show logs similar to:
+
+```text
+[COMMAND] /graceful_restart invoked
+[SHUTDOWN] Graceful teardown initiated
+[SHUTDOWN] Waiting for channel queues to drain
+[SHUTDOWN] Live queue state persisted
+[MONITOR] Stop requested
+[SHUTDOWN] Usage tracker stopped
+[SHUTDOWN] Logging quiesced
+[STARTUP] phase started: ready_runtime_bootstrap
+[STARTUP] phase completed: ready_calendar_scheduler_tasks
+```
+
+The smoke test should not show:
+
+```text
+[CRITICAL] Exception during on_ready
+[STARTUP] phase failed
+[SHUTDOWN] on_graceful_shutdown failed
+[SHUTDOWN] Failed writing shutdown heartbeat
+[QUEUE] Failed to save
+[MONITOR] Task queue_worker
+[MONITOR] Task queue_cleanup crashed
+[MONITOR] Task connection_watchdog crashed
+```
+
+Known best-effort warnings may be acceptable only when intentionally induced or otherwise
+understood, and only when shutdown/restart still continues cleanly.
+
+## Remaining Phase 6 Slices
+
+Recommended order after Phase 6I:
+
+1. Phase 6J graceful restart/shutdown operations:
+   - add `/ops graceful_restart`
+   - remove `/ops restart_bot`
+   - preserve `/ops force_restart` as break-glass
+   - update `graceful_shutdown.py` with a configurable 15-second default fallback
+   - prove the Phase 6I graceful teardown path with production smoke logs
+2. Optional queue persistence hardening slice after Phase 6J, unless Phase 6J requires it directly.
+3. Phase 6K process-entry and bot-construction cleanup.
+
+The wider command-surface migration/renaming programme remains separate from Phase 6.
+
+## Deferred Item Links
+
+This starter continues the DL_bot startup/lifecycle deferred optimisation in
+`docs/reference/deferred_optimisations.md` after Phase 6I completed shutdown and recovery
+coordination with residual graceful smoke-test risk.
+
+Carry forward, but do not implement unless separately approved:
+
+- full queue persistence hardening after Phase 6J, unless required directly by Phase 6J shutdown
+  operations
+- process-entry and bot-construction cleanup as Phase 6K
+- pinned calendar tracker persistence hardening in `event_calendar/pinned_embed.py`

--- a/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
+++ b/docs/task_packs/DL_bot Startup Lifecycle - Phase 6 Audit Starter.md
@@ -5,7 +5,7 @@
 - Task name: `DL_bot startup/lifecycle separation - Phase 6 audit`
 - Date: `2026-05-26`
 - Last updated: `2026-05-28`
-- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F/6G/6H startup lifecycle boundaries were pushed to production`
+- Owner/context: `Follow-up after Phase 5 upload-routing consolidation completed and Phase 6A/6B/6C/6D/6E/6F/6G/6H/6I lifecycle boundaries were pushed to production`
 - Task type: `deferred optimisation batch`
 - One-pass approved: `no`
 
@@ -29,6 +29,7 @@ Before implementation, read the current repository instructions and indexed core
 - `docs/task_packs/Codex Task Pack - DL_bot Upload Routing Deferred Optimisation Audit.md`
 - `docs/task_packs/Codex Chat Starter - DL_bot Phase 6H Queue Worker Lifecycle.md`
 - `docs/task_packs/Codex Chat Starter - DL_bot Phase 6I Shutdown Recovery Coordination.md`
+- `docs/task_packs/Codex Chat Starter - DL_bot Phase 6J Graceful Restart Shutdown Operations.md`
 
 Use `docs/reference/ENV_REFERENCE.md` if environment-variable ownership or runtime configuration
 validation becomes part of the design.
@@ -179,7 +180,37 @@ Phase 6H queue worker/live queue lifecycle is complete:
 - No startup phase failure, `on_ready()` critical exception, queue embed refresh failure,
   `queue_worker` monitor crash, `queue_cleanup` crash, or `connection_watchdog` crash was observed.
 - The PR was merged and pushed to production.
-- Shutdown coordination and process-entry cleanup remain later Phase 6 slices.
+- Shutdown coordination was completed next in Phase 6I.
+
+Phase 6I shutdown and recovery coordination is complete:
+
+- PR 126 (`codex/dlbot-phase-6i-shutdown-recovery`) was merged and pushed to production.
+- `DL_bot.py` signal shutdown now calls bot-side graceful teardown before `bot.close()`.
+- `bot_instance.py` waits briefly for configured `channel_queues`, including in-flight
+  `queue.join()` work, persists live queue state through `save_live_queue()`, cancels supervised
+  `TaskMonitor` tasks, cancels reminder registries, writes shutdown heartbeat, stops usage
+  tracking, and quiesces logging.
+- Focused tests cover shutdown ordering, queue drain before `TaskMonitor.stop()`, zero-`qsize()`
+  in-flight queue work, and signal teardown ordering.
+- Production `/ops force_restart` smoke confirmed the restart flag path, restart recovery,
+  `ready_queue_lifecycle`, queue worker startup, queue cleanup, connection watchdog startup,
+  `full_startup_sequence()`, reminder cleanup, pinned calendar rehydration, and calendar scheduler
+  startup continued normally.
+- The production smoke did not produce a reliable in-process graceful shutdown log trail because
+  `/ops force_restart` remains a break-glass termination-oriented path. Phase 6I is closed with
+  this documented residual risk: the graceful teardown implementation may need rework if the next
+  slice exposes a defect while making it directly smoke-testable.
+
+Phase 6J graceful restart and shutdown operations hardening is the next priority:
+
+- Add `/ops graceful_restart` as the cooperative restart path that intentionally exercises
+  Phase 6I graceful teardown before restart.
+- Remove `/ops restart_bot` rather than keeping overlapping restart routes.
+- Preserve `/ops force_restart` as the break-glass path for stuck or looping bot states.
+- Update `graceful_shutdown.py` so weekly bot-machine restarts request cooperative shutdown first
+  with a configurable timeout defaulting to 15 seconds before falling back to external termination.
+- Use this slice to categorically smoke-test Phase 6I queue drain/state flush/task cancellation
+  logs.
 
 `DL_bot.py` is now much closer to listener/delegation ownership for uploads, but startup and
 lifecycle concerns remain spread across `DL_bot.py`, `bot_instance.py`, `bot_loader.py`,
@@ -405,15 +436,20 @@ Final decisions should be updated after each Phase 6 sub-phase.
 
 Current recommended order after Phase 6H:
 
-1. Phase 6I shutdown and recovery coordination: audit graceful teardown, signal handling, task
-   cancellation, state flush, singleton/PID/shutdown markers, and logging shutdown order. Fix:
-   handle cooperative cancellation, queue draining/state flush, and shutdown ordering.
-2. Optional queue persistence hardening slice: after Phase 6I, or inside Phase 6I only if shutdown
+1. Phase 6I shutdown and recovery coordination: complete in PR 126 and pushed to production.
+   Local validation passed and restart recovery smoke passed, but in-process graceful shutdown logs
+   could not be categorically exercised from the current operator paths.
+2. Phase 6J graceful restart and shutdown operations hardening: add `/ops graceful_restart`,
+   remove `/ops restart_bot`, preserve `/ops force_restart` as break-glass, and update
+   `graceful_shutdown.py` so scheduled machine restarts first request cooperative teardown with a
+   configurable 15-second default fallback. This slice should prove Phase 6I shutdown logs in
+   production.
+3. Optional queue persistence hardening slice: after Phase 6J, or inside Phase 6J only if shutdown
    work requires it, harden live queue load/apply semantics, atomic save verification, stale
    metadata handling, and restart/state-flush tests.
-3. Phase 6J process-entry and bot-construction cleanup: only after the smaller runtime lifecycle slices are
-   stable, review whether `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final
-   ownership split.
+4. Phase 6K process-entry and bot-construction cleanup: only after the smaller runtime lifecycle
+   slices are stable and graceful restart/shutdown operations are smoke-tested, review whether
+   `DL_bot.py`, `bot_loader.py`, and `bot_instance.py` need a clearer final ownership split.
 
 The wider command-surface migration/renaming programme is deliberately separate from Phase 6.
 

--- a/graceful_shutdown.py
+++ b/graceful_shutdown.py
@@ -38,6 +38,36 @@ formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS = 15.0
+
+
+def _cooperative_shutdown_timeout_seconds() -> float:
+    raw = os.getenv("GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS")
+    if raw is None:
+        return DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        msg = (
+            "[SHUTDOWN] Invalid GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS="
+            f"{raw!r}; using {DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS:.1f}s."
+        )
+        print(msg, flush=True)
+        logger.warning(msg)
+        return DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS
+    if timeout <= 0:
+        msg = (
+            "[SHUTDOWN] Non-positive GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS="
+            f"{raw!r}; using {DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS:.1f}s."
+        )
+        print(msg, flush=True)
+        logger.warning(msg)
+        return DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS
+    return timeout
+
+
+COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS = _cooperative_shutdown_timeout_seconds()
+
 
 # --- Helpers for time / UTC ---
 def _now_iso() -> str:
@@ -184,7 +214,10 @@ async def send_shutdown_embed():
 
 
 # === Step 4: Kill all matching DL_bot.py processes ===
-async def terminate_all_dl_bot(reason="scheduled_shutdown"):
+async def terminate_all_dl_bot(
+    reason="scheduled_shutdown",
+    cooperative_timeout_seconds: float = COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS,
+):
     """
     Best-effort: iterate processes that look like DL_bot.py and terminate them.
     - psutil is optional; if absent, we skip termination (but markers are still written).
@@ -249,13 +282,20 @@ async def terminate_all_dl_bot(reason="scheduled_shutdown"):
 
                 print(f"  PID {pid}: {proc.info.get('name')} – {' '.join(cmdline)}", flush=True)
                 try:
-                    # Attempt graceful terminate
+                    log_shutdown("cooperative_requested", pid, cmdline, reason, info=info)
                     proc.terminate()
                     try:
                         if psutil:
-                            proc.wait(timeout=5)
+                            proc.wait(timeout=cooperative_timeout_seconds)
+                        log_shutdown("cooperative_exited", pid, cmdline, reason, info=info)
                     except Exception:
-                        # Timeout or other issues: escalate to kill
+                        log_shutdown(
+                            "cooperative_timeout_kill",
+                            pid,
+                            cmdline,
+                            f"{reason}; timeout={cooperative_timeout_seconds:.1f}s",
+                            info=info,
+                        )
                         try:
                             proc.kill()
                         except Exception:

--- a/tests/test_admin_views_smoke.py
+++ b/tests/test_admin_views_smoke.py
@@ -6,15 +6,6 @@ import types
 
 
 def _load_admin_views(monkeypatch):
-    bot_cfg = types.ModuleType("bot_config")
-    bot_cfg.ADMIN_USER_ID = 123
-    monkeypatch.setitem(sys.modules, "bot_config", bot_cfg)
-
-    const = types.ModuleType("constants")
-    const.RESTART_EXIT_CODE = 17
-    const.RESTART_FLAG_PATH = "/tmp/restart.flag"
-    monkeypatch.setitem(sys.modules, "constants", const)
-
     if "ui.views.admin_views" in sys.modules:
         del sys.modules["ui.views.admin_views"]
     return importlib.import_module("ui.views.admin_views")
@@ -33,39 +24,17 @@ class _DummyInteraction:
         return None
 
 
-class _DummyCtx:
-    def __init__(self):
-        self.interaction = types.SimpleNamespace(original_response=self._orig)
-
-    async def _orig(self):
-        return types.SimpleNamespace(edit=self._async_noop)
-
-    async def _async_noop(self, *args, **kwargs):
-        return None
-
-
-class _DummyBot:
-    def get_channel(self, _cid):
-        return types.SimpleNamespace(send=self._async_noop)
-
-    async def _async_noop(self, *args, **kwargs):
-        return None
-
-
 def test_confirm_views_instantiate_and_callbacks_exist(monkeypatch):
     m = _load_admin_views(monkeypatch)
 
     async def _run():
-        restart_view = m.ConfirmRestartView(_DummyCtx(), bot=_DummyBot(), notify_channel_id=1)
         import_view = m.ConfirmImportView(
             author_id=123, on_confirm_apply=lambda _i: _DummyInteraction()._async_noop()
         )
 
-        assert len(restart_view.children) >= 2
         assert len(import_view.children) >= 2
 
         # buttons exist with callbacks
-        assert callable(restart_view.children[0].callback)
         assert callable(import_view.children[0].callback)
 
         # interaction_check gating works

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _load_graceful_shutdown(monkeypatch, tmp_path, timeout_value: str | None):
+    bot_config = types.ModuleType("bot_config")
+    bot_config.DISCORD_BOT_TOKEN = "token"
+    bot_config.NOTIFY_CHANNEL_ID = 1
+    monkeypatch.setitem(sys.modules, "bot_config", bot_config)
+
+    constants = types.ModuleType("constants")
+    constants.EXIT_CODE_FILE = str(tmp_path / ".exit_code")
+    constants.LAST_SHUTDOWN_INFO = str(tmp_path / "last_shutdown_info.json")
+    constants.SHUTDOWN_LOG_PATH = str(tmp_path / "shutdown.log")
+    constants.SHUTDOWN_MARKER_FILE = str(tmp_path / ".shutdown_marker")
+    monkeypatch.setitem(sys.modules, "constants", constants)
+
+    discord = types.ModuleType("discord")
+    discord.Intents = types.SimpleNamespace(none=lambda: object())
+    discord.Client = lambda intents=None: object()
+    discord.Embed = object
+    monkeypatch.setitem(sys.modules, "discord", discord)
+
+    if timeout_value is None:
+        monkeypatch.delenv("GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", timeout_value)
+
+    sys.modules.pop("graceful_shutdown", None)
+    return importlib.import_module("graceful_shutdown")
+
+
+def test_graceful_shutdown_timeout_env_defaults_when_missing(monkeypatch, tmp_path):
+    module = _load_graceful_shutdown(monkeypatch, tmp_path, None)
+
+    assert module.COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS == 15.0
+
+
+def test_graceful_shutdown_timeout_env_falls_back_on_invalid_value(monkeypatch, tmp_path, capsys):
+    module = _load_graceful_shutdown(monkeypatch, tmp_path, "abc")
+
+    assert module.COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS == 15.0
+    assert "Invalid GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS='abc'" in capsys.readouterr().out
+
+
+def test_graceful_shutdown_timeout_env_accepts_positive_value(monkeypatch, tmp_path):
+    module = _load_graceful_shutdown(monkeypatch, tmp_path, "22.5")
+
+    assert module.COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS == 22.5

--- a/tests/test_restart_operations.py
+++ b/tests/test_restart_operations.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from core import restart_operations
+
+
+@pytest.mark.asyncio
+async def test_write_restart_request_persists_flag_exit_code_and_audit(tmp_path):
+    restart_flag_path = tmp_path / ".restart_flag.json"
+    exit_code_file = tmp_path / ".exit_code"
+    audit_calls = []
+
+    async def append_csv_line(path, row):
+        audit_calls.append((path, row))
+
+    result = await restart_operations.write_restart_request(
+        reason="slash_graceful_restart",
+        user_id="123",
+        append_csv_line=append_csv_line,
+        restart_flag_path=str(restart_flag_path),
+        exit_code_file=str(exit_code_file),
+        exit_code=15,
+        timestamp="2026-05-28T12:00:00+00:00",
+    )
+
+    assert result == {
+        "timestamp": "2026-05-28T12:00:00+00:00",
+        "reason": "slash_graceful_restart",
+        "user_id": "123",
+    }
+    assert json.loads(restart_flag_path.read_text(encoding="utf-8")) == result
+    assert exit_code_file.read_text(encoding="utf-8") == "15"
+    assert audit_calls == [
+        (
+            "restart_log.csv",
+            ["2026-05-28T12:00:00+00:00", "slash_graceful_restart", "123", "success", "", "", ""],
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_restart_request_keeps_marker_when_audit_fails(tmp_path, caplog):
+    restart_flag_path = tmp_path / ".restart_flag.json"
+    exit_code_file = tmp_path / ".exit_code"
+
+    async def append_csv_line(_path, _row):
+        raise OSError("locked")
+
+    result = await restart_operations.write_restart_request(
+        reason="slash_graceful_restart",
+        user_id="123",
+        append_csv_line=append_csv_line,
+        restart_flag_path=str(restart_flag_path),
+        exit_code_file=str(exit_code_file),
+        exit_code=15,
+        timestamp="2026-05-28T12:00:00+00:00",
+    )
+
+    assert json.loads(restart_flag_path.read_text(encoding="utf-8")) == result
+    assert exit_code_file.read_text(encoding="utf-8") == "15"
+    assert "Failed to append restart audit log" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_cooperative_restart_writes_markers_before_teardown_and_close(monkeypatch):
+    calls = []
+
+    async def fake_write_restart_request(**kwargs):
+        calls.append(("write", kwargs["reason"], kwargs["user_id"]))
+        return {"reason": kwargs["reason"], "user_id": kwargs["user_id"]}
+
+    async def graceful_teardown():
+        calls.append(("teardown",))
+
+    async def close_bot():
+        calls.append(("close",))
+
+    def flush_logs():
+        calls.append(("flush",))
+
+    monkeypatch.setattr(restart_operations, "write_restart_request", fake_write_restart_request)
+
+    await restart_operations.run_cooperative_restart(
+        reason="slash_graceful_restart",
+        user_id="123",
+        append_csv_line=None,
+        graceful_teardown=graceful_teardown,
+        close_bot=close_bot,
+        flush_logs=flush_logs,
+        response_delay_seconds=0,
+    )
+
+    assert calls == [
+        ("write", "slash_graceful_restart", "123"),
+        ("teardown",),
+        ("flush",),
+        ("close",),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_cooperative_restart_close_timeout_does_not_hang(monkeypatch, caplog):
+    calls = []
+
+    async def fake_write_restart_request(**kwargs):
+        calls.append(("write", kwargs["reason"], kwargs["user_id"]))
+        return {"reason": kwargs["reason"], "user_id": kwargs["user_id"]}
+
+    async def graceful_teardown():
+        calls.append(("teardown",))
+
+    async def close_bot():
+        calls.append(("close",))
+        await restart_operations.asyncio.sleep(1)
+
+    monkeypatch.setattr(restart_operations, "write_restart_request", fake_write_restart_request)
+
+    await restart_operations.run_cooperative_restart(
+        reason="slash_graceful_restart",
+        user_id="123",
+        append_csv_line=None,
+        graceful_teardown=graceful_teardown,
+        close_bot=close_bot,
+        response_delay_seconds=0,
+        close_timeout_seconds=0.01,
+    )
+
+    assert calls == [
+        ("write", "slash_graceful_restart", "123"),
+        ("teardown",),
+        ("close",),
+    ]
+    assert "bot.close() timed out" in caplog.text
+
+
+def _async_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name
+    )
+
+
+def _command_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if not (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr == "command"
+            ):
+                continue
+            for keyword in decorator.keywords:
+                if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+                    names.add(str(keyword.value.value))
+    return names
+
+
+def _calls_name(node: ast.AST, name: str) -> bool:
+    return any(
+        isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == name
+        for child in ast.walk(node)
+    )
+
+
+def test_ops_restart_surface_has_graceful_and_force_paths_only():
+    tree = ast.parse(Path("commands/admin_cmds.py").read_text(encoding="utf-8"))
+    names = _command_names(tree)
+
+    assert "graceful_restart" in names
+    assert "force_restart" in names
+    assert "restart_bot" not in names
+
+    graceful_restart = _async_function(tree, "graceful_restart")
+    force_restart = _async_function(tree, "force_restart")
+    assert _calls_name(graceful_restart, "run_cooperative_restart")
+    assert _calls_name(force_restart, "write_restart_request")
+
+
+def test_graceful_shutdown_has_configurable_15_second_fallback():
+    src = Path("graceful_shutdown.py").read_text(encoding="utf-8")
+
+    assert 'os.getenv("GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS")' in src
+    assert "DEFAULT_COOPERATIVE_SHUTDOWN_TIMEOUT_SECONDS = 15.0" in src
+    assert "cooperative_requested" in src
+    assert "cooperative_timeout_kill" in src

--- a/ui/views/admin_views.py
+++ b/ui/views/admin_views.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import datetime
@@ -12,14 +11,6 @@ import os
 import re
 
 import discord
-
-from bot_config import ADMIN_USER_ID
-
-try:
-    from constants import RESTART_EXIT_CODE, RESTART_FLAG_PATH
-except Exception:
-    RESTART_EXIT_CODE = 1
-    RESTART_FLAG_PATH = ".restart_flag.json"
 
 
 class LogTailView(discord.ui.View):
@@ -173,77 +164,6 @@ class LogTailView(discord.ui.View):
         await interaction.response.send_message(txt, ephemeral=True)
 
 
-class ConfirmRestartView(discord.ui.View):
-    def __init__(self, ctx, *, bot, notify_channel_id: int, timeout: int = 30):
-        super().__init__(timeout=timeout)
-        self.ctx = ctx
-        self.bot = bot
-        self.notify_channel_id = notify_channel_id
-        self.confirmed = asyncio.Event()
-        self.cancelled = False
-        self.message: discord.Message | None = None
-
-    def _disable_all(self):
-        for c in self.children:
-            c.disabled = True
-
-    async def _try_disable_ui(self):
-        try:
-            if self.message is None:
-                self.message = await self.ctx.interaction.original_response()
-            self._disable_all()
-            await self.message.edit(view=self)
-        except Exception:
-            pass
-
-    @discord.ui.button(label="✅ Confirm Restart", style=discord.ButtonStyle.danger)
-    async def confirm(self, _button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id != ADMIN_USER_ID:
-            await interaction.response.send_message(
-                "❌ Only the admin can confirm this action.", ephemeral=True
-            )
-            return
-
-        embed_user = discord.Embed(
-            title="🔄 Bot Restart Initiated",
-            description="Attempting to restart the bot now. If it doesn't come back online, check your host.",
-            color=0xF39C12,
-        )
-        embed_user.set_footer(text="Restart requested by admin")
-        embed_user.timestamp = datetime.utcnow()
-        await interaction.response.send_message(embed=embed_user, ephemeral=True)
-
-        try:
-            notify_channel = self.bot.get_channel(self.notify_channel_id)
-            if notify_channel:
-                embed_broadcast = discord.Embed(
-                    title="🛠️ Bot Restart Requested",
-                    description=f"Admin <@{interaction.user.id}> initiated a restart via slash command.",
-                    color=0xF39C12,
-                )
-                embed_broadcast.timestamp = datetime.utcnow()
-                await notify_channel.send(embed=embed_broadcast)
-        except Exception:
-            pass
-
-        await self._try_disable_ui()
-        self.confirmed.set()
-        self.stop()
-
-    @discord.ui.button(label="❌ Cancel", style=discord.ButtonStyle.secondary)
-    async def cancel(self, _button: discord.ui.Button, interaction: discord.Interaction):
-        if interaction.user.id != ADMIN_USER_ID:
-            await interaction.response.send_message(
-                "❌ Only the admin can cancel this action.", ephemeral=True
-            )
-            return
-        await interaction.response.send_message("❎ Bot restart cancelled.", ephemeral=True)
-        self.cancelled = True
-        await self._try_disable_ui()
-        self.confirmed.set()
-        self.stop()
-
-
 class ConfirmImportView(discord.ui.View):
     def __init__(
         self,
@@ -301,6 +221,5 @@ class ConfirmImportView(discord.ui.View):
 
 __all__ = [
     "ConfirmImportView",
-    "ConfirmRestartView",
     "LogTailView",
 ]


### PR DESCRIPTION
## Summary

- Add `/ops graceful_restart` as the preferred cooperative restart path for Phase 6J.
- Remove `/ops restart_bot` so operators have two clear routes: safe cooperative restart and break-glass force restart.
- Preserve `/ops force_restart` while moving restart marker / exit-code writing into a shared helper.
- Update `graceful_shutdown.py` to request cooperative process teardown first, with configurable fallback kill timeout defaulting to 15 seconds.
- Update runbooks, deferred optimisation notes, command-surface docs, and Phase 6 task-pack references.

## Details

Phase 6I added the bot-side graceful teardown contract, but production smoke via `/ops force_restart` could not reliably prove the in-process shutdown log trail. This PR adds the operator-facing cooperative path needed to prove queue drain, live queue persistence, supervised task cancellation, usage tracker shutdown, logging flush, watchdog restart, and startup return.

The new `core/restart_operations.py` helper centralizes restart flag writing, exit-code writing, restart audit logging, and cooperative restart orchestration so `/ops graceful_restart` and `/ops force_restart` do not duplicate marker protocol code. Restart audit logging is best-effort, and cooperative bot close is bounded so a stalled Discord close does not leave the watchdog waiting indefinitely after restart markers are written.

## Tests / Validation

- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `python -m pytest -q tests/test_restart_operations.py tests/test_graceful_shutdown.py tests/test_admin_views_smoke.py tests/test_command_registration_smoke.py tests/test_ui_imports.py`
- `python -m pytest -q tests/test_startup_lifecycle.py tests/test_queue_lifecycle.py tests/test_live_queue_persistence.py tests/test_utils_live_queue.py tests/test_singleton_lock_Version2.py tests/test_process_utils.py tests/test_file_utils_lockinfo.py tests/test_file_utils.py tests/test_command_registration_smoke.py`
- `python -m pre_commit run -a`
- `python -m pytest -q tests` -> `1587 passed, 2 skipped`
- `python scripts/analyse_pytest_log_noise.py` -> `1587 passed, 2 skipped`; production operational logs unchanged

## AI Review Gates

Codex Security diff-scoped review: no findings. Reviewed admin command routing, restart marker writes, process shutdown fallback, and file-backed restart state. No attacker-controlled path or authorization bypass survived discovery; `/ops graceful_restart` and `/ops force_restart` remain admin / notify-channel gated.

## Smoke Notes

After deployment, verify:

- `/ops graceful_restart` writes the expected restart marker and enters bot-side graceful teardown.
- Shutdown logs show queue drain / join handling before supervised task cancellation.
- Live queue state is persisted before shutdown completes.
- Usage tracking stops and logging flushes before process exit.
- Watchdog restarts the bot and startup returns through the Phase 6A-I phase logs.
- `/ops force_restart` remains available for stuck or looping states.
- `graceful_shutdown.py` logs cooperative request / exit, or `cooperative_timeout_kill` if the configured timeout is exceeded.

## Risk / Rollback

Risk is medium because this touches admin restart commands, watchdog marker protocol, process shutdown behavior, and file-backed runtime state. Rollback is to revert this PR and restart from the last known-good production branch.