### PR TITLE
Command Platform Phase 3 ops consolidation

### DIFF
--- a/DL_bot.py
+++ b/DL_bot.py
@@ -1,6 +1,5 @@
 # DL_bot.py
 # Note: minimal edit to use centralized logging_setup (UTC timestamps, rotation, console handling).
-import ast
 import io
 import os
 from pathlib import Path
@@ -129,6 +128,10 @@ from bot_config import (
 )
 from bot_helpers import channel_queues
 from Commands import register_commands
+from commands.command_inventory import (
+    collect_declared_command_names,
+    collect_static_primary_inventory,
+)
 from embed_utils import send_embed
 from kvk_all_importer import _auto_export_kvk
 from log_health import LogHeadroomError, preflight_from_env_sync
@@ -260,55 +263,16 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return str(raw).strip().lower() in {"1", "true", "yes", "on", "y"}
 
 
-def _collect_declared_slash_commands(module_relpath: str) -> set[str]:
-    """Collect decorator-declared slash/app command names from a module file."""
-    module_path = Path(__file__).parent / module_relpath
-    names: set[str] = set()
-    if not module_path.exists():
-        if module_relpath == "Commands.py":
-            logger.warning(
-                "[COMMAND AUDIT] Authoritative command module missing: %s",
-                module_relpath,
-            )
-        else:
-            logger.info("[COMMAND AUDIT] Legacy command module retired: %s", module_relpath)
-        return names
-    try:
-        source = module_path.read_text(encoding="utf-8-sig")
-        tree = ast.parse(source, filename=str(module_path))
-    except Exception as exc:
-        logger.warning("[COMMAND AUDIT] Failed parsing %s: %s", module_relpath, exc)
-        return names
-
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for deco in node.decorator_list:
-            if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
-                continue
-            attr = deco.func.attr
-            is_slash = attr == "slash_command"
-            is_app = (
-                attr == "command"
-                and isinstance(deco.func.value, ast.Name)
-                and deco.func.value.id == "app_commands"
-            )
-            if not (is_slash or is_app):
-                continue
-
-            for kw in deco.keywords:
-                if kw.arg == "name" and isinstance(kw.value, ast.Constant) and kw.value.value:
-                    names.add(str(kw.value.value))
-                    break
-    return names
-
-
 def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, list[str]]]:
     """Return registration map and duplicate command-name map across known paths."""
+    root = Path(__file__).parent
+    inventory = collect_static_primary_inventory(root)
     paths = {
-        "Commands.py (authoritative)": _collect_declared_slash_commands("Commands.py"),
-        "cogs/commands.py (secondary)": _collect_declared_slash_commands("cogs/commands.py"),
-        "subscribe.py (secondary)": _collect_declared_slash_commands("subscribe.py"),
+        "commands package (authoritative)": inventory.names,
+        "cogs/commands.py (disabled legacy)": collect_declared_command_names(
+            root / "cogs" / "commands.py"
+        ),
+        "subscribe.py (disabled legacy)": collect_declared_command_names(root / "subscribe.py"),
     }
 
     owners: dict[str, list[str]] = {}
@@ -322,13 +286,21 @@ def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, l
 
 def _log_registration_audit() -> dict[str, list[str]]:
     paths, duplicates = audit_command_registration_paths()
+    root = Path(__file__).parent
+    inventory = collect_static_primary_inventory(root)
+    primary_names = paths["commands package (authoritative)"]
+    secondary_cogs = paths["cogs/commands.py (disabled legacy)"]
+    secondary_subscribe = paths["subscribe.py (disabled legacy)"]
     logger.info(
-        "[COMMAND AUDIT] registration summary: primary=%d secondary_cogs=%d secondary_subscribe=%d total_unique=%d",
-        len(paths["Commands.py (authoritative)"]),
-        len(paths["cogs/commands.py (secondary)"]),
-        len(paths["subscribe.py (secondary)"]),
+        "[COMMAND AUDIT] registration summary: primary=%d grouped_subcommands_detected=%d disabled_legacy=%d secondary_cogs=%d secondary_subscribe=%d total_unique=%d",
+        len(primary_names),
+        inventory.grouped_subcommand_count,
+        len(secondary_cogs) + len(secondary_subscribe),
+        len(secondary_cogs),
+        len(secondary_subscribe),
         len(set().union(*paths.values())),
     )
+    logger.info("[COMMAND AUDIT] active command surface: commands package (authoritative)")
     if duplicates:
         logger.warning(
             "[COMMAND AUDIT] Duplicate slash command names detected across registration paths:"

--- a/DL_bot.py
+++ b/DL_bot.py
@@ -271,8 +271,8 @@ def _collect_declared_command_names_safely(label: str, path: Path) -> set[str]:
         return set()
 
 
-def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, list[str]]]:
-    """Return registration map and duplicate command-name map across known paths."""
+def _collect_command_registration_audit():
+    """Collect startup command audit details with one authoritative inventory pass."""
     root = Path(__file__).parent
     inventory = collect_static_primary_inventory(root)
     paths = {
@@ -291,13 +291,17 @@ def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, l
             owners.setdefault(cmd_name, []).append(source)
 
     duplicates = {name: sorted(srcs) for name, srcs in owners.items() if len(srcs) > 1}
+    return paths, duplicates, inventory
+
+
+def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, list[str]]]:
+    """Return registration map and duplicate command-name map across known paths."""
+    paths, duplicates, _inventory = _collect_command_registration_audit()
     return paths, duplicates
 
 
 def _log_registration_audit() -> dict[str, list[str]]:
-    paths, duplicates = audit_command_registration_paths()
-    root = Path(__file__).parent
-    inventory = collect_static_primary_inventory(root)
+    paths, duplicates, inventory = _collect_command_registration_audit()
     primary_names = paths["commands package (authoritative)"]
     secondary_cogs = paths["cogs/commands.py (disabled legacy)"]
     secondary_subscribe = paths["subscribe.py (disabled legacy)"]

--- a/DL_bot.py
+++ b/DL_bot.py
@@ -263,16 +263,26 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return str(raw).strip().lower() in {"1", "true", "yes", "on", "y"}
 
 
+def _collect_declared_command_names_safely(label: str, path: Path) -> set[str]:
+    try:
+        return collect_declared_command_names(path)
+    except Exception as exc:
+        logger.warning("[COMMAND AUDIT] Failed parsing %s: %s", label, exc)
+        return set()
+
+
 def audit_command_registration_paths() -> tuple[dict[str, set[str]], dict[str, list[str]]]:
     """Return registration map and duplicate command-name map across known paths."""
     root = Path(__file__).parent
     inventory = collect_static_primary_inventory(root)
     paths = {
         "commands package (authoritative)": inventory.names,
-        "cogs/commands.py (disabled legacy)": collect_declared_command_names(
-            root / "cogs" / "commands.py"
+        "cogs/commands.py (disabled legacy)": _collect_declared_command_names_safely(
+            "cogs/commands.py", root / "cogs" / "commands.py"
         ),
-        "subscribe.py (disabled legacy)": collect_declared_command_names(root / "subscribe.py"),
+        "subscribe.py (disabled legacy)": _collect_declared_command_names_safely(
+            "subscribe.py", root / "subscribe.py"
+        ),
     }
 
     owners: dict[str, list[str]] = {}

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -117,7 +117,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @safe_command
     @track_usage()
     async def summary_command(ctx):
-        logger.info("[COMMAND] /summary invoked")
+        logger.info("[COMMAND] /ops summary invoked")
         # Public by default (no ephemeral=True)
         try:
             await safe_defer(ctx)
@@ -134,7 +134,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                     content="⚠️ No summary log available or no files processed today."
                 )
         except Exception as e:
-            logger.exception("[COMMAND] /summary failed")
+            logger.exception("[COMMAND] /ops summary failed")
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to build summary: `{type(e).__name__}: {e}`"
             )
@@ -147,7 +147,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def weeksummary_command(ctx):
 
-        logger.info("[COMMAND] /weeksummary invoked")
+        logger.info("[COMMAND] /ops weeksummary invoked")
 
         try:
             await safe_defer(ctx)
@@ -163,7 +163,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                     content="⚠️ No summary log available or no files processed in the last 7 days."
                 )
         except Exception as e:
-            logger.exception("[COMMAND] /weeksummary failed")
+            logger.exception("[COMMAND] /ops weeksummary failed")
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to build weekly summary: `{type(e).__name__}: {e}`"
             )
@@ -177,7 +177,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def history_command(ctx, page: int = 1):
 
-        logger.info("[COMMAND] /history invoked (page=%s) by %s", page, ctx.user)
+        logger.info("[COMMAND] /ops history invoked (page=%s) by %s", page, ctx.user)
 
         try:
             await safe_defer(ctx)
@@ -192,7 +192,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
         try:
             rows = await read_summary_log_rows(log_file)
         except Exception as e:
-            logger.exception("[COMMAND] /history read_summary_log_rows failed")
+            logger.exception("[COMMAND] /ops history read_summary_log_rows failed")
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to read log: `{type(e).__name__}: {e}`"
             )
@@ -244,7 +244,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def failures_command(ctx, page: int = 1):
 
-        logger.info("[COMMAND] /failures invoked (page=%s) by %s", page, ctx.user)
+        logger.info("[COMMAND] /ops failures invoked (page=%s) by %s", page, ctx.user)
 
         try:
             await safe_defer(ctx)
@@ -259,7 +259,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
         try:
             rows = await read_summary_log_rows(log_file)
         except Exception as e:
-            logger.exception("[COMMAND] /failures read_summary_log_rows failed")
+            logger.exception("[COMMAND] /ops failures read_summary_log_rows failed")
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to read log: `{type(e).__name__}: {e}`"
             )
@@ -1314,10 +1314,10 @@ def register_admin(bot: ext_commands.Bot) -> None:
                     f"- Duration: **{dur:.1f}s**"
                 )
             )
-            logger.info("[/test_embed] success (kvk=%s, dur=%.2fs)", is_kvk, dur)
+            logger.info("[/ops test_embed] success (kvk=%s, dur=%.2fs)", is_kvk, dur)
 
         except Exception as e:
-            logger.exception("[/test_embed] failed")
+            logger.exception("[/ops test_embed] failed")
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to send embed:\n```{type(e).__name__}: {e}```"
             )
@@ -1381,7 +1381,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
             )
             await ctx.interaction.edit_original_response(embed=embed)
         except Exception as e:
-            logger.exception("[/usage] failed")
+            logger.exception("[/ops usage] failed")
             await ctx.interaction.edit_original_response(
                 content=f"Sorry, I couldn't load usage stats: `{type(e).__name__}: {e}`"
             )
@@ -1463,7 +1463,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 await ctx.interaction.edit_original_response(embed=embed)
 
         except Exception as e:
-            logger.exception("[/usage_detail] failed")
+            logger.exception("[/ops usage_detail] failed")
             await ctx.interaction.edit_original_response(
                 content=f"Sorry, I couldn't load usage detail: `{type(e).__name__}: {e}`"
             )

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -104,7 +104,13 @@ def _format_validate_embed(report) -> discord.Embed:
 
 
 def register_admin(bot: ext_commands.Bot) -> None:
-    @bot.slash_command(
+    ops_group = discord.SlashCommandGroup(
+        "ops",
+        "Operational admin controls",
+        guild_ids=[GUILD_ID],
+    )
+
+    @ops_group.command(
         name="summary", description="View today's file processing summary", guild_ids=[GUILD_ID]
     )
     @versioned("v1.05")
@@ -133,7 +139,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to build summary: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="weeksummary", description="View 7-day file processing summary", guild_ids=[GUILD_ID]
     )
     @versioned("v1.01")
@@ -162,7 +168,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to build weekly summary: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="history", description="View recently processed files", guild_ids=[GUILD_ID]
     )
     @versioned("v1.10")
@@ -229,7 +235,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
         except Exception:
             pass
 
