### PR TITLE
[codex] Scope command platform Phase 5A docs

### DIFF
--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -21,6 +21,13 @@ to production. The PR grouped the approved operational/reporting commands under 
 startup command-audit logging with the authoritative command inventory, and confirmed
 `/ops validate_command_cache` remained green after restart.
 
+Phase 4, Ark Command Grouping, was completed in PR 134
+(`codex/command-platform-phase-4-ark-grouping`), smoke tested successfully, merged, and pushed to
+production. The PR grouped all 14 Ark commands under `/ark`, including public
+`/ark reminder_prefs` and `/ark report_players`, preserved existing permissions/options/versions
+and Ark modal/view flows, added a post-merge Discord briefing note, and confirmed
+`/ops validate_command_cache` remained green after restart.
+
 ## Audit Baseline
 
 Static command registration validation after Phase 4 implementation reports:
@@ -62,7 +69,7 @@ commands are marked `none observed` pending SQL usage review.
 
 | Category | Current path | Owner module | Permission model | Usage | Registration | Proposed path / disposition |
 |---|---|---|---|---:|---|---|
-| Activity | `/activity_top` | `commands/activity_cmds.py` | decorator | none observed | top-level | Candidate `/activity top` |
+| Activity | `/activity_top` | `commands/activity_cmds.py` | decorator | none observed | top-level | Phase 5A `/activity top` |
 | Ark | `/ark create_match` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark force_announce` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark amend_match` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -77,29 +84,29 @@ commands are marked `none observed` pending SQL usage review.
 | Ark | `/ark report_players` | `commands/ark_cmds.py` | public | none observed | grouped | Preserve |
 | Ark | `/ark generate_draft` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark create_team` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
-| Calendar | `/calendar` | `commands/calendar_cmds.py` | public | none observed | top-level | Keep or candidate `/calendar browse` after UX approval |
-| Calendar | `/calendar_next_event` | `commands/calendar_cmds.py` | public | none observed | top-level | Candidate `/calendar next_event` |
-| Calendar | `/calendar_reminder_config` | `commands/calendar_cmds.py` | public | none observed | top-level | Candidate `/calendar reminder_config` |
-| Calendar Ops | `/calendar_refresh` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar refresh` |
-| Calendar Ops | `/calendar_generate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar generate` |
-| Calendar Ops | `/calendar_publish_cache` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar publish_cache` |
-| Calendar Ops | `/calendar_status` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/calendar status` |
-| CrystalTech Ops | `/crystaltech_validate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech validate` |
-| CrystalTech Ops | `/crystaltech_reload` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech reload` |
-| CrystalTech Ops | `/crystaltech_admin_reset` | `commands/admin_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech admin_reset` |
-| Events | `/next_kvk_fight` | `commands/events_cmds.py` | public | none observed | top-level | Candidate `/events next_fight` |
-| Events | `/next_kvk_event` | `commands/events_cmds.py` | public | none observed | top-level | Candidate `/events next_event` |
-| Events | `/refresh_events` | `commands/events_cmds.py` | decorator | none observed | top-level | Candidate `/events refresh` |
-| Events | `/refresh_kvk_overview` | `commands/events_cmds.py` | decorator | none observed | top-level | Candidate `/events refresh_kvk_overview` |
-| Honor/KVK | `/honor_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/honor rankings` |
-| Honor/KVK | `/honor_purge_last` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/honor purge_last` |
-| Inventory | `/import_inventory` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Candidate `/inventory import` |
-| Inventory | `/myinventory` | `commands/inventory_cmds.py` | public | none observed | top-level | Candidate `/inventory report` |
-| Inventory | `/inventory_preferences` | `commands/inventory_cmds.py` | public | none observed | top-level | Candidate `/inventory preferences` |
-| Inventory | `/export_inventory` | `commands/inventory_cmds.py` | service authorization context | none observed | top-level | Candidate `/inventory export` |
-| Inventory | `/inventory_import_audit` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Candidate `/inventory audit` |
-| Location | `/import_locations` | `commands/location_cmds.py` | decorator | none observed | top-level | Candidate `/location import` |
-| Location | `/player_location` | `commands/location_cmds.py` | decorator | none observed | top-level | Candidate `/location player` |
+| Calendar | `/calendar` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
+| Calendar | `/calendar_next_event` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
+| Calendar | `/calendar_reminder_config` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Calendar Ops | `/calendar_refresh` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar refresh` |
+| Calendar Ops | `/calendar_generate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar generate` |
+| Calendar Ops | `/calendar_publish_cache` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar publish_cache` |
+| Calendar Ops | `/calendar_status` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar status` |
+| CrystalTech Ops | `/crystaltech_validate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech validate` |
+| CrystalTech Ops | `/crystaltech_reload` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech reload` |
+| CrystalTech Ops | `/crystaltech_admin_reset` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech admin_reset` |
+| Events | `/next_kvk_fight` | `commands/events_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
+| Events | `/next_kvk_event` | `commands/events_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
+| Events | `/refresh_events` | `commands/events_cmds.py` | decorator | none observed | top-level | Phase 5A `/events refresh` |
+| Events | `/refresh_kvk_overview` | `commands/events_cmds.py` | decorator | none observed | top-level | Phase 5A `/events refresh_kvk_overview` |
+| Honor/KVK | `/honor_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer; public/channel-limited ranking UX |
+| Honor/KVK | `/honor_purge_last` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/honor purge_last` |
+| Inventory | `/import_inventory` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Phase 5A `/inventory import` |
+| Inventory | `/myinventory` | `commands/inventory_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Inventory | `/inventory_preferences` | `commands/inventory_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Inventory | `/export_inventory` | `commands/inventory_cmds.py` | service authorization context | none observed | top-level | Defer player self-service workflow redesign |
+| Inventory | `/inventory_import_audit` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Phase 5A `/inventory audit` |
+| Location | `/import_locations` | `commands/location_cmds.py` | decorator | none observed | top-level | Phase 5A `/location import` |
+| Location | `/player_location` | `commands/location_cmds.py` | admin/leadership allowed channels | none observed | top-level | Phase 5A `/location player` |
 | MGE | `/mge leadership_board` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
 | MGE | `/mge import_results` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
 | MGE | `/mge refresh_cache` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -120,46 +127,46 @@ commands are marked `none observed` pending SQL usage review.
 | Ops | `/ops show_logs` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ops | `/ops last_errors` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ops | `/ops crash_log` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
-| Player/KVK | `/mykvktargets` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/kvk targets` |
-| Player/KVK | `/mygovernorid` | `commands/telemetry_cmds.py` | public | none observed | top-level | Candidate `/registry lookup` or keep flat |
-| Player/KVK | `/player_profile` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/profile player` |
-| Player/KVK | `/mykvkcrystaltech` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Candidate `/crystaltech progress` |
+| Player/KVK | `/mykvktargets` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
+| Player/KVK | `/mygovernorid` | `commands/telemetry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Player/KVK | `/player_profile` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Defer profile workflow review |
+| Player/KVK | `/mykvkcrystaltech` | `commands/telemetry_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
 | PreKvK | `/prekvk report` | `commands/prekvk_cmds.py` | public | none observed | grouped | Preserve |
 | PreKvK Admin | `/prekvk import_history` | `commands/prekvk_admin_cmds.py` | decorator | none observed | grouped by helper | Preserve; improve static validator detection |
 | Processing Reports | `/ops summary` | `commands/admin_cmds.py` | public | none observed | grouped | Preserve |
 | Processing Reports | `/ops weeksummary` | `commands/admin_cmds.py` | public | none observed | grouped | Preserve |
 | Processing Reports | `/ops history` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Processing Reports | `/ops failures` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
-| Registry | `/register_governor` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry register` or keep flat |
-| Registry | `/modify_registration` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry modify` or keep flat |
-| Registry | `/remove_registration` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry remove` |
-| Registry | `/remove_registration_by_id` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry remove_by_id` |
-| Registry | `/my_registrations` | `commands/registry_cmds.py` | public | none observed | top-level | Candidate `/registry mine` or keep flat |
-| Registry | `/admin_register_governor` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry admin_register` |
-| Registry | `/registration_audit` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry audit` |
-| Registry | `/bulk_export_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_export` |
-| Registry | `/bulk_import_registrations_dryrun` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import_dryrun` |
-| Registry | `/bulk_import_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Candidate `/registry bulk_import` |
+| Registry | `/register_governor` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Registry | `/modify_registration` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Registry | `/remove_registration` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry remove` |
+| Registry | `/remove_registration_by_id` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry remove_by_id` |
+| Registry | `/my_registrations` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Registry | `/admin_register_governor` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry admin_register` |
+| Registry | `/registration_audit` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry audit` |
+| Registry | `/bulk_export_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_export` |
+| Registry | `/bulk_import_registrations_dryrun` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_import_dryrun` |
+| Registry | `/bulk_import_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_import` |
 | Stats Ops | `/ops test_embed` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
