### PR TITLE
Command Platform Phase 6: Canonical command documentation and review feedback fixes

### DIFF
--- a/docs/calendar/PR_SUMMARY_TASK3.md
+++ b/docs/calendar/PR_SUMMARY_TASK3.md
@@ -1,9 +1,9 @@
-﻿# PR Summary â€” Task 3: Event Instance Generator + SQLâ†’JSON Publish
+# PR Summary — Task 3: Event Instance Generator + SQL→JSON Publish
 
 ## Overview
 This PR completes **Task 3** of the resilient Event Calendar architecture for K98 Bot:
 
-**Google Sheets â†’ SQL source tables â†’ EventInstances â†’ JSON cache â†’ Bot runtime**
+**Google Sheets → SQL source tables → EventInstances → JSON cache → Bot runtime**
 
 The implementation preserves the reliability goals established in Task 1/2:
 - Bot runtime does not depend on live Google Sheets.
@@ -33,15 +33,15 @@ Implemented core generator module with deterministic behavior:
 - Generates recurring occurrences within configurable horizon.
 - Merges one-off events into unified instance set.
 - Applies overrides deterministically:
-  - `cancel` â†’ marks instance cancelled
-  - `modify` â†’ patches non-null `New*` fields
+  - `cancel` → marks instance cancelled
+  - `modify` → patches non-null `New*` fields
 - Sorts deterministically for stable output.
 - Computes/stores `EffectiveHash` on final post-override payload.
 - Writes `EventInstances` with transactional safety.
 
 ---
 
-## 2) SQL â†’ JSON cache publishing
+## 2) SQL → JSON cache publishing
 Implemented cache publisher module:
 
 - `load_runtime_instances(conn, horizon_days=365)`
@@ -62,7 +62,7 @@ Implemented cache publisher module:
 
 - `generate(...)`
 - `publish_cache(...)`
-- `refresh_full(...)` (sync â†’ generate â†’ publish orchestration)
+- `refresh_full(...)` (sync → generate → publish orchestration)
 
 ### Reliability/operations improvements
 - Blocking sync/generate/publish paths run in worker thread via `asyncio.to_thread(...)`.
@@ -133,7 +133,7 @@ Result: **all tests passed**.
 - [x] Override cancel/modify behavior implemented.
 - [x] Deterministic sorting and stable instance output.
 - [x] EffectiveHash generated from final payload.
-- [x] SQLâ†’JSON publish implemented from SQL source.
+- [x] SQL→JSON publish implemented from SQL source.
 - [x] Preserve-on-empty cache guard implemented.
 - [x] Admin controls for generate/publish/status added.
 - [x] Failure telemetry and graceful behavior implemented.
@@ -142,7 +142,7 @@ Result: **all tests passed**.
 
 ## Proposed Task 4 (next)
 
-## Task 4 â€” Runtime Consumption, Quality Gates, and Production Hardening
+## Task 4 — Runtime Consumption, Quality Gates, and Production Hardening
 
 ## Objective
 Finalize the calendar pipeline for production bot usage by integrating runtime command consumption, strengthening idempotency/observability, and adding deployment-grade safeguards.
@@ -169,7 +169,7 @@ Finalize the calendar pipeline for production bot usage by integrating runtime c
 
 ### 4) Observability upgrades
 - Add run duration metrics (sync/generate/publish).
-- Add structured â€œlast successful runâ€ and â€œlast failed runâ€ fields.
+- Add structured “last successful run” and “last failed run” fields.
 - Add `calendar_health` summary block for status command:
   - cache_age_minutes
   - next_upcoming_event

--- a/docs/calendar/PR_SUMMARY_TASK3.md
+++ b/docs/calendar/PR_SUMMARY_TASK3.md
@@ -1,9 +1,9 @@
-# PR Summary — Task 3: Event Instance Generator + SQL→JSON Publish
+﻿# PR Summary â€” Task 3: Event Instance Generator + SQLâ†’JSON Publish
 
 ## Overview
 This PR completes **Task 3** of the resilient Event Calendar architecture for K98 Bot:
 
-**Google Sheets → SQL source tables → EventInstances → JSON cache → Bot runtime**
+**Google Sheets â†’ SQL source tables â†’ EventInstances â†’ JSON cache â†’ Bot runtime**
 
 The implementation preserves the reliability goals established in Task 1/2:
 - Bot runtime does not depend on live Google Sheets.
@@ -33,15 +33,15 @@ Implemented core generator module with deterministic behavior:
 - Generates recurring occurrences within configurable horizon.
 - Merges one-off events into unified instance set.
 - Applies overrides deterministically:
-  - `cancel` → marks instance cancelled
-  - `modify` → patches non-null `New*` fields
+  - `cancel` â†’ marks instance cancelled
+  - `modify` â†’ patches non-null `New*` fields
 - Sorts deterministically for stable output.
 - Computes/stores `EffectiveHash` on final post-override payload.
 - Writes `EventInstances` with transactional safety.
 
 ---
 
-## 2) SQL → JSON cache publishing
+## 2) SQL â†’ JSON cache publishing
 Implemented cache publisher module:
 
 - `load_runtime_instances(conn, horizon_days=365)`
@@ -62,7 +62,7 @@ Implemented cache publisher module:
 
 - `generate(...)`
 - `publish_cache(...)`
-- `refresh_full(...)` (sync → generate → publish orchestration)
+- `refresh_full(...)` (sync â†’ generate â†’ publish orchestration)
 
 ### Reliability/operations improvements
 - Blocking sync/generate/publish paths run in worker thread via `asyncio.to_thread(...)`.
@@ -80,10 +80,10 @@ Implemented cache publisher module:
 ## 4) Admin command wiring (slash commands)
 Added/updated admin commands using repo-native style (`@bot.slash_command`):
 
-- `/calendar_refresh`
-- `/calendar_generate`
-- `/calendar_publish_cache`
-- `/calendar_status`
+- `/ops calendar_refresh`
+- `/ops calendar_generate`
+- `/ops calendar_publish_cache`
+- `/ops calendar_status`
 
 ### Command guarantees
 - Uses operation locks for serialization:
@@ -133,7 +133,7 @@ Result: **all tests passed**.
 - [x] Override cancel/modify behavior implemented.
 - [x] Deterministic sorting and stable instance output.
 - [x] EffectiveHash generated from final payload.
-- [x] SQL→JSON publish implemented from SQL source.
+- [x] SQLâ†’JSON publish implemented from SQL source.
 - [x] Preserve-on-empty cache guard implemented.
 - [x] Admin controls for generate/publish/status added.
 - [x] Failure telemetry and graceful behavior implemented.
@@ -142,7 +142,7 @@ Result: **all tests passed**.
 
 ## Proposed Task 4 (next)
 
-## Task 4 — Runtime Consumption, Quality Gates, and Production Hardening
+## Task 4 â€” Runtime Consumption, Quality Gates, and Production Hardening
 
 ## Objective
 Finalize the calendar pipeline for production bot usage by integrating runtime command consumption, strengthening idempotency/observability, and adding deployment-grade safeguards.
@@ -169,7 +169,7 @@ Finalize the calendar pipeline for production bot usage by integrating runtime c
 
 ### 4) Observability upgrades
 - Add run duration metrics (sync/generate/publish).
-- Add structured “last successful run” and “last failed run” fields.
+- Add structured â€œlast successful runâ€ and â€œlast failed runâ€ fields.
 - Add `calendar_health` summary block for status command:
   - cache_age_minutes
   - next_upcoming_event

--- a/docs/calendar/event_calendar_brief.md
+++ b/docs/calendar/event_calendar_brief.md
@@ -1,4 +1,4 @@
-We are building a resilient Event Calendar feature for the K98 Discord bot.
+﻿We are building a resilient Event Calendar feature for the K98 Discord bot.
 
 Target architecture:
 Google Sheets -> SQL -> JSON cache -> Bot
@@ -18,20 +18,20 @@ Data model already defined in 3 input tabs:
 
 Need production-quality implementation with validation, logging, graceful fallback behaviour, and admin refresh/status controls.
 
-K98 Bot – Event Calendar System
+K98 Bot â€“ Event Calendar System
 System Architecture
 Google Sheets
-      ↓
+      â†“
 Sheet Sync Module
-      ↓
+      â†“
 SQL Tables (persistent)
-      ↓
+      â†“
 Event Generator
-      ↓
+      â†“
 EventInstances table
-      ↓
+      â†“
 JSON Cache
-      ↓
+      â†“
 Discord Bot commands + calendar embed
 
 Key design rules:
@@ -58,8 +58,8 @@ Pipeline must degrade gracefully
 - Sync run logging via `EventSyncLog`
 - Graceful failure behavior enforced (no source table clobber)
 - Admin controls wired:
-  - `/calendar_refresh`
-  - `/calendar_status`
+  - `/ops calendar_refresh`
+  - `/ops calendar_status`
 
 ### Next: Task 3
 - Generate event instances into `EventInstances`

--- a/docs/calendar/event_calendar_brief.md
+++ b/docs/calendar/event_calendar_brief.md
@@ -1,4 +1,4 @@
-﻿We are building a resilient Event Calendar feature for the K98 Discord bot.
+We are building a resilient Event Calendar feature for the K98 Discord bot.
 
 Target architecture:
 Google Sheets -> SQL -> JSON cache -> Bot
@@ -18,20 +18,20 @@ Data model already defined in 3 input tabs:
 
 Need production-quality implementation with validation, logging, graceful fallback behaviour, and admin refresh/status controls.
 
-K98 Bot â€“ Event Calendar System
+K98 Bot – Event Calendar System
 System Architecture
 Google Sheets
-      â†“
+      ↓
 Sheet Sync Module
-      â†“
+      ↓
 SQL Tables (persistent)
-      â†“
+      ↓
 Event Generator
-      â†“
+      ↓
 EventInstances table
-      â†“
+      ↓
 JSON Cache
-      â†“
+      ↓
 Discord Bot commands + calendar embed
 
 Key design rules:

--- a/docs/calendar/event_calendar_task2.md
+++ b/docs/calendar/event_calendar_task2.md
@@ -1,4 +1,4 @@
-﻿# TASK 2 â€” Build Google Sheets â†’ SQL Sync Module âœ… COMPLETED
+# TASK 2 — Build Google Sheets → SQL Sync Module ✅ COMPLETED
 
 ## Objective
 Load Google Sheets data into SQL source tables with validation, normalization, hash-based change detection, and graceful failure handling.

--- a/docs/calendar/event_calendar_task2.md
+++ b/docs/calendar/event_calendar_task2.md
@@ -1,4 +1,4 @@
-# TASK 2 — Build Google Sheets → SQL Sync Module ✅ COMPLETED
+﻿# TASK 2 â€” Build Google Sheets â†’ SQL Sync Module âœ… COMPLETED
 
 ## Objective
 Load Google Sheets data into SQL source tables with validation, normalization, hash-based change detection, and graceful failure handling.
