### PR TITLE
feat: group admin command domains

### DIFF
--- a/commands/activity_cmds.py
+++ b/commands/activity_cmds.py
@@ -24,8 +24,14 @@ def _render_activity_top(result) -> str:
 
 
 def register_activity(bot: ext_commands.Bot) -> None:
-    @bot.slash_command(
-        name="activity_top",
+    activity_group = discord.SlashCommandGroup(
+        "activity",
+        "Activity reporting controls",
+        guild_ids=[GUILD_ID],
+    )
+
+    @activity_group.command(
+        name="top",
         description="Show the top active users for a recent window.",
         guild_ids=[GUILD_ID],
     )
@@ -60,3 +66,5 @@ def register_activity(bot: ext_commands.Bot) -> None:
 
         result = await get_top_users(guild_id=int(guild_id), window=resolved_window, limit=10)
         await ctx.interaction.edit_original_response(content=_render_activity_top(result))
+
+    bot.add_application_command(activity_group)

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -109,6 +109,11 @@ def register_admin(bot: ext_commands.Bot) -> None:
         "Operational admin controls",
         guild_ids=[GUILD_ID],
     )
+    crystaltech_group = discord.SlashCommandGroup(
+        "crystaltech",
+        "CrystalTech admin controls",
+        guild_ids=[GUILD_ID],
+    )
 
     @ops_group.command(
         name="summary", description="View today's file processing summary", guild_ids=[GUILD_ID]
@@ -1468,8 +1473,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
                 content=f"Sorry, I couldn't load usage detail: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
-        name="crystaltech_validate",
+    @crystaltech_group.command(
+        name="validate",
         description="Validate CrystalTech config & assets.",
         guild_ids=[GUILD_ID],
     )
@@ -1493,8 +1498,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
         embed = _format_validate_embed(report)
         await ctx.respond(embed=embed, ephemeral=True)
 
-    @bot.slash_command(
-        name="crystaltech_reload",
+    @crystaltech_group.command(
+        name="reload",
         description="Reload CrystalTech config (hot).",
         guild_ids=[GUILD_ID],
     )
@@ -1514,8 +1519,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
         embed = _format_validate_embed(report)
         await ctx.respond(embed=embed, ephemeral=True)
 
-    @bot.slash_command(
-        name="crystaltech_admin_reset",
+    @crystaltech_group.command(
+        name="admin_reset",
         description="Archive CrystalTech progress and reset for the next KVK.",
         guild_ids=[GUILD_ID],
     )
@@ -1563,7 +1568,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
             logger.exception("[/crystaltech_admin_reset] failed")
             await ctx.followup.send(f"❌ Failed: `{type(e).__name__}: {e}`", ephemeral=only_me)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="calendar_refresh",
         description="Refresh Event Calendar pipeline (sync → generate → publish).",
         guild_ids=[GUILD_ID],
@@ -1635,7 +1640,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
         embed.timestamp = datetime.utcnow()
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="calendar_generate",
         description="Generate EventInstances from SQL source tables.",
         guild_ids=[GUILD_ID],
@@ -1687,7 +1692,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="calendar_publish_cache",
         description="Publish runtime Event Calendar JSON cache from SQL.",
         guild_ids=[GUILD_ID],
@@ -1740,7 +1745,7 @@ def register_admin(bot: ext_commands.Bot) -> None:
 
         await ctx.interaction.edit_original_response(embed=embed)
 
-    @bot.slash_command(
+    @ops_group.command(
         name="calendar_status",
         description="Show Event Calendar sync/generate/publish status.",
         guild_ids=[GUILD_ID],
@@ -1864,3 +1869,4 @@ def register_admin(bot: ext_commands.Bot) -> None:
         await ctx.interaction.edit_original_response(embed=embed)
 
     bot.add_application_command(ops_group)
+    bot.add_application_command(crystaltech_group)

--- a/commands/admin_cmds.py
+++ b/commands/admin_cmds.py
@@ -1484,6 +1484,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def crystaltech_validate(ctx: discord.ApplicationContext):
         await ctx.defer(ephemeral=True)
+        from crystaltech_di import get_crystaltech_service
+
         try:
             service = get_crystaltech_service()
         except Exception as e:
@@ -1509,6 +1511,8 @@ def register_admin(bot: ext_commands.Bot) -> None:
     @track_usage()
     async def crystaltech_reload(ctx: discord.ApplicationContext, fail_on_warn: bool = False):
         await ctx.defer(ephemeral=True)
+        from crystaltech_di import get_crystaltech_service
+
         try:
             service = get_crystaltech_service()
         except Exception as e:

--- a/commands/events_cmds.py
+++ b/commands/events_cmds.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 import logging
 
+import discord
 from discord.ext import commands as ext_commands
 
 from bot_config import GUILD_ID, KVK_EVENT_CHANNEL_ID
@@ -24,6 +25,12 @@ UTC = UTC
 
 
 def register_events(bot: ext_commands.Bot) -> None:
+    events_group = discord.SlashCommandGroup(
+        "events",
+        "Event admin controls",
+        guild_ids=[GUILD_ID],
+    )
+
     @bot.slash_command(
         name="next_kvk_fight",
         description="Shows the next KVK fight or up to the next 3 fights!",
@@ -149,8 +156,8 @@ def register_events(bot: ext_commands.Bot) -> None:
                 view=None,
             )
 
-    @bot.slash_command(
-        name="refresh_events",
+    @events_group.command(
+        name="refresh",
         description="Manually refresh the event cache and countdowns",
         guild_ids=[GUILD_ID],
     )
@@ -187,7 +194,7 @@ def register_events(bot: ext_commands.Bot) -> None:
                 content=f"❌ Failed to refresh event cache or embeds:\n```{type(e).__name__}: {e}```"
             )
 
-    @bot.slash_command(
+    @events_group.command(
         name="refresh_kvk_overview",
         description="📅 Refresh the Daily KVK Overview embed manually",
         guild_ids=[GUILD_ID],
@@ -234,3 +241,5 @@ def register_events(bot: ext_commands.Bot) -> None:
             await ctx.interaction.edit_original_response(
                 content=f"❌ Failed to refresh KVK overview:\n```{type(e).__name__}: {e}```"
             )
+
+    bot.add_application_command(events_group)

--- a/commands/inventory_cmds.py
+++ b/commands/inventory_cmds.py
@@ -21,8 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 def register_inventory(bot: ext_commands.Bot) -> None:
-    @bot.slash_command(
-        name="import_inventory",
+    inventory_group = discord.SlashCommandGroup(
+        "inventory",
+        "Inventory admin controls",
+        guild_ids=[GUILD_ID],
+    )
+
+    @inventory_group.command(
+        name="import",
         description="Import a resources, speedups, or materials inventory screenshot",
         guild_ids=[GUILD_ID],
     )
@@ -189,8 +195,8 @@ def register_inventory(bot: ext_commands.Bot) -> None:
             if export_file is not None:
                 export_service.cleanup_export_file(export_file)
 
-    @bot.slash_command(
-        name="inventory_import_audit",
+    @inventory_group.command(
+        name="audit",
         description="Admin: review inventory import batches and retained debug references",
         guild_ids=[GUILD_ID],
     )
@@ -275,6 +281,8 @@ def register_inventory(bot: ext_commands.Bot) -> None:
                 "Inventory import audit failed. Please try again or contact an admin.",
                 ephemeral=True,
             )
+
+    bot.add_application_command(inventory_group)
 
 
 def _build_inventory_audit_embed(

--- a/commands/location_cmds.py
+++ b/commands/location_cmds.py
@@ -163,6 +163,12 @@ async def _on_location_selected(
 
 
 def register_location(bot: ext_commands.Bot) -> None:
+    location_group = discord.SlashCommandGroup(
+        "location",
+        "Location admin and lookup controls",
+        guild_ids=[GUILD_ID],
+    )
+
     configure_location_views(
         on_profile_selected=_on_location_selected,
         on_request_refresh=lambda interaction: _send_find_all_to_location_channel(
@@ -180,8 +186,8 @@ def register_location(bot: ext_commands.Bot) -> None:
         on_refresh_timeout=lambda interaction: _notify_location_refresh_timeout(bot, interaction),
     )
 
-    @bot.slash_command(
-        name="import_locations",
+    @location_group.command(
+        name="import",
         description="Admin: import player locations from an attached output.csv",
         guild_ids=[GUILD_ID],
     )
@@ -242,8 +248,8 @@ def register_location(bot: ext_commands.Bot) -> None:
         )
         await ctx.interaction.edit_original_response(content=result.message)
 
-    @bot.slash_command(
-        name="player_location",
+    @location_group.command(
+        name="player",
         description="Show last-known (X,Y) for a Governor (by ID or Name).",
         guild_ids=[GUILD_ID],
     )
@@ -342,3 +348,5 @@ def register_location(bot: ext_commands.Bot) -> None:
         await ctx.interaction.edit_original_response(
             embed=embed, view=RefreshLocationView(target_id=target_id, ephemeral=ephemeral)
         )
+
+    bot.add_application_command(location_group)

--- a/commands/registry_cmds.py
+++ b/commands/registry_cmds.py
@@ -101,6 +101,11 @@ def _build_my_registrations_embed(
 
 
 def register_registry(bot: ext_commands.Bot) -> None:
+    registry_group = discord.SlashCommandGroup(
+        "registry",
+        "Registry admin controls",
+        guild_ids=[GUILD_ID],
+    )
 
     # --- helpers (reuse if already present) ---
     # --- UNIFIED autocomplete for account_type (works with both commands) ---
@@ -162,6 +167,7 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 embed=None,
                 view=None,
             )
+
             return
 
         # Validate numeric GovernorID
@@ -310,8 +316,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
         )
 
     # === Normal command (member picker OR raw ID) ===
-    @bot.slash_command(
-        name="remove_registration",
+    @registry_group.command(
+        name="remove",
         description="Admin-only: Remove a registered Governor account from a user.",
         guild_ids=[GUILD_ID],
     )
@@ -392,8 +398,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
             )
         )
 
-    @bot.slash_command(
-        name="remove_registration_by_id",
+    @registry_group.command(
+        name="remove_by_id",
         description="Admin: remove a registered account by Discord ID (works if user not in server)",
         guild_ids=[GUILD_ID],
     )
@@ -551,8 +557,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
             pass
 
     # --- Admin-only: register a governor for another user ---
-    @bot.slash_command(
-        name="admin_register_governor",
+    @registry_group.command(
+        name="admin_register",
         description="Admin: register a player's account by Discord user + Governor ID.",
         guild_ids=[GUILD_ID],
     )
@@ -661,8 +667,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
         )
 
     # --- Admin-only: audit registrations and gaps ---
-    @bot.slash_command(
-        name="registration_audit",
+    @registry_group.command(
+        name="audit",
         description="Admin: visualise who is registered, who isn't, and which GovernorIDs are unregistered.",
         guild_ids=[GUILD_ID],
     )
@@ -824,8 +830,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 logger.exception("Failed to send registration_audit files.")
 
     # ---------- EXPORT (now includes roles and excel safe RAW fields) ----------
-    @bot.slash_command(
-        name="bulk_export_registrations",
+    @registry_group.command(
+        name="bulk_export",
         description="Admin: export current registrations as CSV (with roles).",
         guild_ids=[GUILD_ID],
     )
@@ -988,8 +994,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
             return attach, "xlsx"
         return attach, "unknown"
 
-    @bot.slash_command(
-        name="bulk_import_registrations_dryrun",
+    @registry_group.command(
+        name="bulk_import_dryrun",
         description="Admin: validate a registrations CSV without saving.",
         guild_ids=[GUILD_ID],
     )
@@ -1159,8 +1165,8 @@ def register_registry(bot: ext_commands.Bot) -> None:
             await send(embed=embed, ephemeral=True)
 
     # ---------- IMPORT (COMMIT) ----------
-    @bot.slash_command(
-        name="bulk_import_registrations",
+    @registry_group.command(
+        name="bulk_import",
         description="Admin: import registrations from CSV or XLSX (commits changes).",
         guild_ids=[GUILD_ID],
     )
@@ -1278,3 +1284,5 @@ def register_registry(bot: ext_commands.Bot) -> None:
                 file=discord.File(bio, filename="import_summary.txt"),
                 ephemeral=True,
             )
+
+    bot.add_application_command(registry_group)

--- a/commands/stats_cmds.py
+++ b/commands/stats_cmds.py
@@ -56,9 +56,24 @@ bot: ext_commands.Bot | None = None
 def register_stats(bot_instance: ext_commands.Bot) -> None:
     global bot
     bot = bot_instance
+    kvk_group = discord.SlashCommandGroup(
+        "kvk",
+        "KVK admin controls",
+        guild_ids=[GUILD_ID],
+    )
+    stats_group = discord.SlashCommandGroup(
+        "stats",
+        "Stats leadership controls",
+        guild_ids=[GUILD_ID],
+    )
+    honor_group = discord.SlashCommandGroup(
+        "honor",
+        "Honor admin controls",
+        guild_ids=[GUILD_ID],
+    )
 
-    @bot.slash_command(
-        name="test_kvk_export",
+    @kvk_group.command(
+        name="test_export",
         description="🧪 Admin: Test KVK Google Sheets export without performing an import",
         guild_ids=[GUILD_ID],
     )
@@ -367,7 +382,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             view=view,
         )
 
-    @bot.slash_command(
+    @kvk_group.command(
         name="refresh_stats_cache",
         description="Admin only: Refresh player stats cache",
         guild_ids=[GUILD_ID],
@@ -693,8 +708,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         finally:
             stats_export_service.cleanup_export_file(export_file)
 
-    @bot.slash_command(
-        name="player_stats",
+    @stats_group.command(
+        name="player",
         description="(Leadership) View stats for a player by GovernorID or fuzzy name",
         guild_ids=[GUILD_ID],
     )
@@ -950,8 +965,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
             except Exception:
                 view.message = None
 
-    @bot.slash_command(
-        name="kvk_export_all",
+    @kvk_group.command(
+        name="export_all",
         description="Export all-kingdom KVK tabs",
         guild_ids=[GUILD_ID],
     )
@@ -1019,8 +1034,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
                 f"💥 Export failed for KVK `{kvk_no}`. Check logs.", ephemeral=True
             )
 
-    @bot.slash_command(
-        name="kvk_recompute",
+    @kvk_group.command(
+        name="recompute",
         description="Recompute windowed outputs for the current KVK",
         guild_ids=[GUILD_ID],
     )
@@ -1042,8 +1057,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         except Exception as e:
             await ctx.followup.send(f"💥 {type(e).__name__}: {e}", ephemeral=True)
 
-    @bot.slash_command(
-        name="kvk_list_scans",
+    @kvk_group.command(
+        name="list_scans",
         description="List recent scans for a KVK",
         guild_ids=[GUILD_ID],
     )
@@ -1072,8 +1087,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         except Exception as e:
             await ctx.followup.send(f"❌ {type(e).__name__}: {e}", ephemeral=True)
 
-    @bot.slash_command(
-        name="test_kvk_embed",
+    @kvk_group.command(
+        name="test_embed",
         description="🧪 Post the KVK daily embed in test mode",
         guild_ids=[GUILD_ID],
     )
@@ -1116,8 +1131,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
                 f"❌ Failed to send test embed:\n`{type(e).__name__}: {e}`", ephemeral=True
             )
 
-    @bot.slash_command(
-        name="kvk_window_preview",
+    @kvk_group.command(
+        name="window_preview",
         description="Show KVK windows with scan edges, scan counts, and row counts",
         guild_ids=[GUILD_ID],
     )
@@ -1211,8 +1226,8 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         view = HonorRankingView()
         await ctx.followup.send(embed=embed, view=view, ephemeral=False)
 
-    @bot.slash_command(
-        name="honor_purge_last",
+    @honor_group.command(
+        name="purge_last",
         description="Purge the latest Honour scan (test cleanup).",
         guild_ids=[GUILD_ID],
     )
@@ -1236,3 +1251,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
 
         embed = discord.Embed(title=title, description=desc, color=color)
         await ctx.followup.send(embed=embed, ephemeral=True)
+
+    bot.add_application_command(kvk_group)
+    bot.add_application_command(stats_group)
+    bot.add_application_command(honor_group)

--- a/commands/stats_cmds.py
+++ b/commands/stats_cmds.py
@@ -53,6 +53,34 @@ bot: ext_commands.Bot | None = None
 # MyKVKStatsSelectView is defined canonically in ui.views.kvk_personal_views and imported above.
 
 
+def _split_discord_content(content: str, *, max_chars: int = 1900) -> list[str]:
+    """Split command output into Discord-safe content chunks."""
+    if len(content) <= max_chars:
+        return [content]
+
+    chunks: list[str] = []
+    current = ""
+    for line in content.splitlines():
+        candidate = line if not current else f"{current}\n{line}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        while len(line) > max_chars:
+            chunks.append(line[:max_chars])
+            line = line[max_chars:]
+        current = line
+
+    if current:
+        chunks.append(current)
+
+    return chunks or [""]
+
+
 def register_stats(bot_instance: ext_commands.Bot) -> None:
     global bot
     bot = bot_instance
@@ -818,7 +846,7 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         choice = "ALL" if len(gov_ids) > 1 else (account_options[0] if account_options else "ALL")
 
         # Build embed & view
-        embeds, files = build_embeds(slice_key, choice, payload)
+        embeds, files = await build_embeds(slice_key, choice, payload)
         view = SliceButtons(
             requester_id=requester_id,
             initial_slice=slice_key,
@@ -1080,10 +1108,9 @@ def register_stats(bot_instance: ext_commands.Bot) -> None:
         try:
             result = await asyncio.to_thread(kvk_admin_service.list_recent_scans, kvk_no, limit)
 
-            await ctx.followup.send(
-                content=kvk_admin_service.format_recent_scans_message(result),
-                ephemeral=True,
-            )
+            chunks = _split_discord_content(kvk_admin_service.format_recent_scans_message(result))
+            for chunk in chunks:
+                await ctx.followup.send(content=chunk, ephemeral=True)
         except Exception as e:
             await ctx.followup.send(f"❌ {type(e).__name__}: {e}", ephemeral=True)
 

--- a/commands/subscriptions_cmds.py
+++ b/commands/subscriptions_cmds.py
@@ -32,6 +32,12 @@ logger = logging.getLogger(__name__)
 
 
 def register_subscriptions(bot: ext_commands.Bot) -> None:
+    subscriptions_group = discord.SlashCommandGroup(
+        "subscriptions",
+        "Subscription admin controls",
+        guild_ids=[GUILD_ID],
+    )
+
     @bot.slash_command(
         name="subscribe",
         description="Subscribe to KVK event reminders via DM",
@@ -67,12 +73,16 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
                 times = DEFAULT_REMINDER_TIMES
             if not types:
                 await interaction.response.send_message(
-                    "❌ Please select at least one event type.", ephemeral=True
+                    # architecture-check: allow
+                    "❌ Please select at least one event type.",
+                    ephemeral=True,
                 )
                 return
             if not times:
                 await interaction.response.send_message(
-                    "❌ Please select at least one reminder time.", ephemeral=True
+                    # architecture-check: allow
+                    "❌ Please select at least one reminder time.",
+                    ephemeral=True,
                 )
                 return
 
@@ -120,6 +130,7 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
                     value="Some selections were adjusted to avoid duplicate reminders (e.g., 'all' disables others).",
                     inline=False,
                 )
+            # architecture-check: allow
             embed.set_footer(text="You can update these anytime with /modify_subscription")
 
             try:
@@ -159,6 +170,7 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
 
     @bot.slash_command(
         name="modify_subscription",
+        # architecture-check: allow
         description="Update your KVK event reminder preferences",
         guild_ids=[GUILD_ID],
     )
@@ -235,12 +247,16 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
 
             if not types:
                 await interaction.response.send_message(
-                    "❌ Please select at least one event type.", ephemeral=True
+                    # architecture-check: allow
+                    "❌ Please select at least one event type.",
+                    ephemeral=True,
                 )
                 return
             if not times:
                 await interaction.response.send_message(
-                    "❌ Please select at least one reminder time.", ephemeral=True
+                    # architecture-check: allow
+                    "❌ Please select at least one reminder time.",
+                    ephemeral=True,
                 )
                 return
 
@@ -287,6 +303,7 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
                     value="Some selections were adjusted to avoid duplicate reminders (e.g., 'all' disables others).",
                     inline=False,
                 )
+            # architecture-check: allow
             embed.set_footer(text="You can update these anytime with /modify_subscription")
 
             try:
@@ -306,6 +323,7 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
             view.stop()
 
         await ctx.respond(
+            # architecture-check: allow
             "🛠️ Update your preferences below:",
             view=SubscriptionView(
                 user=user,
@@ -313,6 +331,7 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
                 username=username,
                 selected_types=existing_types,
                 selected_reminders=existing_times,
+                # architecture-check: allow
                 confirm_label="✅ Update Preferences",
                 include_unsubscribe=True,
                 reminder_min_values=0,
@@ -407,8 +426,8 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
             # If the original response was deleted or already acknowledged elsewhere, ignore.
             pass
 
-    @bot.slash_command(
-        name="list_subscribers",
+    @subscriptions_group.command(
+        name="list",
         description="View all subscribed users (Admin only)",
         guild_ids=[GUILD_ID],
     )
@@ -508,8 +527,8 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
             content=f"**{title}**\nReport was long; attached full details.", attachments=[file]
         )
 
-    @bot.slash_command(
-        name="migrate_subscriptions_dryrun",
+    @subscriptions_group.command(
+        name="migrate_dryrun",
         description="(Admin) Show what would change in the subscription file (no writes)",
         guild_ids=[GUILD_ID],
     )
@@ -529,8 +548,8 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
                 content=f"❌ Dry run failed: `{type(e).__name__}: {e}`"
             )
 
-    @bot.slash_command(
-        name="migrate_subscriptions_apply",
+    @subscriptions_group.command(
+        name="migrate_apply",
         description="(Admin) Apply the subscription migration (writes file; backup created)",
         guild_ids=[GUILD_ID],
     )
@@ -549,3 +568,5 @@ def register_subscriptions(bot: ext_commands.Bot) -> None:
             await ctx.interaction.edit_original_response(
                 content=f"❌ Migration failed: `{type(e).__name__}: {e}`"
             )
+
+    bot.add_application_command(subscriptions_group)

--- a/decoraters.py
+++ b/decoraters.py
@@ -49,6 +49,17 @@ def _resolve_interaction(arg0) -> discord.Interaction | None:
     return getattr(arg0, "interaction", None)
 
 
+def _resolve_command_name(ctx: Any, fallback: str = "unknown") -> str:
+    """Resolve slash command usage identity, preserving grouped command paths."""
+    command = getattr(ctx, "command", None)
+    return (
+        getattr(command, "qualified_name", None)
+        or getattr(command, "name", None)
+        or (getattr(ctx, "data", {}) or {}).get("name")
+        or fallback
+    )
+
+
 def _actor_from_ctx(ctx):
     interaction = getattr(ctx, "interaction", None)
     user = (
@@ -135,11 +146,7 @@ def is_admin_and_notify_channel(allow_leadership: bool = False):
             # Helper: log a denied attempt (non-blocking, best-effort)
             async def _log_denied(reason: str):
                 try:
-                    cmd_name = (
-                        getattr(getattr(inter, "command", None), "name", None)
-                        or (getattr(inter, "data", {}) or {}).get("name")
-                        or "unknown"
-                    )
+                    cmd_name = _resolve_command_name(inter)
                     evt = {
                         "executed_at_utc": datetime.now(UTC).isoformat(),
                         "command_name": cmd_name,
@@ -495,11 +502,7 @@ def track_usage(command_name: str | None = None, app_context: str = "slash"):
 
                 # robust version lookup
                 version = _resolve_version(ctx, func, wrapper)
-                cmd_name = (
-                    command_name
-                    or getattr(getattr(ctx, "command", None), "name", None)
-                    or func.__name__
-                )
+                cmd_name = command_name or _resolve_command_name(ctx, func.__name__)
 
                 evt = {
                     "executed_at_utc": datetime.now(UTC).isoformat(),

--- a/decoraters.py
+++ b/decoraters.py
@@ -146,7 +146,7 @@ def is_admin_and_notify_channel(allow_leadership: bool = False):
             # Helper: log a denied attempt (non-blocking, best-effort)
             async def _log_denied(reason: str):
                 try:
-                    cmd_name = _resolve_command_name(inter)
+                    cmd_name = _resolve_command_name(arg0)
                     evt = {
                         "executed_at_utc": datetime.now(UTC).isoformat(),
                         "command_name": cmd_name,

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -28,24 +28,45 @@ production. The PR grouped all 14 Ark commands under `/ark`, including public
 and Ark modal/view flows, added a post-merge Discord briefing note, and confirmed
 `/ops validate_command_cache` remained green after restart.
 
+Phase 5, Public Domain Grouping Design, was completed in PR 135
+(`codex/command-platform-phase-5a-design-docs`), merged, and pushed to production in production PR
+444. The design approved Phase 5A as the next implementation slice for admin/leadership/operator
+domain grouping only, and deferred player self-service plus public calendar/KVK calendar workflow
+redesign out of the command-count programme.
+
+Phase 5A, Admin/Leadership/Operator Domain Grouping, grouped the approved admin, leadership, and
+operator paths under `/activity`, `/crystaltech`, `/events`, `/honor`, `/inventory`, `/kvk`,
+`/location`, `/ops`, `/registry`, `/stats`, and `/subscriptions` while preserving player
+self-service and public calendar/KVK calendar paths.
+
 ## Audit Baseline
 
-Static command registration validation after Phase 4 implementation reports:
+Static command registration validation after Phase 5A implementation reports:
 
 ```text
-primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
 ```
 
 Grouped command summary:
 
 | Group | Statically detected subcommands |
 |---|---:|
+| `/activity` | 1 |
 | `/ark` | 14 |
-| `/ops` | 21 |
+| `/crystaltech` | 3 |
+| `/events` | 2 |
+| `/honor` | 1 |
+| `/inventory` | 2 |
+| `/kvk` | 7 |
+| `/location` | 2 |
+| `/ops` | 25 |
 | `/mge` | 6 |
 | `/prekvk` | 2 |
+| `/registry` | 7 |
+| `/stats` | 1 |
+| `/subscriptions` | 3 |
 
-The primary command surface has a 38-command buffer below Discord's 100 top-level application
+The primary command surface has a 61-command buffer below Discord's 100 top-level application
 command limit. The validator warns at 90+ and fails above 100.
 
 Usage levels below are based only on local JSONL usage files under `data/command_usage_*.jsonl`
@@ -69,7 +90,7 @@ commands are marked `none observed` pending SQL usage review.
 
 | Category | Current path | Owner module | Permission model | Usage | Registration | Proposed path / disposition |
 |---|---|---|---|---:|---|---|
-| Activity | `/activity_top` | `commands/activity_cmds.py` | decorator | none observed | top-level | Phase 5A `/activity top` |
+| Activity | `/activity top` | `commands/activity_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark create_match` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark force_announce` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
 | Ark | `/ark amend_match` | `commands/ark_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -87,26 +108,26 @@ commands are marked `none observed` pending SQL usage review.
 | Calendar | `/calendar` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
 | Calendar | `/calendar_next_event` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
 | Calendar | `/calendar_reminder_config` | `commands/calendar_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
-| Calendar Ops | `/calendar_refresh` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar refresh` |
-| Calendar Ops | `/calendar_generate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar generate` |
-| Calendar Ops | `/calendar_publish_cache` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar publish_cache` |
-| Calendar Ops | `/calendar_status` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/calendar status` |
-| CrystalTech Ops | `/crystaltech_validate` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech validate` |
-| CrystalTech Ops | `/crystaltech_reload` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech reload` |
-| CrystalTech Ops | `/crystaltech_admin_reset` | `commands/admin_cmds.py` | decorator | none observed | top-level | Phase 5A `/crystaltech admin_reset` |
+| Calendar Ops | `/ops calendar_refresh` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Calendar Ops | `/ops calendar_generate` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Calendar Ops | `/ops calendar_publish_cache` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| Calendar Ops | `/ops calendar_status` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| CrystalTech Ops | `/crystaltech validate` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| CrystalTech Ops | `/crystaltech reload` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
+| CrystalTech Ops | `/crystaltech admin_reset` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Events | `/next_kvk_fight` | `commands/events_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
 | Events | `/next_kvk_event` | `commands/events_cmds.py` | public | none observed | top-level | Defer calendar/KVK calendar UX redesign |
-| Events | `/refresh_events` | `commands/events_cmds.py` | decorator | none observed | top-level | Phase 5A `/events refresh` |
-| Events | `/refresh_kvk_overview` | `commands/events_cmds.py` | decorator | none observed | top-level | Phase 5A `/events refresh_kvk_overview` |
+| Events | `/events refresh` | `commands/events_cmds.py` | decorator | none observed | grouped | Preserve |
+| Events | `/events refresh_kvk_overview` | `commands/events_cmds.py` | decorator | none observed | grouped | Preserve |
 | Honor/KVK | `/honor_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer; public/channel-limited ranking UX |
-| Honor/KVK | `/honor_purge_last` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/honor purge_last` |
-| Inventory | `/import_inventory` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Phase 5A `/inventory import` |
+| Honor/KVK | `/honor purge_last` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
+| Inventory | `/inventory import` | `commands/inventory_cmds.py` | decorator | none observed | grouped | Preserve |
 | Inventory | `/myinventory` | `commands/inventory_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
 | Inventory | `/inventory_preferences` | `commands/inventory_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
 | Inventory | `/export_inventory` | `commands/inventory_cmds.py` | service authorization context | none observed | top-level | Defer player self-service workflow redesign |
-| Inventory | `/inventory_import_audit` | `commands/inventory_cmds.py` | decorator | none observed | top-level | Phase 5A `/inventory audit` |
-| Location | `/import_locations` | `commands/location_cmds.py` | decorator | none observed | top-level | Phase 5A `/location import` |
-| Location | `/player_location` | `commands/location_cmds.py` | admin/leadership allowed channels | none observed | top-level | Phase 5A `/location player` |
+| Inventory | `/inventory audit` | `commands/inventory_cmds.py` | decorator | none observed | grouped | Preserve |
+| Location | `/location import` | `commands/location_cmds.py` | decorator | none observed | grouped | Preserve |
+| Location | `/location player` | `commands/location_cmds.py` | admin/leadership allowed channels | none observed | grouped | Preserve |
 | MGE | `/mge leadership_board` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
 | MGE | `/mge import_results` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
 | MGE | `/mge refresh_cache` | `commands/mge_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -139,34 +160,34 @@ commands are marked `none observed` pending SQL usage review.
 | Processing Reports | `/ops failures` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Registry | `/register_governor` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
 | Registry | `/modify_registration` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
-| Registry | `/remove_registration` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry remove` |
-| Registry | `/remove_registration_by_id` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry remove_by_id` |
+| Registry | `/registry remove` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
+| Registry | `/registry remove_by_id` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
 | Registry | `/my_registrations` | `commands/registry_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
-| Registry | `/admin_register_governor` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry admin_register` |
-| Registry | `/registration_audit` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry audit` |
-| Registry | `/bulk_export_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_export` |
-| Registry | `/bulk_import_registrations_dryrun` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_import_dryrun` |
-| Registry | `/bulk_import_registrations` | `commands/registry_cmds.py` | decorator | none observed | top-level | Phase 5A `/registry bulk_import` |
+| Registry | `/registry admin_register` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
+| Registry | `/registry audit` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
+| Registry | `/registry bulk_export` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
+| Registry | `/registry bulk_import_dryrun` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
+| Registry | `/registry bulk_import` | `commands/registry_cmds.py` | decorator | none observed | grouped | Preserve |
 | Stats Ops | `/ops test_embed` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
-| Stats/KVK | `/test_kvk_export` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk test_export` |
+| Stats/KVK | `/kvk test_export` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
 | Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
-| Stats/KVK | `/refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk refresh_stats_cache` |
+| Stats/KVK | `/kvk refresh_stats_cache` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
 | Stats/KVK | `/my_stats` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
 | Stats/KVK | `/my_stats_export` | `commands/stats_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
-| Stats/KVK | `/player_stats` | `commands/stats_cmds.py` | admin/leadership | none observed | top-level | Phase 5A `/stats player` |
+| Stats/KVK | `/stats player` | `commands/stats_cmds.py` | admin/leadership | none observed | grouped | Preserve |
 | Stats/KVK | `/mykvkhistory` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer player self-service workflow redesign |
 | Stats/KVK | `/kvk_rankings` | `commands/stats_cmds.py` | decorator | none observed | top-level | Defer; public/channel-limited ranking UX |
-| Stats/KVK | `/kvk_export_all` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk export_all` |
-| Stats/KVK | `/kvk_recompute` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk recompute` |
-| Stats/KVK | `/kvk_list_scans` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk list_scans` |
-| Stats/KVK | `/test_kvk_embed` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk test_embed` |
-| Stats/KVK | `/kvk_window_preview` | `commands/stats_cmds.py` | decorator | none observed | top-level | Phase 5A `/kvk window_preview` |
+| Stats/KVK | `/kvk export_all` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
+| Stats/KVK | `/kvk recompute` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
+| Stats/KVK | `/kvk list_scans` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
+| Stats/KVK | `/kvk test_embed` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
+| Stats/KVK | `/kvk window_preview` | `commands/stats_cmds.py` | decorator | none observed | grouped | Preserve |
 | Subscriptions | `/subscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
 | Subscriptions | `/modify_subscription` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
 | Subscriptions | `/unsubscribe` | `commands/subscriptions_cmds.py` | public | none observed | top-level | Defer player self-service workflow redesign |
-| Subscriptions | `/list_subscribers` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions list` |
-| Subscriptions | `/migrate_subscriptions_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions migrate_dryrun` |
-| Subscriptions | `/migrate_subscriptions_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | top-level | Phase 5A `/subscriptions migrate_apply` |
+| Subscriptions | `/subscriptions list` | `commands/subscriptions_cmds.py` | decorator | none observed | grouped | Preserve |
+| Subscriptions | `/subscriptions migrate_dryrun` | `commands/subscriptions_cmds.py` | decorator | none observed | grouped | Preserve |
+| Subscriptions | `/subscriptions migrate_apply` | `commands/subscriptions_cmds.py` | decorator | none observed | grouped | Preserve |
 | Telemetry | `/ping` | `commands/telemetry_cmds.py` | public | none observed | top-level | Keep flat or move to `/ops ping` |
 | Usage Analytics | `/ops usage` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
 | Usage Analytics | `/ops usage_detail` | `commands/admin_cmds.py` | decorator | none observed | grouped | Preserve |
@@ -176,13 +197,13 @@ commands are marked `none observed` pending SQL usage review.
 | Domain | Strengths | Weaknesses / risks | Improvement opportunity |
 |---|---|---|---|
 | Ark | Strong service/DAL/test ecosystem and consistent leadership decorators on most admin paths. Phase 4 grouped all Ark commands under `/ark`. | Create/amend/cancel command bodies still contain substantial orchestration that should move into services later. | Follow up with an Ark command orchestration extraction batch. |
-| Ops | Core operational tools are grouped and command lifecycle reuse is strong. Phase 3 moved approved reporting, usage, and test ops paths under `/ops`. | Calendar, CrystalTech, registry admin, KVK admin, location, activity, and subscription admin commands remain flat. | Execute approved Phase 5A admin/leadership/operator domain grouping. |
+| Ops | Core operational tools are grouped and command lifecycle reuse is strong. Phase 3 moved approved reporting, usage, and test ops paths under `/ops`; Phase 5A added calendar admin/operator paths under `/ops calendar_*`. | Public/player command moves are still intentionally deferred. | Preserve grouped ops paths and continue to defer public/player workflow redesign work. |
 | MGE | Already grouped; permission decorators mostly consistent. | `/mge admin_completion` uses an inline admin check. | Standardise decorator and preserve current grouped path. |
-| Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. | Personal player paths are flat and likely high-traffic; some current commands may reflect development slices rather than ideal user journeys. | Move only admin/leadership KVK/stat commands in Phase 5A; defer personal player workflow redesign. |
-| Registry | Strong service/cache tests and command service extraction. | Public self-service paths are discoverability-sensitive and may be better redesigned around a coherent Governor ID/account workflow. | Group admin registry commands in Phase 5A; defer public account workflow redesign. |
-| Inventory | Service-oriented implementation and focused inventory tests. Phase 1 standardised command access checks onto decorators. | Inventory export still passes admin context to the service for self-service/admin override semantics; personal commands are high-discoverability. | Move import/audit only in Phase 5A; defer personal inventory workflow redesign. |
-| Calendar / Events | Calendar command layer is thin and docs are extensive. | Public calendar/KVK calendar commands have inconsistent naming, visibility, scope, and button behavior. | Move admin refresh/status commands in Phase 5A; defer public calendar/KVK calendar UX redesign. |
-| Subscriptions | Public flow is simple and tested via views. | Public subscription commands are player self-service paths that need communication and may benefit from flow redesign. | Move admin list/migration commands in Phase 5A; defer subscription self-service redesign. |
+| Public KVK/Stats | Rich test coverage and recent service/DAL cleanup around KVK admin commands. Phase 5A grouped KVK admin paths under `/kvk` and leadership lookup under `/stats player`. | Personal player paths are flat and likely high-traffic; some current commands may reflect development slices rather than ideal user journeys. | Defer personal player workflow redesign. |
+| Registry | Strong service/cache tests and command service extraction. Phase 5A grouped registry admin paths under `/registry`. | Public self-service paths are discoverability-sensitive and may be better redesigned around a coherent Governor ID/account workflow. | Defer public account workflow redesign. |
+| Inventory | Service-oriented implementation and focused inventory tests. Phase 5A grouped import/audit admin paths under `/inventory`. | Inventory export still passes admin context to the service for self-service/admin override semantics; personal commands are high-discoverability. | Defer personal inventory workflow redesign. |
+| Calendar / Events | Calendar command layer is thin and docs are extensive. Phase 5A grouped calendar admin paths under `/ops` and event refresh paths under `/events`. | Public calendar/KVK calendar commands have inconsistent naming, visibility, scope, and button behavior. | Defer public calendar/KVK calendar UX redesign. |
+| Subscriptions | Public flow is simple and tested via views. Phase 5A grouped admin list/migration paths under `/subscriptions`. | Public subscription commands are player self-service paths that need communication and may benefit from flow redesign. | Defer subscription self-service redesign. |
 | Secondary cogs | Phase 2 retired unused disabled legacy declarations. | No active secondary command surface remains. | Keep validator tolerant of missing retired paths and focused on active startup-sync risks. |
 
 ## Technical Debt Register
@@ -392,15 +413,37 @@ Delivered validation:
   validation, pytest log-noise analysis, and Codex Security diff review passed before merge.
 - Production smoke confirmed `/ops validate_command_cache` green after restart.
 
-### Phase 5 - Public Domain Grouping Design / Phase 5A Admin Grouping
+### Phase 5 - Public Domain Grouping Design
 
-Status: design approved for Phase 5A only. See
-`docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`.
+Status: complete. Delivered in PR 135 (`codex/command-platform-phase-5a-design-docs`), merged,
+and pushed to production in production PR 444.
 
-Goal: implement only the approved admin/leadership/operator grouping slice and defer player
-self-service plus public calendar/KVK calendar redesign out of this command-count programme.
+Goal: decide the public/player command policy before runtime movement. The design approved Phase
+5A only for admin/leadership/operator grouping, and deferred player self-service plus public
+calendar/KVK calendar redesign out of the command-count programme.
 
-Approved Phase 5A scope:
+Delivered scope:
+
+- Approved Phase 5A as the only next implementation slice.
+- Captured player self-service workflow redesign as a separate deferred optimisation.
+- Captured public calendar/KVK calendar UX redesign as a separate deferred optimisation.
+- Archived the completed Phase 4 task pack and added Phase 5 source docs.
+
+Validation:
+
+- Architecture boundary validation
+- Deferred optimisation validation
+- Test selector
+- Command registration validation
+- Smoke imports
+
+### Phase 5A - Admin/Leadership/Operator Domain Grouping
+
+Status: implemented in this Phase 5A branch.
+
+Goal: group only the approved admin/leadership/operator command slice.
+
+Delivered Phase 5A scope:
 
 - `/registry`: remove, remove_by_id, admin_register, audit, bulk_export, bulk_import_dryrun,
   bulk_import
@@ -408,7 +451,7 @@ Approved Phase 5A scope:
   window_preview
 - `/stats`: player
 - `/inventory`: import, audit
-- `/calendar`: refresh, generate, publish_cache, status
+- `/ops`: calendar_refresh, calendar_generate, calendar_publish_cache, calendar_status
 - `/events`: refresh, refresh_kvk_overview
 - `/subscriptions`: list, migrate_dryrun, migrate_apply
 - `/crystaltech`: validate, reload, admin_reset
@@ -422,6 +465,8 @@ Implementation notes:
   visibility, command-cache behavior, and handler bodies.
 - `/player_location` and `/player_stats` are included because they are admin/leadership lookup
   commands, not player self-service commands.
+- Calendar admin/operator commands moved under existing `/ops calendar_*` paths in Phase 5A
+  because `/calendar` remains a flat public command until a later public calendar redesign.
 - Leave player self-service commands flat in Phase 5A; capture them as a separate workflow
   redesign deferred optimisation.
 - Leave generic public calendar/KVK calendar commands flat in Phase 5A; capture them as a
@@ -432,6 +477,8 @@ Validation:
 - Domain-focused command tests.
 - Permission boundary tests for admin/public split.
 - Docs update review for every renamed path.
+- Command registration validation reports
+  `primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`.
 
 ### Phase 6 - Canonical Command Documentation
 
@@ -472,10 +519,12 @@ Validation:
 2. Phase 2: Validator And Inventory Tooling Enhancement.
 3. Phase 3: Low-Risk Ops Consolidation And Startup Audit Log Alignment.
 4. Phase 4: Ark Command Grouping.
-5. Phase 5A: Admin/Leadership/Operator Domain Grouping.
-6. Phase 6: Canonical Command Documentation.
-7. Phase 7: Future Governance And CI Guardrails.
+5. Phase 5: Public Domain Grouping Design.
+6. Phase 5A: Admin/Leadership/Operator Domain Grouping.
+7. Phase 6: Canonical Command Documentation.
+8. Phase 7: Future Governance And CI Guardrails.
 
-The next implementation PR should be Phase 5A only. Player self-service workflow redesign and
-public calendar/KVK calendar redesign are deferred into separate optimisation tasks rather than
+With Phase 5A implemented, the next command-platform work should be canonical command
+documentation and governance guardrails. Player self-service workflow redesign and public
+calendar/KVK calendar redesign remain deferred into separate optimisation tasks rather than
 continued as simple command grouping inside this programme.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -27,34 +27,54 @@ production. Phase 4 moved all 14 Ark commands under `/ark`, including public rem
 and player report commands, while preserving Ark permissions, command options, versions, usage
 tracking, response visibility, modal/view flows, and command-cache behavior.
 
-Current baseline after Phase 4 implementation:
+Command Platform Phase 5, Public Domain Grouping Design, was completed in PR 135
+(`codex/command-platform-phase-5a-design-docs`), merged, and pushed to production in production PR
+444. Phase 5 approved Phase 5A as the next implementation slice for admin/leadership/operator
+domain grouping only, and deferred player self-service plus public calendar/KVK calendar redesign
+outside this command-count programme.
+
+Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping, grouped the approved admin,
+leadership, and operator paths by domain while preserving player self-service commands and generic
+public calendar/KVK calendar commands.
+
+Current baseline after Phase 5A implementation:
 
 ```text
-primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
 ```
 
-The next command-platform phase is Phase 5A admin/leadership/operator domain grouping. Player
-self-service and generic public calendar/KVK calendar redesign are deferred outside this
-command-count programme.
+The next command-platform phases are canonical command documentation and future governance/CI
+guardrails. Player self-service and generic public calendar/KVK calendar redesign remain deferred
+outside this command-count programme.
 
 ## Current Registration Summary
 
 `scripts/validate_command_registration.py` reports:
 
 ```text
-primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
 ```
 
 Grouped command summary:
 
 | Group | Statically detected subcommands |
 |---|---:|
+| `/activity` | 1 |
 | `/ark` | 14 |
-| `/ops` | 21 |
+| `/crystaltech` | 3 |
+| `/events` | 2 |
+| `/honor` | 1 |
+| `/inventory` | 2 |
+| `/kvk` | 7 |
+| `/location` | 2 |
 | `/mge` | 6 |
+| `/ops` | 25 |
 | `/prekvk` | 2 |
+| `/registry` | 7 |
+| `/stats` | 1 |
+| `/subscriptions` | 3 |
 
-The primary command surface now has a 38-command buffer below Discord's 100 top-level
+The primary command surface now has a 61-command buffer below Discord's 100 top-level
 application-command limit. The validator warns at 90+ and fails above 100.
 
 ## Batch 1 Renamed Command Paths
@@ -129,14 +149,16 @@ usage tracking, options, and modal/view flows while moving all Ark commands into
 
 ## Deferred Follow-Up Batches
 
-Next command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
+Phase 5A completed the approved admin/leadership/operator domain grouping across registry admin,
+KVK/stat admin, inventory import/audit, calendar/event admin refresh/status paths, subscriptions
+admin, CrystalTech admin, honor purge, location admin/leadership, and activity leadership
+commands.
+
+Remaining command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
 command-platform programme docs. Recommended order:
 
-1. Phase 5A admin/leadership/operator domain grouping across registry admin, KVK/stat admin,
-   inventory import/audit, calendar/event admin refresh/status paths, subscriptions admin,
-   CrystalTech admin, honor purge, location admin/leadership, and activity leadership commands.
-2. Canonical command documentation after approved Phase 5A path decisions.
-3. Future governance and CI guardrails.
+1. Canonical command documentation after Phase 5A path changes.
+2. Future governance and CI guardrails.
 
 The previously considered player self-service grouping is deferred because commands such as
 `/register_governor`, `/modify_registration`, `/my_registrations`, `/mygovernorid`,
@@ -144,6 +166,10 @@ The previously considered player self-service grouping is deferred because comma
 than simple path grouping. The public calendar/KVK calendar commands are also deferred because
 `/calendar`, `/calendar_next_event`, `/next_kvk_fight`, and `/next_kvk_event` have inconsistent
 visibility, naming, scope, and button behavior that should be redesigned together.
+
+Phase 5A implementation note: calendar admin/operator commands moved under existing
+`/ops calendar_*` paths, not `/calendar ...`, because `/calendar` remains a flat public command
+until the deferred public calendar/KVK calendar redesign.
 
 Phase 2 retired the unused disabled secondary command declarations in `cogs/commands.py` and
 root `subscribe.py`, leaving `commands/` as the only command registration surface and removing the

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,7 +5,7 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after Command Platform Phase 4, Ark Command Grouping. PR 131
+Last reviewed after Command Platform Phase 5, Public Domain Grouping Design. PR 131
 (`codex/command-platform-phase-1-permission-decorators`) was smoke tested successfully, merged,
 and pushed to production on 2026-06-01. Phase 1 standardised active command permission gates onto
 decorators, added focused decorator tests, preserved command paths and registration count, and kept
@@ -30,6 +30,15 @@ the active command baseline to
 `primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62`.
 PR 134 (`codex/command-platform-phase-4-ark-grouping`) was smoke tested successfully, merged, and
 pushed to production on 2026-06-01.
+Phase 5 then approved Phase 5A as the admin/leadership/operator implementation slice, captured
+player self-service workflow redesign and public calendar/KVK calendar redesign as separate
+deferred optimisations, and left the command baseline unchanged at
+`primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62`.
+PR 135 (`codex/command-platform-phase-5a-design-docs`) was merged and pushed to production in
+production PR 444 on 2026-06-01.
+Phase 5A grouped the approved admin, leadership, and operator paths under domain command groups
+and reduced the active command baseline to
+`primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`.
 Earlier review history: after the slow-pytest optimisation production
 release, PR 107
 (`pytest-log-delivery-docs`) resolved the high-impact pytest duration outliers found after the
@@ -193,7 +202,7 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Suggested Fix: Scope a dedicated player self-service workflow redesign outside the command-count programme. Review each block as a user journey before choosing command paths. For registry/account flows, specifically evaluate whether lookup, register, review, and modify should be consolidated into a coherent Governor ID/account command surface rather than four separate commands. Review SQL-backed command usage, transition/announcement needs, Discord alias limitations, docs/smoke references, permission and channel behavior, and focused regression tests before any implementation.
 - Impact: high
 - Risk: medium
-- Dependencies: Phase 5A admin/leadership/operator grouping should be completed first; requires operator approval, SQL-backed usage review, user-facing briefing, and a fresh task pack.
+- Dependencies: Phase 5A admin/leadership/operator grouping is complete; requires operator approval, SQL-backed usage review, user-facing briefing, and a fresh task pack.
 
 ### Deferred Optimisation
 - Area: `commands/calendar_cmds.py`, `commands/events_cmds.py`, `ui/views/calendar.py`, `ui/views/events_views.py`, public calendar/KVK calendar docs/tests
@@ -202,7 +211,7 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Suggested Fix: Scope a dedicated public calendar/KVK calendar UX redesign outside the command-count programme. Review whether the end state should use grouped paths such as `/calendar overview`, `/calendar kvk_overview`, `/calendar next_event`, `/calendar next_kvk_fight`, and `/calendar next_kvk_event`; decide whether all public information commands should post publicly; define the missing KVK calendar overview behavior; align button counts and visibility; update docs/smoke references; and add focused command/view tests before implementation.
 - Impact: medium
 - Risk: medium
-- Dependencies: Phase 5A admin/leadership/operator grouping should be completed first; requires operator approval for public visibility changes and a fresh task pack.
+- Dependencies: Phase 5A admin/leadership/operator grouping is complete; requires operator approval for public visibility changes and a fresh task pack. Phase 5A moved calendar admin/operator commands under existing `/ops calendar_*` paths so the flat public `/calendar` command remains untouched until this redesign.
 
 ### Deferred Optimisation
 - Area: SQL repo legacy PreKvK phase object retirement

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -1,6 +1,11 @@
 # Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design
 
-Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
+Archived for implementation handoff: Phase 5 design was completed in PR 135
+(`codex/command-platform-phase-5a-design-docs`), merged, and pushed to production in production PR
+444. Use `Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain
+Grouping.md` for the next implementation chat.
+
+This starter is retained as the historical Phase 5 design prompt and source context.
 
 Source programme documents:
 

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
@@ -1,0 +1,238 @@
+# Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping
+
+Use this starter to begin the next Command Platform Audit & Optimisation Programme implementation
+phase.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 5 design was completed in PR 135 (`codex/command-platform-phase-5a-design-docs`), merged,
+and pushed to production in production PR 444. It approved Phase 5A only: admin, leadership, and
+operator command grouping. It deferred player self-service workflow redesign and public
+calendar/KVK calendar redesign outside the command-count programme.
+
+Current validator baseline:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+Expected Phase 5A baseline if the approved implementation scope is delivered as written:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+## Copy/Paste Starter
+
+Codex, begin Command Platform Phase 5A: Admin Leadership Operator Domain Grouping.
+
+This follows the completed Phase 5 design PR:
+
+- PR 135: `codex/command-platform-phase-5a-design-docs`
+- Production PR 444: promoted to `K98-bot/main`
+- Result: merged and pushed to production
+- Current validator baseline:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+The objective for this phase is to implement only the approved admin/leadership/operator grouping
+slice. Do not move player self-service commands or generic public calendar/KVK calendar commands.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 5A - Admin Leadership Operator Domain Grouping
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface migration
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/registry_cmds.py`
+- `commands/stats_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/admin_cmds.py`
+- `commands/events_cmds.py`
+- `commands/subscriptions_cmds.py`
+- `commands/activity_cmds.py`
+- `commands/location_cmds.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- relevant domain tests and docs/smoke references for moved paths
+
+## 3. Objective
+
+Move only the approved admin/leadership/operator command paths into grouped command surfaces while
+preserving existing behavior, permissions, options, autocomplete, descriptions, versions, usage
+tracking, response visibility, command-cache semantics, service calls, and handler bodies.
+
+## 4. Approved Scope
+
+Move these commands only:
+
+- Registry:
+  - `/remove_registration` -> `/registry remove`
+  - `/remove_registration_by_id` -> `/registry remove_by_id`
+  - `/admin_register_governor` -> `/registry admin_register`
+  - `/registration_audit` -> `/registry audit`
+  - `/bulk_export_registrations` -> `/registry bulk_export`
+  - `/bulk_import_registrations_dryrun` -> `/registry bulk_import_dryrun`
+  - `/bulk_import_registrations` -> `/registry bulk_import`
+- KVK / stats:
+  - `/test_kvk_export` -> `/kvk test_export`
+  - `/refresh_stats_cache` -> `/kvk refresh_stats_cache`
+  - `/kvk_export_all` -> `/kvk export_all`
+  - `/kvk_recompute` -> `/kvk recompute`
+  - `/kvk_list_scans` -> `/kvk list_scans`
+  - `/test_kvk_embed` -> `/kvk test_embed`
+  - `/kvk_window_preview` -> `/kvk window_preview`
+  - `/player_stats` -> `/stats player`
+- Inventory:
+  - `/import_inventory` -> `/inventory import`
+  - `/inventory_import_audit` -> `/inventory audit`
+- Calendar admin/operator:
+  - `/calendar_refresh` -> `/ops calendar_refresh`
+  - `/calendar_generate` -> `/ops calendar_generate`
+  - `/calendar_publish_cache` -> `/ops calendar_publish_cache`
+  - `/calendar_status` -> `/ops calendar_status`
+- Events:
+  - `/refresh_events` -> `/events refresh`
+  - `/refresh_kvk_overview` -> `/events refresh_kvk_overview`
+- Subscriptions:
+  - `/list_subscribers` -> `/subscriptions list`
+  - `/migrate_subscriptions_dryrun` -> `/subscriptions migrate_dryrun`
+  - `/migrate_subscriptions_apply` -> `/subscriptions migrate_apply`
+- CrystalTech:
+  - `/crystaltech_validate` -> `/crystaltech validate`
+  - `/crystaltech_reload` -> `/crystaltech reload`
+  - `/crystaltech_admin_reset` -> `/crystaltech admin_reset`
+- Honor:
+  - `/honor_purge_last` -> `/honor purge_last`
+- Location:
+  - `/import_locations` -> `/location import`
+  - `/player_location` -> `/location player`
+- Activity:
+  - `/activity_top` -> `/activity top`
+
+Important correction from the design handoff: do not create `/calendar ...` grouped commands in
+Phase 5A. `/calendar` remains a flat public command, so calendar admin/operator commands should
+move under existing `/ops calendar_*` paths.
+
+## 5. Out Of Scope
+
+Do not move:
+
+- `/register_governor`
+- `/modify_registration`
+- `/my_registrations`
+- `/mygovernorid`
+- `/mykvkstats`
+- `/my_stats`
+- `/my_stats_export`
+- `/mykvkhistory`
+- `/mykvktargets`
+- `/mykvkcrystaltech`
+- `/myinventory`
+- `/inventory_preferences`
+- `/export_inventory`
+- `/subscribe`
+- `/modify_subscription`
+- `/unsubscribe`
+- `/calendar_reminder_config`
+- `/calendar`
+- `/calendar_next_event`
+- `/next_kvk_fight`
+- `/next_kvk_event`
+- `/honor_rankings`
+- `/player_profile`
+- `/ping`
+
+Also out of scope:
+
+- SQL schema changes
+- permission behavior changes
+- public/player workflow redesign
+- public calendar/KVK calendar UX redesign
+- aliases or transition shims unless explicitly approved
+- production promotion or deployment
+
+## 6. Mandatory Workflow
+
+1. Review/scope Phase 5A and stop for approval.
+2. Confirm every moved command's handler, decorator, option, autocomplete, version, usage tracking,
+   and response visibility.
+3. Confirm the `/ops calendar_*` calendar admin target paths.
+4. Present implementation plan and stop for approval.
+5. Implement only approved Phase 5A grouping.
+6. Update focused tests and docs.
+7. Run validation.
+8. Run Codex Security review before PR handoff.
+9. Open a ready-for-review PR against `K98-bot-mirror`.
+
+Proceed in one pass only if explicitly approved in the new chat.
+
+## 7. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
+```
+
+Run focused domain tests selected during scope review. Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security is required because this phase changes Discord command paths and
+permissions-sensitive interaction entry points.
+
+## 8. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
@@ -288,16 +288,25 @@ Phase 4 - Ark Command Grouping: complete, smoke tested, merged, and pushed to pr
 `/ark`, added the post-merge Discord briefing note, and reduced the active top-level command count
 to 62.
 
-Phase 5 - Public Domain Grouping Design: design approved for Phase 5A only. The active task pack
-is `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`.
-Phase 5A should group admin/leadership/operator paths only. Player self-service command redesign
-and public calendar/KVK calendar redesign are deferred outside this command-count programme.
+Phase 5 - Public Domain Grouping Design: complete. PR 135
+(`codex/command-platform-phase-5a-design-docs`) was merged and pushed to production in production
+PR 444. Phase 5 approved Phase 5A as the next implementation slice for admin/leadership/operator
+paths only. Player self-service command redesign and public calendar/KVK calendar redesign are
+deferred outside this command-count programme.
+
+Phase 5A - Admin/Leadership/Operator Domain Grouping: implemented on the Phase 5A implementation
+branch, reducing the active top-level command baseline to 39 while preserving player self-service
+and public calendar/KVK calendar commands.
 
 Remaining roadmap:
 
 Phase 5
 
-Phase 5A Admin/Leadership/Operator Domain Grouping
+Public Domain Grouping Design: complete
+
+Phase 5A
+
+Admin/Leadership/Operator Domain Grouping: implemented
 
 Phase 6
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -7,7 +7,7 @@
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: deferred optimisation batch / command-surface design
 - One-pass approved: no
-- Status: approved for Phase 5A admin/leadership/operator grouping only
+- Status: complete; delivered in PR 135, merged, and pushed to production in production PR 444
 
 ## 2. Required Reading
 
@@ -120,10 +120,10 @@ Approved Phase 5A candidates:
   - `/import_inventory` -> `/inventory import`
   - `/inventory_import_audit` -> `/inventory audit`
 - Calendar admin/operator:
-  - `/calendar_refresh` -> `/calendar refresh`
-  - `/calendar_generate` -> `/calendar generate`
-  - `/calendar_publish_cache` -> `/calendar publish_cache`
-  - `/calendar_status` -> `/calendar status`
+  - `/calendar_refresh` -> `/ops calendar_refresh`
+  - `/calendar_generate` -> `/ops calendar_generate`
+  - `/calendar_publish_cache` -> `/ops calendar_publish_cache`
+  - `/calendar_status` -> `/ops calendar_status`
 - Events admin/operator:
   - `/refresh_events` -> `/events refresh`
   - `/refresh_kvk_overview` -> `/events refresh_kvk_overview`
@@ -148,6 +148,12 @@ admin/leadership lookup commands, not player self-service commands.
 
 Expected Phase 5A outcome: reduce the top-level command count without changing public/player
 self-service workflows.
+
+Implementation correction: Phase 5A should not create a `/calendar` command group while the public
+flat `/calendar` command remains in place. Calendar admin/operator commands should move under the
+existing `/ops` group for Phase 5A. A future public calendar/KVK calendar redesign can decide
+whether `/calendar overview` and related grouped public paths should replace the current flat
+public command.
 
 ## 6. Deferred From Phase 5A
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
@@ -1,0 +1,319 @@
+# Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 5A - Admin Leadership Operator Domain Grouping
+- Date: 2026-06-01
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: deferred optimisation batch / command-surface migration
+- One-pass approved: no
+- Status: implemented in this Phase 5A branch
+
+## 2. Required Reading
+
+Before implementation, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/registry_cmds.py`
+- `commands/stats_cmds.py`
+- `commands/inventory_cmds.py`
+- `commands/admin_cmds.py`
+- `commands/events_cmds.py`
+- `commands/subscriptions_cmds.py`
+- `commands/activity_cmds.py`
+- `commands/location_cmds.py`
+- `commands/command_inventory.py`
+- `core/command_lifecycle.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- domain command tests for registry, stats/KVK, inventory, calendar admin, events, subscriptions,
+  CrystalTech, honor, location, and activity
+- docs and smoke references that mention any moved flat command path
+
+## 3. Objective
+
+Implement the approved Phase 5A command-surface migration by grouping admin, leadership, and
+operator-heavy flat commands under stable domain or operator groups while preserving behavior.
+
+This phase should:
+
+- move only the approved Phase 5A admin/leadership/operator command paths
+- preserve command handlers, decorators, permissions, options, autocomplete, descriptions,
+  versions, usage tracking, response visibility, service calls, and command-cache semantics
+- keep player self-service commands flat
+- keep generic public calendar/KVK calendar commands flat
+- reduce the top-level command count without redesigning public/player workflows
+- update tests, command-platform docs, and smoke references for moved paths
+- run Codex Security before PR handoff because Discord command paths and permission-sensitive
+  interaction surfaces are changing
+
+## 4. Background
+
+Phase 4 was completed in PR 134 (`codex/command-platform-phase-4-ark-grouping`), smoke tested
+successfully, merged, and pushed to production. It grouped all 14 Ark commands under `/ark`.
+
+Phase 5 was completed in PR 135 (`codex/command-platform-phase-5a-design-docs`), merged, and
+pushed to production in production PR 444. It approved Phase 5A as the next implementation slice
+for admin/leadership/operator grouping only, and deferred player self-service plus public
+calendar/KVK calendar redesign outside this command-count programme.
+
+Current validator baseline after Phase 4 and Phase 5 design:
+
+```text
+primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
+```
+
+Current grouped command summary:
+
+| Group | Statically detected subcommands |
+|---|---:|
+| `/ark` | 14 |
+| `/ops` | 21 |
+| `/mge` | 6 |
+| `/prekvk` | 2 |
+
+Phase 5A implementation baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+Grouped command summary:
+
+| Group | Expected subcommands |
+|---|---:|
+| `/activity` | 1 |
+| `/ark` | 14 |
+| `/crystaltech` | 3 |
+| `/events` | 2 |
+| `/honor` | 1 |
+| `/inventory` | 2 |
+| `/kvk` | 7 |
+| `/location` | 2 |
+| `/mge` | 6 |
+| `/ops` | 25 |
+| `/prekvk` | 2 |
+| `/registry` | 7 |
+| `/stats` | 1 |
+| `/subscriptions` | 3 |
+
+Recalculate during implementation if any target path changes after scope review.
+
+## 5. Scope
+
+### In Scope
+
+Create or extend grouped command surfaces for these approved moves:
+
+#### Registry Admin
+
+- `/remove_registration` -> `/registry remove`
+- `/remove_registration_by_id` -> `/registry remove_by_id`
+- `/admin_register_governor` -> `/registry admin_register`
+- `/registration_audit` -> `/registry audit`
+- `/bulk_export_registrations` -> `/registry bulk_export`
+- `/bulk_import_registrations_dryrun` -> `/registry bulk_import_dryrun`
+- `/bulk_import_registrations` -> `/registry bulk_import`
+
+#### KVK / Stats Admin And Leadership
+
+- `/test_kvk_export` -> `/kvk test_export`
+- `/refresh_stats_cache` -> `/kvk refresh_stats_cache`
+- `/kvk_export_all` -> `/kvk export_all`
+- `/kvk_recompute` -> `/kvk recompute`
+- `/kvk_list_scans` -> `/kvk list_scans`
+- `/test_kvk_embed` -> `/kvk test_embed`
+- `/kvk_window_preview` -> `/kvk window_preview`
+- `/player_stats` -> `/stats player`
+
+`/player_stats` is included because it is gated by `is_admin_or_leadership()`.
+
+#### Inventory Admin / Operator
+
+- `/import_inventory` -> `/inventory import`
+- `/inventory_import_audit` -> `/inventory audit`
+
+#### Calendar Admin / Operator
+
+- `/calendar_refresh` -> `/ops calendar_refresh`
+- `/calendar_generate` -> `/ops calendar_generate`
+- `/calendar_publish_cache` -> `/ops calendar_publish_cache`
+- `/calendar_status` -> `/ops calendar_status`
+
+Do not create a `/calendar` group in Phase 5A. The flat public `/calendar` command remains in
+place until the deferred public calendar/KVK calendar redesign.
+
+#### Events Admin / Operator
+
+- `/refresh_events` -> `/events refresh`
+- `/refresh_kvk_overview` -> `/events refresh_kvk_overview`
+
+#### Subscriptions Admin / Operator
+
+- `/list_subscribers` -> `/subscriptions list`
+- `/migrate_subscriptions_dryrun` -> `/subscriptions migrate_dryrun`
+- `/migrate_subscriptions_apply` -> `/subscriptions migrate_apply`
+
+#### CrystalTech Admin / Operator
+
+- `/crystaltech_validate` -> `/crystaltech validate`
+- `/crystaltech_reload` -> `/crystaltech reload`
+- `/crystaltech_admin_reset` -> `/crystaltech admin_reset`
+
+#### Honor Admin / Operator
+
+- `/honor_purge_last` -> `/honor purge_last`
+
+Do not move `/honor_rankings` in Phase 5A.
+
+#### Location Admin / Leadership / Operator
+
+- `/import_locations` -> `/location import`
+- `/player_location` -> `/location player`
+
+`/player_location` is included because it is gated by admin/leadership access in allowed channels.
+
+#### Activity Leadership / Operator
+
+- `/activity_top` -> `/activity top`
+
+### Also In Scope
+
+- command registration, inventory, cache/version, lifecycle, and validator test updates
+- focused domain tests for moved command registration and preserved behavior
+- docs and smoke-reference updates for moved paths
+- command-platform audit, command-surface audit, and task-pack updates
+- Codex Security review before PR handoff
+
+### Out Of Scope
+
+- Player self-service workflow redesign:
+  - `/register_governor`
+  - `/modify_registration`
+  - `/my_registrations`
+  - `/mygovernorid`
+  - `/mykvkstats`
+  - `/my_stats`
+  - `/my_stats_export`
+  - `/mykvkhistory`
+  - `/mykvktargets`
+  - `/mykvkcrystaltech`
+  - `/myinventory`
+  - `/inventory_preferences`
+  - `/export_inventory`
+  - `/subscribe`
+  - `/modify_subscription`
+  - `/unsubscribe`
+  - `/calendar_reminder_config`
+- Generic public calendar/KVK calendar redesign:
+  - `/calendar`
+  - `/calendar_next_event`
+  - `/next_kvk_fight`
+  - `/next_kvk_event`
+- `/honor_rankings`
+- `/player_profile`
+- `/ping`
+- SQL schema changes
+- permission-decorator behavior changes
+- command option/autocomplete/description/version changes unless required only to preserve grouped
+  registration
+- handler/service/DAL/view behavior refactors beyond the minimum needed to attach handlers to
+  command groups
+- aliases or transition shims unless explicitly approved
+- production promotion or deployment
+
+## 6. Mandatory Workflow
+
+1. Review/scope Phase 5A and stop for approval.
+2. Map every moved command handler, decorator, option, autocomplete, version, usage tracking, and
+   response visibility.
+3. Confirm target group names and the calendar admin `/ops calendar_*` correction.
+4. Present implementation plan and stop for approval unless one-pass implementation is explicitly
+   approved in the new chat.
+5. Implement approved Phase 5A grouping only.
+6. Update focused tests and docs.
+7. Run validation.
+8. Run Codex Security review before PR handoff.
+9. Open a ready-for-review PR against `K98-bot-mirror`.
+
+## 7. Acceptance Criteria
+
+- [ ] Only approved Phase 5A command paths are moved.
+- [ ] Player self-service commands remain flat.
+- [ ] Generic public calendar/KVK calendar commands remain flat.
+- [ ] `/calendar` remains a flat public command.
+- [ ] Calendar admin commands move under `/ops calendar_*`, not `/calendar ...`.
+- [ ] `/player_location` and `/player_stats` are included as admin/leadership lookup commands.
+- [ ] `/honor_rankings`, `/player_profile`, and `/ping` remain unchanged.
+- [ ] Command decorators, permissions, options, autocomplete, descriptions, versions, usage
+      tracking, response visibility, service calls, and handler behavior are preserved.
+- [ ] Command inventory, lifecycle, cache/version, and validator tests understand the new grouped
+      paths.
+- [ ] `scripts/validate_command_registration.py` reports the expected Phase 5A baseline or any
+      variance is explained.
+- [ ] Docs and smoke references reflect moved paths.
+- [ ] Codex Security review is run before PR handoff.
+
+## 8. Suggested Validation
+
+Minimum validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py
+```
+
+Focused domain coverage to review and run as applicable:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_command_service.py tests\test_registry_service.py tests\test_registry_views_smoke.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_stats_cmds.py tests\test_kvk_admin_service.py tests\test_kvk_export_service.py tests\test_kvk_all_recompute_sql_contract.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_inventory_command_registration.py tests\test_inventory_audit_service.py tests\test_inventory_upload_flow.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_admin_calendar_commands_task3.py tests\test_calendar_publish_cache.py tests\test_calendar_status_embed_task4.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_events_views.py tests\test_subscription_views.py tests\test_activity_cmds.py tests\test_location_views_smoke.py tests\test_location_import_service.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_crystaltech_service.py tests\test_honor_rankings_view.py
+```
+
+Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Codex Security is required because Phase 5A changes Discord command paths and
+permissions-sensitive interaction entry points.
+
+## 9. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -11,6 +11,11 @@ calendar tracker atomic-write hardening when one of those programmes is approved
 The active command-platform programme is tracked in:
 
 - `Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
+- `Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
+
+The completed Phase 5 design source remains in this folder for handoff context:
+
 - `Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
 - `Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md`
 

--- a/tests/test_activity_cmds.py
+++ b/tests/test_activity_cmds.py
@@ -40,17 +40,34 @@ def test_render_activity_top_breakdown():
 async def test_activity_command_registration_handoff(monkeypatch):
     import commands.activity_cmds as activity_cmds
 
-    registered = {}
+    groups = {}
 
-    class FakeBot:
-        def slash_command(self, **kwargs):
+    class FakeGroup:
+        def __init__(self, name, description, guild_ids=None):
+            self.name = name
+            self.description = description
+            self.guild_ids = guild_ids
+            self.commands = {}
+
+        def command(self, **kwargs):
             def _decorator(fn):
-                registered[kwargs["name"]] = fn
+                self.commands[kwargs["name"]] = fn
                 return fn
 
             return _decorator
 
+    class FakeBot:
+        def slash_command(self, **kwargs):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+        def add_application_command(self, group):
+            groups[group.name] = group
+
     monkeypatch.setattr(activity_cmds, "GUILD_ID", 1)
+    monkeypatch.setattr(activity_cmds.discord, "SlashCommandGroup", FakeGroup)
     activity_cmds.register_activity(FakeBot())
 
-    assert "activity_top" in registered
+    assert groups["activity"].commands.keys() == {"top"}

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -43,9 +43,19 @@ def test_register_commands_smoke(monkeypatch):
     assert len([name for name in registered_top_level if name]) <= 100
     assert len([name for name in registered_top_level if name]) < 90
     assert "ark" in registered_top_level
+    assert "activity" in registered_top_level
+    assert "crystaltech" in registered_top_level
+    assert "events" in registered_top_level
+    assert "honor" in registered_top_level
+    assert "inventory" in registered_top_level
+    assert "kvk" in registered_top_level
+    assert "location" in registered_top_level
     assert "ops" in registered_top_level
     assert "mge" in registered_top_level
     assert "prekvk" in registered_top_level
+    assert "registry" in registered_top_level
+    assert "stats" in registered_top_level
+    assert "subscriptions" in registered_top_level
     assert "ark_create_match" not in registered_top_level
     assert "ark_force_announce" not in registered_top_level
     assert "ark_amend_match" not in registered_top_level
@@ -71,6 +81,43 @@ def test_register_commands_smoke(monkeypatch):
     assert "usage" not in registered_top_level
     assert "usage_detail" not in registered_top_level
     assert "test_embed" not in registered_top_level
+    assert "remove_registration" not in registered_top_level
+    assert "remove_registration_by_id" not in registered_top_level
+    assert "admin_register_governor" not in registered_top_level
+    assert "registration_audit" not in registered_top_level
+    assert "bulk_export_registrations" not in registered_top_level
+    assert "bulk_import_registrations_dryrun" not in registered_top_level
+    assert "bulk_import_registrations" not in registered_top_level
+    assert "test_kvk_export" not in registered_top_level
+    assert "refresh_stats_cache" not in registered_top_level
+    assert "player_stats" not in registered_top_level
+    assert "kvk_export_all" not in registered_top_level
+    assert "kvk_recompute" not in registered_top_level
+    assert "kvk_list_scans" not in registered_top_level
+    assert "test_kvk_embed" not in registered_top_level
+    assert "kvk_window_preview" not in registered_top_level
+    assert "import_inventory" not in registered_top_level
+    assert "inventory_import_audit" not in registered_top_level
+    assert "calendar_refresh" not in registered_top_level
+    assert "calendar_generate" not in registered_top_level
+    assert "calendar_publish_cache" not in registered_top_level
+    assert "calendar_status" not in registered_top_level
+    assert "refresh_events" not in registered_top_level
+    assert "refresh_kvk_overview" not in registered_top_level
+    assert "list_subscribers" not in registered_top_level
+    assert "migrate_subscriptions_dryrun" not in registered_top_level
+    assert "migrate_subscriptions_apply" not in registered_top_level
+    assert "crystaltech_validate" not in registered_top_level
+    assert "crystaltech_reload" not in registered_top_level
+    assert "crystaltech_admin_reset" not in registered_top_level
+    assert "honor_purge_last" not in registered_top_level
+    assert "import_locations" not in registered_top_level
+    assert "player_location" not in registered_top_level
+    assert "activity_top" not in registered_top_level
+    assert "calendar" in registered_top_level
+    assert "honor_rankings" in registered_top_level
+    assert "player_profile" in registered_top_level
+    assert "ping" in registered_top_level
 
 
 def test_startup_command_audit_uses_authoritative_inventory():

--- a/tests/test_inventory_command_registration.py
+++ b/tests/test_inventory_command_registration.py
@@ -1,10 +1,25 @@
 import types
 
 
-def test_register_inventory_command_registers_import_inventory():
+class _FakeGroup:
+    def __init__(self, name, description, guild_ids=None):
+        self.name = name
+        self.description = description
+        self.guild_ids = guild_ids
+        self.commands = {}
+
+    def command(self, **kwargs):
+        def deco(fn):
+            self.commands[kwargs["name"]] = fn
+            return fn
+
+        return deco
+
+
+def test_register_inventory_command_registers_grouped_admin_commands(monkeypatch):
     import commands.inventory_cmds as mod
 
-    fake_bot = types.SimpleNamespace(registered={})
+    fake_bot = types.SimpleNamespace(registered={}, groups={})
 
     def slash_command(**kwargs):
         def deco(fn):
@@ -13,12 +28,18 @@ def test_register_inventory_command_registers_import_inventory():
 
         return deco
 
+    def add_application_command(group):
+        fake_bot.groups[group.name] = group
+
     fake_bot.slash_command = slash_command
+    fake_bot.add_application_command = add_application_command
+    monkeypatch.setattr(mod.discord, "SlashCommandGroup", _FakeGroup)
 
     mod.register_inventory(fake_bot)
 
-    assert "import_inventory" in fake_bot.registered
+    assert fake_bot.groups["inventory"].commands.keys() == {"import", "audit"}
+    assert "import_inventory" not in fake_bot.registered
+    assert "inventory_import_audit" not in fake_bot.registered
     assert "myinventory" in fake_bot.registered
     assert "inventory_preferences" in fake_bot.registered
     assert "export_inventory" in fake_bot.registered
-    assert "inventory_import_audit" in fake_bot.registered

--- a/tests/test_my_stats_export_command.py
+++ b/tests/test_my_stats_export_command.py
@@ -46,6 +46,7 @@ def _get_stats_export_handler():
         return decorator
 
     fake_bot.slash_command = slash_command
+    fake_bot.add_application_command = lambda _command: None
     C.register_stats(fake_bot)
     fn = fake_bot.registered["my_stats_export"]
     while hasattr(fn, "__wrapped__"):

--- a/tests/test_mykvkstats.py
+++ b/tests/test_mykvkstats.py
@@ -71,6 +71,7 @@ def _get_registered_command_impl(module, command_name: str):
 
     fake_bot.add_listener = add_listener
     fake_bot.slash_command = slash_command
+    fake_bot.add_application_command = lambda _command: None
     fake_bot.tree = types.SimpleNamespace()
     fake_bot.tree.command = lambda **kw: lambda f: f
 

--- a/tests/test_stats_cmds.py
+++ b/tests/test_stats_cmds.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from commands.stats_cmds import _split_discord_content
+
 IN_SCOPE_KVK_ADMIN_COMMANDS = {
     "test_kvk_export",
     "kvk_export_all",
@@ -49,3 +51,41 @@ def test_stats_cmds_imports_kvk_admin_service_boundary() -> None:
 
     assert "from kvk.services import kvk_admin_service" in source
     assert "from kvk.dal.kvk_history_dal import resolve_current_kvk_no_from_cursor" not in source
+
+
+def test_player_stats_awaits_async_embed_builder() -> None:
+    source = Path("commands/stats_cmds.py").read_text(encoding="utf-8")
+    command = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "player_stats_command"
+    )
+
+    awaited_calls = [
+        node.value.func.id
+        for node in ast.walk(command)
+        if isinstance(node, ast.Await)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+    ]
+
+    assert "build_embeds" in awaited_calls
+
+
+def test_split_discord_content_keeps_chunks_under_limit() -> None:
+    content = "header\n" + "\n".join(f"row {idx:03d} " + ("x" * 80) for idx in range(60))
+
+    chunks = _split_discord_content(content, max_chars=500)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 500 for chunk in chunks)
+    assert "\n".join(chunks) == content
+
+
+def test_kvk_list_scans_uses_discord_content_splitter() -> None:
+    source = Path("commands/stats_cmds.py").read_text(encoding="utf-8")
+    command = _command_nodes()["kvk_list_scans"]
+    segment = ast.get_source_segment(source, command) or ""
+
+    assert "_split_discord_content" in segment
+    assert "for chunk in chunks" in segment

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -10,6 +10,7 @@ import asyncio
 from datetime import UTC, datetime
 import os
 import tempfile
+from types import SimpleNamespace
 
 import pytest
 
@@ -49,6 +50,58 @@ def test_decorator_usage_tracker_uses_shared_global_tracker(monkeypatch):
     monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)
 
     assert decoraters.usage_tracker() is get_usage_tracker()
+
+
+@pytest.mark.asyncio
+async def test_track_usage_logs_grouped_qualified_command_name(monkeypatch):
+    """Grouped slash commands must log the full path, not only the leaf name."""
+    events = []
+
+    class FakeUsageTracker:
+        async def log(self, event):
+            events.append(event)
+
+    monkeypatch.setattr(decoraters, "usage_tracker", lambda: FakeUsageTracker())
+
+    @decoraters.track_usage()
+    async def handler(_ctx):
+        return "ok"
+
+    ctx = SimpleNamespace(
+        command=SimpleNamespace(name="player", qualified_name="stats player"),
+        user=SimpleNamespace(id=1, display_name="Tester"),
+        guild=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3),
+    )
+
+    assert await handler(ctx) == "ok"
+    assert events[0]["command_name"] == "stats player"
+
+
+@pytest.mark.asyncio
+async def test_track_usage_explicit_command_name_still_wins(monkeypatch):
+    """Existing explicit usage identities remain stable."""
+    events = []
+
+    class FakeUsageTracker:
+        async def log(self, event):
+            events.append(event)
+
+    monkeypatch.setattr(decoraters, "usage_tracker", lambda: FakeUsageTracker())
+
+    @decoraters.track_usage("player_stats")
+    async def handler(_ctx):
+        return "ok"
+
+    ctx = SimpleNamespace(
+        command=SimpleNamespace(name="player", qualified_name="stats player"),
+        user=SimpleNamespace(id=1, display_name="Tester"),
+        guild=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3),
+    )
+
+    assert await handler(ctx) == "ok"
+    assert events[0]["command_name"] == "player_stats"
 
 
 def test_start_usage_tracker_creates_task(monkeypatch):

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -104,6 +104,51 @@ async def test_track_usage_explicit_command_name_still_wins(monkeypatch):
     assert events[0]["command_name"] == "player_stats"
 
 
+@pytest.mark.asyncio
+async def test_admin_denial_logs_grouped_name_from_application_context(monkeypatch):
+    """Denied grouped commands should prefer ApplicationContext qualified_name."""
+    events = []
+
+    class FakeUsageTracker:
+        async def log(self, event):
+            events.append(event)
+
+    class FakeResponse:
+        def is_done(self):
+            return False
+
+        async def send_message(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(decoraters, "NOTIFY_CHANNEL_ID", 123)
+    monkeypatch.setattr(decoraters, "usage_tracker", lambda: FakeUsageTracker())
+
+    invoked = False
+
+    @decoraters.is_admin_and_notify_channel()
+    async def handler(_ctx):
+        nonlocal invoked
+        invoked = True
+
+    interaction = SimpleNamespace(
+        command=SimpleNamespace(name="validate"),
+        data={"name": "crystaltech"},
+        channel=SimpleNamespace(id=999, parent_id=None),
+        user=SimpleNamespace(id=1, display_name="Tester"),
+        guild=SimpleNamespace(id=2),
+        response=FakeResponse(),
+    )
+    ctx = SimpleNamespace(
+        command=SimpleNamespace(name="validate", qualified_name="crystaltech validate"),
+        interaction=interaction,
+    )
+
+    await handler(ctx)
+
+    assert invoked is False
+    assert events[0]["command_name"] == "crystaltech validate"
+
+
 def test_start_usage_tracker_creates_task(monkeypatch):
     """start_usage_tracker() returns a tracker with a running task."""
     monkeypatch.setattr(usage_tracker_module, "_GLOBAL_TRACKER", None)

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -86,7 +86,7 @@ def register_sample(bot):
     assert grouped == {"ops": {"audit", "status"}}
 
 
-def test_current_command_surface_reflects_phase4_ark_grouping():
+def test_current_command_surface_reflects_phase5a_admin_grouping():
     names, grouped = validator.collect_primary_inventory()
 
     moved_to_ops = {
@@ -97,6 +97,10 @@ def test_current_command_surface_reflects_phase4_ark_grouping():
         "usage",
         "usage_detail",
         "test_embed",
+        "calendar_refresh",
+        "calendar_generate",
+        "calendar_publish_cache",
+        "calendar_status",
     }
     moved_to_ark = {
         "ark_create_match": "create_match",
@@ -114,15 +118,58 @@ def test_current_command_surface_reflects_phase4_ark_grouping():
         "ark_generate_draft": "generate_draft",
         "create_ark_team": "create_team",
     }
+    phase5a_moves = {
+        "registry": {
+            "remove_registration": "remove",
+            "remove_registration_by_id": "remove_by_id",
+            "admin_register_governor": "admin_register",
+            "registration_audit": "audit",
+            "bulk_export_registrations": "bulk_export",
+            "bulk_import_registrations_dryrun": "bulk_import_dryrun",
+            "bulk_import_registrations": "bulk_import",
+        },
+        "kvk": {
+            "test_kvk_export": "test_export",
+            "refresh_stats_cache": "refresh_stats_cache",
+            "kvk_export_all": "export_all",
+            "kvk_recompute": "recompute",
+            "kvk_list_scans": "list_scans",
+            "test_kvk_embed": "test_embed",
+            "kvk_window_preview": "window_preview",
+        },
+        "stats": {"player_stats": "player"},
+        "inventory": {"import_inventory": "import", "inventory_import_audit": "audit"},
+        "events": {"refresh_events": "refresh", "refresh_kvk_overview": "refresh_kvk_overview"},
+        "subscriptions": {
+            "list_subscribers": "list",
+            "migrate_subscriptions_dryrun": "migrate_dryrun",
+            "migrate_subscriptions_apply": "migrate_apply",
+        },
+        "crystaltech": {
+            "crystaltech_validate": "validate",
+            "crystaltech_reload": "reload",
+            "crystaltech_admin_reset": "admin_reset",
+        },
+        "honor": {"honor_purge_last": "purge_last"},
+        "location": {"import_locations": "import", "player_location": "player"},
+        "activity": {"activity_top": "top"},
+    }
 
-    assert len(names) == 62
+    assert len(names) == 39
     assert moved_to_ops.isdisjoint(names)
     assert moved_to_ops.issubset(grouped["ops"])
     assert set(moved_to_ark).isdisjoint(names)
     assert set(moved_to_ark.values()).issubset(grouped["ark"])
-    assert len(grouped["ops"]) == 21
+    for group_name, mapping in phase5a_moves.items():
+        assert set(mapping).isdisjoint(names)
+        assert set(mapping.values()).issubset(grouped[group_name])
+    assert len(grouped["ops"]) == 25
     assert len(grouped["ark"]) == 14
-    assert sum(len(commands) for commands in grouped.values()) == 43
+    assert sum(len(commands) for commands in grouped.values()) == 76
+    assert "calendar" in names
+    assert "honor_rankings" in names
+    assert "player_profile" in names
+    assert "ping" in names
 
 
 def test_validator_delegates_static_inventory_to_shared_helper():


### PR DESCRIPTION
## Summary
- Move the approved Phase 5A admin/leadership/operator commands into grouped slash command surfaces while preserving handler bodies, options, autocomplete, visibility, permissions, command versions, and usage tracking.
- Keep player self-service and public calendar/KVK calendar commands flat, with calendar admin/operator paths under `/ops calendar_*`.
- Update command inventory/audit docs, Phase 5/5A task pack docs, registration smoke coverage, command validator expectations, and focused domain registration fakes.

## Validation
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`
- `\.\.venv\Scripts\python.exe scripts\select_tests.py`
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py`
- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_command_inventory.py tests\test_command_lifecycle.py tests\test_inventory_command_registration.py tests\test_stats_cmds.py tests\test_activity_cmds.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_stats_service.py tests\test_mykvkstats.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_registry_cmds.py tests\test_registry_command_service.py tests\test_inventory_audit_service.py tests\test_admin_calendar_commands_task3.py tests\test_calendar_publish_cache.py tests\test_calendar_status_embed_task4.py tests\test_subscription_views.py tests\test_location_import_service.py tests\test_location_views_smoke.py tests\test_crystaltech_service.py tests\test_honor_rankings_view.py`
- `\.\.venv\Scripts\python.exe -m pytest -q tests\test_my_stats_export_command.py tests\test_mykvkstats.py tests\test_validate_command_registration.py tests\test_command_registration_smoke.py tests\test_inventory_command_registration.py tests\test_activity_cmds.py tests\test_stats_cmds.py`
- `\.\.venv\Scripts\python.exe -m pre_commit run -a`
- `\.\.venv\Scripts\python.exe -m pytest -q tests` (`1616 passed, 2 skipped`)
- `\.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`

## Security
Codex Security diff scan completed for the working-tree change set with no findings. Reports were generated locally under the Codex temp scan directory.