-| Stats/KVK | `/test_kvk_export` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk test_export` |
-| Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk stats` or keep flat |
-| Stats/KVK | `/refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk refresh_stats_cache` |
-| Stats/KVK | `/my_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/stats mine` or keep flat |
-| Stats/KVK | `/my_stats_export` | `commands/stats_cmds.py` | public | none observed | top-level | Candidate `/stats export` or keep flat |
-| Stats/KVK | `/player_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/stats player` |
-| Stats/KVK | `/mykvkhistory` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk history` or keep flat |
-| Stats/KVK | `/kvk_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk rankings` |
-| Stats/KVK | `/kvk_export_all` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk export_all` |
-| Stats/KVK | `/kvk_recompute` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk recompute` |
-| Stats/KVK | `/kvk_list_scans` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk list_scans` |
-| Stats/KVK | `/test_kvk_embed` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk test_embed` |
-| Stats/KVK | `/kvk_window_preview` | `commands/stats_cmds.py` | decorator | none observed | top-level | Candidate `/kvk window_preview` |
-| Subscriptions | `/subscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions subscribe` or keep flat |
-| Subscriptions | `/modify_subscription` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions modify` or keep flat |
-| Subscriptions | `/unsubscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Candidate `/subscriptions unsubscribe` or keep flat |
-| Subscriptions | `/list_subscribers` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions list` |
-| Subscriptions | `/migrate_subscriptions_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_dryrun` |
-| Subscriptions | `/migrate_subscriptions_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Candidate `/subscriptions migrate_apply` |
+| Stats/KVK | `/test_kvk_export` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk test_export` |
+| Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
+| Stats/KVK | `/refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk refresh_stats_cache` |
+| Stats/KVK | `/my_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
+| Stats/KVK | `/my_stats_export` | `commands/stats_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Stats/KVK | `/player_stats` | `commands/stats_cmds.py` | admin/leadership | none observed | top-level | Phase 5A `/stats player` |
+| Stats/KVK | `/mykvkhistory` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
+| Stats/KVK | `/kvk_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer; public/channel-limited ranking UX |
+| Stats/KVK | `/kvk_export_all` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk export_all` |
+| Stats/KVK | `/kvk_recompute` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk recompute` |
+| Stats/KVK | `/kvk_list_scans` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk list_scans` |
+| Stats/KVK | `/test_kvk_embed` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk test_embed` |
+| Stats/KVK | `/kvk_window_preview` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk window_preview` |
+| Subscriptions | `/subscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Subscriptions | `/modify_subscription` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Subscriptions | `/unsubscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
+| Subscriptions | `/list_subscribers` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions list` |
+| Subscriptions | `/migrate_subscriptions_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions migrate_dryrun` |
+| Subscriptions | `/migrate_subscriptions_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions migrate_apply` |
 | Telemetry | `/ping` | `commands/telemetry_cmds.py` | public | none observed | top-level | Keep flat or move to `/ops ping` |
 | Usage Analytics | `/ops usage` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Usage Analytics | `/ops usage_detail` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -168,14 +175,14 @@ commands are marked `none observed` pending SQL usage review.
 
 | Domain | Strengths | Weaknesses / risks | Improvement opportunity |
 |---|---|---|---|
-| Ark | Strong service/DAL/test ecosystem and consistent leadership decorators on most admin paths. Phase 4 groups all Ark commands under `/ark`. | Create/amend/cancel command bodies still contain substantial orchestration that should move into services later. | Follow up with an Ark command orchestration extraction batch. |
-| Ops | Core operational tools are grouped and command lifecycle reuse is strong. Phase 3 moved approved reporting, usage, and test ops paths under `/ops`. | Calendar and CrystalTech ops remain flat pending later domain grouping. | Continue with domain-specific grouping only after operator approval. |
+| Ark | Strong service/DAL/test ecosystem and consistent leadership decorators on most admin paths. Phase 4 grouped all Ark commands under `/ark`. | Create/amend/cancel command bodies still contain substantial orchestration that should move into services later. | Follow up with an Ark command orchestration extraction batch. |
+| Ops | Core operational tools are grouped and command lifecycle reuse is strong. Phase 3 moved approved reporting, usage, and test ops paths under `/ops`. | Calendar, CrystalTech, registry admin, KVK admin, location, activity, and subscription admin commands remain flat. | Execute approved Phase 5A admin/leadership/operator domain grouping. |
 | MGE | Already grouped; permission decorators mostly consistent. | `/mge admin_completion` uses an inline admin check. | Standardise decorator and preserve current grouped path. |
-| Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. | Many public player paths are flat and highly discoverable; moving them could confuse players. | Split admin KVK commands first; defer player path changes until approved UX rules exist. |
-| Registry | Strong service/cache tests and command service extraction. | Public self-service paths are discoverability-sensitive; admin bulk operations remain flat. | Group admin registry commands first; decide public path policy separately. |
-| Inventory | Service-oriented implementation and focused inventory tests. Phase 1 standardised command access checks onto decorators. | Inventory export still passes admin context to the service for self-service/admin override semantics. | Group under `/inventory` only after public-path UX approval. |
-| Calendar / Events | Calendar command layer is thin and docs are extensive. | Calendar admin commands live in `admin_cmds.py` while public commands live in `calendar_cmds.py`; many docs reference flat paths. | Group calendar public/admin commands with careful docs update. |
-| Subscriptions | Public flow is simple and tested via views. | Public path migration needs communication. | Consider `/subscriptions` grouping after public-path UX approval. |
+| Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. | Personal player paths are flat and likely high-traffic; some current commands may reflect development slices rather than ideal user journeys. | Move only admin/leadership KVK/stat commands in Phase 5A; defer personal player workflow redesign. |
+| Registry | Strong service/cache tests and command service extraction. | Public self-service paths are discoverability-sensitive and may be better redesigned around a coherent Governor ID/account workflow. | Group admin registry commands in Phase 5A; defer public account workflow redesign. |
+| Inventory | Service-oriented implementation and focused inventory tests. Phase 1 standardised command access checks onto decorators. | Inventory export still passes admin context to the service for self-service/admin override semantics; personal commands are high-discoverability. | Move import/audit only in Phase 5A; defer personal inventory workflow redesign. |
+| Calendar / Events | Calendar command layer is thin and docs are extensive. | Public calendar/KVK calendar commands have inconsistent naming, visibility, scope, and button behavior. | Move admin refresh/status commands in Phase 5A; defer public calendar/KVK calendar UX redesign. |
+| Subscriptions | Public flow is simple and tested via views. | Public subscription commands are player self-service paths that need communication and may benefit from flow redesign. | Move admin list/migration commands in Phase 5A; defer subscription self-service redesign. |
 | Secondary cogs | Phase 2 retired unused disabled legacy declarations. | No active secondary command surface remains. | Keep validator tolerant of missing retired paths and focused on active startup-sync risks. |
 
 ## Technical Debt Register
@@ -187,14 +194,19 @@ commands are marked `none observed` pending SQL usage review.
 - Resolution: Added reusable decorator support for admin-only, admin-or-leadership in allowed channels, and missing-config channel denial. Preserved command paths, command count, service handoff behavior, and denial visibility. `/export_inventory` remains service-authorized because it is self-service with admin override context rather than a command-denial gate.
 - Validation: Command registration remained `primary=82 grouped_subcommands_detected=21 secondary_cogs=5 secondary_subscribe=1 total_unique=82`; full pytest, pre-commit, log-noise validation, and Codex Security diff review passed.
 
-### Deferred Optimisation
+### Phase 4 Completed Item
 - Area: `commands/ark_cmds.py`, `docs/ark/`, Ark command tests
 - Type: architecture
-- Description: Ark remains a large flat command surface with stale flat-path documentation and public/operator workflows tied to current names.
-- Suggested Fix: Design an approved `/ark` grouping migration with docs/tests/operator communication.
-- Impact: high
-- Risk: medium
-- Dependencies: Operator approval for public Ark path changes.
+- Description: Phase 4 grouped all Ark commands under `/ark`, including public reminder
+  preferences and player report commands, while preserving existing behavior, permissions, command
+  options, versions, usage tracking, response visibility, modal/view flows, and command-cache
+  semantics.
+- Resolution: Delivered in PR 134
+  (`codex/command-platform-phase-4-ark-grouping`), smoke tested successfully, merged, and pushed to
+  production.
+- Validation: Production smoke confirmed `/ops validate_command_cache` green and the active
+  baseline at
+  `primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62`.
 
 ### Phase 2 Completed Item
 - Area: `scripts/validate_command_registration.py`, `cogs/commands.py`, `subscribe.py`
@@ -348,12 +360,12 @@ Delivered validation:
 
 ### Phase 4 - Ark Command Grouping
 
-Status: implementation in progress in the Phase 4 PR. See
-`docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`.
+Status: complete. Delivered in PR 134, smoke tested successfully, merged, and pushed to
+production.
 
 Goal: group Ark commands under `/ark`, recovering the largest remaining top-level block.
 
-Implemented scope:
+Delivered scope:
 
 - Leadership/admin paths: `create_match`, `force_announce`, `amend_match`, `cancel_match`,
   `set_preference`, `clear_preference`, `ban_add`, `ban_revoke`, `ban_list`, `set_result`,
@@ -362,42 +374,58 @@ Implemented scope:
 
 Implementation notes:
 
-- Public Ark path migration was approved because Ark is fortnightly and the public commands are
-  not currently in active use; publish the post-merge Discord briefing note before the next Ark
-  cycle.
-- Preserve `is_admin_or_leadership_only`, `channel_only`, autocomplete/options, modal/view flows,
+- Public Ark path migration was approved because Ark is fortnightly and the public commands were
+  not currently in active use; a post-merge Discord briefing note was added at
+  `docs/ark/ark_command_grouping_discord_briefing.md`.
+- Preserved `is_admin_or_leadership_only`, `channel_only`, autocomplete/options, modal/view flows,
   and interaction response behavior.
-- Update Ark docs and smoke-test runbooks that reference flat paths.
+- Updated Ark docs and smoke-test runbooks that referenced flat paths.
 - Follow up separately on extracting substantial create/amend/cancel orchestration out of
   `commands/ark_cmds.py` into Ark services.
 
-Validation:
+Delivered validation:
 
 - Ark command tests, including reminder prefs and force announce.
 - Ark registration, draft, ban, cancel, and result focused tests where touched.
 - Command registration validation and smoke imports.
-- Codex Security review required due to permissions, public interactions, and restart-sensitive Ark
-  flows.
+- Full pytest, pre-commit, architecture validation, deferred-item validation, command registration
+  validation, pytest log-noise analysis, and Codex Security diff review passed before merge.
+- Production smoke confirmed `/ops validate_command_cache` green after restart.
 
-### Phase 5 - Public Domain Grouping Design
+### Phase 5 - Public Domain Grouping Design / Phase 5A Admin Grouping
 
-Goal: decide the player-facing command policy before touching high-discoverability paths.
+Status: design approved for Phase 5A only. See
+`docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`.
 
-Scope candidates:
+Goal: implement only the approved admin/leadership/operator grouping slice and defer player
+self-service plus public calendar/KVK calendar redesign out of this command-count programme.
 
-- `/registry`: registration, my registrations, admin registry operations
-- `/kvk` and `/stats`: KVK rankings, personal stats, exports, admin KVK operations
-- `/inventory`: import, report, preferences, export, audit
-- `/calendar` and `/events`: calendar browsing, reminder config, next KVK events/fights,
-  refresh operations
-- `/subscriptions`: subscribe, modify, unsubscribe, list, migration commands
-- `/crystaltech`, `/honor`, `/location`, `/activity`
+Approved Phase 5A scope:
+
+- `/registry`: remove, remove_by_id, admin_register, audit, bulk_export, bulk_import_dryrun,
+  bulk_import
+- `/kvk`: test_export, refresh_stats_cache, export_all, recompute, list_scans, test_embed,
+  window_preview
+- `/stats`: player
+- `/inventory`: import, audit
+- `/calendar`: refresh, generate, publish_cache, status
+- `/events`: refresh, refresh_kvk_overview
+- `/subscriptions`: list, migrate_dryrun, migrate_apply
+- `/crystaltech`: validate, reload, admin_reset
+- `/honor`: purge_last
+- `/location`: import, player
+- `/activity`: top
 
 Implementation notes:
 
-- Split admin-heavy commands from player self-service commands where that reduces UX risk.
-- Keep heavily used/self-service paths flat unless operators approve migration.
-- Consider transition docs or announcement copy for public renames.
+- Preserve behavior, permissions, options, autocomplete, versions, usage tracking, response
+  visibility, command-cache behavior, and handler bodies.
+- `/player_location` and `/player_stats` are included because they are admin/leadership lookup
+  commands, not player self-service commands.
+- Leave player self-service commands flat in Phase 5A; capture them as a separate workflow
+  redesign deferred optimisation.
+- Leave generic public calendar/KVK calendar commands flat in Phase 5A; capture them as a
+  separate calendar UX redesign deferred optimisation.
 
 Validation:
 
@@ -444,9 +472,10 @@ Validation:
 2. Phase 2: Validator And Inventory Tooling Enhancement.
 3. Phase 3: Low-Risk Ops Consolidation And Startup Audit Log Alignment.
 4. Phase 4: Ark Command Grouping.
-5. Phase 5: Public Domain Grouping Design.
+5. Phase 5A: Admin/Leadership/Operator Domain Grouping.
 6. Phase 6: Canonical Command Documentation.
 7. Phase 7: Future Governance And CI Guardrails.
 
-The current implementation PR is Phase 4 only, with all 14 Ark commands approved for grouping.
-Any wider public/player command grouping belongs to later phases.
+The next implementation PR should be Phase 5A only. Player self-service workflow redesign and
+public calendar/KVK calendar redesign are deferred into separate optimisation tasks rather than
+continued as simple command grouping inside this programme.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -21,13 +21,21 @@ and pushed to production. Phase 3 moved the approved low-risk operational/report
 `/ops`, fixed the stale startup command-audit summary, and confirmed command-cache validation
 remained green after restart.
 
+Command Platform Phase 4, Ark Command Grouping, was completed in PR 134
+(`codex/command-platform-phase-4-ark-grouping`), smoke tested successfully, merged, and pushed to
+production. Phase 4 moved all 14 Ark commands under `/ark`, including public reminder preferences
+and player report commands, while preserving Ark permissions, command options, versions, usage
+tracking, response visibility, modal/view flows, and command-cache behavior.
+
 Current baseline after Phase 4 implementation:
 
 ```text
 primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
 ```
 
-The next command-platform phase is Ark grouping under `/ark`.
+The next command-platform phase is Phase 5A admin/leadership/operator domain grouping. Player
+self-service and generic public calendar/KVK calendar redesign are deferred outside this
+command-count programme.
 
 ## Current Registration Summary
 
@@ -124,9 +132,18 @@ usage tracking, options, and modal/view flows while moving all Ark commands into
 Next command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
 command-platform programme docs. Recommended order:
 
-1. Ark grouping under `/ark` is implemented in Phase 4; publish the post-merge Discord briefing
-   note before the next Ark cycle.
-2. Public/player domain grouping across KVK, registry, inventory, calendar, and subscriptions.
+1. Phase 5A admin/leadership/operator domain grouping across registry admin, KVK/stat admin,
+   inventory import/audit, calendar/event admin refresh/status paths, subscriptions admin,
+   CrystalTech admin, honor purge, location admin/leadership, and activity leadership commands.
+2. Canonical command documentation after approved Phase 5A path decisions.
+3. Future governance and CI guardrails.
+
+The previously considered player self-service grouping is deferred because commands such as
+`/register_governor`, `/modify_registration`, `/my_registrations`, `/mygovernorid`,
+`/mykvkstats`, `/my_stats`, `/myinventory`, and `/subscribe` likely need workflow redesign rather
+than simple path grouping. The public calendar/KVK calendar commands are also deferred because
+`/calendar`, `/calendar_next_event`, `/next_kvk_fight`, and `/next_kvk_event` have inconsistent
+visibility, naming, scope, and button behavior that should be redesigned together.
 
 Phase 2 retired the unused disabled secondary command declarations in `cogs/commands.py` and
 root `subscribe.py`, leaving `commands/` as the only command registration surface and removing the

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,8 +5,7 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after Command Platform Phase 3, Low-Risk Ops Consolidation And Startup Audit Log
-Alignment. PR 131
+Last reviewed after Command Platform Phase 4, Ark Command Grouping. PR 131
 (`codex/command-platform-phase-1-permission-decorators`) was smoke tested successfully, merged,
 and pushed to production on 2026-06-01. Phase 1 standardised active command permission gates onto
 decorators, added focused decorator tests, preserved command paths and registration count, and kept
@@ -26,8 +25,11 @@ restart plus `/ops validate_command_cache`. PR 133
 pushed to production on 2026-06-01. The active command baseline after Phase 3 is
 `primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75`.
 Phase 4 then grouped all 14 Ark commands under `/ark`, including the public reminder preferences
-and player report commands after approval, reducing the implementation baseline to
+and player report commands after approval, added a post-merge Discord briefing note, and reduced
+the active command baseline to
 `primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62`.
+PR 134 (`codex/command-platform-phase-4-ark-grouping`) was smoke tested successfully, merged, and
+pushed to production on 2026-06-01.
 Earlier review history: after the slow-pytest optimisation production
 release, PR 107
 (`pytest-log-delivery-docs`) resolved the high-impact pytest duration outliers found after the
@@ -182,16 +184,25 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Suggested Fix: Scope a follow-up Ark command orchestration extraction that moves create/amend/cancel workflow coordination into Ark services while leaving command handlers responsible for permissions, deferral, input collection, and response rendering. Preserve existing DAL contracts, restart-sensitive message/reminder state behavior, and modal/view callback behavior with focused regression tests.
 - Impact: medium
 - Risk: medium
-- Dependencies: Complete and smoke test Phase 4 Ark command grouping first; validate service boundaries against existing Ark registration, confirmation, reminder, cancel, and audit tests.
+- Dependencies: Phase 4 Ark command grouping is complete and smoke tested; validate service boundaries against existing Ark registration, confirmation, reminder, cancel, and audit tests.
 
 ### Deferred Optimisation
-- Area: `commands/stats_cmds.py`, `commands/registry_cmds.py`, `commands/inventory_cmds.py`, `commands/calendar_cmds.py`, `commands/subscriptions_cmds.py`, user-facing command docs/tests
+- Area: `commands/registry_cmds.py`, `commands/telemetry_cmds.py`, `commands/stats_cmds.py`, `commands/inventory_cmds.py`, `commands/subscriptions_cmds.py`, `commands/calendar_cmds.py`, player self-service command docs/tests
 - Type: architecture
-- Description: Public/player-facing command domains still use many top-level paths that could be grouped later (`/kvk`, `/registry`, `/inventory`, `/calendar`, `/subscriptions`). These commands are more discoverability-sensitive than admin-only surfaces and include heavily documented player workflows, so moving them without coordination could confuse users even though it would reduce startup sync risk further.
-- Suggested Fix: Scope a later public command-path migration with operator-approved UX rules, aliases/transition messaging if feasible, and focused docs/test updates. Prioritise admin-heavy subcommands inside each domain first, then evaluate whether player paths should remain flat for discoverability.
+- Description: Player self-service commands are still split across development-era entry points instead of being designed as complete user workflows. The affected paths include `/register_governor`, `/modify_registration`, `/my_registrations`, `/mygovernorid`, `/mykvkstats`, `/my_stats`, `/my_stats_export`, `/mykvkhistory`, `/mykvktargets`, `/mykvkcrystaltech`, `/myinventory`, `/inventory_preferences`, `/export_inventory`, `/subscribe`, `/modify_subscription`, `/unsubscribe`, and `/calendar_reminder_config`. These are high-discoverability, likely high-traffic commands that players use for critical self-service tasks, and simple path grouping could preserve a fragmented user model while still forcing players to relearn command names.
+- Suggested Fix: Scope a dedicated player self-service workflow redesign outside the command-count programme. Review each block as a user journey before choosing command paths. For registry/account flows, specifically evaluate whether lookup, register, review, and modify should be consolidated into a coherent Governor ID/account command surface rather than four separate commands. Review SQL-backed command usage, transition/announcement needs, Discord alias limitations, docs/smoke references, permission and channel behavior, and focused regression tests before any implementation.
+- Impact: high
+- Risk: medium
+- Dependencies: Phase 5A admin/leadership/operator grouping should be completed first; requires operator approval, SQL-backed usage review, user-facing briefing, and a fresh task pack.
+
+### Deferred Optimisation
+- Area: `commands/calendar_cmds.py`, `commands/events_cmds.py`, `ui/views/calendar.py`, `ui/views/events_views.py`, public calendar/KVK calendar docs/tests
+- Type: architecture
+- Description: Generic public calendar and KVK calendar commands have inconsistent naming, visibility, scope, and interaction behavior. `/calendar` is an ephemeral calendar overview; `/calendar_next_event` is ephemeral and shows one next calendar event; `/next_kvk_fight` is public and shows one fight with controls for the next three fights; `/next_kvk_event` is public and shows one event with controls for the next five events. There is also no clearly named `/kvk_calendar` or equivalent KVK calendar overview, so grouping these commands now would tidy paths without resolving the user-facing model.
+- Suggested Fix: Scope a dedicated public calendar/KVK calendar UX redesign outside the command-count programme. Review whether the end state should use grouped paths such as `/calendar overview`, `/calendar kvk_overview`, `/calendar next_event`, `/calendar next_kvk_fight`, and `/calendar next_kvk_event`; decide whether all public information commands should post publicly; define the missing KVK calendar overview behavior; align button counts and visibility; update docs/smoke references; and add focused command/view tests before implementation.
 - Impact: medium
 - Risk: medium
-- Dependencies: Operator approval for public command rename policy; updated command reference/announcement plan; Batch 1 validation remains below the warning threshold.
+- Dependencies: Phase 5A admin/leadership/operator grouping should be completed first; requires operator approval for public visibility changes and a fresh task pack.
 
 ### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase object retirement

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -1,0 +1,181 @@
+# Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design
+
+Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 4 was completed in PR 134 (`codex/command-platform-phase-4-ark-grouping`), smoke tested
+successfully, merged, and pushed to production. Production smoke confirmed:
+
+- `/ops validate_command_cache` remained green after restart
+- all 14 Ark commands are grouped under `/ark`
+- old flat Ark command paths no longer appear in Discord command discovery
+- public `/ark reminder_prefs` and `/ark report_players` work from the grouped path
+- leadership/admin Ark commands preserve existing permission behavior
+- current validator baseline:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+## Copy/Paste Starter
+
+Codex, begin Phase 5 of the Command Platform Audit & Optimisation Programme: Public Domain
+Grouping Design.
+
+This follows the completed Phase 4 Ark grouping PR:
+
+- PR 134: `codex/command-platform-phase-4-ark-grouping`
+- Result: smoke tested successfully, merged, pushed to production
+- Current validator baseline:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+The objective for this phase is to design the public/player command grouping policy before moving
+any additional command paths. Do not move commands in this phase unless explicitly approved after
+the design review.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 5 - Public Domain Grouping Design
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface design
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/registry_cmds.py`
+- `commands/stats_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/calendar_cmds.py`
+- `commands/events_cmds.py`
+- `commands/subscriptions_cmds.py`
+- `commands/admin_cmds.py`
+- `commands/telemetry_cmds.py`
+- `commands/activity_cmds.py`
+- `commands/location_cmds.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- public/user-facing docs and smoke references for registry, KVK/stats, inventory, calendar,
+  events, subscriptions, location, CrystalTech, honor, and activity commands
+
+## 3. Objective
+
+This phase should:
+
+- review remaining flat public/player and admin-heavy domain command paths
+- distinguish public discoverability-sensitive commands from low-risk admin/operator commands
+- propose grouping domains, candidate subcommands, and target paths
+- define which public command moves require operator approval and communication
+- identify the safest next implementation slice or slices after design approval
+- keep the current Phase 4 command baseline unchanged
+- update command-platform docs with the approved Phase 5 design and roadmap
+
+## 4. Scope
+
+### In Scope
+
+Review and design grouping policy for:
+
+- Registry commands
+- KVK, stats, and player profile commands
+- Inventory commands
+- Calendar and events commands
+- Subscription commands
+- CrystalTech, honor, location, activity, and other admin-heavy candidates
+- command-platform audit docs
+- command-surface audit docs
+- deferred optimisation backlog updates
+- operator communication notes for public/player command moves
+- test and validation recommendations for later implementation phases
+
+### Out Of Scope
+
+- moving any slash command path
+- changing command decorators, permissions, options, autocomplete, descriptions, versions, usage
+  tracking, command-cache behavior, or command handlers
+- SQL schema changes
+- runtime code changes except inspection-only findings documented for later approval
+- production promotion or deployment
+
+## 5. Mandatory Workflow
+
+1. Review/scope Phase 5 and stop for approval.
+2. Map remaining flat command paths by domain, owner module, permission model, and user audience.
+3. Review local usage evidence and clearly label any gaps where SQL-backed usage review is needed.
+4. Identify documentation and smoke references that would need updates for each proposed path.
+5. Present grouping policy and candidate path design.
+6. Stop for approval before editing docs beyond the design deliverable or before any runtime work.
+7. Update docs/deferred items only after approval.
+8. Run documentation-focused validation.
+
+Proceed in one pass only if explicitly approved in the new chat.
+
+## 6. Acceptance Criteria
+
+- [ ] No command paths are moved in Phase 5.
+- [ ] Remaining flat commands are classified by domain, audience, permission model, and grouping
+      risk.
+- [ ] Public/player path moves are explicitly marked approval-gated.
+- [ ] Admin-heavy low-risk candidate moves are separated from high-discoverability player commands.
+- [ ] Proposed target paths are consistent and discoverable.
+- [ ] Operator communication needs are identified for every public/player candidate.
+- [ ] Follow-up implementation phase or phases are clearly recommended.
+- [ ] Command-platform docs and deferred backlog are updated with the approved design.
+- [ ] Validation is run or intentionally skipped with reasons.
+
+## 7. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+Codex Security may be skipped for pure documentation/design output. It becomes required before PR
+handoff if Phase 5 changes runtime command registration, permissions, public interactions,
+SQL/data access, file handling, or restart-sensitive behavior.
+
+## 8. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
@@ -283,14 +283,21 @@ merged, and pushed to production in PR 133. This phase fixed the stale `DL_bot.p
 summary and grouped approved low-risk operational/reporting commands under `/ops`, reducing the
 active top-level command count to 75.
 