@@ -20,8 +20,8 @@ Load Google Sheets data into SQL source tables with validation, normalization, h
 - `event_calendar/service.py` now calls `sync_sheets_to_sql()` and stores status/last result.
 
 ### Admin controls (wired)
-- `/calendar_refresh`
-- `/calendar_status`
+- `/ops calendar_refresh`
+- `/ops calendar_status`
 
 ### Config
 - `constants.py`:

--- a/docs/calendar/event_calendar_task3.md
+++ b/docs/calendar/event_calendar_task3.md
@@ -1,9 +1,9 @@
-# TASK 3 — Build Event Instance Generator + SQL→JSON Publish (Production-Ready)
+﻿# TASK 3 â€” Build Event Instance Generator + SQLâ†’JSON Publish (Production-Ready)
 
 ## Objective
 Implement the generation and publish stage of the Event Calendar pipeline:
 
-Google Sheets → SQL source tables → EventInstances → JSON cache → Bot runtime
+Google Sheets â†’ SQL source tables â†’ EventInstances â†’ JSON cache â†’ Bot runtime
 
 Task 3 must generate concrete event instances from SQL source tables, apply overrides deterministically, and publish a runtime JSON cache from SQL with strong resilience guarantees.
 
@@ -55,8 +55,8 @@ Match precedence key:
 
 Actions:
 
-- `cancel` → mark cancelled (preferred) or remove from publish set (must be deterministic and documented)
-- `modify` → patch `New*` fields onto target instance
+- `cancel` â†’ mark cancelled (preferred) or remove from publish set (must be deterministic and documented)
+- `modify` â†’ patch `New*` fields onto target instance
 
 Validation:
 
@@ -77,7 +77,7 @@ Requirements:
 - Compute and store `EffectiveHash` from final post-override payload.
 - Ensure idempotent reruns and deterministic output.
 
-### 4) Publish SQL → JSON runtime cache
+### 4) Publish SQL â†’ JSON runtime cache
 Create module:
 
 - `event_calendar/cache_publisher.py` (or equivalent service-layer function)
@@ -93,9 +93,9 @@ Behavior:
 ### 5) Service + admin controls
 Integrate in `event_calendar/service.py` and admin commands:
 
-- `/calendar_generate` (or include generation as a stage of `/calendar_refresh`)
-- `/calendar_publish_cache`
-- `/calendar_status` must include:
+- `/ops calendar_generate` (or include generation as a stage of `/ops calendar_refresh`)
+- `/ops calendar_publish_cache`
+- `/ops calendar_status` must include:
   - last generate status/time
   - instances generated count
   - publish status/time
@@ -154,7 +154,7 @@ Task 3 implementation should carry forward these quality fixes:
 - `EffectiveHash` reflects final post-override payload.
 - JSON cache publishes from SQL and matches cache contract.
 - Preserve-on-empty guard prevents destructive cache overwrite.
-- `/calendar_status` reports generation/publish metrics and last outcomes.
+- `/ops calendar_status` reports generation/publish metrics and last outcomes.
 - Failures do not wipe last-known-good SQL/JSON runtime state.
 - Unit tests and targeted integration-like tests pass.
 

--- a/docs/calendar/event_calendar_task3.md
+++ b/docs/calendar/event_calendar_task3.md
@@ -1,9 +1,9 @@
-﻿# TASK 3 â€” Build Event Instance Generator + SQLâ†’JSON Publish (Production-Ready)
+# TASK 3 — Build Event Instance Generator + SQL→JSON Publish (Production-Ready)
 
 ## Objective
 Implement the generation and publish stage of the Event Calendar pipeline:
 
-Google Sheets â†’ SQL source tables â†’ EventInstances â†’ JSON cache â†’ Bot runtime
+Google Sheets → SQL source tables → EventInstances → JSON cache → Bot runtime
 
 Task 3 must generate concrete event instances from SQL source tables, apply overrides deterministically, and publish a runtime JSON cache from SQL with strong resilience guarantees.
 
@@ -55,8 +55,8 @@ Match precedence key:
 
 Actions:
 
-- `cancel` â†’ mark cancelled (preferred) or remove from publish set (must be deterministic and documented)
-- `modify` â†’ patch `New*` fields onto target instance
+- `cancel` → mark cancelled (preferred) or remove from publish set (must be deterministic and documented)
+- `modify` → patch `New*` fields onto target instance
 
 Validation:
 
@@ -77,7 +77,7 @@ Requirements:
 - Compute and store `EffectiveHash` from final post-override payload.
 - Ensure idempotent reruns and deterministic output.
 
-### 4) Publish SQL â†’ JSON runtime cache
+### 4) Publish SQL → JSON runtime cache
 Create module:
 
 - `event_calendar/cache_publisher.py` (or equivalent service-layer function)

--- a/docs/calendar/event_calendar_task5.md
+++ b/docs/calendar/event_calendar_task5.md
@@ -1,4 +1,4 @@
-﻿# TASK 5 â€” Runtime Cache Consolidation, Health/Resilience Hardening, and Deterministic Quality Gates âœ… COMPLETED
+# TASK 5 — Runtime Cache Consolidation, Health/Resilience Hardening, and Deterministic Quality Gates ✅ COMPLETED
 
 ## Objective
 Finalize Task 5 by consolidating runtime cache logic, integrating mandatory Task 4 review feedback, improving status/health resilience, and validating via pytest + SQL scripts in local-first deployment flow.
@@ -90,4 +90,4 @@ Result: **local SQL verification checks completed successfully**.
 - `.env` can now tune anomaly thresholds without code changes.
 - Manual PR workflow remains unchanged.
 - Architecture remains resilient:
-  - Sheets (editor surface) â†’ SQL (operational source) â†’ JSON cache (runtime source).
+  - Sheets (editor surface) → SQL (operational source) → JSON cache (runtime source).

--- a/docs/calendar/event_calendar_task5.md
+++ b/docs/calendar/event_calendar_task5.md
@@ -1,4 +1,4 @@
-# TASK 5 — Runtime Cache Consolidation, Health/Resilience Hardening, and Deterministic Quality Gates ✅ COMPLETED
+﻿# TASK 5 â€” Runtime Cache Consolidation, Health/Resilience Hardening, and Deterministic Quality Gates âœ… COMPLETED
 
 ## Objective
 Finalize Task 5 by consolidating runtime cache logic, integrating mandatory Task 4 review feedback, improving status/health resilience, and validating via pytest + SQL scripts in local-first deployment flow.
@@ -38,7 +38,7 @@ Finalize Task 5 by consolidating runtime cache logic, integrating mandatory Task
 ---
 
 ## 3) Status/health behavior (verbose structure preserved)
-- `/calendar_status` remains verbose.
+- `/ops calendar_status` remains verbose.
 - `calendar_health` path hardened:
   - stale/degraded evaluation retained
   - next upcoming event extraction retained
@@ -80,7 +80,7 @@ Result: **local SQL verification checks completed successfully**.
 - [x] Non-blocking status health path implemented
 - [x] Scheduler interval semantics corrected/validated
 - [x] Env-driven anomaly threshold controls added
-- [x] Verbose `/calendar_status` retained with health reporting
+- [x] Verbose `/ops calendar_status` retained with health reporting
 - [x] pytest updates completed and passing
 - [x] SQL verification scripts executed locally
 
@@ -90,4 +90,4 @@ Result: **local SQL verification checks completed successfully**.
 - `.env` can now tune anomaly thresholds without code changes.
 - Manual PR workflow remains unchanged.
 - Architecture remains resilient:
-  - Sheets (editor surface) → SQL (operational source) → JSON cache (runtime source).
+  - Sheets (editor surface) â†’ SQL (operational source) â†’ JSON cache (runtime source).

--- a/docs/calendar/event_calendar_task7_execution_brief.md
+++ b/docs/calendar/event_calendar_task7_execution_brief.md
@@ -1,11 +1,11 @@
-﻿# TASK 7 â€” Execution Brief (Admin Controls + Diagnostics) âœ… COMPLETED
+# TASK 7 — Execution Brief (Admin Controls + Diagnostics) ✅ COMPLETED
 
 ## Objective
 Provide robust admin command controls for manual pipeline execution and diagnostics, while preserving resilience guarantees and reusing existing canonical pipeline logic.
 
 Architecture remains:
 
-**Google Sheets â†’ SQL â†’ JSON cache â†’ Bot**
+**Google Sheets → SQL → JSON cache → Bot**
 
 ---
 

--- a/docs/calendar/event_calendar_task7_execution_brief.md
+++ b/docs/calendar/event_calendar_task7_execution_brief.md
@@ -1,21 +1,21 @@
-# TASK 7 — Execution Brief (Admin Controls + Diagnostics) ✅ COMPLETED
+﻿# TASK 7 â€” Execution Brief (Admin Controls + Diagnostics) âœ… COMPLETED
 
 ## Objective
 Provide robust admin command controls for manual pipeline execution and diagnostics, while preserving resilience guarantees and reusing existing canonical pipeline logic.
 
 Architecture remains:
 
-**Google Sheets → SQL → JSON cache → Bot**
+**Google Sheets â†’ SQL â†’ JSON cache â†’ Bot**
 
 ---
 
 ## Final implementation status
 
 ### 1) Command behavior
-- `/calendar_refresh` retained (no rename) and upgraded to trigger canonical full pipeline orchestration.
-- `/calendar_status` retained embed structure and extended diagnostic fields.
+- `/ops calendar_refresh` retained (no rename) and upgraded to trigger canonical full pipeline orchestration.
+- `/ops calendar_status` retained embed structure and extended diagnostic fields.
 
-### 2) `/calendar_refresh` operator summary
+### 2) `/ops calendar_refresh` operator summary
 Implemented output includes:
 - overall `ok`
 - `severity` (`ok|warning|degraded|failed`)
@@ -26,7 +26,7 @@ Implemented output includes:
 - publish reason
 - concise error context on failure paths
 
-### 3) `/calendar_status` diagnostics
+### 3) `/ops calendar_status` diagnostics
 Extended output now includes:
 - sync/generate/publish blocks with last timestamps
 - pipeline status + last run timestamp + run id
@@ -63,8 +63,8 @@ Extended output now includes:
 - Task 7 SQL verification scripts passed locally in SQL workflow.
 
 ### Manual smoke tests
-- `/calendar_refresh`: successful, run id + durations + counts shown.
-- `/calendar_status`: successful, pipeline + health diagnostics shown.
+- `/ops calendar_refresh`: successful, run id + durations + counts shown.
+- `/ops calendar_status`: successful, pipeline + health diagnostics shown.
 
 ---
 

