### PR TITLE
Command Platform: mark Phase 6 complete and prepare Phase 7

### DIFF
--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -564,6 +564,6 @@ Validation:
 8. Phase 7: Future Governance And CI Guardrails.
 
 With Phase 6 delivered, merged, marked complete, and pushed to production, Phase 7 governance and
-CI guardrails is the final planned command-platform programme phase. Player self-service workflow
+CI guardrails are the final planned command-platform programme phase. Player self-service workflow
 redesign and public calendar/KVK calendar redesign remain deferred into separate optimisation
 tasks rather than continued as simple command grouping inside this programme.

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -43,6 +43,12 @@ calendar paths. Smoke follow-up fixes preserved grouped usage-log identities, re
 CrystalTech service imports, awaited `/stats player` embed rendering, and chunked long
 `/kvk list_scans` output below Discord content limits.
 
+Phase 6, Canonical Command Documentation, was completed in PR 137
+(`codex/command-platform-phase-6-canonical-docs`), merged, marked complete, and pushed to
+production. It created `canonical_command_reference.md` as the maintained current command
+reference, updated stale active command docs and smoke references, and prepared Phase 7 governance
+and CI guardrails as the final programme phase.
+
 ## Audit Baseline
 
 Static command registration validation after Phase 5A delivery reports:
@@ -73,7 +79,7 @@ Grouped command summary:
 The primary command surface has a 61-command buffer below Discord's 100 top-level application
 command limit. The validator warns at 90+ and fails above 100.
 
-The maintained command reference after Phase 6 lives in `canonical_command_reference.md`. Use that
+The maintained command reference lives in `canonical_command_reference.md`. Use that
 file for current command paths, owner modules, permission models, response visibility, and
 version/usage expectations. The inventory below remains audit context for the command-platform
 programme.
@@ -257,8 +263,9 @@ commands are marked `none observed` pending SQL usage review.
 - Resolution: Phase 6 promoted the current command inventory into `canonical_command_reference.md`
   with path, owner, permissions, response visibility, usage/version expectations, migration
   status, and operator-facing notes.
-- Validation: Documentation validation, command registration validation, focused command
-  inventory/registration tests, and pre-commit are required before PR handoff.
+- Validation: Delivered in PR 137 with deferred-item validation, test selector, command
+  registration validation, smoke imports, focused command inventory/registration tests, and
+  pre-commit passing.
 
 ## Phased Roadmap
 
@@ -505,7 +512,8 @@ Delivered validation:
 
 ### Phase 6 - Canonical Command Documentation
 
-Status: complete.
+Status: complete. Delivered in PR 137 (`codex/command-platform-phase-6-canonical-docs`), merged,
+marked complete, and pushed to production.
 
 Goal: make command ownership, permissions, and path status discoverable.
 
@@ -521,8 +529,14 @@ Validation:
 - Documentation review.
 - `python scripts/validate_deferred_items.py`
 - `python scripts/select_tests.py`
+- `python scripts/validate_command_registration.py`
+- `python scripts/smoke_imports.py`
+- `python -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py`
+- `python -m pre_commit run -a`
 
 ### Phase 7 - Future Governance And CI Guardrails
+
+Status: final planned phase.
 
 Goal: prevent command-limit drift after the programme ends.
 
@@ -549,8 +563,7 @@ Validation:
 7. Phase 6: Canonical Command Documentation.
 8. Phase 7: Future Governance And CI Guardrails.
 