-Phase 4 - Ark Command Grouping: implementation approved for all 14 Ark commands. The active task
-pack is `docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`.
+Phase 4 - Ark Command Grouping: complete, smoke tested, merged, and pushed to production in PR 134
+(`codex/command-platform-phase-4-ark-grouping`). This phase grouped all 14 Ark commands under
+`/ark`, added the post-merge Discord briefing note, and reduced the active top-level command count
+to 62.
+
+Phase 5 - Public Domain Grouping Design: design approved for Phase 5A only. The active task pack
+is `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`.
+Phase 5A should group admin/leadership/operator paths only. Player self-service command redesign
+and public calendar/KVK calendar redesign are deferred outside this command-count programme.
 
 Remaining roadmap:
 
 Phase 5
 
-Public Domain Grouping Design
+Phase 5A Admin/Leadership/Operator Domain Grouping
 
 Phase 6
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -1,0 +1,408 @@
+# Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 5 - Public Domain Grouping Design
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface design
+- One-pass approved: no
+- Status: approved for Phase 5A admin/leadership/operator grouping only
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/registry_cmds.py`
+- `commands/stats_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/calendar_cmds.py`
+- `commands/events_cmds.py`
+- `commands/subscriptions_cmds.py`
+- `commands/admin_cmds.py`
+- `commands/telemetry_cmds.py`
+- `commands/activity_cmds.py`
+- `commands/location_cmds.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- public/user-facing docs and smoke references for registry, KVK/stats, inventory, calendar,
+  events, subscriptions, location, CrystalTech, honor, and activity commands
+
+## 3. Objective
+
+Design the next command grouping strategy and approve only the low-disruption
+admin/leadership/operator implementation slice. Public/player self-service and generic public
+calendar/KVK calendar commands are intentionally deferred for deeper workflow redesign.
+
+This phase should:
+
+- review remaining flat public/player and admin-heavy domain command paths
+- approve Phase 5A for admin/leadership/operator grouping only
+- distinguish high-discoverability public/player workflows that should not be moved by simple
+  path grouping
+- capture player self-service and generic calendar/KVK calendar redesign as deferred
+  optimisations
+- identify the safest next implementation slice after design approval
+- keep the current Phase 4 command baseline unchanged
+- update command-platform docs with the approved Phase 5 design and roadmap
+
+## 4. Background
+
+Phase 4 was completed in PR 134 (`codex/command-platform-phase-4-ark-grouping`), smoke tested
+successfully, merged, and pushed to production. It grouped all 14 Ark commands under `/ark`,
+including public `/ark reminder_prefs` and `/ark report_players`, and confirmed command-cache
+validation remained green after restart.
+
+Current validator baseline:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+Grouped command summary:
+
+| Group | Statically detected subcommands |
+|---|---:|
+| `/ark` | 14 |
+| `/ops` | 21 |
+| `/mge` | 6 |
+| `/prekvk` | 2 |
+
+The top-level command surface now has a 38-command buffer below Discord's 100-command limit. Phase
+5 is not urgent command-count emergency work; it is the policy/design phase for public and
+player-facing domains where discoverability and operator communication matter more than raw count
+reduction.
+
+## 5. Approved Phase 5A Scope
+
+Phase 5A is the only approved implementation slice from this design phase. It should group
+admin/leadership/operator-heavy commands by domain while preserving behavior, permissions,
+options, versions, usage tracking, autocomplete, response visibility, command-cache semantics,
+and handler bodies.
+
+Approved Phase 5A candidates:
+
+- Registry admin:
+  - `/remove_registration` -> `/registry remove`
+  - `/remove_registration_by_id` -> `/registry remove_by_id`
+  - `/admin_register_governor` -> `/registry admin_register`
+  - `/registration_audit` -> `/registry audit`
+  - `/bulk_export_registrations` -> `/registry bulk_export`
+  - `/bulk_import_registrations_dryrun` -> `/registry bulk_import_dryrun`
+  - `/bulk_import_registrations` -> `/registry bulk_import`
+- KVK / stats admin and leadership:
+  - `/test_kvk_export` -> `/kvk test_export`
+  - `/refresh_stats_cache` -> `/kvk refresh_stats_cache`
+  - `/player_stats` -> `/stats player`
+  - `/kvk_export_all` -> `/kvk export_all`
+  - `/kvk_recompute` -> `/kvk recompute`
+  - `/kvk_list_scans` -> `/kvk list_scans`
+  - `/test_kvk_embed` -> `/kvk test_embed`
+  - `/kvk_window_preview` -> `/kvk window_preview`
+- Inventory admin/operator:
+  - `/import_inventory` -> `/inventory import`
+  - `/inventory_import_audit` -> `/inventory audit`
+- Calendar admin/operator:
+  - `/calendar_refresh` -> `/calendar refresh`
+  - `/calendar_generate` -> `/calendar generate`
+  - `/calendar_publish_cache` -> `/calendar publish_cache`
+  - `/calendar_status` -> `/calendar status`
+- Events admin/operator:
+  - `/refresh_events` -> `/events refresh`
+  - `/refresh_kvk_overview` -> `/events refresh_kvk_overview`
+- Subscriptions admin/operator:
+  - `/list_subscribers` -> `/subscriptions list`
+  - `/migrate_subscriptions_dryrun` -> `/subscriptions migrate_dryrun`
+  - `/migrate_subscriptions_apply` -> `/subscriptions migrate_apply`
+- CrystalTech admin/operator:
+  - `/crystaltech_validate` -> `/crystaltech validate`
+  - `/crystaltech_reload` -> `/crystaltech reload`
+  - `/crystaltech_admin_reset` -> `/crystaltech admin_reset`
+- Honor admin/operator:
+  - `/honor_purge_last` -> `/honor purge_last`
+- Location admin/leadership/operator:
+  - `/import_locations` -> `/location import`
+  - `/player_location` -> `/location player`
+- Activity leadership/operator:
+  - `/activity_top` -> `/activity top`
+
+`/player_location` and `/player_stats` are included in Phase 5A because they are
+admin/leadership lookup commands, not player self-service commands.
+
+Expected Phase 5A outcome: reduce the top-level command count without changing public/player
+self-service workflows.
+
+## 6. Deferred From Phase 5A
+
+### Player Self-Service Workflow Redesign
+
+The following commands are high-discoverability, player-specific, and should not be moved by a
+simple grouped-path migration:
+
+- Registry/account self-service:
+  - `/register_governor`
+  - `/modify_registration`
+  - `/my_registrations`
+  - `/mygovernorid`
+- KVK/stats/crystal personal self-service:
+  - `/mykvkstats`
+  - `/my_stats`
+  - `/my_stats_export`
+  - `/mykvkhistory`
+  - `/mykvktargets`
+  - `/mykvkcrystaltech`
+- Inventory personal self-service:
+  - `/myinventory`
+  - `/inventory_preferences`
+  - `/export_inventory`
+- Subscription self-service:
+  - `/subscribe`
+  - `/modify_subscription`
+  - `/unsubscribe`
+- Personal calendar preferences:
+  - `/calendar_reminder_config`
+
+Design note: these commands may represent development-time splits rather than ideal player
+workflows. For example, governor/account commands may be better redesigned around one coherent
+Governor ID or account command surface with lookup, register, review, and modify actions instead
+of four separate entry points. That redesign should consider multi-step user journeys, SQL-backed
+usage evidence, migration communication, command aliases/transition limits, and whether any
+current command should remain flat for habit/discoverability.
+
+### Public Calendar / KVK Calendar Redesign
+
+The following commands are generic public/everybody-facing commands and are also deferred from
+Phase 5A:
+
+- `/calendar`
+- `/calendar_next_event`
+- `/next_kvk_fight`
+- `/next_kvk_event`
+
+Design note: these are inconsistent today:
+
+- `/calendar` is an ephemeral calendar overview.
+- `/calendar_next_event` is ephemeral and shows one next calendar event.
+- `/next_kvk_fight` is public and shows one fight with controls for the next three fights.
+- `/next_kvk_event` is public and shows one event with controls for the next five events.
+
+A future calendar/KVK calendar design should review visibility, naming, and interaction behavior
+together. Candidate end state to assess:
+
+- `/calendar overview`
+- `/calendar kvk_overview`
+- `/calendar next_event`
+- `/calendar next_kvk_fight`
+- `/calendar next_kvk_event`
+
+The future task should also evaluate the missing `/kvk_calendar` or equivalent KVK calendar
+overview need and whether these public information commands should all display publicly.
+
+## 7. Original Review Scope
+
+### In Scope
+
+Review and design grouping policy for:
+
+- Registry:
+  - `/register_governor`
+  - `/modify_registration`
+  - `/remove_registration`
+  - `/remove_registration_by_id`
+  - `/my_registrations`
+  - `/admin_register_governor`
+  - `/registration_audit`
+  - `/bulk_export_registrations`
+  - `/bulk_import_registrations_dryrun`
+  - `/bulk_import_registrations`
+- KVK / Stats / Player profile:
+  - `/mykvktargets`
+  - `/mygovernorid`
+  - `/player_profile`
+  - `/mykvkcrystaltech`
+  - `/test_kvk_export`
+  - `/mykvkstats`
+  - `/refresh_stats_cache`
+  - `/my_stats`
+  - `/my_stats_export`
+  - `/player_stats`
+  - `/mykvkhistory`
+  - `/kvk_rankings`
+  - `/kvk_export_all`
+  - `/kvk_recompute`
+  - `/kvk_list_scans`
+  - `/test_kvk_embed`
+  - `/kvk_window_preview`
+- Inventory:
+  - `/import_inventory`
+  - `/myinventory`
+  - `/inventory_preferences`
+  - `/export_inventory`
+  - `/inventory_import_audit`
+- Calendar / Events:
+  - `/calendar`
+  - `/calendar_next_event`
+  - `/calendar_reminder_config`
+  - `/calendar_refresh`
+  - `/calendar_generate`
+  - `/calendar_publish_cache`
+  - `/calendar_status`
+  - `/next_kvk_fight`
+  - `/next_kvk_event`
+  - `/refresh_events`
+  - `/refresh_kvk_overview`
+- Subscriptions:
+  - `/subscribe`
+  - `/modify_subscription`
+  - `/unsubscribe`
+  - `/list_subscribers`
+  - `/migrate_subscriptions_dryrun`
+  - `/migrate_subscriptions_apply`
+- Other admin-heavy or low-use candidates:
+  - `/activity_top`
+  - `/honor_rankings`
+  - `/honor_purge_last`
+  - `/import_locations`
+  - `/player_location`
+  - `/crystaltech_validate`
+  - `/crystaltech_reload`
+  - `/crystaltech_admin_reset`
+
+Also in scope:
+
+- command-platform audit docs
+- command-surface audit docs
+- deferred optimisation backlog updates
+- new candidate implementation phase recommendations
+- operator communication notes for public/player command moves
+- test and validation recommendations for later implementation phases
+
+### Out Of Scope
+
+- Moving any slash command path
+- Changing command decorators, permissions, options, autocomplete, descriptions, versions, usage
+  tracking, command-cache behavior, or command handlers
+- SQL schema changes
+- Runtime code changes except inspection-only findings documented for later approval
+- Production promotion or deployment
+
+## 8. Design Questions
+
+Phase 5 answered:
+
+1. Public/player self-service commands should stay flat for now and move into a separate workflow
+   redesign task rather than a simple grouping implementation.
+2. Admin/leadership/operator commands listed in the approved Phase 5A scope can move first.
+3. Phase 5A should use domain groups where ownership is clear: `/registry`, `/kvk`, `/stats`,
+   `/inventory`, `/calendar`, `/events`, `/subscriptions`, `/crystaltech`, `/honor`, `/location`,
+   and `/activity`.
+4. Public/player self-service command moves require separate operator approval, SQL-backed usage
+   review, and clear briefing before implementation.
+5. Public calendar/KVK calendar commands require a separate UX redesign before path grouping.
+6. Aliases/transition messaging should be assessed in the deferred player and calendar redesign
+   tasks; Phase 5A can use direct rename because it targets admin/leadership/operator surfaces.
+7. The next safest implementation phase is Phase 5A only.
+
+## 9. Expected Deliverables
+
+1. Updated command-platform design section listing:
+   - current path
+   - owner module
+   - permission model
+   - public/admin classification
+   - usage evidence available
+   - recommended disposition
+   - proposed target path where applicable
+   - operator-communication requirement
+2. Phase 5A admin/leadership/operator grouping policy.
+3. Admin-heavy grouping candidate set for the next implementation PR.
+4. Deferred player self-service redesign item requiring explicit operator approval.
+5. Deferred public calendar/KVK calendar redesign item.
+6. Documentation and smoke-test impact inventory.
+7. Updated deferred optimisation items for any out-of-scope command architecture, docs, or test
+   findings.
+8. Proposed roadmap updates showing Phase 5A as the final command-count implementation slice in
+   this programme.
+
+## 10. Mandatory Workflow
+
+1. Review/scope Phase 5 and stop for approval.
+2. Map remaining flat command paths by domain, owner module, permission model, and user audience.
+3. Review local usage evidence and clearly label any gaps where SQL-backed usage review is needed.
+4. Identify documentation and smoke references that would need updates for each proposed path.
+5. Present grouping policy and candidate path design.
+6. Stop for approval before editing docs beyond the design deliverable or before any runtime work.
+7. Update docs/deferred items only after approval.
+8. Run documentation-focused validation.
+9. Stop again before Phase 5A runtime implementation.
+
+Proceed in one pass only if explicitly approved in the new chat.
+
+## 11. Acceptance Criteria
+
+- [ ] No command paths are moved in Phase 5.
+- [ ] Remaining flat commands are classified by domain, audience, permission model, and grouping
+      risk.
+- [ ] Public/player self-service path moves are deferred into a separate workflow redesign task.
+- [ ] Generic public calendar/KVK calendar moves are deferred into a separate UX redesign task.
+- [ ] Admin-heavy low-risk candidate moves are separated from high-discoverability player and
+      public information commands.
+- [ ] Proposed target paths are consistent and discoverable.
+- [ ] Operator communication needs are identified for future public/player candidates.
+- [ ] Follow-up implementation phase or phases are clearly recommended.
+- [ ] Command-platform docs and deferred backlog are updated with the approved design.
+- [ ] Validation is run or intentionally skipped with reasons.
+
+## 12. Suggested Validation
+
+Documentation/design-only validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+```
+
+If Phase 5 edits tests or runtime code despite the default design-only scope, add focused pytest
+coverage for the affected command domains and rerun:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
+```
+
+Codex Security may be skipped for pure documentation/design output. It becomes required before PR
+handoff if Phase 5 changes runtime command registration, permissions, public interactions,
+SQL/data access, file handling, or restart-sensitive behavior.
+
+## 13. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -11,8 +11,8 @@ calendar tracker atomic-write hardening when one of those programmes is approved
 The active command-platform programme is tracked in:
 
 - `Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
-- `Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`
-- `Codex Chat Starter - Command Platform Phase 4 Ark Command Grouping.md`
+- `Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md`
 
-Phase 1, Phase 2, Phase 3, and the superseded command-surface balancing audit pack are archived as
-execution records.
+Phase 1, Phase 2, Phase 3, Phase 4, and the superseded command-surface balancing audit pack are
+archived as execution records.

--- a/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 4 Ark Command Grouping.md
+++ b/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 4 Ark Command Grouping.md
@@ -1,4 +1,45 @@
-# Codex Task Pack - Command Platform Phase 4 Ark Command Grouping
+# Codex Chat Starter - Command Platform Phase 4 Ark Command Grouping
+
+Archived: Phase 4 was completed in PR 134 (`codex/command-platform-phase-4-ark-grouping`), smoke
+tested successfully, merged, and pushed to production. Use the Phase 5 chat starter for the next
+command-platform phase.
+
+Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 3 was completed in PR 133 (`codex/command-platform-phase-3-ops-startup-audit`), smoke tested
+successfully, merged, and pushed to production. Production smoke confirmed:
+
+- startup command audit reports
+  `primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75`
+- the stale `primary=0 ... total_unique=0` startup summary is gone
+- `/ops validate_command_cache` reports all commands correctly versioned and cached
+- the moved `/ops` commands execute correctly
+
+## Copy/Paste Starter
+
+Codex, begin Phase 4 of the Command Platform Audit & Optimisation Programme: Ark Command Grouping.
+
+This follows the completed Phase 3 ops consolidation and startup audit alignment PR:
+
+- PR 133: `codex/command-platform-phase-3-ops-startup-audit`
+- Result: smoke tested successfully, merged, pushed to production
+- Current validator baseline:
+
+```text
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
+```
+
+The objective for this phase is to recover command headroom by grouping approved Ark commands
+under `/ark` while preserving behavior, permissions, options, autocomplete, modal/view flows,
+versions, usage tracking, and command-cache semantics.
 
 ## 1. Task Header
 
@@ -6,8 +47,7 @@
 - Date: 2026-06-01
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: deferred optimisation batch / command-surface migration
-- One-pass approved: yes, after review/scope approval in implementation chat
-- Status: implementation approved
+- One-pass approved: no
 
 ## 2. Required Reading
 
@@ -22,6 +62,7 @@ Before implementation, read:
 - `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
 - `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
 - `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`
 - `docs/reference/command_platform_audit.md`
 - `docs/reference/command_surface_audit.md`
 - `docs/reference/deferred_optimisations.md`
@@ -42,49 +83,21 @@ Also review:
 
 ## 3. Objective
 
-Recover the largest remaining low-risk command headroom block by grouping approved Ark commands
-under `/ark` while preserving existing behavior, permissions, options, autocomplete, modal/view
-flows, response behavior, versions, usage tracking, and restart-sensitive Ark workflows.
-
 This phase should:
 
-- migrate approved Ark command paths from flat top-level names to `/ark` subcommands
-- preserve leadership/admin decorators and channel restrictions exactly
-- preserve public Ark command behavior; public `/ark_reminder_prefs` and `/ark_report_players`
-  migration is explicitly approved for this phase
+- migrate approved Ark top-level commands under `/ark`
+- preserve existing command behavior, permissions, options, autocomplete, descriptions, versions,
+  usage tracking, modal/view flows, and response behavior
+- public `/ark_reminder_prefs` and `/ark_report_players` are approved for grouping
+- leave unapproved public/player command paths unchanged
 - reduce active top-level command count without touching non-Ark command domains
-- update tests and docs for moved paths
-- keep command registration validation and startup smoke evidence aligned with the new baseline
+- update tests and docs for any moved paths
 
-## 4. Background
-
-Phase 3 was completed in PR 133 (`codex/command-platform-phase-3-ops-startup-audit`), smoke tested
-successfully, merged, and pushed to production. It moved the approved low-risk operational and
-reporting commands under `/ops`, fixed the stale startup command-audit summary, and left the active
-baseline at:
-
-```text
-primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
-```
-
-The current grouped command summary is:
-
-| Group | Statically detected subcommands |
-|---|---:|
-| `/ops` | 21 |
-| `/mge` | 6 |
-| `/prekvk` | 2 |
-
-Ark is now the largest remaining flat command block and is the next planned command-platform
-optimisation phase. The public Ark paths are approved for this phase because Ark runs every two
-weeks and the public Ark commands are not currently in active use. Add a simple post-merge Discord
-briefing note before the next Ark cycle.
-
-## 5. Scope
+## 4. Scope
 
 ### In Scope
 
-Create an `/ark` command group and move approved Ark commands:
+Leadership/admin Ark grouping candidates:
 
 - `/ark_create_match` -> `/ark create_match`
 - `/ark_force_announce` -> `/ark force_announce`
@@ -99,7 +112,7 @@ Create an `/ark` command group and move approved Ark commands:
 - `/ark_generate_draft` -> `/ark generate_draft`
 - `/create_ark_team` -> `/ark create_team`
 
-Public Ark paths approved for this phase:
+Public Ark grouping candidates, only if explicitly approved:
 
 - `/ark_reminder_prefs` -> `/ark reminder_prefs`
 - `/ark_report_players` -> `/ark report_players`
@@ -107,38 +120,20 @@ Public Ark paths approved for this phase:
 Also in scope:
 
 - `commands/ark_cmds.py`
-- command inventory, registration, cache/version, and validator tests
-- Ark command docs and smoke/runbook references
-- Discord briefing note for post-merge operator sharing
+- command registration, cache/version, and validator tests
+- Ark docs and smoke/runbook updates
 - command-platform docs updates
-- command-cache validation expectations for grouped Ark paths
 
 ### Out Of Scope
 
-- Non-Ark command grouping
-- Public/player command migration beyond explicitly approved Ark paths
+- non-Ark command grouping
+- public/player command migration outside approved Ark paths
 - aliases or transition messaging unless explicitly approved
 - SQL schema changes
 - permission-decorator changes except preserving existing gates during movement
 - production promotion or deployment
 
-## 6. Baseline And Expected Count
-
-Starting validator baseline:
-
-```text
-primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
-```
-
-All 14 Ark commands are approved, so the expected top-level baseline is:
-
-```text
-primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
-```
-
-Recalculate during implementation only if the final command set changes unexpectedly.
-
-## 7. Mandatory Workflow
+## 5. Mandatory Workflow
 
 1. Review/scope Phase 4 and stop for approval.
 2. Map every Ark command handler, decorator, option, autocomplete, usage-tracking version, and
@@ -151,12 +146,12 @@ Recalculate during implementation only if the final command set changes unexpect
 7. Run validation.
 8. Run Codex Security review before PR handoff.
 
-One-pass implementation was approved after the scope review for the full 14-command Ark grouping.
+Proceed in one pass only if explicitly approved in the new chat.
 
-## 8. Acceptance Criteria
+## 6. Acceptance Criteria
 
 - [ ] Approved Ark commands are grouped under `/ark` without behavior regressions.
-- [ ] Unapproved public/player paths remain unchanged.
+- [ ] Unapproved public/player command paths remain unchanged.
 - [ ] Command descriptions, options, autocomplete, versions, usage tracking, permissions, and
       response behavior are preserved.
 - [ ] Modal/view flows still open and respond correctly from grouped handlers.
@@ -167,7 +162,7 @@ One-pass implementation was approved after the scope review for the full 14-comm
 - [ ] Ark docs, smoke expectations, and command-platform docs reflect the new paths and baseline.
 - [ ] Codex Security review is completed before PR handoff.
 
-## 9. Suggested Validation
+## 7. Suggested Validation
 
 ```powershell
 .\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