--- a/docs/calendar/event_calendar_task7_scope.md
+++ b/docs/calendar/event_calendar_task7_scope.md
@@ -1,4 +1,4 @@
-# TASK 7 — Admin Commands (Manual Control + Diagnostics)
+﻿# TASK 7 â€” Admin Commands (Manual Control + Diagnostics)
 
 ## Objective
 Provide robust admin command controls for manual pipeline execution and diagnostics, while preserving Task 6 resilience guarantees and integrating Task 6 code-review follow-ups.
@@ -17,7 +17,7 @@ Primary operator outcomes:
 Implement/standardize:
 
 - `/refresh_calendar`
-- `/calendar_status`
+- `/ops calendar_status`
 
 Suggested file:
 
@@ -33,7 +33,7 @@ Runs canonical pipeline and returns concise operational summary:
 - generated/published counts
 - errors (if any)
 
-### `/calendar_status`
+### `/ops calendar_status`
 Must work at all times (even before any refresh) and display:
 
 - last sync time/status
@@ -76,7 +76,7 @@ Remove non-essential inline fixture comment:
 
 - `type_index_path = "cache/event_type_index.json"`
 
-(no inline “add this” comment)
+(no inline â€œadd thisâ€ comment)
 
 ### D) Retry policy currently bypassed by stage wrappers
 Issue:
@@ -132,7 +132,7 @@ Task 7 requirement:
 - error embeds/messages must include stage + concise error detail
 
 ### 2) Status behavior without refresh
-`/calendar_status` must return meaningful output if no pipeline run has happened yet:
+`/ops calendar_status` must return meaningful output if no pipeline run has happened yet:
 
 - explicit `not_started` values
 - no crashes on missing cache file
@@ -157,7 +157,7 @@ Task 7 requirement:
 ## Acceptance criteria
 
 - [x] `/refresh_calendar` triggers canonical pipeline and returns summary
-- [x] `/calendar_status` works before and after refresh runs
+- [x] `/ops calendar_status` works before and after refresh runs
 - [x] status includes sync/generate/publish/pipeline + cache health elements
 - [x] errors are clearly reported with stage context
 - [x] command path remains Sheets-decoupled at runtime read layer
@@ -188,8 +188,8 @@ Cover:
 
 1. `/refresh_calendar` happy path response includes run id + stage summary
 2. `/refresh_calendar` failure path includes stage + error detail
-3. `/calendar_status` works with no prior run (`not_started` states)
-4. `/calendar_status` with cache missing/invalid returns safe diagnostics
+3. `/ops calendar_status` works with no prior run (`not_started` states)
+4. `/ops calendar_status` with cache missing/invalid returns safe diagnostics
 5. scheduler timeout policy bound is valid for configured stage policies
 6. result-based retry path retries configured retryable statuses
 7. non-retryable statuses do not retry
@@ -218,7 +218,7 @@ Suggested additions:
 ## Implementation order (recommended)
 
 1. Wire/standardize `/refresh_calendar` command to canonical pipeline call
-2. Wire/standardize `/calendar_status` output contract
+2. Wire/standardize `/ops calendar_status` output contract
 3. Add stage/run-id summary formatting helpers
 4. Fix scheduler outer-timeout policy strategy
 5. Update service retry logic to support result-based retry eligibility

--- a/docs/calendar/event_calendar_task7_scope.md
+++ b/docs/calendar/event_calendar_task7_scope.md
@@ -1,4 +1,4 @@
-﻿# TASK 7 â€” Admin Commands (Manual Control + Diagnostics)
+# TASK 7 — Admin Commands (Manual Control + Diagnostics)
 
 ## Objective
 Provide robust admin command controls for manual pipeline execution and diagnostics, while preserving Task 6 resilience guarantees and integrating Task 6 code-review follow-ups.
@@ -76,7 +76,7 @@ Remove non-essential inline fixture comment:
 
 - `type_index_path = "cache/event_type_index.json"`
 
-(no inline â€œadd thisâ€ comment)
+(no inline “add this” comment)
 
 ### D) Retry policy currently bypassed by stage wrappers
 Issue:

--- a/docs/calendar/task4_runbook_local_validation.md
+++ b/docs/calendar/task4_runbook_local_validation.md
@@ -1,4 +1,4 @@
-﻿# Task 4 Local Validation Runbook
+# Task 4 Local Validation Runbook
 
 ## 1) Pytest (calendar target suites)
 

--- a/docs/calendar/task4_runbook_local_validation.md
+++ b/docs/calendar/task4_runbook_local_validation.md
@@ -1,4 +1,4 @@
-# Task 4 Local Validation Runbook
+﻿# Task 4 Local Validation Runbook
 
 ## 1) Pytest (calendar target suites)
 
@@ -54,7 +54,7 @@ Expected:
 
 ## 5) Status and stale-cache checks
 
-Run `/calendar_status` and verify:
+Run `/ops calendar_status` and verify:
 
 - `sync`, `generate`, `publish` sections present
 - `calendar_health` includes:

--- a/docs/inventory/Codex Task Pack - Inventory Image Import Module.md
+++ b/docs/inventory/Codex Task Pack - Inventory Image Import Module.md
@@ -1,4 +1,4 @@
-﻿# Codex Task Pack - Inventory Image Import Module
+# Codex Task Pack - Inventory Image Import Module
 
 ## Status Summary
 

--- a/docs/inventory/Codex Task Pack - Inventory Image Import Module.md
+++ b/docs/inventory/Codex Task Pack - Inventory Image Import Module.md
@@ -1,4 +1,4 @@
-# Codex Task Pack - Inventory Image Import Module
+﻿# Codex Task Pack - Inventory Image Import Module
 
 ## Status Summary
 
@@ -42,9 +42,9 @@ Phase 0 PRs:
 
 Phase 1A delivered:
 
-- Canonical `/import_inventory` command.
+- Canonical `/inventory import` command.
 - Upload-first inventory image detection limited to `INVENTORY_UPLOAD_CHANNEL_ID`.
-- `/import_inventory` restricted to `INVENTORY_UPLOAD_CHANNEL_ID`.
+- `/inventory import` restricted to `INVENTORY_UPLOAD_CHANNEL_ID`.
 - Vision-derived image type instead of asking the user to choose Resources vs Speedups first.
 - Resources and Speedups import foundation.
 - Materials detection handled as disabled until Phase 2.
@@ -110,7 +110,7 @@ Phase 1B validation:
 Phase 1C delivered:
 
 - `/export_inventory` raw inventory exports.
-- `/inventory_import_audit` admin audit tooling.
+- `/inventory audit` admin audit tooling.
 - Export and audit logic kept behind service/DAL boundaries.
 - Admin audit/debug reference access for import review.
 - Interaction boundary hardening follow-up.
@@ -319,12 +319,12 @@ Phase 1A established the import foundation and live intake path for Resources an
 
 Use these command names:
 
-- `/import_inventory`
+- `/inventory import`
 - `/myinventory`
 - `/export_inventory`
-- `/inventory_import_audit`
+- `/inventory audit`
 
-Canonical import command name is `/import_inventory`.
+Canonical import command name is `/inventory import`.
 
 Do not use `/inventory_import` for the user-facing command name.
 
@@ -332,10 +332,10 @@ Do not use `/inventory_import` for the user-facing command name.
 
 Add:
 
-- `/import_inventory` - complete in Phase 1A.
+- `/inventory import` - complete in Phase 1A.
 - `/myinventory` - complete in Phase 1B.
 - `/export_inventory` - complete in Phase 1C.
-- `/inventory_import_audit` - complete in Phase 1C.
+- `/inventory audit` - complete in Phase 1C.
 
 Commands must live in the target architecture, likely `commands/inventory_cmds.py`, with business logic in service modules and data access in DAL/repository modules.
 
@@ -350,15 +350,15 @@ Commands must use existing project command standards:
 
 Commands must not contain direct SQL or business logic.
 
-`/import_inventory` must be restricted to `INVENTORY_UPLOAD_CHANNEL_ID` using the existing channel restriction pattern. Admin override may be allowed where consistent with existing command behaviour, but the command must not be available across arbitrary channels.
+`/inventory import` must be restricted to `INVENTORY_UPLOAD_CHANNEL_ID` using the existing channel restriction pattern. Admin override may be allowed where consistent with existing command behaviour, but the command must not be available across arbitrary channels.
 
 Upload-first detection must also be restricted to `INVENTORY_UPLOAD_CHANNEL_ID`. Do not scan arbitrary server image uploads.
 
-### `/import_inventory` Flow
+### `/inventory import` Flow
 
 Status: complete in Phase 1A.
 
-1. User runs `/import_inventory`.
+1. User runs `/inventory import`.
 2. Bot shows standard governor selector, reusing the `/mykvktargets` / registry account-selection pattern where practical.
 3. User selects governor.
 4. Bot opens or uses a private ephemeral upload workflow.
@@ -391,7 +391,7 @@ If the detected type is Materials during Phase 1, the bot must explain that Mate
 
 Status: complete in Phase 1A.
 
-Users may start an import by uploading an image directly in the configured inventory channel instead of running `/import_inventory`.
+Users may start an import by uploading an image directly in the configured inventory channel instead of running `/inventory import`.
 
 1. User uploads an image attachment in `INVENTORY_UPLOAD_CHANNEL_ID`.
 2. Bot confirms the message is in the configured inventory channel and contains a supported image attachment.
@@ -402,7 +402,7 @@ Users may start an import by uploading an image directly in the configured inven
 7. If multiple registered governors exist, bot asks which governor the image is for using the standard account selector.
 8. Once the governor is confirmed, bot deletes the original public upload message when it has permission to reduce the public visibility window.
 9. If the user does not respond to the governor-selection follow-up before timeout, bot deletes the original public upload message when it has permission and exits cleanly.
-10. After governor confirmation, the same vision analysis, confirmation, correction, cancellation, approval, daily limit, and debug retention rules as `/import_inventory` apply.
+10. After governor confirmation, the same vision analysis, confirmation, correction, cancellation, approval, daily limit, and debug retention rules as `/inventory import` apply.
 
 Upload-first detection must never run outside `INVENTORY_UPLOAD_CHANNEL_ID`.
 
@@ -813,7 +813,7 @@ Phase 1C is complete, tested, and deployed.
 Delivered scope:
 
 - `/export_inventory`
-- `/inventory_import_audit`
+- `/inventory audit`
 - raw inventory export using service/DAL boundaries
 - admin audit filtering and debug-message reference access
 - compare detected, corrected, and final JSON for retained admin review
@@ -1368,7 +1368,7 @@ Materials:
 
 Add:
 
-- `/inventory_import_audit`
+- `/inventory audit`
 
 Admin only.
 
@@ -1402,7 +1402,7 @@ Test:
 
 - registered governor permission - Phase 1A complete
 - admin override - Phase 1A complete