-With Phase 5A delivered, merged, smoke tested, and promoted, Phase 6 is creating the maintained
-canonical command reference. Phase 7 governance and CI guardrails should follow once the reference
-is merged. Player self-service workflow redesign and public calendar/KVK calendar redesign remain
-deferred into separate optimisation tasks rather than continued as simple command grouping inside
-this programme.
+With Phase 6 delivered, merged, marked complete, and pushed to production, Phase 7 governance and
+CI guardrails is the final planned command-platform programme phase. Player self-service workflow
+redesign and public calendar/KVK calendar redesign remain deferred into separate optimisation
+tasks rather than continued as simple command grouping inside this programme.

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -47,10 +47,14 @@ Current baseline after Phase 5A delivery:
 primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
 ```
 
-Phase 6, Canonical Command Documentation, created `canonical_command_reference.md` as the
-maintained current command reference. Phase 7 governance and CI guardrails should follow after the
-canonical command reference is merged. Player self-service and generic public calendar/KVK calendar
-redesign remain deferred outside this command-count programme.
+Command Platform Phase 6, Canonical Command Documentation, was completed in PR 137
+(`codex/command-platform-phase-6-canonical-docs`), merged, marked complete, and pushed to
+production. It created `canonical_command_reference.md` as the maintained current command
+reference and updated stale active command docs and smoke references.
+
+Phase 7 governance and CI guardrails is the final planned command-platform programme phase. Player
+self-service and generic public calendar/KVK calendar redesign remain deferred outside this
+command-count programme.
 
 This file remains the historical command-surface audit and migration record.
 
@@ -165,8 +169,7 @@ production.
 Remaining command-surface batches are staged in `docs/reference/deferred_optimisations.md` and the
 command-platform programme docs. Recommended order:
 
-1. Phase 6: Canonical command documentation after Phase 5A path changes.
-2. Phase 7: Future governance and CI guardrails.
+1. Phase 7: Future governance and CI guardrails.
 
 The previously considered player self-service grouping is deferred because commands such as
 `/register_governor`, `/modify_registration`, `/my_registrations`, `/mygovernorid`,

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -52,7 +52,7 @@ Command Platform Phase 6, Canonical Command Documentation, was completed in PR 1
 production. It created `canonical_command_reference.md` as the maintained current command
 reference and updated stale active command docs and smoke references.
 
-Phase 7 governance and CI guardrails is the final planned command-platform programme phase. Player
+Phase 7 governance and CI guardrails are the final planned command-platform programme phase. Player
 self-service and generic public calendar/KVK calendar redesign remain deferred outside this
 command-count programme.
 

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -5,9 +5,11 @@ to GitHub issues/task packs.
 
 Resolved historical notes were moved to `archive/deferred_optimisations_resolved.md`.
 
-Last reviewed after Command Platform Phase 5A, Admin/Leadership/Operator Domain Grouping. PR 136
+Last reviewed after Command Platform Phase 6, Canonical Command Documentation. PR 137
+(`codex/command-platform-phase-6-canonical-docs`) was merged, marked complete, and pushed to
+production on 2026-06-02. Earlier in the programme, PR 136
 (`codex/command-platform-phase-5a-admin-grouping`) was smoke tested successfully, merged, and
-pushed to production on 2026-06-02. Earlier in the programme, PR 131
+pushed to production on 2026-06-02, and PR 131
 (`codex/command-platform-phase-1-permission-decorators`) was smoke tested successfully, merged,
 and pushed to production on 2026-06-01. Phase 1 standardised active command permission gates onto
 decorators, added focused decorator tests, preserved command paths and registration count, and kept
@@ -45,7 +47,8 @@ PR 136 (`codex/command-platform-phase-5a-admin-grouping`) was smoke tested succe
 and pushed to production on 2026-06-02. Smoke follow-up fixes preserved grouped command usage
 logging, restored CrystalTech service imports, awaited `/stats player` embed rendering, and
 chunked long `/kvk list_scans` output below Discord content limits. Phase 6 created the maintained
-canonical command reference in `docs/reference/canonical_command_reference.md`. The next
+canonical command reference in `docs/reference/canonical_command_reference.md`, updated stale
+active command docs and smoke references, and was delivered in PR 137. The next and final
 command-platform phase is Phase 7 governance and CI guardrails.
 Earlier review history: after the slow-pytest optimisation production
 release, PR 107
@@ -182,7 +185,7 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
 - Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Phase 3 later moved approved low-risk ops/reporting commands under `/ops`, reducing the primary set to 75. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation remains planned.
-- Suggested Fix: Continue the command-platform programme through Phase 6 canonical command documentation and Phase 7 governance/CI guardrails. Group related commands by domain only through separately approved future task packs where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
+- Suggested Fix: Complete the command-platform programme with Phase 7 governance/CI guardrails. Group related commands by domain only through separately approved future task packs where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
 - Impact: high
 - Risk: medium
 - Dependencies: Batch 1 `/ops` and `/mge` grouping, Phase 1 permission decorator standardisation, Phase 4 Ark grouping, and Phase 5A admin/leadership/operator grouping remain deployed cleanly; coordinate with bot operators before renaming public command paths; preserve standard decorator permission checks when commands move into groups.

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -5,7 +5,7 @@ Archived for implementation handoff: Phase 5 design was completed in PR 135
 444. Phase 5A was later completed in PR 136
 (`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
 to production on 2026-06-02. Use