@@ -175,13 +170,7 @@ One-pass implementation was approved after the scope review for the full 14-comm
 .\.venv\Scripts\python.exe scripts\select_tests.py
 .\.venv\Scripts\python.exe scripts\smoke_imports.py
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
-.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
-```
-
-Run focused Ark coverage based on the approved paths, likely including:
-
-```powershell
-.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_reminder_prefs_command.py tests\test_ark_preference_commands.py tests\test_ark_ban_commands.py tests\test_ark_cancel_match.py tests\test_ark_phase3a_create_match.py tests\test_ark_phase3b_amend_match.py tests\test_ark_registration_flow.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py tests\test_ark_reminder_prefs_command.py tests\test_ark_preference_commands.py tests\test_ark_ban_commands.py tests\test_ark_cancel_match.py tests\test_ark_phase3a_create_match.py tests\test_ark_phase3b_amend_match.py tests\test_ark_registration_flow.py
 ```
 
 Before PR handoff, run or justify skipping:
@@ -195,7 +184,7 @@ Before PR handoff, run or justify skipping:
 Codex Security is required because this phase changes Discord command paths, permissions-sensitive
 handlers, public interaction entry points if approved, and restart-sensitive Ark workflows.
 
-## 10. Required Delivery Output
+## 8. Required Delivery Output
 
 Use this delivery shape:
 

--- a/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md
+++ b/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md
@@ -1,41 +1,4 @@
-# Codex Chat Starter - Command Platform Phase 4 Ark Command Grouping
-
-Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
-
-Source programme documents:
-
-- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
-- `docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`
-- `docs/reference/command_platform_audit.md`
-- `docs/reference/command_surface_audit.md`
-- `docs/reference/deferred_optimisations.md`
-
-Phase 3 was completed in PR 133 (`codex/command-platform-phase-3-ops-startup-audit`), smoke tested
-successfully, merged, and pushed to production. Production smoke confirmed:
-
-- startup command audit reports
-  `primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75`
-- the stale `primary=0 ... total_unique=0` startup summary is gone
-- `/ops validate_command_cache` reports all commands correctly versioned and cached
-- the moved `/ops` commands execute correctly
-
-## Copy/Paste Starter
-
-Codex, begin Phase 4 of the Command Platform Audit & Optimisation Programme: Ark Command Grouping.
-
-This follows the completed Phase 3 ops consolidation and startup audit alignment PR:
-
-- PR 133: `codex/command-platform-phase-3-ops-startup-audit`
-- Result: smoke tested successfully, merged, pushed to production
-- Current validator baseline:
-
-```text
-primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
-```
-
-The objective for this phase is to recover command headroom by grouping approved Ark commands
-under `/ark` while preserving behavior, permissions, options, autocomplete, modal/view flows,
-versions, usage tracking, and command-cache semantics.
+# Codex Task Pack - Command Platform Phase 4 Ark Command Grouping
 
 ## 1. Task Header
 
@@ -43,7 +6,8 @@ versions, usage tracking, and command-cache semantics.
 - Date: 2026-06-01
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: deferred optimisation batch / command-surface migration
-- One-pass approved: no
+- One-pass approved: yes, after review/scope approval in implementation chat
+- Status: complete; delivered in PR 134, smoke tested, merged, and pushed to production
 
 ## 2. Required Reading
 
@@ -58,7 +22,6 @@ Before implementation, read:
 - `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
 - `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
 - `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