-- `/import_inventory` restricted to `INVENTORY_UPLOAD_CHANNEL_ID` - Phase 1A complete
+- `/inventory import` restricted to `INVENTORY_UPLOAD_CHANNEL_ID` - Phase 1A complete
 - upload-first detection restricted to `INVENTORY_UPLOAD_CHANNEL_ID` - Phase 1A complete
 - upload-first ignores images outside the configured inventory channel - Phase 1A complete
 - upload-first no registered governors path - Phase 1A complete
@@ -1420,7 +1420,7 @@ Test:
 - image output generation - Phase 1B complete for Resources and Speedups
 - visibility preference persistence - Phase 1B complete
 - `/export_inventory` - Phase 1C
-- `/inventory_import_audit` - Phase 1C
+- `/inventory audit` - Phase 1C
 - restart/persistence behaviour for active/imported state - Phase 1A complete for import batches; Phase 1B complete for reporting preferences
 - cache safety where applicable - continue in Phase 1C
 
@@ -1453,14 +1453,14 @@ Complete, tested, and deployed.
 Delivered scope:
 
 - `/export_inventory`
-- `/inventory_import_audit`
+- `/inventory audit`
 - raw inventory export files using service/DAL boundaries
 - admin audit filtering and debug-message reference access
 - targeted cleanup of Phase 1A inventory view/service boundaries
 
 Recommended Phase 1C audit points:
 
-- Verify command names remain canonical: `/export_inventory`, `/inventory_import_audit`.
+- Verify command names remain canonical: `/export_inventory`, `/inventory audit`.
 - Keep `/export_inventory` service/DAL-based and do not copy direct SQL from `/my_stats_export`.
 - Confirm GitHub issue #46 remains the tracking item for the existing stats export direct-SQL refactor.
 - Do not expand into `/my_stats` integration.
@@ -1566,7 +1566,7 @@ Do not include in Phase 1B:
 - Import Again button
 - Export button under image
 - `/export_inventory`
-- `/inventory_import_audit`
+- `/inventory audit`
 - Further OCR/prompt tuning unless a Phase 1A production issue specifically requires it
 
 Do not include in Phase 1C:

--- a/docs/inventory/Codex_Task_Pack_Inventory_Phase_2_Materials.md
+++ b/docs/inventory/Codex_Task_Pack_Inventory_Phase_2_Materials.md
@@ -1,8 +1,8 @@
-﻿# Codex Task Pack â€” Inventory Image Import Module â€” Phase 2 Materials
+# Codex Task Pack — Inventory Image Import Module — Phase 2 Materials
 
 ## Status / Context
 
-Phase 0 and Phase 1Aâ€“1E are complete and deployed. Phase 1F should already be complete before this phase begins. Phase 2 is the Materials phase only.
+Phase 0 and Phase 1A–1E are complete and deployed. Phase 1F should already be complete before this phase begins. Phase 2 is the Materials phase only.
 
 Phase 2 must extend the existing Inventory Image Import Module to support Rise of Kingdoms equipment materials screenshots, while preserving the current Resources and Speedups behaviour.
 
@@ -224,19 +224,19 @@ Keep current privacy behaviour:
 
 ## Accepted Materials Image Types
 
-### Type A â€” Choice Chest screen
+### Type A — Choice Chest screen
 
 Recognise Equipment Material Choice Chests in these rarities:
 
-- Normal choice chest â€” grey
-- Advanced choice chest â€” green
-- Elite choice chest â€” blue
-- Epic choice chest â€” purple
-- Legendary choice chest â€” orange
+- Normal choice chest — grey
+- Advanced choice chest — green
+- Elite choice chest — blue
+- Epic choice chest — purple
+- Legendary choice chest — orange
 
 Store choice chests separately from fixed material types because they are flexible inventory, not committed to Bone, Leather, Ebony, or Iron.
 
-### Type B/C â€” Individual materials
+### Type B/C — Individual materials
 
 Recognise these material types:
 
@@ -247,11 +247,11 @@ Recognise these material types:
 
 Each material can appear in these rarities:
 
-- Normal â€” grey
-- Advanced â€” green
-- Elite â€” blue
-- Epic â€” purple
-- Legendary â€” orange
+- Normal — grey
+- Advanced — green
+- Elite — blue
+- Epic — purple
+- Legendary — orange
 
 The individual material rows may be split over two or more screenshots.
 
@@ -567,11 +567,11 @@ Codex must explicitly address this in Step 1 audit and Step 4 implementation pla
 
 Use these uploaded samples during local testing:
 
-- `material_summary_exampleonly_output.png` â€” output design reference only.
-- `Materials_import1.png` â€” materials import test image.
-- `Materials_import2.png` â€” materials import test image.
-- `Materials_import3.png` â€” materials import test image.
-- `Materials_import4.png` â€” materials import test image.
+- `material_summary_exampleonly_output.png` — output design reference only.
+- `Materials_import1.png` — materials import test image.
+- `Materials_import2.png` — materials import test image.
+- `Materials_import3.png` — materials import test image.
+- `Materials_import4.png` — materials import test image.
 
 Expected interpretation from supplied samples should be established during audit/test setup. More samples will be added during actual testing.
 
@@ -695,5 +695,5 @@ Codex must return:
 ## Suggested Opening Prompt for Codex
 
 ```text
-Start Phase 2 review/scope for the Inventory Image Import Module: Materials Import. Phase 0 and Phase 1Aâ€“1F are complete. Use the updated task pack at docs/inventory/Codex Task Pack - Inventory Image Import Module.md and the Phase 2 Materials task pack. Scope is Materials only: up to 4 screenshots per governor/day, choice chests, individual materials, raw SQL storage, legendary-equivalent calculations, typed correction flow, /myinventory Materials output, export, and audit. Keep AP, /my_stats integration, export button under images, import-again button, and broad Resources/Speedups redesign out of scope. Begin with audit/scope only and STOP for architecture validation before coding.
+Start Phase 2 review/scope for the Inventory Image Import Module: Materials Import. Phase 0 and Phase 1A–1F are complete. Use the updated task pack at docs/inventory/Codex Task Pack - Inventory Image Import Module.md and the Phase 2 Materials task pack. Scope is Materials only: up to 4 screenshots per governor/day, choice chests, individual materials, raw SQL storage, legendary-equivalent calculations, typed correction flow, /myinventory Materials output, export, and audit. Keep AP, /my_stats integration, export button under images, import-again button, and broad Resources/Speedups redesign out of scope. Begin with audit/scope only and STOP for architecture validation before coding.
 ```

--- a/docs/inventory/Codex_Task_Pack_Inventory_Phase_2_Materials.md
+++ b/docs/inventory/Codex_Task_Pack_Inventory_Phase_2_Materials.md
@@ -1,8 +1,8 @@
-# Codex Task Pack — Inventory Image Import Module — Phase 2 Materials
+﻿# Codex Task Pack â€” Inventory Image Import Module â€” Phase 2 Materials
 
 ## Status / Context
 
-Phase 0 and Phase 1A–1E are complete and deployed. Phase 1F should already be complete before this phase begins. Phase 2 is the Materials phase only.
+Phase 0 and Phase 1Aâ€“1E are complete and deployed. Phase 1F should already be complete before this phase begins. Phase 2 is the Materials phase only.
 
 Phase 2 must extend the existing Inventory Image Import Module to support Rise of Kingdoms equipment materials screenshots, while preserving the current Resources and Speedups behaviour.
 
@@ -24,7 +24,7 @@ Implemented capability:
 - Approval writes one logical import batch with material child rows.
 - `/myinventory` supports Materials output with KPI cards, trend graph, range controls, and `assets/materials_logo.png`.
 - `/export_inventory` includes Materials rows.
-- `/inventory_import_audit` supports Materials imports and Materials-related debug metadata.
+- `/inventory audit` supports Materials imports and Materials-related debug metadata.
 - Admin debug captures failed, rejected, cancelled, corrected, and low-confidence Materials paths.
 - Existing Resources and Speedups behaviour was preserved.
 
@@ -103,7 +103,7 @@ Final local validation snapshot:
 - Materials approval workflow.
 - Materials output image under `/myinventory`.
 - Materials support in `/export_inventory`.
-- Materials support in `/inventory_import_audit`.
+- Materials support in `/inventory audit`.
 - Admin debug retention for failed, corrected, cancelled, rejected, or low-confidence material imports.
 - Test coverage for parsing, conversion, import sessions, reporting, export, and audit.
 
@@ -224,19 +224,19 @@ Keep current privacy behaviour:
 
 ## Accepted Materials Image Types
 
-### Type A — Choice Chest screen
+### Type A â€” Choice Chest screen
 
 Recognise Equipment Material Choice Chests in these rarities:
 
-- Normal choice chest — grey
-- Advanced choice chest — green
-- Elite choice chest — blue
-- Epic choice chest — purple
-- Legendary choice chest — orange
+- Normal choice chest â€” grey
+- Advanced choice chest â€” green
+- Elite choice chest â€” blue
+- Epic choice chest â€” purple
+- Legendary choice chest â€” orange
 
 Store choice chests separately from fixed material types because they are flexible inventory, not committed to Bone, Leather, Ebony, or Iron.
 
-### Type B/C — Individual materials
+### Type B/C â€” Individual materials
 
 Recognise these material types:
 
@@ -247,11 +247,11 @@ Recognise these material types:
 
 Each material can appear in these rarities:
 
-- Normal — grey
-- Advanced — green
-- Elite — blue
-- Epic — purple
-- Legendary — orange
+- Normal â€” grey
+- Advanced â€” green
+- Elite â€” blue
+- Epic â€” purple
+- Legendary â€” orange
 
 The individual material rows may be split over two or more screenshots.
 
@@ -520,7 +520,7 @@ Do not expose private image URLs to normal users unless already allowed by the e
 
 ## Admin Audit Requirements
 
-Extend `/inventory_import_audit` filters and display to support `materials` import type.
+Extend `/inventory audit` filters and display to support `materials` import type.
 
 Audit should allow review of:
 
@@ -567,11 +567,11 @@ Codex must explicitly address this in Step 1 audit and Step 4 implementation pla
 
 Use these uploaded samples during local testing:
 
-- `material_summary_exampleonly_output.png` — output design reference only.
-- `Materials_import1.png` — materials import test image.
-- `Materials_import2.png` — materials import test image.
-- `Materials_import3.png` — materials import test image.
-- `Materials_import4.png` — materials import test image.
+- `material_summary_exampleonly_output.png` â€” output design reference only.
+- `Materials_import1.png` â€” materials import test image.
+- `Materials_import2.png` â€” materials import test image.
+- `Materials_import3.png` â€” materials import test image.
+- `Materials_import4.png` â€” materials import test image.
 
 Expected interpretation from supplied samples should be established during audit/test setup. More samples will be added during actual testing.
 
@@ -617,7 +617,7 @@ Add focused tests.
 ### Export/audit tests
 
 - `/export_inventory` includes Materials rows.