-`Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md` for the next
+`Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md` for the final
 command-platform chat.
 
 This starter is retained as the historical Phase 5 design prompt and source context.

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md
@@ -4,9 +4,9 @@ Archived for implementation handoff: Phase 5 design was completed in PR 135
 (`codex/command-platform-phase-5a-design-docs`), merged, and pushed to production in production PR
 444. Phase 5A was later completed in PR 136
 (`codex/command-platform-phase-5a-admin-grouping`), smoke tested successfully, merged, and pushed
-to production on 2026-06-02. Use
-`Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md` for the final
-command-platform chat.
+to production on 2026-06-02.
+Use `Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md` for
+the final command-platform chat.
 
 This starter is retained as the historical Phase 5 design prompt and source context.
 

--- a/docs/task_packs/Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md
+++ b/docs/task_packs/Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md
@@ -1,0 +1,131 @@
+# Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails
+
+Use this starter to begin the final planned Command Platform Audit & Optimisation Programme phase.
+
+Source programme documents:
+
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md`
+- `docs/reference/canonical_command_reference.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Phase 6 was completed in PR 137 (`codex/command-platform-phase-6-canonical-docs`), merged, marked
+complete, and pushed to production on 2026-06-02.
+
+Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+## Copy/Paste Starter
+
+Codex, begin Command Platform Phase 7: Governance And CI Guardrails.
+
+This follows the completed Phase 6 documentation PR:
+
+- PR 137: `codex/command-platform-phase-6-canonical-docs`
+- Result: merged, marked complete, and pushed to production
+- Current validator baseline:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+The objective for this phase is governance and guardrail preparation. Add or update validation,
+CI/pre-commit wiring, command-design guidance, and task-pack checklist material so the command
+surface does not drift back toward Discord's command limit. Do not move, rename, retire, or add
+slash commands in Phase 7.
+
+Phase 7 is expected to be the final phase of the Command Platform Audit & Optimisation Programme.
+Player self-service workflow redesign and public calendar/KVK calendar redesign remain separate
+deferred optimisation programmes.
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 7 - Governance And CI Guardrails
+- Date: 2026-06-02
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: governance / validation tooling / CI preparation
+- One-pass approved: no
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md`
+- `docs/reference/canonical_command_reference.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/command_inventory.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, validator, and CI/pre-commit tests
+- existing CI, pre-commit, and local validation configuration
+
+## 3. Objective
+
+Complete the Command Platform Audit & Optimisation Programme by adding governance and guardrails
+that prevent future command-limit drift and keep the canonical command reference maintainable.
+
+## 4. Out Of Scope
+
+Do not move, rename, retire, or add slash commands.
+
+Also out of scope:
+
+- player self-service workflow redesign
+- public calendar/KVK calendar UX redesign
+- SQL schema changes
+- permission behavior changes
+- runtime command handler implementation changes
+- production promotion or deployment
+
+## 5. Mandatory Workflow
+
+1. Review/scope Phase 7 and stop for approval.
+2. Inventory existing validator, CI, pre-commit, and command-governance docs.
+3. Present the proposed guardrail design and stop for approval.
+4. Implement approved governance/tooling/docs updates.
+5. Run focused validation.
+6. Open a ready-for-review PR against `K98-bot-mirror`.
+
+## 6. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+## 7. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations
+10. Programme Closure Recommendation

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md
@@ -1,0 +1,147 @@
+# Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails
+
+## 1. Task Header
+
+- Task name: Command Platform Phase 7 - Governance And CI Guardrails
+- Date: 2026-06-02
+- Owner/context: Command Platform Audit & Optimisation Programme
+- Task type: governance / validation tooling / CI preparation
+- One-pass approved: no
+- Status: final planned command-platform phase
+
+## 2. Required Reading
+
+Before implementation or documentation changes, read:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+- `docs/reference/K98 Bot - Project Engineering Standards.md`
+- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
+- `docs/reference/K98 Bot - Testing Standards.md`
+- `docs/reference/K98 Bot - Skills & Refactor Triggers.md`
+- `docs/reference/K98 Bot - Deferred Optimisation Framework.md`
+- `docs/task_packs/Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
+- `docs/reference/canonical_command_reference.md`
+- `docs/reference/command_platform_audit.md`
+- `docs/reference/command_surface_audit.md`
+- `docs/reference/deferred_optimisations.md`
+
+Also review:
+
+- `commands/command_inventory.py`
+- `scripts/validate_command_registration.py`
+- command registration, inventory, lifecycle, validator, and CI/pre-commit tests
+- existing CI, pre-commit, and local validation configuration
+
+## 3. Objective
+
+Complete the Command Platform Audit & Optimisation Programme by adding governance and guardrails
+that prevent future command-limit drift and keep the canonical command reference maintainable.
+
+Phase 7 should make it difficult to accidentally:
+
+- exceed Discord's 100 top-level application-command limit
+- add ungrouped admin/leadership/operator commands without review
+- bypass standard command decorators
+- forget command registration validation
+- forget to update `canonical_command_reference.md` after command-surface changes
+
+## 4. Background
+
+Phase 6 was completed in PR 137 (`codex/command-platform-phase-6-canonical-docs`), merged, marked
+complete, and pushed to production. It created `docs/reference/canonical_command_reference.md`,
+updated stale active command docs and smoke references, and left the command baseline at:
+
+```text
+primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+```
+
+The command surface now has a 61-command buffer below Discord's top-level command limit. Phase 7
+should preserve that headroom through governance rather than more command movement.
+
+## 5. Scope
+
+### In Scope
+
+- Review current command validator output and failure modes.
+- Decide whether `scripts/validate_command_registration.py` should emit a richer machine-readable
+  or Markdown inventory artifact.
+- Add or update local validation, pre-commit, or CI wiring so command registration validation is
+  consistently run before command-surface PRs.
+- Add governance documentation for new commands:
+  - group-first command design
+  - when a flat path is allowed
+  - required permission decorators
+  - version/usage tracking expectations
+  - canonical reference update requirement
+  - command-count impact review
+- Add tests for any validator, artifact, CI, or checklist changes.
+- Update `docs/reference/canonical_command_reference.md` only for governance metadata; do not
+  change command paths.
+- Close or update command-platform deferred optimisation items that are resolved by governance.
+
+### Out Of Scope
+
+- Moving, renaming, retiring, or adding slash commands.
+- Player self-service workflow redesign.
+- Public calendar/KVK calendar UX redesign.
+- SQL schema changes.
+- Permission behavior changes.
+- Runtime command handler implementation changes.
+- Production promotion or deployment.
+
+## 6. Mandatory Workflow
+
+1. Review/scope Phase 7 and stop for approval.
+2. Inventory existing validator, CI, pre-commit, and command-governance docs.
+3. Present the proposed guardrail design and stop for approval.
+4. Implement approved governance/tooling/docs updates.
+5. Run focused validation.
+6. Open a ready-for-review PR against `K98-bot-mirror`.
+
+## 7. Design Questions
+
+- Should command registration validation be enforced only in CI, or also through pre-commit?
+- Should the validator produce a reusable command inventory artifact for PR review?
+- Should the validator fail on ungrouped admin/leadership/operator commands, or only warn?
+- What exact checklist should future task packs include when adding or changing commands?
+- Should Phase 7 close the programme after guardrails land?
+
+Recommended answer for the final question: yes. Phase 7 is the final planned command-platform
+programme phase. Player self-service workflow redesign and public calendar/KVK calendar redesign
+should remain separate deferred optimisation programmes.
+
+## 8. Suggested Validation
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
+```
+
+Before PR handoff, run or justify skipping:
+
+```powershell
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+Codex Security review is usually optional for governance/docs/tooling-only Phase 7 work. Run it if
+the phase expands into permission behavior, command runtime behavior, SQL/data access, file
+handling, secrets/config, deployment, network calls, user-controlled input parsing, or
+restart-sensitive persistence.
+
+## 9. Required Delivery Output
+
+1. Summary
+2. File Manifest
+3. SQL Changes
+4. Helpers Reused
+5. Refactor Findings
+6. Test Plan And Results
+7. AI Review Gates
+8. Deployment / Rollback Notes
+9. Deferred Optimisations
+10. Programme Closure Recommendation

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -11,13 +11,17 @@ calendar tracker atomic-write hardening when one of those programmes is approved
 The active command-platform programme is tracked in:
 
 - `Codex Task Pack - Command Platform Audit & Optimisation Programme.md`
-- `Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md`
-- `Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md`
+- `Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md`
+- `Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md`
 
 The completed Phase 5 design source remains in this folder for handoff context:
 
 - `Codex Task Pack - Command Platform Phase 5 Public Domain Grouping Design.md`
 - `Codex Chat Starter - Command Platform Phase 5 Public Domain Grouping Design.md`
 
-Phase 1, Phase 2, Phase 3, Phase 4, Phase 5A, and the superseded command-surface balancing audit
-pack are archived as execution records.
+Phase 1, Phase 2, Phase 3, Phase 4, Phase 5A, Phase 6, and the superseded command-surface
+balancing audit pack are archived as execution records.
+
+Phase 7 is planned as the final phase of the Command Platform Audit & Optimisation Programme.
+Player self-service workflow redesign and public calendar/KVK calendar UX redesign remain separate
+deferred optimisation programmes, not additional command-platform phases.

--- a/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/archive/Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation.md
@@ -1,6 +1,12 @@
 # Codex Chat Starter - Command Platform Phase 6 Canonical Command Documentation
 
-Use this starter to begin the next Command Platform Audit & Optimisation Programme phase.
+Archived starter for completed Command Platform Phase 6.
+
+Phase 6 was delivered in PR 137 (`codex/command-platform-phase-6-canonical-docs`), merged, marked
+complete, and pushed to production on 2026-06-02. Use the Phase 7 starter for the next and final
+command-platform programme phase.
+
+Historical starter content follows.
 
 Source programme documents:
 

--- a/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
+++ b/docs/task_packs/archive/Codex Task Pack - Command Platform Phase 6 Canonical Command Documentation.md
@@ -7,7 +7,8 @@
 - Owner/context: Command Platform Audit & Optimisation Programme
 - Task type: documentation / governance preparation
 - One-pass approved: no
-- Status: next active command-platform phase
+- Status: complete. Delivered in PR 137 (`codex/command-platform-phase-6-canonical-docs`),
+  merged, marked complete, and pushed to production on 2026-06-02.
 
 ## 2. Required Reading
 
@@ -42,6 +43,10 @@ Create a canonical maintained command reference after the Phase 5A path migratio
 The reference should make command ownership, path status, permissions, response visibility,
 versioning, usage tracking, and migration/disposition discoverable without requiring maintainers
 to inspect every command module.
+
+Completion note: Phase 6 created `docs/reference/canonical_command_reference.md`, updated active
+command docs and smoke references after Phase 5A path changes, archived completed Phase 5A
+task-pack records, and set Phase 7 governance/CI guardrails as the final command-platform phase.
 
 ## 4. Background
 


### PR DESCRIPTION
## Summary
- Marks Command Platform Phase 6 complete after PR 137 was merged, marked complete, and pushed to production.
- Archives the completed Phase 6 task pack and chat starter.
- Adds the Phase 7 Governance and CI Guardrails task pack and chat starter.
- Updates active command-platform programme docs to state Phase 7 is the final planned programme phase.

## File Manifest
- `docs/reference/command_platform_audit.md`
- `docs/reference/command_surface_audit.md`
- `docs/reference/deferred_optimisations.md`
- `docs/task_packs/README.md`
- `docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md`
- `docs/task_packs/Codex Chat Starter - Command Platform Phase 7 Governance And CI Guardrails.md`
- archived Phase 6 task-pack and chat-starter files

## SQL Changes
None.

## Helpers Reused
No runtime helpers changed.

## Refactor Findings
No runtime refactors. Phase 7 is documented as the final planned command-platform phase; player self-service and public calendar/KVK calendar redesign remain separate deferred optimisation programmes.

## Test Plan And Results
- Passed: `./.venv/Scripts/python.exe scripts/validate_deferred_items.py`
- Passed: `./.venv/Scripts/python.exe scripts/select_tests.py`
- Passed: `./.venv/Scripts/python.exe scripts/validate_command_registration.py`
- Passed: `./.venv/Scripts/python.exe scripts/smoke_imports.py`
- Passed: `./.venv/Scripts/python.exe -m pre_commit run -a`

## AI Review Gates
Codex Security skipped: documentation-only change with no runtime command behavior, permission, SQL/data access, file handling, config, network, user-input, or restart-sensitive persistence changes.

## Deployment / Rollback Notes
No deployment required. Rollback is a normal docs-only revert of this branch/PR.

## Deferred Optimisations
Player self-service workflow redesign and public calendar/KVK calendar UX redesign remain deferred outside the command-platform programme.

## Programme Closure Recommendation
Yes: Phase 7 should be the final phase of this command-platform programme. Its goal is to install governance and CI guardrails after the command surface and canonical documentation are in place.