-- `docs/task_packs/Codex Task Pack - Command Platform Phase 4 Ark Command Grouping.md`
 - `docs/reference/command_platform_audit.md`
 - `docs/reference/command_surface_audit.md`
 - `docs/reference/deferred_optimisations.md`
@@ -79,21 +42,54 @@ Also review:
 
 ## 3. Objective
 
+Recover the largest remaining low-risk command headroom block by grouping approved Ark commands
+under `/ark` while preserving existing behavior, permissions, options, autocomplete, modal/view
+flows, response behavior, versions, usage tracking, and restart-sensitive Ark workflows.
+
 This phase should:
 
-- migrate approved Ark top-level commands under `/ark`
-- preserve existing command behavior, permissions, options, autocomplete, descriptions, versions,
-  usage tracking, modal/view flows, and response behavior
-- public `/ark_reminder_prefs` and `/ark_report_players` are approved for grouping
-- leave unapproved public/player command paths unchanged
+- migrate approved Ark command paths from flat top-level names to `/ark` subcommands
+- preserve leadership/admin decorators and channel restrictions exactly
+- preserve public Ark command behavior; public `/ark_reminder_prefs` and `/ark_report_players`
+  migration is explicitly approved for this phase
 - reduce active top-level command count without touching non-Ark command domains