-- `/inventory_import_audit` supports Materials filter.
+- `/inventory audit` supports Materials filter.
 - Corrected Materials imports show detected/corrected/final metadata.
 - Failed/cancelled Materials imports retain debug references where expected.
 
@@ -669,7 +669,7 @@ Phase 2 is complete when:
 - `/myinventory` can render Materials output with KPI cards and trend graph.
 - `/myinventory` output selector includes Materials but not AP.
 - `/export_inventory` includes Materials rows.
-- `/inventory_import_audit` supports Materials imports.
+- `/inventory audit` supports Materials imports.
 - Failed/cancelled/corrected Materials imports are retained in admin debug where required.
 - Restart/timeout safety is explicitly handled.
 - Existing Resources and Speedups behaviour is unchanged.
@@ -695,5 +695,5 @@ Codex must return:
 ## Suggested Opening Prompt for Codex
 
 ```text
-Start Phase 2 review/scope for the Inventory Image Import Module: Materials Import. Phase 0 and Phase 1A–1F are complete. Use the updated task pack at docs/inventory/Codex Task Pack - Inventory Image Import Module.md and the Phase 2 Materials task pack. Scope is Materials only: up to 4 screenshots per governor/day, choice chests, individual materials, raw SQL storage, legendary-equivalent calculations, typed correction flow, /myinventory Materials output, export, and audit. Keep AP, /my_stats integration, export button under images, import-again button, and broad Resources/Speedups redesign out of scope. Begin with audit/scope only and STOP for architecture validation before coding.
+Start Phase 2 review/scope for the Inventory Image Import Module: Materials Import. Phase 0 and Phase 1Aâ€“1F are complete. Use the updated task pack at docs/inventory/Codex Task Pack - Inventory Image Import Module.md and the Phase 2 Materials task pack. Scope is Materials only: up to 4 screenshots per governor/day, choice chests, individual materials, raw SQL storage, legendary-equivalent calculations, typed correction flow, /myinventory Materials output, export, and audit. Keep AP, /my_stats integration, export button under images, import-again button, and broad Resources/Speedups redesign out of scope. Begin with audit/scope only and STOP for architecture validation before coding.
 ```

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -22,6 +22,7 @@ Read the task brief, issue, or task pack before these documents when one exists.
 |------|-----------|
 | Deferred optimisation backlog | `deferred_optimisations.md` |
 | Deferred optimisation batching/scoring | `K98 Bot Deferred Optimisation Scoring Model.md` |
+| Command reference and command-surface governance | `canonical_command_reference.md` |
 | Promotion or deployment | `Promotion Guide.md`, `runbook_devops.md` |
 | Environment variables or runtime config | `ENV_REFERENCE.md` |
 | Startup lifecycle | `runbook_startup.md`, `singleton_lock.md` |

--- a/docs/reference/canonical_command_reference.md
+++ b/docs/reference/canonical_command_reference.md
@@ -1,0 +1,196 @@
+# Canonical Command Reference
+
+Last updated: 2026-06-02
+
+This is the maintained command reference for the K98 bot after Command Platform Phase 5A. Use
+this document for current command paths, ownership, permissions, visibility, and command-surface
+governance. Historical migration notes remain in `command_platform_audit.md` and
+`command_surface_audit.md`.
+
+## Source Of Truth
+
+The runtime source of truth is the active `commands/` package registered through
+`commands/register_all()`. Static command-count validation is provided by
+`scripts/validate_command_registration.py`, which uses `commands/command_inventory.py`.
+
+Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+Grouped command summary:
+
+| Group | Subcommands |
+|---|---:|
+| `/activity` | 1 |
+| `/ark` | 14 |
+| `/crystaltech` | 3 |
+| `/events` | 2 |
+| `/honor` | 1 |
+| `/inventory` | 2 |
+| `/kvk` | 7 |
+| `/location` | 2 |
+| `/mge` | 6 |
+| `/ops` | 25 |
+| `/prekvk` | 2 |
+| `/registry` | 7 |
+| `/stats` | 1 |
+| `/subscriptions` | 3 |
+
+## Command Surface Rules
+
+- New admin, leadership, operator, diagnostic, and domain-maintenance commands should be designed
+  group-first unless an approved task explicitly keeps them flat.
+- Preserve player self-service and public calendar/KVK calendar commands as flat paths until a
+  dedicated workflow redesign is approved.
+- All active commands are expected to use `@versioned()`, `@safe_command`, and `@track_usage()`
+  unless a task explicitly documents a local exception.
+- Grouped usage tracking should record the qualified command path, for example `stats player` or
+  `inventory import`.
+- Any command path change must update this file, relevant operator docs, command-registration
+  validation expectations, and smoke references.
+- Keep `scripts/validate_command_registration.py` green. The current warning threshold is 90
+  top-level commands and the hard limit is Discord's 100 top-level application-command ceiling.
+
+## Canonical Command Table
+
+Legend:
+
+- `Grouped` means the current path is a subcommand under a top-level group.
+- `Flat` means the command remains a top-level application command.
+- `Standard` version/usage means `@versioned()`, `@safe_command`, and `@track_usage()` are expected.
+- `Public` permission means there is no command-level admin/leadership decorator; channel, service,
+  or view-level checks may still apply.
+
+| Domain | Current path | Owner module | Status | Permission model | Response visibility | Version/usage | Migration/disposition | Operator notes |
+|---|---|---|---|---|---|---|---|---|
+| Activity | `/activity top` | `commands/activity_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Leadership activity report. |
+| Ark | `/ark create_match` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Ark setup workflow. |
+| Ark | `/ark force_announce` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral command response; public announcement side effect | Standard | Preserve | Reposts active Ark registration. |
+| Ark | `/ark amend_match` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Ark match amendment workflow. |
+| Ark | `/ark cancel_match` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Cancels Ark match and related reminders/DMs. |
+| Ark | `/ark reminder_prefs` | `commands/ark_cmds.py` | Grouped | Public command-level access | Ephemeral | Standard | Preserve | Player reminder settings. |
+| Ark | `/ark set_preference` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Sets player team preference. |
+| Ark | `/ark clear_preference` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Clears player team preference. |
+| Ark | `/ark ban_add` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Adds Ark signup ban. |
+| Ark | `/ark ban_revoke` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Revokes Ark signup ban. |
+| Ark | `/ark ban_list` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Lists active Ark bans. |
+| Ark | `/ark set_result` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Records Ark result. |
+| Ark | `/ark report_players` | `commands/ark_cmds.py` | Grouped | Public command-level access | Public | Standard | Preserve | Player report. |
+| Ark | `/ark generate_draft` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Generates draft Ark teams. |
+| Ark | `/ark create_team` | `commands/ark_cmds.py` | Grouped | Admin or leadership plus Ark setup channel | Ephemeral | Standard | Preserve | Creates Ark team record. |
+| Calendar | `/calendar` | `commands/calendar_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer public calendar redesign | Calendar overview remains flat. |
+| Calendar | `/calendar_next_event` | `commands/calendar_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer public calendar redesign | Next generic calendar event. |
+| Calendar | `/calendar_reminder_config` | `commands/calendar_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player reminder configuration. |
+| Calendar Ops | `/ops calendar_refresh` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Runs full calendar refresh pipeline. |
+| Calendar Ops | `/ops calendar_generate` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Generates calendar cache/source data. |
+| Calendar Ops | `/ops calendar_publish_cache` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Publishes calendar runtime cache. |
+| Calendar Ops | `/ops calendar_status` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral by default; operator can choose public | Standard | Preserve | Calendar diagnostics. |
+| CrystalTech Ops | `/crystaltech validate` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Validates CrystalTech config. |
+| CrystalTech Ops | `/crystaltech reload` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Reloads CrystalTech config/cache. |
+| CrystalTech Ops | `/crystaltech admin_reset` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Resets CrystalTech state. |
+| Events | `/next_kvk_fight` | `commands/events_cmds.py` | Flat | Public command-level access | Public | Standard | Defer public calendar/KVK calendar redesign | Public KVK fight view. |
+| Events | `/next_kvk_event` | `commands/events_cmds.py` | Flat | Public command-level access | Public | Standard | Defer public calendar/KVK calendar redesign | Public KVK event view. |
+| Events | `/events refresh` | `commands/events_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Refreshes event cache/countdowns. |
+| Events | `/events refresh_kvk_overview` | `commands/events_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Refreshes daily KVK overview. |
+| Honor/KVK | `/honor_rankings` | `commands/stats_cmds.py` | Flat | KVK stats channel decorator | Public | Standard | Defer public ranking UX | Public/channel-limited ranking output. |
+| Honor/KVK | `/honor purge_last` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Purges latest honor scan. |
+| Inventory | `/inventory import` | `commands/inventory_cmds.py` | Grouped | Inventory upload channel decorator with admin override | Ephemeral | Standard | Preserve | Imports resources, speedups, or materials screenshots. |
+| Inventory | `/myinventory` | `commands/inventory_cmds.py` | Flat | Public command-level access | Ephemeral prompt; report visibility follows user preference | Standard | Defer player self-service redesign | Player inventory report. |
+| Inventory | `/inventory_preferences` | `commands/inventory_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Report visibility preference. |
+| Inventory | `/export_inventory` | `commands/inventory_cmds.py` | Flat | Service authorization with admin override context | Ephemeral | Standard | Defer player self-service redesign | Exports approved inventory records. |
+| Inventory | `/inventory audit` | `commands/inventory_cmds.py` | Grouped | Admin-only decorator | Ephemeral | Standard | Preserve | Inventory import audit. |
+| Location | `/location import` | `commands/location_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Imports location data. |
+| Location | `/location player` | `commands/location_cmds.py` | Grouped | Admin or leadership in allowed channels | User-selectable | Standard | Preserve | Leadership player-location lookup. |
+| MGE | `/mge leadership_board` | `commands/mge_cmds.py` | Grouped | Decorator-gated leadership/admin path | Ephemeral | Standard | Preserve | Leadership board controls. |
+| MGE | `/mge import_results` | `commands/mge_cmds.py` | Grouped | Decorator-gated admin path | Ephemeral | Standard | Preserve | Manual MGE results import. |
+| MGE | `/mge refresh_cache` | `commands/mge_cmds.py` | Grouped | Decorator-gated admin path | Ephemeral | Standard | Preserve | Refreshes MGE caches. |
+| MGE | `/mge refresh_award_reminders` | `commands/mge_cmds.py` | Grouped | Decorator-gated admin path | Ephemeral | Standard | Preserve | Refreshes MGE award reminders. |
+| MGE | `/mge commanders` | `commands/mge_cmds.py` | Grouped | Decorator-gated admin path | Ephemeral | Standard | Preserve | MGE commander controls. |
+| MGE | `/mge admin_completion` | `commands/mge_cmds.py` | Grouped | Decorator-gated admin path | Ephemeral | Standard | Preserve | Admin completion controls. |
+| Ops | `/ops summary` | `commands/admin_cmds.py` | Grouped | Public command-level access | Public | Standard | Preserve | Daily file-processing summary. |
+| Ops | `/ops weeksummary` | `commands/admin_cmds.py` | Grouped | Public command-level access | Public | Standard | Preserve | Seven-day file-processing summary. |
+| Ops | `/ops history` | `commands/admin_cmds.py` | Grouped | Admin-only decorator | Public | Standard | Preserve | Processed-file history. |
+| Ops | `/ops failures` | `commands/admin_cmds.py` | Grouped | Admin-only decorator | Public | Standard | Preserve | Failed-file history. |
+| Ops | `/ops run_sql_proc` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Runs configured SQL procedure. |
+| Ops | `/ops run_gsheets_export` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Runs Google Sheets export. |
+| Ops | `/ops graceful_restart` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Preferred cooperative restart. |
+| Ops | `/ops force_restart` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator plus permission checks | Ephemeral | Standard | Preserve | Break-glass restart. |
+| Ops | `/ops resync_commands` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Manual command sync/cache update. |
+| Ops | `/ops show_command_versions` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Version report. |
+| Ops | `/ops validate_command_cache` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Command-cache validation. |
+| Ops | `/ops view_restart_log` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Restart log output. |
+| Ops | `/ops import_proc_config` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator plus permission checks | Ephemeral | Standard | Preserve | ProcConfig import. |
+| Ops | `/ops dl_bot_status` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Bot status. |
+| Ops | `/ops logs` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Log tail controls. |
+| Ops | `/ops show_logs` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Log display. |
+| Ops | `/ops last_errors` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Recent errors. |
+| Ops | `/ops crash_log` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Crash log excerpt. |
+| Ops | `/ops test_embed` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Test embed dispatch. |
+| Ops | `/ops usage` | `commands/admin_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Usage analytics summary. |
+| Ops | `/ops usage_detail` | `commands/admin_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Usage analytics detail. |
+| Player/KVK | `/mykvktargets` | `commands/telemetry_cmds.py` | Flat | KVK target channel decorator with admin override | User-selectable | Standard | Defer player self-service redesign | Player target lookup. |
+| Player/KVK | `/mygovernorid` | `commands/telemetry_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Governor ID lookup. |
+| Player/KVK | `/player_profile` | `commands/telemetry_cmds.py` | Flat | Admin or leadership in allowed channels | Ephemeral | Standard | Defer profile workflow review | Leadership profile lookup. |
+| Player/KVK | `/mykvkcrystaltech` | `commands/telemetry_cmds.py` | Flat | CrystalTech channel decorator with admin override | User-selectable; defaults private | Standard | Defer player self-service redesign | Player CrystalTech progress. |
+| PreKvK | `/prekvk report` | `commands/prekvk_cmds.py` | Grouped | Public command-level access | Ephemeral | Standard | Preserve | Public read-only PreKvK report. |
+| PreKvK Admin | `/prekvk import_history` | `commands/prekvk_admin_cmds.py` | Grouped helper-attached | Admin notify-channel decorator | Ephemeral | Standard | Preserve | PreKvK history import. |
+| Registry | `/register_governor` | `commands/registry_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player account registration. |
+| Registry | `/modify_registration` | `commands/registry_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player registration modification. |
+| Registry | `/registry remove` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Removes registration by Discord user/slot. |
+| Registry | `/registry remove_by_id` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Removes registration by Governor ID. |
+| Registry | `/my_registrations` | `commands/registry_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player registration list/actions. |
+| Registry | `/registry admin_register` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Admin registration flow. |
+| Registry | `/registry audit` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Registry audit. |
+| Registry | `/registry bulk_export` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Registry bulk export. |
+| Registry | `/registry bulk_import_dryrun` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Registry import preview. |
+| Registry | `/registry bulk_import` | `commands/registry_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Registry import apply. |
+| Stats/KVK | `/kvk test_export` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | KVK export test. |
+| Stats/KVK | `/mykvkstats` | `commands/stats_cmds.py` | Flat | KVK stats channel decorator with admin override | Ephemeral | Standard | Defer player self-service redesign | Personal KVK stats. |
+| Stats/KVK | `/kvk refresh_stats_cache` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Refreshes stats cache. |
+| Stats/KVK | `/my_stats` | `commands/stats_cmds.py` | Flat | KVK stats channel decorator | User-selectable | Standard | Defer player self-service redesign | Personal stats report. |
+| Stats/KVK | `/my_stats_export` | `commands/stats_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Personal stats export. |
+| Stats/KVK | `/stats player` | `commands/stats_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Leadership player stats lookup. |
+| Stats/KVK | `/mykvkhistory` | `commands/stats_cmds.py` | Flat | KVK stats channel decorator with admin override | User-selectable | Standard | Defer player self-service redesign | Personal KVK history. |
+| Stats/KVK | `/kvk_rankings` | `commands/stats_cmds.py` | Flat | KVK stats channel decorator | Public | Standard | Defer public ranking UX | KVK rankings. |
+| Stats/KVK | `/kvk export_all` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | KVK Google Sheets export. |
+| Stats/KVK | `/kvk recompute` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Recompute KVK outputs. |
+| Stats/KVK | `/kvk list_scans` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Recent scan diagnostics. |
+| Stats/KVK | `/kvk test_embed` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | KVK embed test. |
+| Stats/KVK | `/kvk window_preview` | `commands/stats_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | KVK window preview. |
+| Subscriptions | `/subscribe` | `commands/subscriptions_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player subscription signup. |
+| Subscriptions | `/modify_subscription` | `commands/subscriptions_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player subscription edit. |
+| Subscriptions | `/unsubscribe` | `commands/subscriptions_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Player unsubscribe. |
+| Subscriptions | `/subscriptions list` | `commands/subscriptions_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Subscriber list. |
+| Subscriptions | `/subscriptions migrate_dryrun` | `commands/subscriptions_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Subscription migration preview. |
+| Subscriptions | `/subscriptions migrate_apply` | `commands/subscriptions_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Subscription migration apply. |
+| Telemetry | `/ping` | `commands/telemetry_cmds.py` | Flat | Public command-level access | Public | Standard | Preserve flat health/debug path | Basic bot response test. |
+
+## Migration And Disposition Notes
+
+- Phase 3 grouped low-risk ops/reporting commands under `/ops`.
+- Phase 4 grouped all Ark commands under `/ark`.
+- Phase 5A grouped approved admin, leadership, and operator paths under `/activity`,
+  `/crystaltech`, `/events`, `/honor`, `/inventory`, `/kvk`, `/location`, `/ops`, `/registry`,
+  `/stats`, and `/subscriptions`.
+- Player self-service paths remain flat pending a dedicated workflow redesign.
+- Public calendar and KVK calendar paths remain flat pending a dedicated UX redesign.
+- `/ping` remains flat for simple health/debug discoverability.
+
+## Validation Expectations
+
+For command documentation or command-surface changes, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+For runtime command changes, also run focused command, permission, interaction, and lifecycle tests
+for the affected domain. Run or justify skipping Codex Security review when command runtime,
+permission, interaction, SQL/data access, file handling, config, network, user-input, or
+restart-sensitive persistence behavior changes.

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -1,6 +1,6 @@
 # Command Platform Audit
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 ## Programme Status
 