-    @bot.slash_command(
+    @ops_group.command(
         name="failures", description="View recently failed jobs", guild_ids=[GUILD_ID]
     )
     @versioned("v1.10")
@@ -290,12 +296,6 @@ def register_admin(bot: ext_commands.Bot) -> None:
             await ctx.interaction.edit_original_response(content="")
         except Exception:
             pass
-
-    ops_group = discord.SlashCommandGroup(
-        "ops",
-        "Operational admin controls",
-        guild_ids=[GUILD_ID],
-    )
 
     @ops_group.command(
         name="run_sql_proc",
@@ -1273,7 +1273,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to read crash log: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         # architecture-check: allow
         name="test_embed",
         description="🧪 Manually trigger the stats update embed",  # architecture-check: allow
@@ -1322,7 +1322,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to send embed:\n```{type(e).__name__}: {e}```"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="usage",
         description="View bot usage summary (admin/leadership)",
         guild_ids=[GUILD_ID],
@@ -1386,7 +1386,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"Sorry, I couldn't load usage stats: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
+    @ops_group.command(
         name="usage_detail",
         description="Drill down into a specific command or user (admin/leadership)",
         guild_ids=[GUILD_ID],

--- a/commands/command_inventory.py
+++ b/commands/command_inventory.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
+import ast
 from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+
+
+@dataclass(frozen=True)
+class StaticCommandInventory:
+    names: set[str]
+    grouped: dict[str, set[str]]
+    name_sources: dict[str, list[str]]
+
+    @property
+    def grouped_subcommand_count(self) -> int:
+        return sum(len(commands) for commands in self.grouped.values())
 
 
 def flatten_application_commands(commands: Iterable[Any]) -> Iterator[tuple[str, Any]]:
@@ -19,3 +33,218 @@ def flatten_application_commands(commands: Iterable[Any]) -> Iterator[tuple[str,
                     yield f"{command.name} {subcommand.name} {nested_command.name}", nested_command
             else:
                 yield f"{command.name} {subcommand.name}", subcommand
+
+
+def _literal_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value:
+        return str(node.value)
+    return None
+
+
+def _node_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _node_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return None
+
+
+def _call_name(call: ast.Call) -> str | None:
+    return _node_name(call.func)
+
+
+def collect_declared_command_names(path: Path) -> set[str]:
+    """Collect decorator-declared slash/app command names from one Python module."""
+    names: set[str] = set()
+    if not path.exists():
+        return names
+    source = path.read_text(encoding="utf-8-sig")
+    tree = ast.parse(source, filename=str(path))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for deco in node.decorator_list:
+            if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
+                continue
+            attr = deco.func.attr
+            is_slash = attr == "slash_command"
+            is_app = (
+                attr == "command"
+                and isinstance(deco.func.value, ast.Name)
+                and deco.func.value.id == "app_commands"
+            )
+            if not (is_slash or is_app):
+                continue
+            for kw in deco.keywords:
+                name = _literal_string(kw.value) if kw.arg == "name" else None
+                if name:
+                    names.add(name)
+                    break
+    return names
+
+
+def _collect_group_helper_commands(command_paths: list[Path]) -> dict[str, set[str]]:
+    helpers: dict[str, set[str]] = {}
+
+    for path in command_paths:
+        source = path.read_text(encoding="utf-8-sig")
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.args.args:
+                continue
+            group_arg_name = node.args.args[0].arg
+            command_names: set[str] = set()
+
+            for child in ast.walk(node):
+                if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for deco in child.decorator_list:
+                    if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
+                        continue
+                    if deco.func.attr != "command":
+                        continue
+                    if not (
+                        isinstance(deco.func.value, ast.Name)
+                        and deco.func.value.id == group_arg_name
+                    ):
+                        continue
+                    for kw in deco.keywords:
+                        name = _literal_string(kw.value) if kw.arg == "name" else None
+                        if name:
+                            command_names.add(name)
+                            break
+
+            if command_names:
+                helpers[node.name] = command_names
+
+    return helpers
+
+
+def _active_command_paths(root: Path, command_paths: list[Path]) -> list[Path]:
+    init_path = root / "commands" / "__init__.py"
+    if not init_path.exists():
+        return command_paths
+
+    source = init_path.read_text(encoding="utf-8-sig")
+    tree = ast.parse(source, filename=str(init_path))
+    imported_registers: dict[str, str] = {}
+    active_registers: set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            module_name = node.module.lstrip(".")
+            for alias in node.names:
+                imported_registers[alias.asname or alias.name] = module_name
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            active_registers.add(node.func.id)
+
+    active_paths = []
+    for register_name in active_registers:
+        module_name = imported_registers.get(register_name)
+        if not module_name:
+            continue
+        path = root / "commands" / f"{module_name}.py"
+        if path.exists():
+            active_paths.append(path)
+
+    return sorted(set(active_paths)) or command_paths
+
+
+def _relative_label(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def collect_static_primary_inventory(root: Path) -> StaticCommandInventory:
+    """Collect the authoritative static command surface from the commands package."""
+    names: set[str] = set()
+    grouped: dict[str, set[str]] = {}
+    name_sources: dict[str, list[str]] = {}
+    all_command_paths = [
+        path for path in sorted((root / "commands").glob("*.py")) if path.name != "__init__.py"
+    ]
+    active_command_paths = _active_command_paths(root, all_command_paths)
+    group_helpers = _collect_group_helper_commands(all_command_paths)
+
+    for path in active_command_paths:
+        source_label = _relative_label(path, root)
+        source = path.read_text(encoding="utf-8-sig")
+        tree = ast.parse(source, filename=str(path))
+        group_vars: dict[str, str] = {}
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                continue
+            if not (_call_name(node.value) or "").endswith("SlashCommandGroup"):
+                continue
+
+            group_name = None
+            if node.value.args:
+                group_name = _literal_string(node.value.args[0])
+            for kw in node.value.keywords:
+                if kw.arg == "name":
+                    group_name = _literal_string(kw.value) or group_name
+
+            if not group_name:
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    group_vars[target.id] = group_name
+            names.add(group_name)
+            name_sources.setdefault(group_name, []).append(source_label)
+            grouped.setdefault(group_name, set())
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for deco in node.decorator_list:
+                    if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
+                        continue
+                    attr = deco.func.attr
+                    owner = deco.func.value
+                    is_bot_slash = (
+                        attr == "slash_command"
+                        and isinstance(owner, ast.Name)
+                        and owner.id in {"bot", "bot_instance"}
+                    )
+                    is_app_command = (
+                        attr == "command"
+                        and isinstance(owner, ast.Name)
+                        and owner.id == "app_commands"
+                    )
+                    if not (is_bot_slash or is_app_command):
+                        if attr == "command" and isinstance(owner, ast.Name):
+                            group_name = group_vars.get(owner.id)
+                            if group_name:
+                                for kw in deco.keywords:
+                                    name = _literal_string(kw.value) if kw.arg == "name" else None
+                                    if name:
+                                        grouped.setdefault(group_name, set()).add(name)
+                                        break
+                        continue
+                    for kw in deco.keywords:
+                        name = _literal_string(kw.value) if kw.arg == "name" else None
+                        if name:
+                            names.add(name)
+                            name_sources.setdefault(name, []).append(source_label)
+                            break
+            elif isinstance(node, ast.Call):
+                helper_name = _call_name(node)
+                helper_commands = group_helpers.get(helper_name or "") or group_helpers.get(
+                    (helper_name or "").split(".")[-1]
+                )
+                if not helper_commands or not node.args:
+                    continue
+                first_arg = node.args[0]
+                if not isinstance(first_arg, ast.Name):
+                    continue
+                group_name = group_vars.get(first_arg.id)
+                if group_name:
+                    # architecture-check: allow - "update" is set mutation, not SQL.
+                    grouped.setdefault(group_name, set()).update(helper_commands)
+
+    return StaticCommandInventory(names=names, grouped=grouped, name_sources=name_sources)

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -9,26 +9,33 @@ Phase 1, Permission Decorator Standardisation, was completed in PR 131
 pushed to production. The PR standardised active command permission gates onto decorators without
 changing command paths, command grouping, or command registration count.
 
-The next approved programme slice should start from Phase 2, Validator And Inventory Tooling
-Enhancement, before any further command grouping migrations.
+Phase 2, Validator And Inventory Tooling Enhancement, was completed in PR 132
+(`codex/command-platform-phase-2-validator-inventory`), smoke tested successfully, merged, and
+pushed to production. The PR retired unused disabled secondary command declarations, made
+`/prekvk import_history` visible to static grouped-subcommand reporting, and preserved all active
+command paths and the active top-level command count.
+
+Phase 3, Low-Risk Ops Consolidation And Startup Audit Log Alignment, grouped the approved
+operational/reporting commands under `/ops` and aligned startup command-audit logging with the
+authoritative command inventory.
 
 ## Audit Baseline
 
 Static command registration validation currently reports:
 
 ```text
-primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
 ```
 
 Grouped command summary:
 
 | Group | Statically detected subcommands |
 |---|---:|
-| `/ops` | 14 |
+| `/ops` | 21 |
 | `/mge` | 6 |
 | `/prekvk` | 2 |
 
-The primary command surface has an 18-command buffer below Discord's 100 top-level application
+The primary command surface has a 25-command buffer below Discord's 100 top-level application
 command limit. The validator warns at 90+ and fails above 100.
 
 Usage levels below are based only on local JSONL usage files under `data/command_usage_*.jsonl`
@@ -115,10 +122,10 @@ commands are marked `none observed` pending SQL usage review.
 | Player/KVK | `/mykvkcrystaltech` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech progress` |
 | PreKvK | `/prekvk report` | `commands/prekvk_cmds.py` | public | none observed | grouped | Preserve |
 | PreKvK Admin | `/prekvk import_history` | `commands/prekvk_admin_cmds.py` | decorator | none observed | grouped by helper | Preserve; improve static validator detection |
-| Processing Reports | `/summary` | `commands/admin_cmds.py` | public | none observed | top-level | Candidate `/ops summary`; confirm public/admin intent |
-| Processing Reports | `/weeksummary` | `commands/admin_cmds.py` | public | none observed | top-level | Candidate `/ops weeksummary`; confirm public/admin intent |
-| Processing Reports | `/history` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops history` |
-| Processing Reports | `/failures` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops failures` |
+| Processing Reports | `/ops summary` | `commands/admin_cmds.py` | public | none observed | grouped | Preserve |
+| Processing Reports | `/ops weeksummary` | `commands/admin_cmds.py` | public | none observed | grouped | Preserve |
+| Processing Reports | `/ops history` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Processing Reports | `/ops failures` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Registry | `/register_governor` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry register` or keep flat |
 | Registry | `/modify_registration` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry modify` or keep flat |
 | Registry | `/remove_registration` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry remove` |
@@ -129,7 +136,7 @@ commands are marked `none observed` pending SQL usage review.
 | Registry | `/bulk_export_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_export` |
 | Registry | `/bulk_import_registrations_dryrun` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import_dryrun` |
 | Registry | `/bulk_import_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import` |
-| Stats Ops | `/test_embed` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops test_embed` |
+| Stats Ops | `/ops test_embed` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Stats/KVK | `/test_kvk_export` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk test_export` |
 | Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk stats` or keep flat |
 | Stats/KVK | `/refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk refresh_stats_cache` |
@@ -150,15 +157,15 @@ commands are marked `none observed` pending SQL usage review.
 | Subscriptions | `/migrate_subscriptions_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_dryrun` |
 | Subscriptions | `/migrate_subscriptions_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_apply` |
 | Telemetry | `/ping` | `commands/telemetry_cmds.py` | public | none observed | top-level | Keep flat or move to `/ops ping` |
-| Usage Analytics | `/usage` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops usage` |
-| Usage Analytics | `/usage_detail` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/ops usage_detail` |
+| Usage Analytics | `/ops usage` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Usage Analytics | `/ops usage_detail` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 
 ## Domain Review Summary
 
 | Domain | Strengths | Weaknesses / risks | Improvement opportunity |
 |---|---|---|---|
 | Ark | Strong service/DAL/test ecosystem and consistent leadership decorators on most admin paths. | Largest flat top-level block; public paths require operator communication; docs reference flat names. | First high-value grouping phase after decorator audit. |
-| Ops | Core operational tools already grouped and command lifecycle reuse is strong. Phase 1 standardised `/history`, `/failures`, and redundant already-decorated admin gates. | Processing report commands remain flat. | Move remaining report/usage/test ops commands under `/ops` after operator approval. |
+| Ops | Core operational tools are grouped and command lifecycle reuse is strong. Phase 3 moved approved reporting, usage, and test ops paths under `/ops`. | Calendar and CrystalTech ops remain flat pending later domain grouping. | Continue with domain-specific grouping only after operator approval. |
 | MGE | Already grouped; permission decorators mostly consistent. | `/mge admin_completion` uses an inline admin check. | Standardise decorator and preserve current grouped path. |
 | Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. | Many public player paths are flat and highly discoverable; moving them could confuse players. | Split admin KVK commands first; defer player path changes until approved UX rules exist. |
 | Registry | Strong service/cache tests and command service extraction. | Public self-service paths are discoverability-sensitive; admin bulk operations remain flat. | Group admin registry commands first; decide public path policy separately. |
@@ -193,7 +200,9 @@ commands are marked `none observed` pending SQL usage review.
   legacy declarations when retained in test fixtures.
 - Resolution: Removed the legacy `cogs/commands.py` and root `subscribe.py` files after confirming
   startup uses `Commands.register_commands(bot)` as the authoritative path and does not load these
-  cogs. The validator now reports no retained disabled legacy command surfaces.
+  cogs. The validator now reports no retained disabled legacy command surfaces. PR 132 was smoke
+  tested with a graceful restart and `/ops validate_command_cache`, merged, and pushed to
+  production.
 
 ### Deferred Optimisation
 - Area: `commands/`, command documentation
@@ -255,7 +264,7 @@ Delivered validation:
 
 ### Phase 2 - Validator And Inventory Tooling Enhancement
 
-Status: next.
+Status: complete. Delivered in PR 132, smoke tested successfully, merged, and pushed to production.
 
 Goal: improve command-platform reporting before large migrations.
 
@@ -282,28 +291,48 @@ Validation:
 - `tests/test_command_registration_smoke.py`
 - `python scripts/validate_command_registration.py`
 
-### Phase 3 - Low-Risk Ops Consolidation
+Delivered validation:
+
+- Command registration now reports
+  `primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82`.
+- Focused validator, inventory, lifecycle, and registration smoke tests passed.
+- Full pytest, pre-commit, smoke imports, architecture validation, deferred-item validation,
+  command registration validation, and pytest log-noise analysis passed before merge.
+- Production smoke testing completed via graceful restart and `/ops validate_command_cache`.
+
+### Phase 3 - Low-Risk Ops Consolidation And Startup Audit Log Alignment
+
+Status: implemented in the current Phase 3 branch.
 
 Goal: recover command headroom with low public-UX risk after permissions are standardised.
 
-Scope candidates:
+Delivered scope:
 
-- Move `/summary`, `/weeksummary`, `/history`, `/failures` under `/ops`.
-- Move `/usage` and `/usage_detail` under `/ops`.
-- Move `/test_embed` under `/ops` or retire if no longer useful.
-- Consider `/ping` ownership: keep flat for health/debug discoverability or move to `/ops ping`.
+- Moved `/summary`, `/weeksummary`, `/history`, `/failures` under `/ops`.
+- Moved `/usage` and `/usage_detail` under `/ops`.
+- Moved `/test_embed` under `/ops`.
+- Kept `/ping` flat for health/debug discoverability.
+- Fixed stale `DL_bot.py` startup command audit logging so startup smoke logs do not show
+  `primary=0 ... total_unique=0` when the authoritative validator reports the real active command
+  inventory.
 
 Implementation notes:
 
 - Preserve existing command behavior, output, and usage tracking.
 - Update docs that mention the old paths.
-- Treat public visibility of `/summary` and `/weeksummary` as an explicit operator decision.
+- Public visibility of `/summary` and `/weeksummary` was explicitly approved for grouping and
+  preserved at `/ops summary` and `/ops weeksummary`.
+- Complete startup audit log alignment before or alongside command grouping so Phase 3 smoke logs
+  can be trusted.
 
 Validation:
 
 - Command registration smoke tests.
 - Focused tests for migrated handlers.
 - Command cache/version tests where grouped names affect signatures.
+- Startup log smoke for corrected command audit summary or explicit removal of stale counts.
+- Expected validator baseline after Phase 3:
+  `primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75`.
 
 ### Phase 4 - Ark Command Grouping
 
@@ -394,7 +423,7 @@ Validation:
 
 1. Phase 1: Permission Decorator Standardisation.
 2. Phase 2: Validator And Inventory Tooling Enhancement.
-3. Phase 3: Low-Risk Ops Consolidation.
+3. Phase 3: Low-Risk Ops Consolidation And Startup Audit Log Alignment.
 4. Phase 4: Ark Command Grouping.
 5. Phase 5: Public Domain Grouping Design.
 6. Phase 6: Canonical Command Documentation.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -8,32 +8,40 @@ Command Platform Phase 1, Permission Decorator Standardisation, was completed in
 (`codex/command-platform-phase-1-permission-decorators`), smoke tested successfully, merged, and
 pushed to production. Phase 1 did not rename, retire, regroup, or change the count of any slash
 commands. It standardised active command permission gates onto decorators and kept the registration
-baseline unchanged:
+baseline unchanged.
+
+Command Platform Phase 2, Validator And Inventory Tooling Enhancement, was completed in PR 132
+(`codex/command-platform-phase-2-validator-inventory`), smoke tested successfully, merged, and
+pushed to production. Phase 2 retired unused disabled secondary command declarations and made
+helper-attached `/prekvk import_history` visible in static grouped-subcommand reporting.
+
+Current baseline:
 
 ```text
-primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
 ```
 
-The next programme slice is Phase 2, Validator And Inventory Tooling Enhancement. It should improve
-registration reporting and disabled-secondary classification before further grouping migrations.
+Phase 3, Low-Risk Ops Consolidation And Startup Audit Log Alignment, moved the approved low-risk
+operational/reporting commands under `/ops` and aligned startup command-audit logging with the
+authoritative command inventory.
 
 ## Current Registration Summary
 
 `scripts/validate_command_registration.py` reports:
 
 ```text
-primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
 ```
 
 Grouped command summary:
 
 | Group | Statically detected subcommands |
 |---|---:|
-| `/ops` | 14 |
+| `/ops` | 21 |
 | `/mge` | 6 |
 | `/prekvk` | 2 |
 
-The primary command surface now has an 18-command buffer below Discord's 100 top-level
+The primary command surface now has a 25-command buffer below Discord's 100 top-level
 application-command limit. The validator warns at 90+ and fails above 100.
 
 ## Batch 1 Renamed Command Paths
@@ -57,6 +65,13 @@ application-command limit. The validator warns at 90+ and fails above 100.
 | `/show_logs` | `/ops show_logs` |
 | `/last_errors` | `/ops last_errors` |
 | `/crash_log` | `/ops crash_log` |
+| `/summary` | `/ops summary` |
+| `/weeksummary` | `/ops weeksummary` |
+| `/history` | `/ops history` |
+| `/failures` | `/ops failures` |
+| `/usage` | `/ops usage` |
+| `/usage_detail` | `/ops usage_detail` |
+| `/test_embed` | `/ops test_embed` |
 
 Permission decorators were preserved during Batch 1. Phase 1 later removed redundant inline admin
 checks from already-decorated `/ops run_sql_proc`, `/ops run_gsheets_export`, and
@@ -82,12 +97,14 @@ changing the grouped command path.
 Next command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
 command-platform programme docs. Recommended order:
 
-1. Validator and command inventory tooling enhancement.
-2. Low-risk Ops consolidation, after validator reporting is clearer.
-3. Ark grouping under `/ark`, with operator communication for public paths.
-4. Public/player domain grouping across KVK, registry, inventory, calendar, and subscriptions.
+1. Ark grouping under `/ark`, with operator communication for public paths.
+2. Public/player domain grouping across KVK, registry, inventory, calendar, and subscriptions.
 
 Phase 2 retired the unused disabled secondary command declarations in `cogs/commands.py` and
 root `subscribe.py`, leaving `commands/` as the only command registration surface and removing the
 previous informational duplicate warnings for `/summary`, `/weeksummary`, `/history`,
 `/failures`, `/ping`, and `/subscribe`.
+
+Phase 3 corrected the stale `DL_bot.py` startup audit count so restart smoke logs use the same
+authoritative command inventory semantics as the validator instead of reporting
+`primary=0 ... total_unique=0` from the legacy `Commands.py` shim.

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -16,6 +16,11 @@ declarations in `cogs/commands.py` and root `subscribe.py`, updated validator te
 active versus disabled legacy surfaces, and detected helper-attached grouped subcommands including
 `/prekvk import_history`. The active command baseline after Phase 2 is
 `primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82`.
+PR 132 (`codex/command-platform-phase-2-validator-inventory`) was smoke tested successfully,
+merged, and pushed to production on 2026-06-01. Phase 3 grouped the approved low-risk
+operational/reporting commands under `/ops` and aligned startup command-audit logging. The active
+command baseline after Phase 3 is
+`primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75`.
 Earlier review history: after the slow-pytest optimisation production
 release, PR 107
 (`pytest-log-delivery-docs`) resolved the high-impact pytest duration outliers found after the
@@ -150,8 +155,8 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 ### Deferred Optimisation
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
-- Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Phase 1 then standardised active command permission gates onto decorators without changing the command count. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation and validator improvements remain planned.
-- Suggested Fix: Continue the command-platform programme through the staged follow-up batches. Start with validator and command-inventory tooling enhancement, then group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
+- Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Phase 3 later moved approved low-risk ops/reporting commands under `/ops`, reducing the primary set to 75. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation remains planned.
+- Suggested Fix: Continue the command-platform programme through staged follow-up batches. Group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
 - Impact: high
 - Risk: medium
 - Dependencies: Batch 1 `/ops` and `/mge` grouping and Phase 1 permission decorator standardisation remain deployed cleanly; coordinate with bot operators before renaming public command paths; preserve standard decorator permission checks when commands move into groups.

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 2 Validator And Inventory Tooling Enhancement.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 2 Validator And Inventory Tooling Enhancement.md
@@ -1,7 +1,8 @@
 # Codex Chat Starter - Command Platform Phase 2 Validator And Inventory Tooling Enhancement
 
-Status: implemented in the Phase 2 validator and inventory tooling PR. This starter remains as
-the execution record for Phase 2 of the Command Platform Audit & Optimisation Programme.
+Status: complete. Implemented in PR 132 (`codex/command-platform-phase-2-validator-inventory`),
+smoke tested successfully, merged, and pushed to production. This starter remains as the execution
+record for Phase 2 of the Command Platform Audit & Optimisation Programme.
 
 Source programme documents:
 
@@ -14,7 +15,8 @@ Source programme documents:
 Phase 1, Permission Decorator Standardisation, was completed in PR 131
 (`codex/command-platform-phase-1-permission-decorators`), smoke tested successfully, merged, and
 pushed to production. Phase 2 then retired the unused disabled secondary command declarations and
-updated validator reporting. The current command-platform baseline is:
+updated validator reporting in PR 132, which was also smoke tested, merged, and pushed to
+production. The current command-platform baseline is:
 
 ```text
 primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
@@ -97,6 +99,7 @@ Implemented result:
 - detected `/prekvk import_history` as a helper-attached grouped subcommand
 - preserved all active command paths and the active top-level command count
 - updated validator output to report no active duplicate risks
+- captured the stale `DL_bot.py` startup audit summary follow-up for Phase 3
 
 ## 4. Scope
 

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md
@@ -1,0 +1,189 @@
+# Codex Chat Starter - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment
+
+Status: complete. Phase 3 was implemented in PR 133
+(`codex/command-platform-phase-3-ops-startup-audit`). This starter remains as the execution record
+for Phase 3 of the Command Platform Audit & Optimisation Programme.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 1, Permission Decorator Standardisation, was completed in PR 131
+(`codex/command-platform-phase-1-permission-decorators`), smoke tested successfully, merged, and
+pushed to production.
+
+Phase 2, Validator And Inventory Tooling Enhancement, was completed in PR 132
+(`codex/command-platform-phase-2-validator-inventory`), smoke tested successfully, merged, and
+pushed to production. Phase 3 then grouped the approved low-risk operational/reporting commands
+under `/ops` and aligned startup command-audit logging. The current command-platform baseline is:
+
+```text
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
+```
+
+Phase 3 also corrected the stale `DL_bot.py` startup command-audit summary that previously logged
+`primary=0 ... total_unique=0`.
+
+## Copy/Paste Starter
+
+Codex, begin Phase 3 of the Command Platform Audit & Optimisation Programme: Low-Risk Ops
+Consolidation And Startup Audit Log Alignment.
+
+This follows the completed Phase 2 validator and inventory tooling PR:
+
+- PR 132: `codex/command-platform-phase-2-validator-inventory`
+- Result: smoke tested successfully, merged, pushed to production
+- Current validator baseline:
+
+```text
+primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
+```
+
+The objective for this phase is to recover low-risk command headroom by grouping approved
+operational/reporting commands under `/ops`, and to fix the stale startup command-audit log that
+currently reports `primary=0 ... total_unique=0`.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 3 - Low-Risk Ops Consolidation And Startup Audit Log Alignment
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface migration
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `scripts/validate_command_registration.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `DL_bot.py`
+- `Commands.py`
+- `commands/admin_cmds.py`
+- `tests/test_command_registration_smoke.py`
+- `tests/test_validate_command_registration.py`
+- `tests/test_command_inventory.py`
+- `tests/test_command_lifecycle.py`
+- existing admin command, command cache, and command registration tests
+
+## 3. Objective
+
+This phase should:
+
+- fix or remove the misleading `DL_bot.py` startup audit summary that currently logs
+  `primary=0 ... total_unique=0`
+- migrate approved low-risk operational/reporting commands under `/ops`
+- preserve existing command behavior, permissions, options, descriptions, versions, usage tracking,
+  and response behavior
+- reduce active top-level command count without touching public/player domain paths beyond the
+  explicitly approved low-risk ops/reporting set
+- update tests and docs for any moved paths
+
+## 4. Scope
+
+### In Scope
+
+- `DL_bot.py` startup command-audit log alignment.
+- Low-risk `/ops` grouping candidates:
+  - `/history`
+  - `/failures`
+  - `/usage`
+  - `/usage_detail`
+  - `/test_embed`
+  - `/summary`, only if public/operator visibility is approved
+  - `/weeksummary`, only if public/operator visibility is approved
+- `commands/admin_cmds.py`
+- command registration, cache/version, and validator tests
+- command-platform docs updates
+
+### Out Of Scope
+
+- Ark command grouping
+- public/player domain grouping
+- aliases or migration messaging unless explicitly approved
+- SQL schema changes
+- permission-decorator changes except preserving existing gates during movement
+- production promotion or deployment
+
+## 5. Mandatory Workflow
+
+1. Review/scope Phase 3 and stop for approval.
+2. Map the stale startup audit log path and exact low-risk ops command candidates.
+3. Confirm which candidate commands are approved for grouping, especially `/summary` and
+   `/weeksummary`.
+4. Present implementation plan and stop for approval.
+5. Implement approved startup-log and ops-grouping changes only.
+6. Add/update focused tests and docs.
+7. Run validation.
+8. Run Codex Security review or justify skipping before PR handoff.
+
+Proceed in one pass only if the user explicitly approves one-pass implementation in the new chat.
+
+## 6. Acceptance Criteria
+
+- [ ] Startup command audit logs no longer show `primary=0 ... total_unique=0` for a healthy bot.
+- [ ] Startup smoke expectations identify the authoritative command surface clearly.
+- [ ] Approved low-risk ops commands are grouped under `/ops` without behavior regressions.
+- [ ] Unapproved public/player command paths remain unchanged.
+- [ ] Command descriptions, options, versions, usage tracking, and permissions are preserved.
+- [ ] `scripts/validate_command_registration.py` reports the expected reduced active top-level
+      command count after approved grouping.
+- [ ] Focused tests cover startup audit log semantics and moved command registration/cache names.
+- [ ] Command-platform docs reflect the new paths and baseline.
+
+## 7. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py tests\test_admin_command_cache_paths.py
+```
+
+Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security is likely required if this phase changes Discord command paths, permissions,
+public/admin command visibility, or startup command sync behavior.
+
+## 8. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
@@ -59,10 +59,17 @@ pushed to production. Phase 1 standardised active command permission gates onto 
 introduced the reusable decorator support needed by the current command estate, added focused
 permission-decorator tests, and preserved all command paths and the registration count.
 
+Phase 2 of this programme, Validator And Inventory Tooling Enhancement, was completed in PR 132
+(`codex/command-platform-phase-2-validator-inventory`), smoke tested successfully, merged, and
+pushed to production. Phase 2 retired unused disabled secondary command declarations, updated
+duplicate-risk terminology, detected helper-attached grouped subcommands, and preserved all active
+command paths.
+
 The current validator reports:
 
 82 primary commands
-21 grouped subcommands
+22 grouped subcommands
+0 disabled legacy command declarations
 warning threshold at 90
 hard fail at 100
 
@@ -262,9 +269,12 @@ Current phase status:
 Phase 1 - Permission Decorator Standardisation: complete, smoke tested, merged, and pushed to
 production in PR 131.
 
-Phase 2 - Validator And Inventory Tooling Enhancement: next executable phase. This phase should
-improve command-platform reporting and disabled-secondary classification before additional command
-grouping.
+Phase 2 - Validator And Inventory Tooling Enhancement: complete, smoke tested, merged, and pushed
+to production in PR 132.
+
+Phase 3 - Low-Risk Ops Consolidation And Startup Audit Log Alignment: implemented. This phase
+fixed the stale `DL_bot.py` startup audit summary and grouped approved low-risk
+operational/reporting commands under `/ops`, reducing the active top-level command count to 75.
 
 Example:
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 2 Validator And Inventory Tooling Enhancement.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 2 Validator And Inventory Tooling Enhancement.md
@@ -7,7 +7,8 @@
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: deferred optimisation batch / tooling refactor
 - One-pass approved: no
-- Status: implemented
+- Status: complete; delivered in PR 132, smoke tested successfully, merged, and pushed to
+  production
 
 ## 2. Required Reading
 
@@ -52,8 +53,10 @@ permission gates onto decorators while preserving the current command baseline:
 primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82
 ```
 
-Phase 2 preserved the active command count and active command paths while retiring the unused
-disabled secondary command declarations. The validator now reports:
+Phase 2 was delivered in PR 132 (`codex/command-platform-phase-2-validator-inventory`), smoke
+tested successfully, merged, and pushed to production. It preserved the active command count and
+active command paths while retiring the unused disabled secondary command declarations. The
+validator now reports:
 
 ```text
 primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
@@ -62,6 +65,10 @@ primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 se
 The next migration phases will move or group command paths. Before that work begins, the validator
 and command inventory should clearly report what is active, what is disabled legacy surface, what
 is grouped, and which warnings represent real startup-sync risk.
+
+Production smoke note: graceful restart and `/ops validate_command_cache` were green. The smoke log
+also showed the stale `DL_bot.py` startup command-audit summary as `primary=0 ... total_unique=0`;
+that follow-up is captured in Phase 3.
 
 Known current issue:
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md
@@ -1,0 +1,190 @@
+# Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 3 - Low-Risk Ops Consolidation And Startup Audit Log Alignment
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface migration
+- One-pass approved: no
+- Status: implemented
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 2 Validator And Inventory Tooling Enhancement.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `scripts/validate_command_registration.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `DL_bot.py`
+- `Commands.py`
+- `commands/admin_cmds.py`
+- `tests/test_command_registration_smoke.py`
+- `tests/test_validate_command_registration.py`
+- `tests/test_command_inventory.py`
+- `tests/test_command_lifecycle.py`
+- existing admin command, command cache, and command registration tests
+
+## 3. Objective
+
+Recover low-risk command headroom by grouping selected operational/reporting commands under
+`/ops`, and fix the stale startup command-audit log so restart smoke evidence shows the correct
+command surface.
+
+This phase should:
+
+- fix or remove the misleading `DL_bot.py` startup audit summary that currently logs
+  `primary=0 ... total_unique=0`
+- migrate approved low-risk operational commands under the existing `/ops` group
+- preserve command behavior, permissions, options, descriptions, versions, usage tracking, and
+  response behavior
+- reduce active top-level command count without touching public/player domain paths beyond the
+  explicitly approved low-risk ops/reporting set
+- update tests and docs for any moved paths
+
+## 4. Background
+
+Phase 1 was completed in PR 131 and pushed to production. It standardised active command
+permission gates onto decorators while preserving command paths and registration count.
+
+Phase 2 was completed in PR 132 and pushed to production. It retired unused disabled secondary
+command declarations, detected helper-attached grouped subcommands, and established this baseline:
+
+```text
+primary=82 grouped_subcommands_detected=22 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=82
+```
+
+Phase 2 production smoke confirmed restart and `/ops validate_command_cache` were green, but the
+restart log exposed a stale `DL_bot.py` startup audit line:
+
+```text
+[COMMAND AUDIT] registration summary: primary=0 secondary_cogs=0 secondary_subscribe=0 total_unique=0
+```
+
+That log is confusing because the authoritative static validator correctly reports 82 active
+top-level commands. Phase 3 must address this before the command-platform programme is considered
+log-clean.
+
+Phase 3 implementation result:
+
+```text
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
+```
+
+The `/ops` group now has 21 statically detected subcommands, including `/ops summary`,
+`/ops weeksummary`, `/ops history`, `/ops failures`, `/ops usage`, `/ops usage_detail`, and
+`/ops test_embed`.
+
+## 5. Scope
+
+### In Scope
+
+- Correcting startup command-audit logging in `DL_bot.py`, either by reusing authoritative
+  inventory semantics or by removing stale count output and pointing to the validator-backed
+  command surface.
+- Grouping low-risk ops/reporting command candidates under `/ops`, subject to review and approval:
+  - `/history` -> `/ops history`
+  - `/failures` -> `/ops failures`
+  - `/usage` -> `/ops usage`
+  - `/usage_detail` -> `/ops usage_detail`
+  - `/test_embed` -> `/ops test_embed` or explicitly defer/retire after review
+  - `/summary` -> `/ops summary` only if public/operator visibility is approved
+  - `/weeksummary` -> `/ops weeksummary` only if public/operator visibility is approved
+- Updating command registration, command cache/version tests, and docs for approved moved paths.
+- Preserving existing `/ops` grouped command behavior and Phase 2 validator semantics.
+
+### Out Of Scope
+
+- Ark command grouping.
+- Public/player domain grouping across registry, KVK/stats, inventory, calendar, subscriptions,
+  honor, location, activity, or CrystalTech.
+- Command aliases or migration messaging unless explicitly approved.
+- SQL schema changes.
+- Permission-decorator changes except to preserve existing gates during movement.
+- Production promotion or deployment.
+
+## 6. Mandatory Workflow
+
+1. Review/scope Phase 3 and stop for approval.
+2. Map the stale startup audit log path and exact low-risk ops command candidates.
+3. Confirm which candidate commands are approved for grouping, especially `/summary` and
+   `/weeksummary` public visibility.
+4. Present implementation plan and stop for approval.
+5. Implement approved startup-log and ops-grouping changes only.
+6. Add/update focused tests and docs.
+7. Run validation.
+8. Run Codex Security review or justify skipping before PR handoff.
+
+Proceed in one pass only if the user explicitly approves one-pass implementation in the new chat.
+
+## 7. Acceptance Criteria
+
+- [ ] Startup command audit logs no longer show `primary=0 ... total_unique=0` for a healthy bot.
+- [ ] Startup smoke expectations identify the authoritative command surface clearly.
+- [ ] Approved low-risk ops commands are grouped under `/ops` without behavior regressions.
+- [ ] Unapproved public/player command paths remain unchanged.
+- [ ] Command descriptions, options, versions, usage tracking, and permissions are preserved.
+- [ ] `scripts/validate_command_registration.py` reports the expected reduced active top-level
+      command count after approved grouping.
+- [ ] Focused tests cover startup audit log semantics and moved command registration/cache names.
+- [ ] Command-platform docs reflect the new paths and baseline.
+- [ ] Any deferred command-platform findings are captured structurally.
+
+## 8. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
+```
+
+Add focused admin command tests based on the exact moved commands, likely including:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_admin_command_cache_paths.py
+```
+
+Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security is likely required if this phase changes Discord command paths, permissions,
+public/admin command visibility, or startup command sync behavior. If the final implementation is
+limited to log wording and pure reporting, document a skip rationale.
+
+## 9. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -4,6 +4,12 @@ Active task packs live in this folder. Completed DL_bot upload-routing and start
 programme packs were moved to `archive/` after Phase 6L to keep the active task-pack list focused.
 
 Do not continue the completed DL_bot programme as Phase 6M. Open a fresh task pack for the
-command-surface migration, queue-domain redesign, optional SQL-backed queue persistence, disabled
-secondary command-surface cleanup, SQL deployment workflow, or pinned calendar tracker atomic-write
-hardening when one of those programmes is approved.
+queue-domain redesign, optional SQL-backed queue persistence, SQL deployment workflow, or pinned
+calendar tracker atomic-write hardening when one of those programmes is approved.
+
+The active command-platform programme is tracked in:
+
+- `Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `Codex Task Pack - Command Platform Phase 3 Low-Risk Ops Consolidation And Startup Audit Log Alignment.md`
+
+Phase 1 and Phase 2 command-platform packs remain in this folder as execution records.

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -7,7 +7,6 @@ Usage:
 
 from __future__ import annotations
 
-import ast
 from dataclasses import dataclass
 import importlib.util
 from pathlib import Path
@@ -44,102 +43,8 @@ SECONDARY_MODULES = [
 ]
 
 
-def _literal_string(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value:
-        return str(node.value)
-    return None
-
-
-def _node_name(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        parent = _node_name(node.value)
-        return f"{parent}.{node.attr}" if parent else node.attr
-    return None
-
-
-def _call_name(call: ast.Call) -> str | None:
-    return _node_name(call.func)
-
-
 def collect_names(path: Path) -> set[str]:
     return collect_declared_command_names(path)
-
-
-def _collect_group_helper_commands(command_paths: list[Path]) -> dict[str, set[str]]:
-    helpers: dict[str, set[str]] = {}
-
-    for path in command_paths:
-        source = path.read_text(encoding="utf-8-sig")
-        tree = ast.parse(source, filename=str(path))
-
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or not node.args.args:
-                continue
-            group_arg_name = node.args.args[0].arg
-            command_names: set[str] = set()
-
-            for child in ast.walk(node):
-                if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    continue
-                for deco in child.decorator_list:
-                    if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
-                        continue
-                    if deco.func.attr != "command":
-                        continue
-                    if not (
-                        isinstance(deco.func.value, ast.Name)
-                        and deco.func.value.id == group_arg_name
-                    ):
-                        continue
-                    for kw in deco.keywords:
-                        name = _literal_string(kw.value) if kw.arg == "name" else None
-                        if name:
-                            command_names.add(name)
-                            break
-
-            if command_names:
-                helpers[node.name] = command_names
-
-    return helpers
-
-
-def _active_command_paths(command_paths: list[Path]) -> list[Path]:
-    init_path = ROOT / "commands" / "__init__.py"
-    if not init_path.exists():
-        return command_paths
-
-    source = init_path.read_text(encoding="utf-8-sig")
-    tree = ast.parse(source, filename=str(init_path))
-    imported_registers: dict[str, str] = {}
-    active_registers: set[str] = set()
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module:
-            module_name = node.module.lstrip(".")
-            for alias in node.names:
-                imported_registers[alias.asname or alias.name] = module_name
-        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            active_registers.add(node.func.id)
-
-    active_paths = []
-    for register_name in active_registers:
-        module_name = imported_registers.get(register_name)
-        if not module_name:
-            continue
-        path = ROOT / "commands" / f"{module_name}.py"
-        if path.exists():
-            active_paths.append(path)
-
-    return sorted(set(active_paths)) or command_paths
-
-
-def _relative_label(path: Path) -> str:
-    try:
-        return path.resolve().relative_to(ROOT.resolve()).as_posix()
-    except ValueError:
-        return path.as_posix()
 
 
 def _collect_primary_inventory_details() -> (

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -9,9 +9,24 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+import importlib.util
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_COMMAND_INVENTORY_SPEC = importlib.util.spec_from_file_location(
+    "_command_inventory", ROOT / "commands" / "command_inventory.py"
+)
+if _COMMAND_INVENTORY_SPEC is None or _COMMAND_INVENTORY_SPEC.loader is None:
+    raise RuntimeError("Could not load commands/command_inventory.py")
+_COMMAND_INVENTORY = importlib.util.module_from_spec(_COMMAND_INVENTORY_SPEC)
+sys.modules[_COMMAND_INVENTORY_SPEC.name] = _COMMAND_INVENTORY
+_COMMAND_INVENTORY_SPEC.loader.exec_module(_COMMAND_INVENTORY)
+collect_declared_command_names = _COMMAND_INVENTORY.collect_declared_command_names
+collect_static_primary_inventory = _COMMAND_INVENTORY.collect_static_primary_inventory
 
 PRIMARY_COMMAND_LIMIT = 100
 PRIMARY_COMMAND_WARNING_THRESHOLD = 90
@@ -49,33 +64,7 @@ def _call_name(call: ast.Call) -> str | None:
 
 
 def collect_names(path: Path) -> set[str]:
-    names: set[str] = set()
-    if not path.exists():
-        return names
-    source = path.read_text(encoding="utf-8-sig")
-    tree = ast.parse(source, filename=str(path))
-
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for deco in node.decorator_list:
-            if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
-                continue
-            attr = deco.func.attr
-            is_slash = attr == "slash_command"
-            is_app = (
-                attr == "command"
-                and isinstance(deco.func.value, ast.Name)
-                and deco.func.value.id == "app_commands"
-            )
-            if not (is_slash or is_app):
-                continue
-            for kw in deco.keywords:
-                name = _literal_string(kw.value) if kw.arg == "name" else None
-                if name:
-                    names.add(name)
-                    break
-    return names
+    return collect_declared_command_names(path)
 
 
 def _collect_group_helper_commands(command_paths: list[Path]) -> dict[str, set[str]]:
@@ -156,91 +145,8 @@ def _relative_label(path: Path) -> str:
 def _collect_primary_inventory_details() -> (
     tuple[set[str], dict[str, set[str]], dict[str, list[str]]]
 ):
-    names: set[str] = set()
-    grouped: dict[str, set[str]] = {}
-    name_sources: dict[str, list[str]] = {}
-    all_command_paths = [
-        path for path in sorted((ROOT / "commands").glob("*.py")) if path.name != "__init__.py"
-    ]
-    active_command_paths = _active_command_paths(all_command_paths)
-    group_helpers = _collect_group_helper_commands(all_command_paths)
-
-    for path in active_command_paths:
-        source_label = _relative_label(path)
-        source = path.read_text(encoding="utf-8-sig")
-        tree = ast.parse(source, filename=str(path))
-        group_vars: dict[str, str] = {}
-
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
-                continue
-            if not (_call_name(node.value) or "").endswith("SlashCommandGroup"):
-                continue
-
-            group_name = None
-            if node.value.args:
-                group_name = _literal_string(node.value.args[0])
-            for kw in node.value.keywords:
-                if kw.arg == "name":
-                    group_name = _literal_string(kw.value) or group_name
-
-            if not group_name:
-                continue
-            for target in node.targets:
-                if isinstance(target, ast.Name):
-                    group_vars[target.id] = group_name
-            names.add(group_name)
-            name_sources.setdefault(group_name, []).append(source_label)
-            grouped.setdefault(group_name, set())
-
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                for deco in node.decorator_list:
-                    if not isinstance(deco, ast.Call) or not isinstance(deco.func, ast.Attribute):
-                        continue
-                    attr = deco.func.attr
-                    owner = deco.func.value
-                    is_bot_slash = (
-                        attr == "slash_command"
-                        and isinstance(owner, ast.Name)
-                        and owner.id in {"bot", "bot_instance"}
-                    )
-                    is_app_command = (
-                        attr == "command"
-                        and isinstance(owner, ast.Name)
-                        and owner.id == "app_commands"
-                    )
-                    if not (is_bot_slash or is_app_command):
-                        if attr == "command" and isinstance(owner, ast.Name):
-                            group_name = group_vars.get(owner.id)
-                            if group_name:
-                                for kw in deco.keywords:
-                                    name = _literal_string(kw.value) if kw.arg == "name" else None
-                                    if name:
-                                        grouped.setdefault(group_name, set()).add(name)
-                                        break
-                        continue
-                    for kw in deco.keywords:
-                        name = _literal_string(kw.value) if kw.arg == "name" else None
-                        if name:
-                            names.add(name)
-                            name_sources.setdefault(name, []).append(source_label)
-                            break
-            elif isinstance(node, ast.Call):
-                helper_name = _call_name(node)
-                helper_commands = group_helpers.get(helper_name or "") or group_helpers.get(
-                    (helper_name or "").split(".")[-1]
-                )
-                if not helper_commands or not node.args:
-                    continue
-                first_arg = node.args[0]
-                if not isinstance(first_arg, ast.Name):
-                    continue
-                group_name = group_vars.get(first_arg.id)
-                if group_name:
-                    grouped.setdefault(group_name, set()).update(helper_commands)
-
-    return names, grouped, name_sources
+    inventory = collect_static_primary_inventory(ROOT)
+    return inventory.names, inventory.grouped, inventory.name_sources
 
 
 def collect_primary_inventory() -> tuple[set[str], dict[str, set[str]]]:

--- a/tests/test_admin_command_cache_paths.py
+++ b/tests/test_admin_command_cache_paths.py
@@ -22,3 +22,47 @@ def test_admin_command_cache_handlers_use_canonical_cache_path():
     assert "command_cache_update(" in functions["resync_commands"]
     assert "build_command_cache_validation(" in functions["validate_command_cache"]
     assert "flatten_application_commands" not in combined
+
+
+def test_phase3_ops_commands_are_grouped_with_existing_wrappers():
+    source = Path("commands/admin_cmds.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    moved = {
+        "summary_command": "summary",
+        "weeksummary_command": "weeksummary",
+        "history_command": "history",
+        "failures_command": "failures",
+        "test_embed_command": "test_embed",
+        "usage_command": "usage",
+        "usage_detail_command": "usage_detail",
+    }
+
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name in moved
+    }
+
+    assert set(functions) == set(moved)
+    for function_name, command_name in moved.items():
+        node = functions[function_name]
+        decorators = node.decorator_list
+        command_decorator = decorators[0]
+        assert isinstance(command_decorator, ast.Call)
+        assert isinstance(command_decorator.func, ast.Attribute)
+        assert isinstance(command_decorator.func.value, ast.Name)
+        assert command_decorator.func.value.id == "ops_group"
+        assert command_decorator.func.attr == "command"
+        assert any(
+            keyword.arg == "name"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value == command_name
+            for keyword in command_decorator.keywords
+        )
+        decorator_names = {
+            decorator.func.id
+            for decorator in decorators
+            if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name)
+        } | {decorator.id for decorator in decorators if isinstance(decorator, ast.Name)}
+        assert "safe_command" in decorator_names
+        assert "track_usage" in decorator_names

--- a/tests/test_admin_command_cache_paths.py
+++ b/tests/test_admin_command_cache_paths.py
@@ -66,3 +66,31 @@ def test_phase3_ops_commands_are_grouped_with_existing_wrappers():
         } | {decorator.id for decorator in decorators if isinstance(decorator, ast.Name)}
         assert "safe_command" in decorator_names
         assert "track_usage" in decorator_names
+
+
+def test_phase3_ops_command_logs_use_grouped_paths():
+    source = Path("commands/admin_cmds.py").read_text(encoding="utf-8")
+
+    expected_paths = [
+        "/ops summary",
+        "/ops weeksummary",
+        "/ops history",
+        "/ops failures",
+        "/ops test_embed",
+        "/ops usage",
+        "/ops usage_detail",
+    ]
+    for path in expected_paths:
+        assert path in source
+
+    stale_log_markers = [
+        "[COMMAND] /summary",
+        "[COMMAND] /weeksummary",
+        "[COMMAND] /history",
+        "[COMMAND] /failures",
+        "[/test_embed]",
+        "[/usage]",
+        "[/usage_detail]",
+    ]
+    for marker in stale_log_markers:
+        assert marker not in source

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from pathlib import Path
 import sys
 import types
 
@@ -48,3 +49,20 @@ def test_register_commands_smoke(monkeypatch):
     assert "mge_refresh_award_reminders" not in registered_top_level
     assert "prekvk_report" not in registered_top_level
     assert "prekvk_import_history" not in registered_top_level
+    assert "summary" not in registered_top_level
+    assert "weeksummary" not in registered_top_level
+    assert "history" not in registered_top_level
+    assert "failures" not in registered_top_level
+    assert "usage" not in registered_top_level
+    assert "usage_detail" not in registered_top_level
+    assert "test_embed" not in registered_top_level
+
+
+def test_startup_command_audit_uses_authoritative_inventory():
+    source = Path("DL_bot.py").read_text(encoding="utf-8")
+
+    assert "collect_static_primary_inventory" in source
+    assert "commands package (authoritative)" in source
+    assert "grouped_subcommands_detected" in source
+    assert "Commands.py (authoritative)" not in source
+    assert "_collect_declared_slash_commands" not in source

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -64,5 +64,7 @@ def test_startup_command_audit_uses_authoritative_inventory():
     assert "collect_static_primary_inventory" in source
     assert "commands package (authoritative)" in source
     assert "grouped_subcommands_detected" in source
+    assert "_collect_declared_command_names_safely" in source
+    assert "Failed parsing %s" in source
     assert "Commands.py (authoritative)" not in source
     assert "_collect_declared_slash_commands" not in source

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -86,6 +86,26 @@ def register_sample(bot):
     assert grouped == {"ops": {"audit", "status"}}
 
 
+def test_current_command_surface_reflects_phase3_ops_grouping():
+    names, grouped = validator.collect_primary_inventory()
+
+    moved_to_ops = {
+        "summary",
+        "weeksummary",
+        "history",
+        "failures",
+        "usage",
+        "usage_detail",
+        "test_embed",
+    }
+
+    assert len(names) == 75
+    assert moved_to_ops.isdisjoint(names)
+    assert moved_to_ops.issubset(grouped["ops"])
+    assert len(grouped["ops"]) == 21
+    assert sum(len(commands) for commands in grouped.values()) == 29
+
+
 def test_main_reports_active_duplicate_risks(tmp_path, monkeypatch, capsys):
     _write(
         tmp_path / "commands" / "one_cmds.py",

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -106,6 +106,17 @@ def test_current_command_surface_reflects_phase3_ops_grouping():
     assert sum(len(commands) for commands in grouped.values()) == 29
 
 
+def test_validator_delegates_static_inventory_to_shared_helper():
+    source = Path("scripts/validate_command_registration.py").read_text(encoding="utf-8")
+
+    assert "collect_static_primary_inventory" in source
+    assert "def _collect_group_helper_commands" not in source
+    assert "def _active_command_paths" not in source
+    assert "def _relative_label" not in source
+    assert "def _literal_string" not in source
+    assert "def _call_name" not in source
+
+
 def test_main_reports_active_duplicate_risks(tmp_path, monkeypatch, capsys):
     _write(
         tmp_path / "commands" / "one_cmds.py",


### PR DESCRIPTION
## Summary
- Group approved low-risk ops/reporting commands under `/ops`: `summary`, `weeksummary`, `history`, `failures`, `usage`, `usage_detail`, and `test_embed`.
- Align `DL_bot.py` startup command-audit logging with the authoritative `commands/` static inventory instead of the legacy `Commands.py` shim.
- Update validator/inventory tests and command-platform docs for the new Phase 3 baseline.

## Baseline
```text
primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
```

## Validation
- `python scripts/validate_architecture_boundaries.py`
- `python scripts/validate_deferred_items.py`
- `python scripts/select_tests.py`
- `python scripts/smoke_imports.py`
- `python scripts/validate_command_registration.py`
- `python -m pytest -q tests/test_validate_command_registration.py tests/test_command_registration_smoke.py tests/test_command_inventory.py tests/test_command_lifecycle.py tests/test_admin_command_cache_paths.py`
- `python -m pytest -q tests` (`1611 passed, 2 skipped`)
- `python -m pre_commit run -a`
- `python scripts/analyse_pytest_log_noise.py`
- Codex Security diff review: no reportable findings

## Notes
- No SQL changes.
- Public visibility for `/summary` and `/weeksummary` is preserved at `/ops summary` and `/ops weeksummary` as approved.