-- update tests and docs for any moved paths
+- update tests and docs for moved paths
+- keep command registration validation and startup smoke evidence aligned with the new baseline
 
-## 4. Scope
+## 4. Background
+
+Phase 3 was completed in PR 133 (`codex/command-platform-phase-3-ops-startup-audit`), smoke tested
+successfully, merged, and pushed to production. It moved the approved low-risk operational and
+reporting commands under `/ops`, fixed the stale startup command-audit summary, and left the active
+baseline at:
+
+```text
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
+```
+
+The current grouped command summary is:
+
+| Group | Statically detected subcommands |
+|---|---:|
+| `/ops` | 21 |
+| `/mge` | 6 |
+| `/prekvk` | 2 |
+
+Ark is now the largest remaining flat command block and is the next planned command-platform
+optimisation phase. The public Ark paths are approved for this phase because Ark runs every two
+weeks and the public Ark commands are not currently in active use. Add a simple post-merge Discord
+briefing note before the next Ark cycle.
+
+Phase 4 was completed in PR 134 (`codex/command-platform-phase-4-ark-grouping`), smoke tested
+successfully, merged, and pushed to production. Production smoke confirmed
+`/ops validate_command_cache` remained green after restart and Discord command discovery showed
+the new `/ark` group with the old flat Ark paths removed.
+
+## 5. Scope
 
 ### In Scope
 