@@ -34,14 +34,18 @@ Phase 5, Public Domain Grouping Design, was completed in PR 135
 domain grouping only, and deferred player self-service plus public calendar/KVK calendar workflow
 redesign out of the command-count programme.
 
-Phase 5A, Admin/Leadership/Operator Domain Grouping, grouped the approved admin, leadership, and
-operator paths under `/activity`, `/crystaltech`, `/events`, `/honor`, `/inventory`, `/kvk`,
-`/location`, `/ops`, `/registry`, `/stats`, and `/subscriptions` while preserving player
-self-service and public calendar/KVK calendar paths.
+Phase 5A, Admin/Leadership/Operator Domain Grouping, was completed in PR 136
+(`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
+to production. It grouped the approved admin, leadership, and operator paths under `/activity`,
+`/crystaltech`, `/events`, `/honor`, `/inventory`, `/kvk`, `/location`, `/ops`, `/registry`,
+`/stats`, and `/subscriptions` while preserving player self-service and public calendar/KVK
+calendar paths. Smoke follow-up fixes preserved grouped usage-log identities, restored
+CrystalTech service imports, awaited `/stats player` embed rendering, and chunked long
+`/kvk list_scans` output below Discord content limits.
 
 ## Audit Baseline
 
-Static command registration validation after Phase 5A implementation reports:
+Static command registration validation after Phase 5A delivery reports:
 
 ```text
 primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
@@ -68,6 +72,11 @@ Grouped command summary:
 
 The primary command surface has a 61-command buffer below Discord's 100 top-level application
 command limit. The validator warns at 90+ and fails above 100.
+
+The maintained command reference after Phase 6 lives in `canonical_command_reference.md`. Use that
+file for current command paths, owner modules, permission models, response visibility, and
+version/usage expectations. The inventory below remains audit context for the command-platform
+programme.
 
 Usage levels below are based only on local JSONL usage files under `data/command_usage_*.jsonl`
 available during the audit. SQL-backed production history may contain broader usage evidence.
@@ -241,14 +250,15 @@ commands are marked `none observed` pending SQL usage review.
   tested with a graceful restart and `/ops validate_command_cache`, merged, and pushed to
   production.
 
-### Deferred Optimisation
+### Phase 6 Completed Item
 - Area: `commands/`, command documentation
 - Type: consistency
 - Description: Permission model and command-path documentation are not consistently discoverable across domains.
-- Suggested Fix: Promote this inventory into a canonical command reference with path, owner, permissions, usage, migration status, and operator-facing notes.
-- Impact: high
-- Risk: low
-- Dependencies: Complete SQL-backed usage review or explicitly accept local JSONL-only usage evidence.
+- Resolution: Phase 6 promoted the current command inventory into `canonical_command_reference.md`
+  with path, owner, permissions, response visibility, usage/version expectations, migration
+  status, and operator-facing notes.
+- Validation: Documentation validation, command registration validation, focused command
+  inventory/registration tests, and pre-commit are required before PR handoff.
 
 ## Phased Roadmap
 
@@ -439,7 +449,8 @@ Validation:
 
 ### Phase 5A - Admin/Leadership/Operator Domain Grouping
 
-Status: implemented in this Phase 5A branch.
+Status: complete. Delivered in PR 136 (`codex/command-platform-phase-5a-admin-grouping`), smoke
+tested successfully, merged, and pushed to production.
 
 Goal: group only the approved admin/leadership/operator command slice.
 
@@ -480,13 +491,27 @@ Validation:
 - Command registration validation reports
   `primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`.
 
+Delivered validation:
+
+- Architecture boundary validation, deferred optimisation validation, test selector, smoke
+  imports, command registration validation, pre-commit, full pytest, pytest log-noise analysis,
+  and Codex Security diff review passed before PR handoff.
+- Production smoke confirmed the grouped command surface and exposed two runtime issues that were
+  fixed before final merge/promotion: `/stats player` now awaits async embed rendering and
+  `/kvk list_scans` chunks long scan output under Discord's content limit.
+- Review follow-ups confirmed grouped command usage logging records full paths such as
+  `stats player`, `inventory import`, and `location import`, including denied grouped
+  invocations where `ApplicationContext.command.qualified_name` is available.
+
 ### Phase 6 - Canonical Command Documentation
+
+Status: in progress.
 
 Goal: make command ownership, permissions, and path status discoverable.
 
 Scope:
 
-- Promote this audit into a maintained command reference.
+- Promote this audit into `canonical_command_reference.md` as the maintained command reference.
 - Update stale Ark, calendar, inventory, registry, and KVK docs after approved path changes.
 - Add guidance for new commands: group-first design, permission decorator choice, test minimums,
   and command-count impact.
@@ -524,7 +549,8 @@ Validation:
 7. Phase 6: Canonical Command Documentation.
 8. Phase 7: Future Governance And CI Guardrails.
 
-With Phase 5A implemented, the next command-platform work should be canonical command
-documentation and governance guardrails. Player self-service workflow redesign and public
-calendar/KVK calendar redesign remain deferred into separate optimisation tasks rather than
-continued as simple command grouping inside this programme.
+With Phase 5A delivered, merged, smoke tested, and promoted, Phase 6 is creating the maintained
+canonical command reference. Phase 7 governance and CI guardrails should follow once the reference
+is merged. Player self-service workflow redesign and public calendar/KVK calendar redesign remain
+deferred into separate optimisation tasks rather than continued as simple command grouping inside
+this programme.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -1,6 +1,6 @@
 # Command Surface Audit
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 ## Post-Audit Programme Updates
 
@@ -33,19 +33,26 @@ Command Platform Phase 5, Public Domain Grouping Design, was completed in PR 135
 domain grouping only, and deferred player self-service plus public calendar/KVK calendar redesign
 outside this command-count programme.
 
-Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping, grouped the approved admin,
-leadership, and operator paths by domain while preserving player self-service commands and generic
-public calendar/KVK calendar commands.
+Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping, was completed in PR 136
+(`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
+to production. Phase 5A grouped the approved admin, leadership, and operator paths by domain while
+preserving player self-service commands and generic public calendar/KVK calendar commands. Smoke
+follow-up fixes preserved grouped usage-log identities, restored CrystalTech service imports,
+awaited `/stats player` embed rendering, and chunked long `/kvk list_scans` output under
+Discord's content limit.
 
-Current baseline after Phase 5A implementation:
+Current baseline after Phase 5A delivery:
 
 ```text
 primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
 ```
 
-The next command-platform phases are canonical command documentation and future governance/CI
-guardrails. Player self-service and generic public calendar/KVK calendar redesign remain deferred
-outside this command-count programme.
+Phase 6, Canonical Command Documentation, created `canonical_command_reference.md` as the
+maintained current command reference. Phase 7 governance and CI guardrails should follow after the
+canonical command reference is merged. Player self-service and generic public calendar/KVK calendar
+redesign remain deferred outside this command-count programme.
+
+This file remains the historical command-surface audit and migration record.
 
 ## Current Registration Summary
 
@@ -152,13 +159,14 @@ usage tracking, options, and modal/view flows while moving all Ark commands into
 Phase 5A completed the approved admin/leadership/operator domain grouping across registry admin,
 KVK/stat admin, inventory import/audit, calendar/event admin refresh/status paths, subscriptions
 admin, CrystalTech admin, honor purge, location admin/leadership, and activity leadership
-commands.
+commands. It was delivered in PR 136, smoke tested successfully, merged, and pushed to
+production.
 
 Remaining command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
 command-platform programme docs. Recommended order:
 
-1. Canonical command documentation after Phase 5A path changes.
-2. Future governance and CI guardrails.
+1. Phase 6: Canonical command documentation after Phase 5A path changes.
+2. Phase 7: Future governance and CI guardrails.
 
 The previously considered player self-service grouping is deferred because commands such as
 `/register_governor`, `/modify_registration`, `/my_registrations`, `/mygovernorid`,

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,7 +5,7 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after Command Platform Phase 5, Public Domain Grouping Design. PR 131
+Last reviewed after Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping. PR 131
 (`codex/command-platform-phase-1-permission-decorators`) was smoke tested successfully, merged,
 and pushed to production on 2026-06-01. Phase 1 standardised active command permission gates onto
 decorators, added focused decorator tests, preserved command paths and registration count, and kept
@@ -39,6 +39,12 @@ production PR 444 on 2026-06-01.
 Phase 5A grouped the approved admin, leadership, and operator paths under domain command groups
 and reduced the active command baseline to
 `primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`.
+PR 136 (`codex/command-platform-phase-5a-admin-grouping`) was smoke tested successfully, merged,
+and pushed to production on 2026-06-02. Smoke follow-up fixes preserved grouped command usage
+logging, restored CrystalTech service imports, awaited `/stats player` embed rendering, and
+chunked long `/kvk list_scans` output below Discord content limits. Phase 6 created the maintained
+canonical command reference in `docs/reference/canonical_command_reference.md`. The next
+command-platform phase is Phase 7 governance and CI guardrails.
 Earlier review history: after the slow-pytest optimisation production
 release, PR 107
 (`pytest-log-delivery-docs`) resolved the high-impact pytest duration outliers found after the
@@ -174,10 +180,10 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
 - Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Phase 3 later moved approved low-risk ops/reporting commands under `/ops`, reducing the primary set to 75. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation remains planned.
-- Suggested Fix: Continue the command-platform programme through staged follow-up batches. Group related commands by domain where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
+- Suggested Fix: Continue the command-platform programme through Phase 6 canonical command documentation and Phase 7 governance/CI guardrails. Group related commands by domain only through separately approved future task packs where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
 - Impact: high
 - Risk: medium
-- Dependencies: Batch 1 `/ops` and `/mge` grouping and Phase 1 permission decorator standardisation remain deployed cleanly; coordinate with bot operators before renaming public command paths; preserve standard decorator permission checks when commands move into groups.
+- Dependencies: Batch 1 `/ops` and `/mge` grouping, Phase 1 permission decorator standardisation, Phase 4 Ark grouping, and Phase 5A admin/leadership/operator grouping remain deployed cleanly; coordinate with bot operators before renaming public command paths; preserve standard decorator permission checks when commands move into groups.
 
 ### Phase 4 Completed Item
 - Area: `commands/ark_cmds.py`, `docs/ark/`, Ark command tests

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,7 +5,9 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping. PR 131
+Last reviewed after Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping. PR 136
+(`codex/command-platform-phase-5a-admin-grouping`) was smoke tested successfully, merged, and
+pushed to production on 2026-06-02. Earlier in the programme, PR 131
 (`codex/command-platform-phase-1-permission-decorators`) was smoke tested successfully, merged,
 and pushed to production on 2026-06-01. Phase 1 standardised active command permission gates onto
 decorators, added focused decorator tests, preserved command paths and registration count, and kept

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -2,8 +2,11 @@
 
 Archived for implementation handoff: Phase 5 design was completed in PR 135
 (`codex/command-platform-phase-5a-design-docs`), merged, and pushed to production in production PR
-444. Use `Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain
-Grouping.md` for the next implementation chat.
+444. Phase 5A was later completed in PR 136
+(`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
+to production on 2026-06-02. Use
+`Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md` for the next
+command-platform chat.
 
 This starter is retained as the historical Phase 5 design prompt and source context.
 

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
@@ -1,0 +1,124 @@
+# Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation
+
+Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 5A was completed in PR 136 (`codex/command-platform-phase-5a-admin-grouping`), smoke tested
+successfully, merged, and pushed to production on 2026-06-02.
+
+Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+## Copy/Paste Starter
+
+Codex, begin Command Platform Phase 6: Canonical Command Documentation.
+
+This follows the completed Phase 5A implementation PR:
+
+- PR 136: `codex/command-platform-phase-5a-admin-grouping`
+- Result: smoke tested successfully, merged, and pushed to production
+- Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+The objective for this phase is documentation and governance preparation only. Create the
+canonical maintained command reference after Phase 5A path changes, and update stale command docs
+and smoke references. Do not move, rename, retire, or add commands in Phase 6.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 6 - Canonical Command Documentation
+- Date: 2026-06-02
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: documentation / governance preparation
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/command_inventory.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- existing command docs and smoke references for every active command domain
+
+## 3. Objective
+
+Create or update a canonical command reference that documents every active command's current path,
+owner module, permission model, response visibility, grouping/top-level status, version/usage
+tracking expectations, and migration/disposition notes.
+
+## 4. Out Of Scope
+
+Do not move, rename, retire, or add slash commands.
+
+Also out of scope:
+
+- player self-service workflow redesign
+- public calendar/KVK calendar UX redesign
+- SQL schema changes
+- permission behavior changes
+- runtime command implementation changes
+- production promotion or deployment
+
+## 5. Mandatory Workflow
+
+1. Review/scope Phase 6 and stop for approval.
+2. Inventory existing command docs and smoke references.
+3. Present the canonical command reference shape and stop for approval.
+4. Implement documentation updates only.
+5. Run focused validation.
+6. Open a ready-for-review PR against `K98-bot-mirror`.
+
+## 6. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+## 7. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations
+

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
@@ -121,4 +121,3 @@ Use this delivery shape:
 7. AI Review Gates
 8. Deployment / Rollback Notes
 9. Deferred Optimisations
-

--- a/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md
@@ -73,8 +73,8 @@ authoritative inventory, and confirmed command-cache validation remained green a
 
 The current validator reports:
 
-75 primary commands
-29 grouped subcommands
+39 primary commands
+76 grouped subcommands
 0 disabled legacy command declarations
 warning threshold at 90
 hard fail at 100
@@ -294,9 +294,13 @@ PR 444. Phase 5 approved Phase 5A as the next implementation slice for admin/lea
 paths only. Player self-service command redesign and public calendar/KVK calendar redesign are
 deferred outside this command-count programme.
 
-Phase 5A - Admin/Leadership/Operator Domain Grouping: implemented on the Phase 5A implementation
-branch, reducing the active top-level command baseline to 39 while preserving player self-service
-and public calendar/KVK calendar commands.
+Phase 5A - Admin/Leadership/Operator Domain Grouping: complete. PR 136
+(`codex/command-platform-phase-5a-admin-grouping`) was smoke tested successfully, merged, and
+pushed to production. This phase reduced the active top-level command baseline to 39 while
+preserving player self-service and public calendar/KVK calendar commands. Smoke follow-up fixes
+preserved grouped usage-log identities, restored CrystalTech service imports, awaited
+`/stats player` embed rendering, and chunked long `/kvk list_scans` output below Discord content
+limits.
 
 Remaining roadmap:
 
@@ -306,11 +310,12 @@ Public Domain Grouping Design: complete
 
 Phase 5A
 
-Admin/Leadership/Operator Domain Grouping: implemented
+Admin/Leadership/Operator Domain Grouping: complete, smoke tested, merged, and pushed to
+production
 
 Phase 6
 
-Canonical Command Documentation
+Canonical Command Documentation: next active command-platform phase
 
 Phase 7
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -8,6 +8,8 @@
 - Task type: deferred optimisation batch / command-surface design
 - One-pass approved: no
 - Status: complete; delivered in PR 135, merged, and pushed to production in production PR 444
+  Phase 5A was later delivered in PR 136, smoke tested successfully, merged, and pushed to
+  production on 2026-06-02.
 
 ## 2. Required Reading
 
@@ -96,6 +98,12 @@ Phase 5A is the only approved implementation slice from this design phase. It sh
 admin/leadership/operator-heavy commands by domain while preserving behavior, permissions,
 options, versions, usage tracking, autocomplete, response visibility, command-cache semantics,
 and handler bodies.
+
+Phase 5A completion note: PR 136 (`codex/command-platform-phase-5a-admin-grouping`) delivered the
+approved implementation slice, passed smoke testing, merged, and was pushed to production. The
+delivered baseline is
+`primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`.
+The next command-platform phase is Phase 6, Canonical Command Documentation.
 
 Approved Phase 5A candidates:
 

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
@@ -150,4 +150,3 @@ deployment, network calls, or restart-sensitive persistence.
 7. AI Review Gates
 8. Deployment / Rollback Notes
 9. Deferred Optimisations
-

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
@@ -1,0 +1,153 @@
+# Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 6 - Canonical Command Documentation
+- Date: 2026-06-02
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: documentation / governance preparation
+- One-pass approved: no
+- Status: next active command-platform phase
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/command_inventory.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, and validator tests
+- current command docs and smoke references for Ark, ops, registry, stats/KVK, inventory,
+  calendar/events, subscriptions, CrystalTech, honor, location, activity, MGE, PreKvK, and
+  telemetry commands
+
+## 3. Objective
+
+Create a canonical maintained command reference after the Phase 5A path migrations.
+
+The reference should make command ownership, path status, permissions, response visibility,
+versioning, usage tracking, and migration/disposition discoverable without requiring maintainers
+to inspect every command module.
+
+## 4. Background
+
+Phase 5A was completed in PR 136 (`codex/command-platform-phase-5a-admin-grouping`), smoke tested
+successfully, merged, and pushed to production on 2026-06-02.
+
+Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+Grouped command summary:
+
+| Group | Statically detected subcommands |
+|---|---:|
+| `/activity` | 1 |
+| `/ark` | 14 |
+| `/crystaltech` | 3 |
+| `/events` | 2 |
+| `/honor` | 1 |
+| `/inventory` | 2 |
+| `/kvk` | 7 |
+| `/location` | 2 |
+| `/mge` | 6 |
+| `/ops` | 25 |
+| `/prekvk` | 2 |
+| `/registry` | 7 |
+| `/stats` | 1 |
+| `/subscriptions` | 3 |
+
+Phase 5A preserved player self-service and public calendar/KVK calendar commands as flat paths.
+Those workflows remain deferred and should not be moved by Phase 6.
+
+## 5. Scope
+
+### In Scope
+
+- Create or update a canonical command reference covering every active slash command.
+- For each command, document:
+  - current path
+  - owner module
+  - command group/top-level status
+  - permission model
+  - response visibility
+  - version/usage tracking expectations
+  - migration status or disposition
+  - operator-facing notes where relevant
+- Update stale docs and smoke references that still mention old Phase 3, Phase 4, or Phase 5A flat
+  paths.
+- Add command-design guidance for new work:
+  - group-first design
+  - standard permission decorators
+  - command-count impact
+  - minimum command registration and smoke-test expectations
+- Keep the validator baseline and grouped command summary aligned with
+  `scripts/validate_command_registration.py`.
+- Capture any out-of-scope command UX redesign findings as deferred optimisations.
+
+### Out Of Scope
+
+- Moving, renaming, retiring, or adding slash commands.
+- Player self-service workflow redesign.
+- Public calendar/KVK calendar UX redesign.
+- SQL schema changes.
+- Permission behavior changes.
+- Runtime command implementation changes beyond documentation-only corrections.
+- Production promotion or deployment.
+
+## 6. Mandatory Workflow
+
+1. Review/scope Phase 6 and stop for approval.
+2. Inventory existing command docs and smoke references.
+3. Propose the canonical command reference shape and stop for approval.
+4. Implement documentation updates only.
+5. Run focused documentation and validator checks.
+6. Open a ready-for-review PR against `K98-bot-mirror`.
+
+## 7. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
+```
+
+Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+Codex Security review is usually optional for documentation-only Phase 6 work. Run it if the phase
+expands into permissions, command runtime behavior, SQL/data access, file handling, secrets/config,
+deployment, network calls, or restart-sensitive persistence.
+
+## 8. Required Delivery Output
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations
+

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -11,13 +11,13 @@ calendar tracker atomic-write hardening when one of those programmes is approved
 The active command-platform programme is tracked in:
 
 - `Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
-- `Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
-- `Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md`
+- `Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md`
+- `Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md`
 
 The completed Phase 5 design source remains in this folder for handoff context:
 
 - `Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
 - `Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md`
 
-Phase 1, Phase 2, Phase 3, Phase 4, and the superseded command-surface balancing audit pack are
-archived as execution records.
+Phase 1, Phase 2, Phase 3, Phase 4, Phase 5A, and the superseded command-surface balancing audit
+pack are archived as execution records.

--- a/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
+++ b/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
@@ -1,7 +1,13 @@
 # Codex Chat Starter - Command Platform Phase 5A Admin Leadership Operator Domain Grouping
 
-Use this starter to begin the next Command Platform Audit & Optimisation Programme implementation
-phase.
+Archived for implementation handoff: Phase 5A was completed in PR 136
+(`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
+to production on 2026-06-02.
+
+Use `Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md` for the
+next command-platform chat.
+
+This starter is retained as the historical Phase 5A implementation prompt and source context.
 
 Source programme documents:
 
@@ -17,13 +23,13 @@ and pushed to production in production PR 444. It approved Phase 5A only: admin,
 operator command grouping. It deferred player self-service workflow redesign and public
 calendar/KVK calendar redesign outside the command-count programme.
 
-Current validator baseline:
+Phase 5A starting validator baseline:
 
 ```text
 primary=62 grouped_subcommands_detected=43 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=62
 ```
 
-Expected Phase 5A baseline if the approved implementation scope is delivered as written:
+Delivered Phase 5A baseline:
 
 ```text
 primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39

--- a/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
+++ b/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 5A Admin Leadership Operator Domain Grouping.md
@@ -7,7 +7,8 @@
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: deferred optimisation batch / command-surface migration
 - One-pass approved: no
-- Status: implemented in this Phase 5A branch
+- Status: complete; delivered in PR 136, smoke tested successfully, merged, and pushed to
+  production
 
 ## 2. Required Reading
 
@@ -113,6 +114,17 @@ Grouped command summary:
 | `/subscriptions` | 3 |
 
 Recalculate during implementation if any target path changes after scope review.
+
+Phase 5A completion note:
+
+- Mirror PR: 136 (`codex/command-platform-phase-5a-admin-grouping`)
+- Result: smoke tested successfully, merged, and pushed to production on 2026-06-02
+- Delivered baseline:
+  `primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39`
+- Smoke follow-up fixes preserved grouped usage-log identities, restored CrystalTech service
+  imports, awaited `/stats player` embed rendering, and chunked long `/kvk list_scans` output
+  below Discord content limits.
+- Next phase: Command Platform Phase 6 - Canonical Command Documentation.
 
 ## 5. Scope
 


### PR DESCRIPTION
## Summary
- Adds `docs/reference/canonical_command_reference.md` as the maintained command reference after Phase 5A.
- Updates command-platform audit/surface/deferred docs to point at the canonical reference and Phase 7 governance follow-up.
- Updates stale active inventory and calendar smoke references to the Phase 5A grouped paths.
- Adds Phase 6 task-pack/chat-starter docs and archives the completed Phase 5A task-pack records.
- Applies review-feedback corrections: removes BOM markers, fixes mojibake/UTF-8 punctuation artifacts in affected calendar/inventory docs, and corrects the opening review-history line in `docs/reference/deferred_optimisations.md` to align Phase 5A context with PR 136.

## File Manifest
- `docs/reference/canonical_command_reference.md`
- `docs/reference/README.md`
- `docs/reference/command_platform_audit.md`
- `docs/reference/command_surface_audit.md`
- `docs/reference/deferred_optimisations.md`
- `docs/calendar/*.md` active calendar runbook/smoke docs
- `docs/inventory/*.md` active inventory task/smoke docs
- `docs/task_packs/*Command Platform*.md`
- `docs/task_packs/archive/*Phase 5A Admin Leadership Operator Domain Grouping.md`

## Helpers Reused
No runtime helpers changed. Documentation uses existing validator/inventory references as source-of-truth.

## SQL Changes
None.

## Architecture Checks
- [x] Commands remain thin
- [x] Views remain interaction-only
- [x] Services own business logic
- [x] No SQL in commands/views
- [x] Restart safety preserved

## Tests Run
- Passed: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- Passed: `./.venv/Scripts/python.exe scripts/select_tests.py`
- Passed: `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- Passed: `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- Passed: `./.venv/Scripts/python.exe -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py`
- Passed: `./.venv/Scripts/python.exe -m pre_commit run -a`
- Passed: review follow-up validation via `parallel_validation` (Code Review clean; CodeQL skipped as trivial docs-only)
- Note: local sandbox does not have `pytest` installed (`python -m pytest` unavailable), so no additional in-sandbox pytest run was possible for the docs-only follow-up commit.

## Deployment / Migration Notes
No deployment or migration required. Rollback is a standard docs-only revert.

## Codex Review Pass
- [x] Review pass completed
- [x] Issues fixed or deferred
- [x] No scope expansion during review

## Deferred Optimisations

### Deferred Optimisation
- Area: Command platform governance
- Type: Process/CI guardrails
- Description: Phase 7 governance and CI guardrails remain the next command-platform phase.
- Suggested Fix: Implement Phase 7 command-surface governance checks in CI.
- Impact: Sustains command-surface consistency and prevents future drift.
- Risk: Low
- Dependencies: Existing command inventory/validation scripts and canonical reference maintenance.