### PR TITLE
[codex] Standardize command permission decorators

### DIFF
--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -20,7 +20,6 @@ import discord
 
 from admin_helpers import prompt_admin_inputs, log_processing_result
 from bot_config import (
-    ADMIN_USER_ID,
     GUILD_ID,
     NOTIFY_CHANNEL_ID,
     OFFSEASON_STATS_CHANNEL_ID,
@@ -49,10 +48,7 @@ from utils import utcnow
 from versioning import versioned
 
 from decoraters import (
-    _has_leadership_role,
-    _is_admin,
-    _is_allowed_channel,
-    channel_only,
+    admin_only,
     is_admin_and_notify_channel,
     is_admin_or_leadership,
     track_usage,
@@ -171,6 +167,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.02")
     @safe_command
+    @admin_only()
     @track_usage()
     async def history_command(ctx, page: int = 1):
 
@@ -180,13 +177,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
             await safe_defer(ctx)
         except Exception:
             pass  # already acknowledged elsewhere
-
-        # Admin gate
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         log_file = CSV_LOG
         if not os.path.exists(log_file):
@@ -244,6 +234,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.01")
     @safe_command
+    @admin_only()
     @track_usage()
     async def failures_command(ctx, page: int = 1):
 
@@ -253,13 +244,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
             await safe_defer(ctx)
         except Exception:
             pass  # already acknowledged
-
-        # Admin gate
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         log_file = FAILED_LOG
         if not os.path.exists(log_file):
@@ -330,13 +314,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
             await safe_defer(ctx)
         except Exception:
             pass  # already acknowledged elsewhere
-
-        # Hard admin gate (in addition to decorator)
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         # Let the user know we’ve started
         try:
@@ -429,13 +406,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
             await safe_defer(ctx)
         except Exception:
             pass  # already acked
-
-        # Extra admin gate (in addition to decorator)
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         # Let caller know we're starting
         try:
@@ -1012,13 +982,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def status_command(ctx):
         await safe_defer(ctx, ephemeral=True)
-
-        # Belt-and-braces admin gate (decorator already limits usage)
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         # --- Check DB connection
         try:

--- a/commands/inventory_cmds.py
+++ b/commands/inventory_cmds.py
@@ -5,9 +5,9 @@ import logging
 import discord
 from discord.ext import commands as ext_commands
 
-from bot_config import ADMIN_USER_ID, GUILD_ID, INVENTORY_UPLOAD_CHANNEL_ID
+from bot_config import GUILD_ID, INVENTORY_UPLOAD_CHANNEL_ID
 from core.interaction_safety import safe_command, safe_defer
-from decoraters import _is_admin, track_usage
+from decoraters import _is_admin, admin_only, channel_only, track_usage
 from inventory import audit_service, export_service, reporting_service
 from inventory.models import InventoryAuditRecord
 from ui.views.inventory_report_views import (
@@ -28,32 +28,16 @@ def register_inventory(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.00")
     @safe_command
+    @channel_only(
+        INVENTORY_UPLOAD_CHANNEL_ID,
+        admin_override=True,
+        missing_config_message=(
+            "Inventory imports are not configured yet. Missing inventory channel."
+        ),
+    )
     @track_usage()
     async def import_inventory(ctx: discord.ApplicationContext) -> None:
         await safe_defer(ctx, ephemeral=True)
-        if not INVENTORY_UPLOAD_CHANNEL_ID:
-            await ctx.followup.send(
-                "Inventory imports are not configured yet. Missing inventory channel.",
-                ephemeral=True,
-            )
-            return
-        chan = getattr(ctx, "channel", None)
-        chan_id = getattr(chan, "id", None)
-        parent_id = getattr(chan, "parent_id", None)
-        try:
-            is_admin = int(ctx.user.id) == int(ADMIN_USER_ID)
-        except Exception:
-            is_admin = False
-        if (
-            not is_admin
-            and chan_id != INVENTORY_UPLOAD_CHANNEL_ID
-            and parent_id != INVENTORY_UPLOAD_CHANNEL_ID
-        ):
-            await ctx.followup.send(
-                f"❌ This command may only be used in <#{INVENTORY_UPLOAD_CHANNEL_ID}>. Please try there.",
-                ephemeral=True,
-            )
-            return
         try:
             await start_import_command(ctx, bot)
         except PermissionError as exc:
@@ -212,6 +196,7 @@ def register_inventory(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.00")
     @safe_command
+    @admin_only(denial_message="You do not have permission to use this command.")
     @track_usage()
     async def inventory_import_audit(
         ctx: discord.ApplicationContext,
@@ -267,11 +252,6 @@ def register_inventory(bot: ext_commands.Bot) -> None:
         ),
     ) -> None:
         await safe_defer(ctx, ephemeral=True)
-        if not _is_admin(ctx.user):
-            await ctx.followup.send(
-                "You do not have permission to use this command.", ephemeral=True
-            )
-            return
         try:
             parsed_status = audit_service.parse_audit_status(
                 status.strip().lower().replace(" ", "_")

--- a/commands/location_cmds.py
+++ b/commands/location_cmds.py
@@ -12,7 +12,7 @@ from core.interaction_safety import safe_command, safe_defer
 from decoraters import (
     _has_leadership_role,
     _is_admin,
-    _is_allowed_channel,
+    admin_or_leadership_in_allowed_channels,
     is_admin_and_notify_channel,
     track_usage,
 )
@@ -249,6 +249,7 @@ def register_location(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.07")
     @safe_command
+    @admin_or_leadership_in_allowed_channels(ALLOWED_CHANNEL_IDS)
     @track_usage()
     async def player_location(
         ctx: discord.ApplicationContext,
@@ -261,19 +262,6 @@ def register_location(bot: ext_commands.Bot) -> None:
         ),
         ephemeral: bool = discord.Option(bool, "Only show to me", required=False, default=False),
     ):
-        # Channel + role gates (same model used in /player_profile)
-        if not _is_allowed_channel(ctx.channel):
-            mentions = " or ".join(f"<#{cid}>" for cid in ALLOWED_CHANNEL_IDS)
-            await ctx.respond(f"🔒 This command can only be used in {mentions}.", ephemeral=True)
-            return
-
-        member = ctx.author if isinstance(ctx.author, discord.Member) else None
-        if not (_is_admin(ctx.user) or _has_leadership_role(member)):
-            await ctx.respond(
-                "❌ This command is restricted to Admin or Leadership.", ephemeral=True
-            )
-            return
-
         # Resolve target ID (ID takes precedence; name can be autocomplete-id or fuzzy free-text)
         lookup = resolve_profile_lookup(governor_id=governor_id, governor_name=governor_name)
         if lookup.status == "not_found":

--- a/commands/mge_cmds.py
+++ b/commands/mge_cmds.py
@@ -8,8 +8,8 @@ from discord.ext import commands as ext_commands
 
 from bot_config import GUILD_ID, MGE_LEADERSHIP_CHANNEL_ID, MGE_SIMPLIFIED_FLOW_ENABLED
 from core.interaction_safety import safe_command, safe_defer
-from core.mge_permissions import is_admin_interaction
 from decoraters import (
+    admin_only,
     channel_only,
     is_admin_and_notify_channel,
     is_admin_or_leadership_only,
@@ -367,18 +367,11 @@ def register_mge(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.0")
     @safe_command
+    @admin_only(denial_message="You do not have permission to use this command.")
     @track_usage()
     async def mge_admin_completion(ctx: discord.ApplicationContext, event_id: int) -> None:
         await safe_defer(ctx, ephemeral=True)
         interaction = ctx.interaction
-        if interaction is None or not is_admin_interaction(interaction):
-            if interaction is not None:
-                await interaction.followup.send(
-                    "You do not have permission to use this command.",
-                    ephemeral=True,
-                )
-            return
-
         view = MgeAdminCompletionView(
             event_id=event_id,
             leadership_channel_id=MGE_LEADERSHIP_CHANNEL_ID,

--- a/commands/stats_cmds.py
+++ b/commands/stats_cmds.py
@@ -10,7 +10,6 @@ import discord
 from discord.ext import commands as ext_commands
 
 from bot_config import (
-    ADMIN_USER_ID,
     GUILD_ID,
     KVK_PLAYER_STATS_CHANNEL_ID,
     STATS_ALERT_CHANNEL_ID,
@@ -113,13 +112,6 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             await safe_defer(ctx, ephemeral=True)
         except Exception:
             pass
-
-        # Extra admin gate (decorator already limits usage)
-        if ctx.user.id != ADMIN_USER_ID:
-            await ctx.interaction.edit_original_response(
-                content="❌ This command is restricted to admins."
-            )
-            return
 
         # Resolve current KVK if not provided (reuse existing helper)
         if kvk_no == 0:

--- a/commands/telemetry_cmds.py
+++ b/commands/telemetry_cmds.py
@@ -24,9 +24,7 @@ from bot_config import (
 from commands.crystaltech_flow import run_crystaltech_flow as run_crystaltech_flow_service
 from commands.player_profile_flow import send_profile_to_channel as send_profile_to_channel_service
 from decoraters import (
-    _has_leadership_role,
-    _is_admin,
-    _is_allowed_channel,
+    admin_or_leadership_in_allowed_channels,
     channel_only,
     track_usage,
 )
@@ -558,6 +556,7 @@ def register_commands(bot_instance):
     )
     @versioned("v1.11")
     @safe_command
+    @admin_or_leadership_in_allowed_channels(ALLOWED_CHANNEL_IDS)
     @track_usage()
     async def player_profile_command(
         ctx: discord.ApplicationContext,
@@ -569,19 +568,6 @@ def register_commands(bot_instance):
             required=False,
         ),
     ):
-
-        # --- Gates BEFORE any defer (keep ephemeral one-shot replies here) ---
-        if not _is_allowed_channel(ctx.channel):
-            mentions = " or ".join(f"<#{cid}>" for cid in ALLOWED_CHANNEL_IDS)
-            await ctx.respond(f"🔒 This command can only be used in {mentions}.", ephemeral=True)
-            return
-
-        member = ctx.author if isinstance(ctx.author, discord.Member) else None
-        if not (_is_admin(ctx.user) or _has_leadership_role(member)):
-            await ctx.respond(
-                "❌ This command is restricted to Admin or Leadership.", ephemeral=True
-            )
-            return
 
         # --- Resolve target (accept autocomplete value as ID) ---
         lookup = resolve_profile_lookup(governor_id=governor_id, governor_name=governor_name)

--- a/decoraters.py
+++ b/decoraters.py
@@ -222,6 +222,30 @@ def is_admin_or_leadership():
     return deco
 
 
+def admin_only(
+    *,
+    denial_message: str = "❌ This command is restricted to admins.",
+):
+    """Gate: Admin by ADMIN_USER_ID, with no channel restriction."""
+
+    def deco(func):
+        @wraps(func)
+        async def wrapper(arg0, *args, **kwargs):
+            inter = _resolve_interaction(arg0)
+            if not inter:
+                return
+
+            if not _is_admin(getattr(inter, "user", None)):
+                await _safe_ephemeral_send(inter, denial_message)
+                return
+
+            return await func(arg0, *args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
 def is_admin_or_leadership_only():
     """
     Gate: (Admin by ADMIN_USER_ID) OR (has Leadership role).
@@ -252,11 +276,12 @@ def is_admin_or_leadership_only():
 
 
 def channel_only(
-    channels: int | Iterable[int],
+    channels: int | str | Iterable[int | str] | None,
     *,
     allow_threads: bool = True,
     admin_override: bool = True,
     allow_leadership: bool = False,
+    missing_config_message: str | None = None,
 ):
     """
     Restrict a command to one or more channel IDs (threads allowed via parent).
@@ -264,17 +289,21 @@ def channel_only(
     - allow_threads: if True, a thread whose parent is one of the allowed channels is allowed
     - admin_override: if True the ADMIN_USER_ID can bypass the guard
     - allow_leadership: if True also permit the preconfigured LEADERSHIP channel(s) in ALLOWED_CHANNEL_IDS
+    - missing_config_message: if supplied, deny with this message when no channel IDs are configured
     Returns an async decorator suitable for your command functions (slash handlers).
     """
-    # normalize to set of ints
-    if isinstance(channels, int):
-        allowed = {int(channels)}
+    # normalize to configured channel IDs; config defaults such as 0 mean "unset"
+    if channels is None:
+        raw_channels = ()
+    elif isinstance(channels, (int, str)):
+        raw_channels = (channels,)
     else:
-        allowed = {int(x) for x in (channels or [])}
+        raw_channels = channels or ()
+    allowed = {channel_id for channel_id in (int(x) for x in raw_channels) if channel_id}
 
     # optionally include leadership IDs
     if allow_leadership:
-        allowed |= ALLOWED_CHANNEL_IDS
+        allowed |= {cid for cid in ALLOWED_CHANNEL_IDS if cid}
 
     def decorator(func):
         @wraps(func)
@@ -288,6 +317,10 @@ def channel_only(
             parent_id = getattr(
                 chan, "parent_id", getattr(getattr(chan, "parent", None), "id", None)
             )
+
+            if not allowed and missing_config_message:
+                await _safe_ephemeral_send(inter, missing_config_message)
+                return
 
             # admin bypass
             if admin_override and _is_admin(getattr(inter, "user", None)):
@@ -308,6 +341,53 @@ def channel_only(
         return wrapper
 
     return decorator
+
+
+def admin_or_leadership_in_allowed_channels(
+    channels: int | str | Iterable[int | str],
+    *,
+    allow_threads: bool = True,
+    channel_denial_message: str | None = None,
+    permission_denial_message: str = "❌ This command is restricted to Admin or Leadership.",
+):
+    """Gate: allowed channel first, then Admin or Leadership."""
+    if isinstance(channels, (int, str)):
+        allowed = {int(channels)}
+    else:
+        allowed = {int(x) for x in (channels or [])}
+
+    def deco(func):
+        @wraps(func)
+        async def wrapper(arg0, *args, **kwargs):
+            inter = _resolve_interaction(arg0)
+            if not inter:
+                return
+
+            chan = getattr(inter, "channel", None)
+            chan_id = getattr(chan, "id", None)
+            parent_id = getattr(
+                chan, "parent_id", getattr(getattr(chan, "parent", None), "id", None)
+            )
+            in_channel = (chan_id in allowed) or (allow_threads and parent_id in allowed)
+            if not in_channel:
+                mentions = " or ".join(f"<#{cid}>" for cid in sorted(allowed))
+                await _safe_ephemeral_send(
+                    inter,
+                    channel_denial_message or f"🔒 This command can only be used in {mentions}.",
+                )
+                return
+
+            user = getattr(inter, "user", None)
+            member = user if isinstance(user, discord.Member) else getattr(arg0, "author", None)
+            if not (_is_admin(user) or _has_leadership_role(member)):
+                await _safe_ephemeral_send(inter, permission_denial_message)
+                return
+
+            return await func(arg0, *args, **kwargs)
+
+        return wrapper
+
+    return deco
 
 
 def usage_tracker() -> AsyncUsageTracker:

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -1,0 +1,377 @@
+# Command Platform Audit
+
+Last updated: 2026-06-01
+
+## Audit Baseline
+
+Static command registration validation currently reports:
+
+```text
+primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
+```
+
+Grouped command summary:
+
+| Group | Statically detected subcommands |
+|---|---:|
+| `/ops` | 14 |
+| `/mge` | 6 |
+| `/prekvk` | 1 |
+
+The primary command surface has an 18-command buffer below Discord's 100 top-level application
+command limit. The validator warns at 90+ and fails above 100.
+
+Usage levels below are based only on local JSONL usage files under `data/command_usage_*.jsonl`
+available during the audit. SQL-backed production history may contain broader usage evidence.
+Observed local usage only showed `/ark_reminder_prefs` activity, with 439 events. All other
+commands are marked `none observed` pending SQL usage review.
+
+## Audit Decisions
+
+- Inline permission checks are non-compliant for command-platform standardisation. Commands marked
+  `inline check` must be moved to standard decorators before or during any command-path migration.
+- Existing grouped command paths should be preserved unless a later phase explicitly approves a
+  second migration.
+- Public/player command moves require operator approval and user-facing communication.
+- Disabled secondary command surfaces must be retired or classified separately by the validator.
+
+## Command Inventory
+
+| Category | Current path | Owner module | Permission model | Usage | Registration | Proposed path / disposition |
+|---|---|---|---|---:|---|---|
+| Activity | `/activity_top` | `commands/activity_cmds.py` | decorator | none observed | top-level | Candidate `/activity top` |
+| Ark | `/ark_create_match` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark create_match` |
+| Ark | `/ark_force_announce` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark force_announce` |
+| Ark | `/ark_amend_match` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark amend_match` |
+| Ark | `/ark_cancel_match` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark cancel_match` |
+| Ark | `/ark_reminder_prefs` | `commands/ark_cmds.py` | public | high local JSONL | top-level | Candidate `/ark reminder_prefs`; public migration needs approval |
+| Ark | `/ark_set_preference` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark set_preference` |
+| Ark | `/ark_clear_preference` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark clear_preference` |
+| Ark | `/ark_ban_add` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark ban_add` |
+| Ark | `/ark_ban_revoke` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark ban_revoke` |
+| Ark | `/ark_ban_list` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark ban_list` |
+| Ark | `/ark_set_result` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark set_result` |
+| Ark | `/ark_report_players` | `commands/ark_cmds.py` | public | none observed | top-level | Candidate `/ark report_players`; public migration needs approval |
+| Ark | `/ark_generate_draft` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark generate_draft` |
+| Ark | `/create_ark_team` | `commands/ark_cmds.py` | decorator | none observed | top-level | Candidate `/ark create_team` |
+| Calendar | `/calendar` | `commands/calendar_cmds.py` | public | none observed | top-level | Keep or candidate `/calendar browse` after UX approval |
+| Calendar | `/calendar_next_event` | `commands/calendar_cmds.py` | public | none observed | top-level | Candidate `/calendar next_event` |
+| Calendar | `/calendar_reminder_config` | `commands/calendar_cmds.py` | public | none observed | top-level | Candidate `/calendar reminder_config` |
+| Calendar Ops | `/calendar_refresh` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar refresh` |
+| Calendar Ops | `/calendar_generate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar generate` |
+| Calendar Ops | `/calendar_publish_cache` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar publish_cache` |
+| Calendar Ops | `/calendar_status` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar status` |
+| CrystalTech Ops | `/crystaltech_validate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech validate` |
+| CrystalTech Ops | `/crystaltech_reload` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech reload` |
+| CrystalTech Ops | `/crystaltech_admin_reset` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech admin_reset` |
+| Events | `/next_kvk_fight` | `commands/events_cmds.py` | public | none observed | top-level | Candidate `/events next_fight` |
+| Events | `/next_kvk_event` | `commands/events_cmds.py` | public | none observed | top-level | Candidate `/events next_event` |
+| Events | `/refresh_events` | `commands/events_cmds.py` | decorator | none observed | top-level | Candidate `/events refresh` |
+| Events | `/refresh_kvk_overview` | `commands/events_cmds.py` | decorator | none observed | top-level | Candidate `/events refresh_kvk_overview` |
+| Honor/KVK | `/honor_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/honor rankings` |
+| Honor/KVK | `/honor_purge_last` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/honor purge_last` |
+| Inventory | `/import_inventory` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Candidate `/inventory import` |
+| Inventory | `/myinventory` | `commands/inventory_cmds.py` | public | none observed | top-level | Candidate `/inventory report` |
+| Inventory | `/inventory_preferences` | `commands/inventory_cmds.py` | public | none observed | top-level | Candidate `/inventory preferences` |
+| Inventory | `/export_inventory` | `commands/inventory_cmds.py` | service authorization context | none observed | top-level | Candidate `/inventory export` |
+| Inventory | `/inventory_import_audit` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Candidate `/inventory audit` |
+| Location | `/import_locations` | `commands/location_cmds.py` | decorator | none observed | top-level | Candidate `/location import` |
+| Location | `/player_location` | `commands/location_cmds.py` | decorator | none observed | top-level | Candidate `/location player` |
+| MGE | `/mge leadership_board` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| MGE | `/mge import_results` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| MGE | `/mge refresh_cache` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| MGE | `/mge refresh_award_reminders` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| MGE | `/mge commanders` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| MGE | `/mge admin_completion` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops run_sql_proc` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops run_gsheets_export` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops graceful_restart` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops force_restart` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops resync_commands` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops show_command_versions` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops validate_command_cache` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops view_restart_log` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops import_proc_config` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops dl_bot_status` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops logs` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops show_logs` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops last_errors` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Ops | `/ops crash_log` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Player/KVK | `/mykvktargets` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/kvk targets` |
+| Player/KVK | `/mygovernorid` | `commands/telemetry_cmds.py` | public | none observed | top-level | Candidate `/registry lookup` or keep flat |
+| Player/KVK | `/player_profile` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/profile player` |
+| Player/KVK | `/mykvkcrystaltech` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech progress` |
+| PreKvK | `/prekvk report` | `commands/prekvk_cmds.py` | public | none observed | grouped | Preserve |
+| PreKvK Admin | `/prekvk import_history` | `commands/prekvk_admin_cmds.py` | decorator | none observed | grouped by helper | Preserve; improve static validator detection |
+| Processing Reports | `/summary` | `commands/admin_cmds.py` | public | none observed | top-level | Candidate `/ops summary`; confirm public/admin intent |
+| Processing Reports | `/weeksummary` | `commands/admin_cmds.py` | public | none observed | top-level | Candidate `/ops weeksummary`; confirm public/admin intent |
+| Processing Reports | `/history` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops history` |
+| Processing Reports | `/failures` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops failures` |
+| Registry | `/register_governor` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry register` or keep flat |
+| Registry | `/modify_registration` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry modify` or keep flat |
+| Registry | `/remove_registration` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry remove` |
+| Registry | `/remove_registration_by_id` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry remove_by_id` |
+| Registry | `/my_registrations` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry mine` or keep flat |
+| Registry | `/admin_register_governor` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry admin_register` |
+| Registry | `/registration_audit` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry audit` |
+| Registry | `/bulk_export_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_export` |
+| Registry | `/bulk_import_registrations_dryrun` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import_dryrun` |
+| Registry | `/bulk_import_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import` |
+| Stats Ops | `/test_embed` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops test_embed` |
+| Stats/KVK | `/test_kvk_export` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk test_export` |
+| Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk stats` or keep flat |
+| Stats/KVK | `/refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk refresh_stats_cache` |
+| Stats/KVK | `/my_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/stats mine` or keep flat |
+| Stats/KVK | `/my_stats_export` | `commands/stats_cmds.py` | public | none observed | top-level | Candidate `/stats export` or keep flat |
+| Stats/KVK | `/player_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/stats player` |
+| Stats/KVK | `/mykvkhistory` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk history` or keep flat |
+| Stats/KVK | `/kvk_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk rankings` |
+| Stats/KVK | `/kvk_export_all` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk export_all` |
+| Stats/KVK | `/kvk_recompute` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk recompute` |
+| Stats/KVK | `/kvk_list_scans` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk list_scans` |
+| Stats/KVK | `/test_kvk_embed` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk test_embed` |
+| Stats/KVK | `/kvk_window_preview` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk window_preview` |
+| Subscriptions | `/subscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions subscribe` or keep flat |
+| Subscriptions | `/modify_subscription` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions modify` or keep flat |
+| Subscriptions | `/unsubscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions unsubscribe` or keep flat |
+| Subscriptions | `/list_subscribers` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions list` |
+| Subscriptions | `/migrate_subscriptions_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_dryrun` |
+| Subscriptions | `/migrate_subscriptions_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_apply` |
+| Telemetry | `/ping` | `commands/telemetry_cmds.py` | public | none observed | top-level | Keep flat or move to `/ops ping` |
+| Usage Analytics | `/usage` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops usage` |
+| Usage Analytics | `/usage_detail` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops usage_detail` |
+
+## Domain Review Summary
+
+| Domain | Strengths | Weaknesses / risks | Improvement opportunity |
+|---|---|---|---|
+| Ark | Strong service/DAL/test ecosystem and consistent leadership decorators on most admin paths. | Largest flat top-level block; public paths require operator communication; docs reference flat names. | First high-value grouping phase after decorator audit. |
+| Ops | Core operational tools already grouped and command lifecycle reuse is strong. Phase 1 standardised `/history`, `/failures`, and redundant already-decorated admin gates. | Processing report commands remain flat. | Move remaining report/usage/test ops commands under `/ops` after operator approval. |
+| MGE | Already grouped; permission decorators mostly consistent. | `/mge admin_completion` uses an inline admin check. | Standardise decorator and preserve current grouped path. |
+| Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. | Many public player paths are flat and highly discoverable; moving them could confuse players. | Split admin KVK commands first; defer player path changes until approved UX rules exist. |
+| Registry | Strong service/cache tests and command service extraction. | Public self-service paths are discoverability-sensitive; admin bulk operations remain flat. | Group admin registry commands first; decide public path policy separately. |
+| Inventory | Service-oriented implementation and focused inventory tests. Phase 1 standardised command access checks onto decorators. | Inventory export still passes admin context to the service for self-service/admin override semantics. | Group under `/inventory` only after public-path UX approval. |
+| Calendar / Events | Calendar command layer is thin and docs are extensive. | Calendar admin commands live in `admin_cmds.py` while public commands live in `calendar_cmds.py`; many docs reference flat paths. | Group calendar public/admin commands with careful docs update. |
+| Subscriptions | Public flow is simple and tested via views. | Legacy `subscribe.py` still duplicates `/subscribe`; public path migration needs communication. | Retire or classify legacy cog first, then consider `/subscriptions` group. |
+| Secondary cogs | Disabled by default, reducing active startup risk. | Validator duplicate output does not distinguish disabled code from active risk. | Enhance validator or retire legacy declarations. |
+
+## Technical Debt Register
+
+### Phase 1 Completed Item
+- Area: `commands/admin_cmds.py`, `commands/inventory_cmds.py`, `commands/location_cmds.py`, `commands/mge_cmds.py`, `commands/stats_cmds.py`, `commands/telemetry_cmds.py`, `decoraters.py`
+- Type: consistency
+- Description: Phase 1 moved active command access control for the reviewed inline admin/channel/leadership checks onto standard decorators and removed redundant inline admin gates from already-decorated commands.
+- Resolution: Added reusable decorator support for admin-only, admin-or-leadership in allowed channels, and missing-config channel denial. Preserved command paths, command count, service handoff behavior, and denial visibility. `/export_inventory` remains service-authorized because it is self-service with admin override context rather than a command-denial gate.
+- Validation: Command registration remained `primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82`; full pytest, pre-commit, log-noise validation, and Codex Security diff review passed.
+
+### Deferred Optimisation
+- Area: `commands/ark_cmds.py`, `docs/ark/`, Ark command tests
+- Type: architecture
+- Description: Ark remains a large flat command surface with stale flat-path documentation and public/operator workflows tied to current names.
+- Suggested Fix: Design an approved `/ark` grouping migration with docs/tests/operator communication.
+- Impact: high
+- Risk: medium
+- Dependencies: Operator approval for public Ark path changes.
+
+### Deferred Optimisation
+- Area: `scripts/validate_command_registration.py`, `cogs/commands.py`, `subscribe.py`
+- Type: cleanup
+- Description: Duplicate command warnings do not distinguish disabled legacy surfaces from active startup-sync risk.
+- Suggested Fix: Add active/disabled classification or retire disabled declarations after confirmation.
+- Impact: medium
+- Risk: low
+- Dependencies: Confirm secondary cogs are never production-loaded.
+
+### Deferred Optimisation
+- Area: `commands/`, command documentation
+- Type: consistency
+- Description: Permission model and command-path documentation are not consistently discoverable across domains.
+- Suggested Fix: Promote this inventory into a canonical command reference with path, owner, permissions, usage, migration status, and operator-facing notes.
+- Impact: high
+- Risk: low
+- Dependencies: Complete SQL-backed usage review or explicitly accept local JSONL-only usage evidence.
+
+## Phased Roadmap
+
+### Phase 1 - Permission Decorator Standardisation
+
+Goal: remove inline permission checks from command handlers and move command access control onto
+standard decorators.
+
+Scope:
+
+- `commands/admin_cmds.py`: `/history`, `/failures`
+- `commands/inventory_cmds.py`: `/import_inventory`, `/export_inventory`,
+  `/inventory_import_audit`
+- `commands/location_cmds.py`: `/player_location`
+- `commands/mge_cmds.py`: `/mge admin_completion`
+- `commands/stats_cmds.py`: redundant inline admin gate in `/test_kvk_export`
+- `commands/telemetry_cmds.py`: `/player_profile`
+- Redundant inline admin gates in already-decorated `/ops run_sql_proc`,
+  `/ops run_gsheets_export`, and `/ops dl_bot_status`
+
+Implementation notes:
+
+- Prefer existing decorators: `is_admin_and_notify_channel`, `is_admin_or_leadership_only`,
+  `is_admin_or_leadership`, and `channel_only`.
+- Add a new standard decorator only if an existing rule cannot represent the current behavior,
+  especially for self-service commands with admin override or channel-specific public access.
+- Preserve current ephemeral/public responses.
+- Do not group or rename commands in this phase.
+
+Validation:
+
+- Focused permission tests for every command whose inline check is removed.
+- Existing command registration smoke tests.
+- `python scripts/validate_command_registration.py`
+- `python scripts/smoke_imports.py`
+- Codex Security review required before PR because this phase touches permission boundaries and
+  Discord interactions.
+
+### Phase 2 - Validator And Inventory Tooling Enhancement
+
+Goal: improve command-platform reporting before large migrations.
+
+Scope:
+
+- `scripts/validate_command_registration.py`
+- `commands/command_inventory.py`
+- tests around command inventory, grouped command flattening, warning thresholds, and duplicate
+  classification
+
+Implementation notes:
+
+- Distinguish active authoritative command paths from disabled secondary cogs.
+- Detect helper-attached grouped subcommands such as `/prekvk import_history`.
+- Report command owner module, group/subcommand path, duplicate source, and near-limit risk.
+- Keep the existing hard fail above 100 top-level commands and warning at 90+.
+
+Validation:
+
+- `tests/test_validate_command_registration.py`
+- `tests/test_command_inventory.py`
+- `tests/test_command_lifecycle.py`
+- `tests/test_command_registration_smoke.py`
+- `python scripts/validate_command_registration.py`
+
+### Phase 3 - Low-Risk Ops Consolidation
+
+Goal: recover command headroom with low public-UX risk after permissions are standardised.
+
+Scope candidates:
+
+- Move `/summary`, `/weeksummary`, `/history`, `/failures` under `/ops`.
+- Move `/usage` and `/usage_detail` under `/ops`.
+- Move `/test_embed` under `/ops` or retire if no longer useful.
+- Consider `/ping` ownership: keep flat for health/debug discoverability or move to `/ops ping`.
+
+Implementation notes:
+
+- Preserve existing command behavior, output, and usage tracking.
+- Update docs that mention the old paths.
+- Treat public visibility of `/summary` and `/weeksummary` as an explicit operator decision.
+
+Validation:
+
+- Command registration smoke tests.
+- Focused tests for migrated handlers.
+- Command cache/version tests where grouped names affect signatures.
+
+### Phase 4 - Ark Command Grouping
+
+Goal: group Ark commands under `/ark`, recovering the largest remaining top-level block.
+
+Scope candidates:
+
+- Leadership/admin paths: `create_match`, `force_announce`, `amend_match`, `cancel_match`,
+  `set_preference`, `clear_preference`, `ban_add`, `ban_revoke`, `ban_list`, `set_result`,
+  `generate_draft`, `create_team`
+- Public paths: `reminder_prefs`, `report_players`
+
+Implementation notes:
+
+- Public Ark path migration requires operator approval and communication timing.
+- Preserve `is_admin_or_leadership_only`, `channel_only`, autocomplete/options, modal/view flows,
+  and interaction response behavior.
+- Update Ark docs and smoke-test runbooks that reference flat paths.
+
+Validation:
+
+- Ark command tests, including reminder prefs and force announce.
+- Ark registration, draft, ban, cancel, and result focused tests where touched.
+- Command registration validation and smoke imports.
+- Codex Security review required due to permissions, public interactions, and restart-sensitive Ark
+  flows.
+
+### Phase 5 - Public Domain Grouping Design
+
+Goal: decide the player-facing command policy before touching high-discoverability paths.
+
+Scope candidates:
+
+- `/registry`: registration, my registrations, admin registry operations
+- `/kvk` and `/stats`: KVK rankings, personal stats, exports, admin KVK operations
+- `/inventory`: import, report, preferences, export, audit
+- `/calendar` and `/events`: calendar browsing, reminder config, next KVK events/fights,
+  refresh operations
+- `/subscriptions`: subscribe, modify, unsubscribe, list, migration commands
+- `/crystaltech`, `/honor`, `/location`, `/activity`
+
+Implementation notes:
+
+- Split admin-heavy commands from player self-service commands where that reduces UX risk.
+- Keep heavily used/self-service paths flat unless operators approve migration.
+- Consider transition docs or announcement copy for public renames.
+
+Validation:
+
+- Domain-focused command tests.
+- Permission boundary tests for admin/public split.
+- Docs update review for every renamed path.
+
+### Phase 6 - Canonical Command Documentation
+
+Goal: make command ownership, permissions, and path status discoverable.
+
+Scope:
+
+- Promote this audit into a maintained command reference.
+- Update stale Ark, calendar, inventory, registry, and KVK docs after approved path changes.
+- Add guidance for new commands: group-first design, permission decorator choice, test minimums,
+  and command-count impact.
+
+Validation:
+
+- Documentation review.
+- `python scripts/validate_deferred_items.py`
+- `python scripts/select_tests.py`
+
+### Phase 7 - Future Governance And CI Guardrails
+
+Goal: prevent command-limit drift after the programme ends.
+
+Scope:
+
+- CI enforcement around validator output.
+- Optional richer command inventory artifact from validation.
+- Command design checklist for task packs.
+- Near-limit risk reporting and domain owner summaries.
+
+Validation:
+
+- Validator tests.
+- CI/pre-commit integration checks where applicable.
+
+## Recommended Execution Order
+
+1. Phase 1: Permission Decorator Standardisation.
+2. Phase 2: Validator And Inventory Tooling Enhancement.
+3. Phase 3: Low-Risk Ops Consolidation.
+4. Phase 4: Ark Command Grouping.
+5. Phase 5: Public Domain Grouping Design.
+6. Phase 6: Canonical Command Documentation.
+7. Phase 7: Future Governance And CI Guardrails.
+
+The first implementation PR should be Phase 1 only. Grouping before decorator standardisation would
+make permission preservation harder to verify and would mix behavior-risk cleanup with path
+migration.

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 1 Permission Decorator Standardisation.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 1 Permission Decorator Standardisation.md
@@ -1,0 +1,357 @@
+# Codex Chat Starter - Command Platform Phase 1 Permission Decorator Standardisation
+
+Status: implemented in the Phase 1 permission decorator standardisation PR. This starter remains
+as the execution record for Phase 1 of the Command Platform Audit & Optimisation Programme.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 1 is intentionally limited to permission decorator standardisation. Do not group, rename,
+retire, or otherwise migrate command paths in this phase.
+
+## Copy/Paste Starter
+
+Codex, begin Phase 1 of the Command Platform Audit & Optimisation Programme: Permission Decorator
+Standardisation.
+
+This is part of the wider command-platform roadmap documented in
+`docs/reference/command_platform_audit.md`. The full programme goal is to make the command platform
+scalable, maintainable, discoverable, consistent, well documented, operationally safe,
+architecturally aligned, and future-proofed against Discord command registration limits.
+
+The current command-platform baseline is:
+
+```text
+primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
+```
+
+Existing groups:
+
+- `/ops`: 14 statically detected subcommands
+- `/mge`: 6 statically detected subcommands
+- `/prekvk`: 1 statically detected subcommand, plus `/prekvk import_history` attached through the
+  PreKvK admin helper
+
+Important operator decision already made:
+
+- Inline permission checks are not intentional and should be treated as incorrect.
+- Permission-sensitive command access must use standard decorators.
+- If existing decorators cannot express the current rule safely, create a small standard decorator
+  in the existing decorator layer and test it.
+
+This phase must not change user-facing command paths. Grouping begins only after Phase 1 is
+complete and approved.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 1 - Permission Decorator Standardisation
+- Date: 2026-05-29
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / refactor
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Read conditional docs only if the implementation touches that subsystem beyond permission
+decorator placement.
+
+## 3. Objective
+
+Move command access control for inline-check commands onto standard decorators while preserving
+current behavior, responses, visibility, command names, and command registration count.
+
+This phase should make later grouping migrations safer by making permission boundaries explicit and
+testable at the decorator layer.
+
+## 4. Background
+
+The command-platform audit found several permission-sensitive commands using inline user,
+leadership, admin, or channel checks inside command handlers. The operator confirmed these are
+incorrect and should be standardised.
+
+The relevant deferred optimisation is:
+
+```md
+### Deferred Optimisation
+- Area: `commands/admin_cmds.py`, `commands/inventory_cmds.py`, `commands/location_cmds.py`, `commands/mge_cmds.py`, `commands/telemetry_cmds.py`
+- Type: consistency
+- Description: Several permission-sensitive commands rely on inline user/channel checks instead of the standard decorator model. This is inconsistent with the command-platform standard and makes future grouped-path migrations harder to verify.
+- Suggested Fix: Replace inline permission checks with standard decorators or create missing standard decorators where existing decorators cannot express the rule. Preserve existing public/ephemeral responses and add focused permission tests before grouping these commands.
+- Impact: high
+- Risk: medium
+- Dependencies: Confirm exact decorator semantics for admin-only, admin-or-leadership, channel-only, and self-service-with-admin-override cases.
+```
+
+## 5. Scope
+
+### Implemented Scope
+
+Audit and standardise permission decorators for active command access checks:
+
+- `commands/admin_cmds.py`
+  - `/history`
+  - `/failures`
+  - redundant inline admin gates in `/ops run_sql_proc`, `/ops run_gsheets_export`, and
+    `/ops dl_bot_status`
+- `commands/inventory_cmds.py`
+  - `/import_inventory`
+  - `/export_inventory`
+  - `/inventory_import_audit`
+- `commands/location_cmds.py`
+  - `/player_location`
+- `commands/mge_cmds.py`
+  - `/mge admin_completion`
+- `commands/stats_cmds.py`
+  - redundant inline admin gate in `/test_kvk_export`
+- `commands/telemetry_cmds.py`
+  - `/player_profile`
+
+Also in scope:
+
+- Reviewed existing decorators in `decoraters.py`.
+- Added standard decorators for admin-only and admin-or-leadership-in-allowed-channels cases.
+- Extended `channel_only` with missing-config denial support for configured channel gates.
+- Added focused tests for decorator/permission behavior.
+- Kept command registration output unchanged.
+- Treated `/export_inventory` as service authorization context rather than a command denial gate.
+- Captured larger command-platform findings structurally as deferred optimisations.
+
+### Out of Scope
+
+- Command grouping, renaming, retirement, aliases, or migration messaging.
+- Ark grouping under `/ark`.
+- Public domain grouping for registry, KVK/stats, inventory, calendar/events, subscriptions,
+  CrystalTech, Honor, location, or activity.
+- Validator enhancement for disabled secondary command surfaces.
+- SQL schema changes.
+- Business-logic redesign in the touched command handlers.
+- Large command documentation rewrite beyond any small note needed for this phase.
+- Production promotion or deployment.
+
+## 6. Codex Skills To Use
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | use | Required first; identify affected command decorators, tests, and behavior boundaries. |
+| `k98-discord-command-feature` | use | This touches Discord slash command permissions and interaction behavior. |
+| `k98-sql-validation` | not applicable unless discovered | Use only if implementation unexpectedly touches SQL-backed contracts. |
+| `k98-test-selection` | use | Select focused permission, command, and registration tests. |
+| `k98-deferred-optimisation-capture` | use | Capture command-platform debt outside Phase 1. |
+| `k98-pr-review` | use | Required before PR handoff. |
+| `k98-promotion-check` | not applicable for local implementation | Use only before production promotion/deployment. |
+| `codex-security:security-scan` | use before PR handoff | Permission boundaries and Discord interactions are security-sensitive. |
+
+## 7. Mandatory Workflow
+
+1. Review/scope Phase 1 and stop for approval.
+2. Confirm exact permission semantics for each inline-check command.
+3. Present implementation plan and stop for approval.
+4. Implement approved decorator standardisation only.
+5. Add/update focused tests.
+6. Run validation.
+7. Run or explicitly complete the Codex Security review gate before PR handoff.
+
+Proceed in one pass only if the user explicitly approves one-pass implementation in the new chat.
+
+## 8. Audit Requirements
+
+For each command in scope, map:
+
+- Current command path
+- Current inline permission condition
+- Existing response on denial
+- Existing ephemeral/public behavior
+- Existing allowed channels or role/admin semantics
+- Existing service handoff behavior
+- Target decorator or new decorator requirement
+- Test coverage needed
+
+Also review:
+
+- Whether `decoraters.py` already has the correct reusable decorator.
+- Whether decorator denial logging/usage tracking semantics match current inline behavior.
+- Whether decorator ordering with `@safe_command`, `@track_usage()`, and `@versioned()` preserves
+  expected behavior.
+
+## 9. Architecture Targets
+
+| Concern | Target |
+|---|---|
+| Permission decorators | `decoraters.py` |
+| Slash command handlers | existing `commands/<domain>_cmds.py` modules |
+| Business logic | existing services only; do not move business logic in this phase |
+| Views / modals | unchanged unless a permission test requires import coverage |
+| Tests | focused files under `tests/` |
+| Documentation | this starter and `docs/reference/command_platform_audit.md` only if needed |
+
+## 10. Likely Files
+
+### Review
+
+- `decoraters.py`
+- `commands/admin_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/location_cmds.py`
+- `commands/mge_cmds.py`
+- `commands/telemetry_cmds.py`
+- `tests/test_interaction_safety.py`
+- existing command/domain tests for the touched modules
+- `docs/reference/command_platform_audit.md`
+
+### Modify
+
+- `decoraters.py` if a missing standard decorator is required
+- `commands/admin_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/location_cmds.py`
+- `commands/mge_cmds.py`
+- `commands/telemetry_cmds.py`
+- focused tests for permission behavior
+
+### Create
+
+- Optional focused test file, such as `tests/test_command_permission_decorators.py`, if extending
+  existing tests would scatter coverage too much.
+
+## 11. Implementation Requirements
+
+- Preserve all current command names and paths.
+- Preserve current successful command behavior.
+- Preserve current denial behavior as closely as practical, including ephemeral responses.
+- Preserve `@versioned()`, `@safe_command`, and `@track_usage()` local patterns.
+- Keep commands thin; do not move service/business behavior unless required by permission cleanup.
+- Do not add direct SQL to commands or views.
+- Do not alter command grouping or registration count.
+- Do not silently loosen any admin, leadership, or channel restriction.
+- Add focused tests proving denied and allowed cases for each changed permission pattern.
+
+## 12. Refactor Decisions
+
+Initial classification:
+
+| Issue | Decision | Reason |
+|---|---|---|
+| Inline permission checks in active Phase 1 command set | fixed | Explicit operator decision; needed before grouping. |
+| Redundant inline admin checks behind existing decorators | fixed | Keeps active command estate clean before grouping. |
+| Command grouping / renames | defer | Phase 1 is permission-only. |
+| Disabled secondary duplicate command surfaces | defer | Phase 2 validator/tooling scope. |
+| Public-domain grouping design | defer | Later roadmap phase requiring operator UX approval. |
+| SQL-backed command usage review | defer unless needed | Not required for decorator standardisation. |
+
+## 13. Testing Requirements
+
+Minimum focused coverage:
+
+- Permission denied path for each changed command or reusable decorator pattern.
+- Permission allowed path for each reusable decorator pattern.
+- Command registration remains at the current baseline.
+- Grouped command signatures remain stable.
+- No command paths are renamed.
+
+Suggested validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_command_registration_smoke.py tests\test_interaction_safety.py
+```
+
+Add focused domain tests depending on actual files changed, likely including one or more of:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_mge_permissions.py tests\test_mge_award_reminder_refresh.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_stats_cmds.py
+```
+
+Before PR handoff, run or explicitly document:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security review is required before PR handoff because this phase touches permission
+boundaries and Discord interactions.
+
+## 14. Acceptance Criteria
+
+- [x] All Phase 1 inline command permission checks are replaced by standard decorators or a new
+      standard decorator.
+- [x] No command path, command group, or command registration count changes.
+- [x] Existing successful command behavior is preserved.
+- [x] Denied users receive safe, ephemeral denial responses.
+- [x] Permission tests cover changed patterns.
+- [x] Command registration validation remains clean except known disabled-secondary duplicate
+      warnings.
+- [x] No new direct SQL exists in commands or views.
+- [x] New out-of-scope findings are captured structurally.
+- [x] Codex Security review is run before PR handoff.
+
+## 15. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused / Decorators Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations
+
+## 16. PR Summary Template
+
+```md
+## Summary
+
+- Standardised Phase 1 command permission checks onto decorators.
+- Preserved command paths and registration count.
+
+## Changes
+
+- <file/change>
+
+## Tests
+
+- <commands run>
+
+## AI Review Gates
+
+- Codex Security: <run/result>
+
+## Deferred Optimisations
+
+- <none or structured items>
+
+## Risk / Rollback
+
+- Risk: permission-boundary regressions if decorator semantics differ from the prior inline checks.
+- Rollback: revert the Phase 1 branch; no SQL or command path migration is involved.
+```

--- a/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
@@ -1,0 +1,317 @@
+Codex Task Pack - Command Platform Audit & Optimisation Programme
+1. Task Header
+Task name: Command Platform Audit & Optimisation Programme
+Date: 2026-05-28
+Owner/context: Command architecture, UX, registration, documentation and operational command audit
+Task type: deferred optimisation batch
+One-pass approved: no
+2. Required Reading
+
+Before implementation, read:
+
+AGENTS.md
+README-DEV.md
+docs/reference/README.md
+
+Then follow the required reading order defined by:
+
+docs/reference/README.md
+
+Also review:
+
+docs/reference/deferred_optimisations.md
+docs/reference/command_surface_audit.md
+scripts/validate_command_registration.py
+All command modules under commands/
+Any command registration helpers
+Usage tracking and command analytics modules
+Permission decorators
+Command cache and sync lifecycle modules
+
+Reference sources include the original command surface audit and the active deferred optimisation backlog.
+
+3. Objective
+
+Perform a complete end-to-end audit of the K98 command platform.
+
+This is not limited to command-count reduction.
+
+The goal is to ensure the command platform is:
+
+Scalable
+Maintainable
+Discoverable
+Consistent
+Well documented
+Operationally safe
+Architecturally aligned
+Future-proofed against Discord command registration limits
+
+All command-related issues, optimisations, inconsistencies, architecture concerns, documentation gaps, UX issues and technical debt should be identified, classified and prioritised.
+
+4. Background
+
+Batch 1 command grouping successfully reduced the command count from the Discord limit boundary and introduced grouped /ops and /mge commands.
+
+The current validator reports:
+
+82 primary commands
+21 grouped subcommands
+warning threshold at 90
+hard fail at 100
+
+Additional deferred items already exist covering:
+
+Ark grouping
+Public command grouping
+Validator improvements
+Secondary command surface cleanup
+
+However these items were created as tactical follow-ups.
+
+No full command-platform review has yet been performed. Existing command ownership, UX consistency, documentation quality, discoverability, permissions, duplication, architecture boundaries, and operational tooling have not been comprehensively reviewed together.
+
+5. Scope
+In Scope
+
+Anything related to command behaviour, structure, lifecycle or discoverability.
+
+Including but not limited to:
+
+Command Inventory
+Full command catalogue
+Usage analysis
+Public/admin classification
+Domain ownership mapping
+Registration analysis
+Command count management
+Command Architecture
+Command grouping opportunities
+Domain ownership
+Service boundaries
+Repository boundaries
+Interaction ownership
+Command lifecycle ownership
+Command sync ownership
+Command UX
+Naming consistency
+Discoverability
+Autocomplete quality
+Parameter consistency
+Error messaging
+Embed consistency
+Response consistency
+Command Security
+Permission checks
+Admin validation
+Leadership validation
+Channel restrictions
+Abuse prevention
+Dangerous command review
+Command Documentation
+Missing docs
+Stale docs
+Command reference accuracy
+User guides
+Admin guides
+Promotion guide updates
+Command Testing
+Registration coverage
+Permission coverage
+Interaction coverage
+Validation coverage
+Missing tests
+Command Operations
+Sync process
+Cache process
+Validator coverage
+Monitoring
+Logging
+Version reporting
+Command Optimisation
+Dead commands
+Legacy commands
+Duplicate commands
+Redundant workflows
+Consolidation opportunities
+Future Readiness
+Command growth forecast
+Future command grouping strategy
+Governance standards
+Command design standards
+Out of Scope
+
+Nothing is automatically out of scope.
+
+Items may only be deferred after:
+
+Audit
+Classification
+Risk assessment
+Approval
+6. Existing Deferred Items To Include
+Phase Candidate A
+
+Ark Command Surface Migration
+
+Current Ark command set remains a significant opportunity for grouping and command-count reduction.
+
+Phase Candidate B
+
+Public Command Domain Grouping
+
+Review:
+
+KVK
+Registry
+Inventory
+Calendar
+Subscription commands
+
+for possible grouping strategy.
+
+Phase Candidate C
+
+Legacy Command Surface Cleanup
+
+Review:
+
+Secondary cogs
+Disabled command surfaces
+Duplicate command declarations
+Validator classification improvements
+
+Phase Candidate D
+
+Command Validator Enhancement
+
+Review:
+
+Registration reporting
+Threshold warnings
+Duplicate reporting
+Risk reporting
+CI enforcement
+7. Mandatory Audit Deliverables
+
+Codex must produce:
+
+Deliverable 1
+
+Complete command inventory.
+
+For every command:
+
+name
+category
+owner module
+permissions
+usage level
+registration path
+proposed path
+Deliverable 2
+
+Command architecture review.
+
+For every command domain:
+
+strengths
+weaknesses
+risks
+improvement opportunities
+Deliverable 3
+
+Command UX review.
+
+Including:
+
+naming consistency
+discoverability
+onboarding quality
+admin usability
+player usability
+Deliverable 4
+
+Technical debt register.
+
+Including:
+
+duplication
+dead code
+missing tests
+documentation gaps
+architecture violations
+Deliverable 5
+
+Future roadmap.
+
+Recommended phased implementation plan.
+
+8. Phase Planning Rules
+
+After audit completion, Codex must propose phases.
+
+Example:
+
+Phase 1
+
+Low-risk admin consolidation
+
+Phase 2
+
+Ark grouping
+
+Phase 3
+
+Validator improvements
+
+Phase 4
+
+Documentation standardisation
+
+Phase 5
+
+Public command optimisation
+
+Phase 6
+
+Architecture cleanup
+
+Phase 7
+
+Future command governance
+
+Codex may create additional phases if justified.
+
+9. Codex Skills
+Skill	Decision
+k98-architecture-scope	use
+k98-discord-command-feature	use
+k98-sql-validation	use if SQL-backed command dependencies discovered
+k98-test-selection	use
+k98-deferred-optimisation-capture	use
+k98-pr-review	use
+k98-promotion-check	use
+codex-security:security-scan	use
+10. Mandatory Workflow
+Full command audit.
+Stop for approval.
+Produce command inventory.
+Stop for approval.
+Produce phased roadmap.
+Stop for approval.
+Implement approved phase only.
+Validate.
+PR review.
+Promotion review.
+11. Success Criteria
+Complete command inventory produced.
+All existing command deferred items reviewed.
+New command-related findings captured.
+Command platform roadmap created.
+Discord command limit risk assessed.
+Documentation gaps identified.
+Permission model reviewed.
+UX consistency reviewed.
+Architecture consistency reviewed.
+Future command governance recommendations documented.

--- a/tests/test_command_permission_decorators.py
+++ b/tests/test_command_permission_decorators.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+from commands import admin_cmds, inventory_cmds, location_cmds, mge_cmds, stats_cmds, telemetry_cmds
+import decoraters
+from decoraters import admin_only, admin_or_leadership_in_allowed_channels, channel_only
+
+
+class _Response:
+    def __init__(self, *, done: bool = False):
+        self._done = done
+        self.messages: list[tuple[str, bool]] = []
+
+    def is_done(self) -> bool:
+        return self._done
+
+    async def send_message(self, message: str, *, ephemeral: bool = True):
+        self.messages.append((message, ephemeral))
+        self._done = True
+
+
+class _Followup:
+    def __init__(self):
+        self.messages: list[tuple[str, bool]] = []
+
+    async def send(self, message: str, *, ephemeral: bool = True):
+        self.messages.append((message, ephemeral))
+
+
+class _Role:
+    def __init__(self, role_id: int, name: str):
+        self.id = role_id
+        self.name = name
+
+
+class _Ctx:
+    def __init__(
+        self,
+        *,
+        user_id: int = 42,
+        channel_id: int = 100,
+        parent_id: int | None = None,
+        response_done: bool = False,
+        roles: list[_Role] | None = None,
+    ):
+        self.user = SimpleNamespace(id=user_id, display_name=f"user-{user_id}")
+        self.author = SimpleNamespace(id=user_id, roles=roles or [])
+        self.channel = SimpleNamespace(id=channel_id, parent_id=parent_id)
+        self.interaction = SimpleNamespace(
+            user=self.user,
+            channel=self.channel,
+            guild=SimpleNamespace(id=1),
+            response=_Response(done=response_done),
+            followup=_Followup(),
+        )
+        self.followup = self.interaction.followup
+        self.called = False
+
+
+def test_admin_only_allows_admin(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    ctx = _Ctx(user_id=1)
+
+    @admin_only()
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is True
+    assert ctx.interaction.response.messages == []
+
+
+def test_admin_only_denies_non_admin_before_defer(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    ctx = _Ctx(user_id=2)
+
+    @admin_only()
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.interaction.response.messages == [("❌ This command is restricted to admins.", True)]
+
+
+def test_admin_only_denies_non_admin_after_defer(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    ctx = _Ctx(user_id=2, response_done=True)
+
+    @admin_only(denial_message="Nope.")
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.followup.messages == [("Nope.", True)]
+
+
+def test_channel_only_handles_missing_config_before_admin_override(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    ctx = _Ctx(user_id=1)
+
+    @channel_only(None, missing_config_message="Missing channel.", admin_override=True)
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.interaction.response.messages == [("Missing channel.", True)]
+
+
+def test_channel_only_treats_zero_channel_id_as_missing_config(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    ctx = _Ctx(user_id=1)
+
+    @channel_only(0, missing_config_message="Missing channel.", admin_override=True)
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.interaction.response.messages == [("Missing channel.", True)]
+
+
+def test_channel_only_allows_thread_parent_and_admin_override(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    thread_ctx = _Ctx(user_id=2, channel_id=999, parent_id=100)
+    admin_ctx = _Ctx(user_id=1, channel_id=999)
+
+    @channel_only(100, admin_override=True)
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(thread_ctx))
+    asyncio.run(handler(admin_ctx))
+
+    assert thread_ctx.called is True
+    assert admin_ctx.called is True
+
+
+def test_admin_or_leadership_in_allowed_channels_checks_channel_first(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    monkeypatch.setattr(decoraters, "_has_leadership_role", lambda _member: True)
+    ctx = _Ctx(user_id=2, channel_id=999)
+
+    @admin_or_leadership_in_allowed_channels({100})
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.interaction.response.messages == [
+        ("🔒 This command can only be used in <#100>.", True)
+    ]
+
+
+def test_admin_or_leadership_in_allowed_channels_allows_admin_and_leadership(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    monkeypatch.setattr(decoraters, "_has_leadership_role", lambda member: member is not None)
+    admin_ctx = _Ctx(user_id=1, channel_id=100)
+    leadership_ctx = _Ctx(user_id=2, channel_id=999, parent_id=100, roles=[_Role(5, "Lead")])
+
+    @admin_or_leadership_in_allowed_channels({100})
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(admin_ctx))
+    asyncio.run(handler(leadership_ctx))
+
+    assert admin_ctx.called is True
+    assert leadership_ctx.called is True
+
+
+def test_admin_or_leadership_in_allowed_channels_denies_non_leadership(monkeypatch):
+    monkeypatch.setattr(decoraters, "ADMIN_USER_ID", 1)
+    monkeypatch.setattr(decoraters, "_has_leadership_role", lambda _member: False)
+    ctx = _Ctx(user_id=2, channel_id=100)
+
+    @admin_or_leadership_in_allowed_channels({100})
+    async def handler(inner_ctx):
+        inner_ctx.called = True
+
+    asyncio.run(handler(ctx))
+
+    assert ctx.called is False
+    assert ctx.interaction.response.messages == [
+        ("❌ This command is restricted to Admin or Leadership.", True)
+    ]
+
+
+def test_active_command_modules_do_not_keep_inline_permission_gates():
+    sources = "\n".join(
+        inspect.getsource(module)
+        for module in (
+            admin_cmds,
+            inventory_cmds,
+            location_cmds,
+            mge_cmds,
+            stats_cmds,
+            telemetry_cmds,
+        )
+    )
+
+    assert "ctx.user.id != ADMIN_USER_ID" not in sources
+    assert "if not _is_admin(ctx.user):" not in sources
+    assert "if not _is_allowed_channel(ctx.channel):" not in sources
+    assert "not is_admin_interaction(interaction)" not in sources


### PR DESCRIPTION
## Summary

- Standardised expanded Phase 1 command permission checks onto decorators across the active command estate.
- Added reusable decorator support for admin-only, admin/leadership-in-allowed-channels, and missing-config channel-denial cases.
- Preserved command paths, command groups, and registration count.
- Included updated command-platform audit/task-pack docs.

## Changes

- Added `admin_only()` and `admin_or_leadership_in_allowed_channels()` in `decoraters.py`.
- Extended `channel_only()` with `missing_config_message` handling.
- Replaced inline gates in active commands including `/history`, `/failures`, `/import_inventory`, `/inventory_import_audit`, `/player_location`, `/mge admin_completion`, and `/player_profile`.
- Removed redundant inline admin checks behind existing decorators for `/ops run_sql_proc`, `/ops run_gsheets_export`, `/ops dl_bot_status`, and `/test_kvk_export`.
- Added focused permission decorator tests and source guard coverage.
- Updated command-platform audit and task-pack docs to reflect the expanded/completed Phase 1 scope.

## Tests

- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `python -m pytest -q tests/test_command_permission_decorators.py tests/test_command_registration_smoke.py tests/test_interaction_safety.py tests/test_inventory_command_registration.py tests/test_mge_permissions.py`
- `python -m pytest -q tests/test_stats_service.py tests/test_mykvkstats.py`
- `python -m pytest -q tests`
- `python -m pre_commit run -a`
- `python scripts/analyse_pytest_log_noise.py`
- Final post-hook spot check: `python -m pytest -q tests/test_command_permission_decorators.py tests/test_stats_service.py tests/test_mykvkstats.py`

Registration remained: `primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82`.

## AI Review Gates

- Codex Security scoped diff scan: passed, no plausible security regression candidates found.
- Independent subagent review: passed for all scoped files, no candidate findings.

## Deferred Optimisations

- Disabled secondary command-surface cleanup remains deferred to the validator/tooling phase.
- No new deferred optimisation items were added.

## Risk / Rollback

- Risk: permission-boundary regressions if decorator semantics differ from prior inline checks; mitigated with focused permission tests and Codex Security review.
- Rollback: revert this PR; no SQL, command path migration, or deployment sequencing is involved.