-Leadership/admin Ark grouping candidates:
+Create an `/ark` command group and move approved Ark commands:
 
 - `/ark_create_match` -> `/ark create_match`
 - `/ark_force_announce` -> `/ark force_announce`
@@ -108,7 +104,7 @@ Leadership/admin Ark grouping candidates:
 - `/ark_generate_draft` -> `/ark generate_draft`
 - `/create_ark_team` -> `/ark create_team`
 
-Public Ark grouping candidates, only if explicitly approved:
+Public Ark paths approved for this phase:
 
 - `/ark_reminder_prefs` -> `/ark reminder_prefs`
 - `/ark_report_players` -> `/ark report_players`
@@ -116,20 +112,38 @@ Public Ark grouping candidates, only if explicitly approved:
 Also in scope:
 
 - `commands/ark_cmds.py`
-- command registration, cache/version, and validator tests
-- Ark docs and smoke/runbook updates
+- command inventory, registration, cache/version, and validator tests
+- Ark command docs and smoke/runbook references
+- Discord briefing note for post-merge operator sharing
 - command-platform docs updates
+- command-cache validation expectations for grouped Ark paths
 
 ### Out Of Scope
 
-- non-Ark command grouping
-- public/player command migration outside approved Ark paths
+- Non-Ark command grouping
+- Public/player command migration beyond explicitly approved Ark paths
 - aliases or transition messaging unless explicitly approved
 - SQL schema changes
 - permission-decorator changes except preserving existing gates during movement
 - production promotion or deployment
 
-## 5. Mandatory Workflow
+## 6. Baseline And Expected Count
+
+Starting validator baseline:
+
+```text
+primary=75 grouped_subcommands_detected=29 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=75
+```
+
+All 14 Ark commands are approved, so the expected top-level baseline is:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+Recalculate during implementation only if the final command set changes unexpectedly.
+
+## 7. Mandatory Workflow
 
 1. Review/scope Phase 4 and stop for approval.
 2. Map every Ark command handler, decorator, option, autocomplete, usage-tracking version, and
@@ -142,12 +156,12 @@ Also in scope:
 7. Run validation.
 8. Run Codex Security review before PR handoff.
 
-Proceed in one pass only if explicitly approved in the new chat.
+One-pass implementation was approved after the scope review for the full 14-command Ark grouping.
 
-## 6. Acceptance Criteria
+## 8. Acceptance Criteria
 
 - [ ] Approved Ark commands are grouped under `/ark` without behavior regressions.
-- [ ] Unapproved public/player command paths remain unchanged.
+- [ ] Unapproved public/player paths remain unchanged.
 - [ ] Command descriptions, options, autocomplete, versions, usage tracking, permissions, and
       response behavior are preserved.
 - [ ] Modal/view flows still open and respond correctly from grouped handlers.
@@ -158,7 +172,7 @@ Proceed in one pass only if explicitly approved in the new chat.
 - [ ] Ark docs, smoke expectations, and command-platform docs reflect the new paths and baseline.
 - [ ] Codex Security review is completed before PR handoff.
 
-## 7. Suggested Validation
+## 9. Suggested Validation
 
 ```powershell
 .\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
@@ -166,7 +180,13 @@ Proceed in one pass only if explicitly approved in the new chat.
 .\.venv\Scripts\python.exe scripts\select_tests.py
 .\.venv\Scripts\python.exe scripts\smoke_imports.py
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
-.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py tests\test_ark_reminder_prefs_command.py tests\test_ark_preference_commands.py tests\test_ark_ban_commands.py tests\test_ark_cancel_match.py tests\test_ark_phase3a_create_match.py tests\test_ark_phase3b_amend_match.py tests\test_ark_registration_flow.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
+```
+
+Run focused Ark coverage based on the approved paths, likely including:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_ark_reminder_prefs_command.py tests\test_ark_preference_commands.py tests\test_ark_ban_commands.py tests\test_ark_cancel_match.py tests\test_ark_phase3a_create_match.py tests\test_ark_phase3b_amend_match.py tests\test_ark_registration_flow.py
 ```
 
 Before PR handoff, run or justify skipping:
@@ -180,7 +200,7 @@ Before PR handoff, run or justify skipping:
 Codex Security is required because this phase changes Discord command paths, permissions-sensitive
 handlers, public interaction entry points if approved, and restart-sensitive Ark workflows.
 
-## 8. Required Delivery Output
+## 10. Required Delivery Output
 
 Use this delivery shape:
 


### PR DESCRIPTION
## Summary

- Updates the command-platform Phase 5 design to proceed with Phase 5A only: admin/leadership/operator domain grouping.
- Captures player self-service workflow redesign as a separate deferred optimisation instead of simple command grouping.
- Captures public calendar/KVK calendar UX redesign as a separate deferred optimisation.
- Archives the completed Phase 4 Ark grouping task pack/chat starter and adds the Phase 5 task pack/chat starter as active docs.

## Notes

Phase 5A explicitly includes `/player_location` and `/player_stats` because both are admin/leadership lookup commands, not player self-service commands.

The player self-service commands and generic public calendar/KVK calendar commands remain flat for now and require fresh task packs, operator approval, usage review, and user-facing briefing before any runtime implementation.

## Validation

- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `.\.venv\Scripts\python.exe scripts\select_tests.py`
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`

Command baseline remains unchanged:

```text
primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
```