### PR TITLE
Command Platform Phase 7 governance guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,12 @@
 - [ ] No SQL in commands/views
 - [ ] Restart safety preserved
 
+## Command Surface Checks
+- [ ] Command surface impact stated: no change / grouped subcommand change / top-level command change
+- [ ] Command registration validation run or explicitly skipped with reason
+- [ ] If a new top-level command/group was added, operator approval is documented and `APPROVED_TOP_LEVEL_COMMANDS` plus `docs/reference/canonical_command_reference.md` were updated
+- [ ] If grouped commands changed, canonical command table, grouped summary, docs, smoke references, versions, usage tracking, permissions, and command-cache behavior were reviewed
+
 ## Tests Run
 
 ## Deployment / Migration Notes

--- a/.github/workflows/command-governance.yml
+++ b/.github/workflows/command-governance.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     paths:
       - "commands/**"
+      - "Commands.py"
+      - "DL_bot.py"
       - "scripts/validate_command_registration.py"
       - "commands/command_inventory.py"
       - "tests/test_validate_command_registration.py"
       - "tests/test_command_inventory.py"
       - "tests/test_command_registration_smoke.py"
+      - "tests/test_command_governance_config.py"
       - "docs/reference/canonical_command_reference.md"
       - ".github/pull_request_template.md"
       - ".github/workflows/command-governance.yml"
@@ -37,7 +40,7 @@ jobs:
         run: python scripts/validate_command_registration.py --format markdown --output command-registration-inventory.md
 
       - name: Run command governance tests
-        run: python -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py
+        run: python -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py tests/test_command_governance_config.py
 
       - name: Upload command inventory artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/command-governance.yml
+++ b/.github/workflows/command-governance.yml
@@ -1,0 +1,46 @@
+name: Command Governance
+
+on:
+  pull_request:
+    paths:
+      - "commands/**"
+      - "scripts/validate_command_registration.py"
+      - "commands/command_inventory.py"
+      - "tests/test_validate_command_registration.py"
+      - "tests/test_command_inventory.py"
+      - "tests/test_command_registration_smoke.py"
+      - "docs/reference/canonical_command_reference.md"
+      - ".github/pull_request_template.md"
+      - ".github/workflows/command-governance.yml"
+  workflow_dispatch:
+
+jobs:
+  command-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Validate command registration
+        run: python scripts/validate_command_registration.py
+
+      - name: Write command inventory artifact
+        run: python scripts/validate_command_registration.py --format markdown --output command-registration-inventory.md
+
+      - name: Run command governance tests
+        run: python -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py
+
+      - name: Upload command inventory artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: command-registration-inventory
+          path: command-registration-inventory.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,3 +106,9 @@ repos:
             if bad:
                 print("logging.basicConfig() is not allowed. Offenders:\n - " + "\n - ".join(bad))
                 sys.exit(1)
+      - id: validate-command-registration
+        name: Validate command registration
+        entry: python scripts/validate_command_registration.py
+        language: system
+        pass_filenames: false
+        files: '^(commands/|scripts/validate_command_registration\.py|docs/reference/canonical_command_reference\.md|\.github/pull_request_template\.md)'

--- a/docs/reference/K98 Bot - Coding Execution Guidelines.md
+++ b/docs/reference/K98 Bot - Coding Execution Guidelines.md
@@ -193,6 +193,12 @@ Silently leaving it in place is not acceptable.
 
 All new commands live in `commands/<domain>_cmds.py`.
 
+New admin, leadership, operator, diagnostic, and domain-maintenance command work should be
+group-first. A new top-level slash command or command group requires explicit task approval,
+operator rationale for why an existing group is unsuitable, an
+`APPROVED_TOP_LEVEL_COMMANDS` update in `scripts/validate_command_registration.py`, and a matching
+update to `docs/reference/canonical_command_reference.md`.
+
 Commands must:
 
 - use `@versioned()`, `@safe_command`, and `@track_usage()` where the local command pattern requires them

--- a/docs/reference/Promotion Guide.md
+++ b/docs/reference/Promotion Guide.md
@@ -93,6 +93,22 @@ git diff --check
 git status
 ```
 
+For command-surface changes, also confirm:
+
+- `scripts/validate_command_registration.py` reports the expected primary/grouped baseline.
+- If a new top-level command or command group was approved, the production PR includes the
+  operator approval rationale, the `APPROVED_TOP_LEVEL_COMMANDS` update, and the matching
+  `docs/reference/canonical_command_reference.md` update.
+- If grouped subcommands changed, the canonical command table, grouped summary, smoke references,
+  command versions, usage tracking, permissions, and command-cache behavior were reviewed.
+- When useful for review, attach or paste the Markdown inventory generated with:
+
+```powershell
+.\.venv\Scripts\python.exe scripts/validate_command_registration.py `
+  --format markdown `
+  --output command-registration-inventory.md
+```
+
 If pre-commit reformats files or makes other changes:
 ```powershell
 git add -A

--- a/docs/reference/canonical_command_reference.md
+++ b/docs/reference/canonical_command_reference.md
@@ -42,6 +42,9 @@ Grouped command summary:
 
 - New admin, leadership, operator, diagnostic, and domain-maintenance commands should be designed
   group-first unless an approved task explicitly keeps them flat.
+- New top-level slash commands are blocked by `scripts/validate_command_registration.py` unless
+  the task explicitly approves the new flat path, updates the approved top-level baseline in that
+  validator, updates this reference, and documents why a grouped command is not suitable.
 - Preserve player self-service and public calendar/KVK calendar commands as flat paths until a
   dedicated workflow redesign is approved.
 - All active commands are expected to use `@versioned()`, `@safe_command`, and `@track_usage()`
@@ -52,6 +55,32 @@ Grouped command summary:
   validation expectations, and smoke references.
 - Keep `scripts/validate_command_registration.py` green. The current warning threshold is 90
   top-level commands and the hard limit is Discord's 100 top-level application-command ceiling.
+
+## Approved Top-Level Baseline
+
+The approved top-level command baseline is enforced by `APPROVED_TOP_LEVEL_COMMANDS` in
+`scripts/validate_command_registration.py`. The current approved baseline is:
+
+```text
+activity, ark, calendar, calendar_next_event, calendar_reminder_config, crystaltech, events,
+export_inventory, honor, honor_rankings, inventory, inventory_preferences, kvk, kvk_rankings,
+location, mge, modify_registration, modify_subscription, my_registrations, my_stats,
+my_stats_export, mygovernorid, myinventory, mykvkcrystaltech, mykvkhistory, mykvkstats,
+mykvktargets, next_kvk_event, next_kvk_fight, ops, ping, player_profile, prekvk,
+register_governor, registry, stats, subscribe, subscriptions, unsubscribe
+```
+
+If a task proposes a new top-level command, it must:
+
+- state why the command cannot be grouped under an existing domain group
+- include operator approval for the flat path
+- update `APPROVED_TOP_LEVEL_COMMANDS`
+- update this canonical command table and grouped summary if applicable
+- update operator/user docs and smoke references for the new path
+- run command registration validation and focused command inventory tests
+
+Grouped subcommands do not require changing the approved top-level baseline unless they create a
+new group.
 
 ## Canonical Command Table
 

--- a/docs/reference/command_platform_audit.md
+++ b/docs/reference/command_platform_audit.md
@@ -536,16 +536,19 @@ Validation:
 
 ### Phase 7 - Future Governance And CI Guardrails
 
-Status: final planned phase.
+Status: in implementation as the final planned phase.
 
 Goal: prevent command-limit drift after the programme ends.
 
 Scope:
 
 - CI enforcement around validator output.
-- Optional richer command inventory artifact from validation.
-- Command design checklist for task packs.
-- Near-limit risk reporting and domain owner summaries.
+- Pre-commit enforcement around command registration validation.
+- Approved top-level command baseline enforcement in `scripts/validate_command_registration.py`.
+- Optional JSON/Markdown command inventory artifacts from validation.
+- Command design checklist for task packs and PRs.
+- Near-limit risk reporting, grouped summary reporting, duplicate-risk reporting, and command
+  drift reporting.
 
 Validation:
 

--- a/docs/reference/command_surface_audit.md
+++ b/docs/reference/command_surface_audit.md
@@ -56,6 +56,11 @@ Phase 7 governance and CI guardrails are the final planned command-platform prog
 self-service and generic public calendar/KVK calendar redesign remain deferred outside this
 command-count programme.
 
+Phase 7 guardrails enforce the approved top-level command baseline in
+`scripts/validate_command_registration.py`, wire command registration validation into local
+pre-commit and focused CI, and require future top-level command additions to update the canonical
+command reference with operator-approved rationale.
+
 This file remains the historical command-surface audit and migration record.
 
 ## Current Registration Summary

--- a/docs/reference/deferred_optimisations.md
+++ b/docs/reference/deferred_optimisations.md
@@ -181,11 +181,15 @@ atomic-write hardening; each requires a fresh scope instead of an additional Pha
 - Risk: medium
 - Dependencies: Use the post-PR-107 audit baseline (`1450 passed, 2 skipped, 19 warnings in 54.86s`); preserve genuine timeout, subprocess, lock, negative-path, and log-noise coverage.
 
-### Deferred Optimisation
+### Phase 7 In-Progress Item
 - Area: `commands/`, `scripts/validate_command_registration.py`
 - Type: architecture
 - Description: Batch 1 of the command-surface balancing audit grouped admin-heavy `/ops` and `/mge` commands, reducing the primary Discord application-command set from 100 to 82 top-level commands. Phase 3 later moved approved low-risk ops/reporting commands under `/ops`, reducing the primary set to 75. Future standalone slash commands can still erode this buffer and eventually break startup sync with Discord error 30032 unless additional command-surface consolidation remains planned.
-- Suggested Fix: Complete the command-platform programme with Phase 7 governance/CI guardrails. Group related commands by domain only through separately approved future task packs where user experience allows, identify stale/low-use admin commands for consolidation or retirement, update docs for renamed paths, and keep `scripts/validate_command_registration.py` enforcing the 100-command ceiling with a warning at 90+.
+- Resolution In Progress: Command Platform Phase 7 adds approved top-level baseline enforcement,
+  JSON/Markdown validator artifact output, focused command-governance CI, pre-commit validation,
+  and command-change checklist material. After Phase 7 lands, this command-limit drift item can be
+  closed; player self-service workflow redesign and public calendar/KVK calendar redesign remain
+  separate deferred optimisation programmes.
 - Impact: high
 - Risk: medium
 - Dependencies: Batch 1 `/ops` and `/mge` grouping, Phase 1 permission decorator standardisation, Phase 4 Ark grouping, and Phase 5A admin/leadership/operator grouping remain deployed cleanly; coordinate with bot operators before renaming public command paths; preserve standard decorator permission checks when commands move into groups.

--- a/docs/reference/runbook_devops.md
+++ b/docs/reference/runbook_devops.md
@@ -44,6 +44,11 @@ promotion or when the blast radius is broad. Use `python scripts/analyse_pytest_
 when deployment validation needs proof that pytest did not write WARNING/ERROR records to
 production operational logs.
 
+For command-surface changes, `scripts/validate_command_registration.py` also enforces the approved
+top-level command baseline. New top-level commands or command groups require operator approval,
+an `APPROVED_TOP_LEVEL_COMMANDS` update, and a matching
+`docs/reference/canonical_command_reference.md` update before promotion.
+
 ## Runtime Configuration
 
 Use `ENV_REFERENCE.md` for variable details. Common required/important values:

--- a/docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md
+++ b/docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md
@@ -103,10 +103,20 @@ should preserve that headroom through governance rather than more command moveme
 ## 7. Design Questions
 
 - Should command registration validation be enforced only in CI, or also through pre-commit?
+  - Decision: enforce in both. Pre-commit gives fast local feedback; focused CI protects PRs.
 - Should the validator produce a reusable command inventory artifact for PR review?
+  - Decision: yes. Support JSON and Markdown output; CI uploads a Markdown inventory artifact.
 - Should the validator fail on ungrouped admin/leadership/operator commands, or only warn?
+  - Decision: fail on any unexpected top-level command not present in the approved baseline. A new
+    top-level command or command group requires explicit operator approval, validator baseline
+    update, canonical reference update, and docs/smoke review.
 - What exact checklist should future task packs include when adding or changing commands?
+  - Decision: require a command-surface impact statement, group-first design, top-level approval
+    rationale when applicable, canonical docs update, validator run, focused command inventory
+    tests, and preservation/review of decorators, versions, usage tracking, response visibility,
+    command-cache behavior, docs, and smoke references.
 - Should Phase 7 close the programme after guardrails land?
+  - Decision: yes.
 
 Recommended answer for the final question: yes. Phase 7 is the final planned command-platform
 programme phase. Player self-service workflow redesign and public calendar/KVK calendar redesign

--- a/docs/templates/Codex Task Pack Template.md
+++ b/docs/templates/Codex Task Pack Template.md
@@ -172,6 +172,31 @@ Map the likely:
 - Add or update tests unless the change is documentation-only or tooling-only.
 - Capture new out-of-scope findings as deferred optimisations.
 
+### Command Surface Governance
+
+Use this section when the task creates, moves, renames, retires, or changes any slash command,
+command group, grouped subcommand, command decorator, command registration helper, or command
+lifecycle/cache behavior. Delete it only when the task has no command-surface impact.
+
+- [ ] State whether the task changes top-level command count, grouped subcommand count, or neither.
+- [ ] Prefer grouped commands for admin, leadership, operator, diagnostic, and domain-maintenance
+  work.
+- [ ] If the task creates a new top-level command, document why an existing command group is not
+  suitable, record operator approval for the flat path, update
+  `scripts/validate_command_registration.py::APPROVED_TOP_LEVEL_COMMANDS`, update
+  `docs/reference/canonical_command_reference.md`, update relevant user/operator docs and smoke
+  references, and run command registration validation.
+- [ ] If the task creates a grouped subcommand under an existing group, update the canonical
+  command table and grouped summary, but do not change the approved top-level baseline.
+- [ ] If the task creates a new command group, treat it as a new top-level command and complete
+  the flat-path approval/baseline steps above.
+- [ ] Preserve or explicitly update `@versioned()`, `@safe_command`, `@track_usage()`, permission
+  decorators, response visibility, autocomplete/options, usage-log identity, and command-cache
+  behavior.
+- [ ] Run or justify skipping `scripts/validate_command_registration.py`,
+  `tests/test_validate_command_registration.py`, `tests/test_command_inventory.py`, and
+  `tests/test_command_registration_smoke.py`.
+
 ## 13. Refactor Decisions
 
 Classify each issue found during audit:

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -31,6 +31,9 @@ collect_static_primary_inventory = _COMMAND_INVENTORY.collect_static_primary_inv
 
 PRIMARY_COMMAND_LIMIT = 100
 PRIMARY_COMMAND_WARNING_THRESHOLD = 90
+PRIMARY_COMMAND_SURFACE_LABEL = "commands package (authoritative)"
+SECONDARY_COGS_LABEL = "cogs/commands.py (disabled legacy)"
+SECONDARY_SUBSCRIBE_LABEL = "subscribe.py (disabled legacy)"
 APPROVED_TOP_LEVEL_COMMANDS = frozenset(
     {
         "activity",
@@ -107,15 +110,19 @@ class CommandRegistrationReport:
 
     @property
     def secondary_cogs_count(self) -> int:
-        return len(self.paths["cogs/commands.py (disabled legacy)"])
+        return len(self.paths.get(SECONDARY_COGS_LABEL, set()))
 
     @property
     def secondary_subscribe_count(self) -> int:
-        return len(self.paths["subscribe.py (disabled legacy)"])
+        return len(self.paths.get(SECONDARY_SUBSCRIBE_LABEL, set()))
 
     @property
     def disabled_legacy_count(self) -> int:
-        return self.secondary_cogs_count + self.secondary_subscribe_count
+        return sum(
+            len(names)
+            for label, names in self.paths.items()
+            if label != PRIMARY_COMMAND_SURFACE_LABEL
+        )
 
     @property
     def headroom(self) -> int:
@@ -123,8 +130,8 @@ class CommandRegistrationReport:
 
 
 SECONDARY_MODULES = [
-    CommandSource("cogs/commands.py (disabled legacy)", ROOT / "cogs" / "commands.py"),
-    CommandSource("subscribe.py (disabled legacy)", ROOT / "subscribe.py"),
+    CommandSource(SECONDARY_COGS_LABEL, ROOT / "cogs" / "commands.py"),
+    CommandSource(SECONDARY_SUBSCRIBE_LABEL, ROOT / "subscribe.py"),
 ]
 
 
@@ -151,7 +158,7 @@ def collect_primary_names() -> set[str]:
 
 def _build_report() -> CommandRegistrationReport:
     primary_names, grouped, primary_name_sources = _collect_primary_inventory_details()
-    paths = {"commands package (authoritative)": primary_names}
+    paths = {PRIMARY_COMMAND_SURFACE_LABEL: primary_names}
     paths.update({source.label: collect_names(source.path) for source in SECONDARY_MODULES})
     owners: dict[str, list[str]] = {}
     for label, names in paths.items():
@@ -215,11 +222,13 @@ def _report_payload(report: CommandRegistrationReport) -> dict[str, object]:
 
 def _format_text(report: CommandRegistrationReport) -> str:
     lines = [_summary_line(report)]
-    lines.append("active command surface: commands package (authoritative)")
+    lines.append(f"active command surface: {PRIMARY_COMMAND_SURFACE_LABEL}")
     if report.disabled_legacy_count:
         lines.append("disabled legacy command surfaces retained:")
         for source in SECONDARY_MODULES:
-            lines.append(f"  {source.label}: {len(report.paths[source.label])} command(s)")
+            lines.append(
+                f"  {source.label}: {len(report.paths.get(source.label, set()))} command(s)"
+            )
     else:
         lines.append("disabled legacy command surfaces: none retained")
 
@@ -306,11 +315,11 @@ def _format_markdown(report: CommandRegistrationReport) -> str:
         lines.append("- No unexpected top-level command drift detected.")
     if report.missing_approved_top_level:
         lines.append("- Approved top-level commands missing from current inventory:")
-        lines.extend(f"- `/{name}`" for name in sorted(report.missing_approved_top_level))
+        lines.extend(f"  - `/{name}`" for name in sorted(report.missing_approved_top_level))
     if report.active_duplicates:
         lines.append("- Active duplicate risks detected:")
         lines.extend(
-            f"- `/{name}`: {', '.join(report.active_duplicates[name])}"
+            f"  - `/{name}`: {', '.join(report.active_duplicates[name])}"
             for name in sorted(report.active_duplicates)
         )
     else:

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -7,8 +7,10 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass
 import importlib.util
+import json
 from pathlib import Path
 import sys
 
@@ -29,12 +31,95 @@ collect_static_primary_inventory = _COMMAND_INVENTORY.collect_static_primary_inv
 
 PRIMARY_COMMAND_LIMIT = 100
 PRIMARY_COMMAND_WARNING_THRESHOLD = 90
+APPROVED_TOP_LEVEL_COMMANDS = frozenset(
+    {
+        "activity",
+        "ark",
+        "calendar",
+        "calendar_next_event",
+        "calendar_reminder_config",
+        "crystaltech",
+        "events",
+        "export_inventory",
+        "honor",
+        "honor_rankings",
+        "inventory",
+        "inventory_preferences",
+        "kvk",
+        "kvk_rankings",
+        "location",
+        "mge",
+        "modify_registration",
+        "modify_subscription",
+        "my_registrations",
+        "my_stats",
+        "my_stats_export",
+        "mygovernorid",
+        "myinventory",
+        "mykvkcrystaltech",
+        "mykvkhistory",
+        "mykvkstats",
+        "mykvktargets",
+        "next_kvk_event",
+        "next_kvk_fight",
+        "ops",
+        "ping",
+        "player_profile",
+        "prekvk",
+        "register_governor",
+        "registry",
+        "stats",
+        "subscribe",
+        "subscriptions",
+        "unsubscribe",
+    }
+)
 
 
 @dataclass(frozen=True)
 class CommandSource:
     label: str
     path: Path
+
+
+@dataclass(frozen=True)
+class CommandRegistrationReport:
+    primary_names: set[str]
+    grouped: dict[str, set[str]]
+    primary_name_sources: dict[str, list[str]]
+    paths: dict[str, set[str]]
+    active_duplicates: dict[str, list[str]]
+    disabled_legacy_duplicates: dict[str, list[str]]
+    unexpected_top_level: set[str]
+    missing_approved_top_level: set[str]
+
+    @property
+    def grouped_subcommand_detected_count(self) -> int:
+        return sum(len(commands) for commands in self.grouped.values())
+
+    @property
+    def primary_count(self) -> int:
+        return len(self.primary_names)
+
+    @property
+    def total_unique(self) -> int:
+        return len(set().union(*self.paths.values()))
+
+    @property
+    def secondary_cogs_count(self) -> int:
+        return len(self.paths["cogs/commands.py (disabled legacy)"])
+
+    @property
+    def secondary_subscribe_count(self) -> int:
+        return len(self.paths["subscribe.py (disabled legacy)"])
+
+    @property
+    def disabled_legacy_count(self) -> int:
+        return self.secondary_cogs_count + self.secondary_subscribe_count
+
+    @property
+    def headroom(self) -> int:
+        return PRIMARY_COMMAND_LIMIT - self.primary_count
 
 
 SECONDARY_MODULES = [
@@ -64,9 +149,8 @@ def collect_primary_names() -> set[str]:
     return names
 
 
-def main() -> int:
+def _build_report() -> CommandRegistrationReport:
     primary_names, grouped, primary_name_sources = _collect_primary_inventory_details()
-    grouped_subcommand_detected_count = sum(len(commands) for commands in grouped.values())
     paths = {"commands package (authoritative)": primary_names}
     paths.update({source.label: collect_names(source.path) for source in SECONDARY_MODULES})
     owners: dict[str, list[str]] = {}
@@ -81,61 +165,197 @@ def main() -> int:
         for name, labels in owners.items()
         if len(labels) > 1 and name not in active_duplicates
     }
-
-    primary_count = len(paths["commands package (authoritative)"])
-    total_unique = len(set().union(*paths.values()))
-    secondary_cogs_count = len(paths["cogs/commands.py (disabled legacy)"])
-    secondary_subscribe_count = len(paths["subscribe.py (disabled legacy)"])
-    disabled_legacy_count = secondary_cogs_count + secondary_subscribe_count
-    print(
-        f"registration summary: primary={primary_count} "
-        f"grouped_subcommands_detected={grouped_subcommand_detected_count} "
-        f"disabled_legacy={disabled_legacy_count} "
-        f"secondary_cogs={secondary_cogs_count} "
-        f"secondary_subscribe={secondary_subscribe_count} "
-        f"total_unique={total_unique}"
+    return CommandRegistrationReport(
+        primary_names=primary_names,
+        grouped=grouped,
+        primary_name_sources=primary_name_sources,
+        paths=paths,
+        active_duplicates=active_duplicates,
+        disabled_legacy_duplicates=disabled_legacy_duplicates,
+        unexpected_top_level=primary_names - APPROVED_TOP_LEVEL_COMMANDS,
+        missing_approved_top_level=APPROVED_TOP_LEVEL_COMMANDS - primary_names,
     )
-    print("active command surface: commands package (authoritative)")
-    if disabled_legacy_count:
-        print("disabled legacy command surfaces retained:")
+
+
+def _summary_line(report: CommandRegistrationReport) -> str:
+    return (
+        f"registration summary: primary={report.primary_count} "
+        f"grouped_subcommands_detected={report.grouped_subcommand_detected_count} "
+        f"disabled_legacy={report.disabled_legacy_count} "
+        f"secondary_cogs={report.secondary_cogs_count} "
+        f"secondary_subscribe={report.secondary_subscribe_count} "
+        f"total_unique={report.total_unique}"
+    )
+
+
+def _report_payload(report: CommandRegistrationReport) -> dict[str, object]:
+    return {
+        "summary": {
+            "primary": report.primary_count,
+            "grouped_subcommands_detected": report.grouped_subcommand_detected_count,
+            "disabled_legacy": report.disabled_legacy_count,
+            "secondary_cogs": report.secondary_cogs_count,
+            "secondary_subscribe": report.secondary_subscribe_count,
+            "total_unique": report.total_unique,
+            "primary_limit": PRIMARY_COMMAND_LIMIT,
+            "warning_threshold": PRIMARY_COMMAND_WARNING_THRESHOLD,
+            "headroom": report.headroom,
+        },
+        "top_level_commands": sorted(report.primary_names),
+        "approved_top_level_commands": sorted(APPROVED_TOP_LEVEL_COMMANDS),
+        "unexpected_top_level_commands": sorted(report.unexpected_top_level),
+        "missing_approved_top_level_commands": sorted(report.missing_approved_top_level),
+        "grouped_commands": {
+            group_name: sorted(commands) for group_name, commands in sorted(report.grouped.items())
+        },
+        "active_duplicates": report.active_duplicates,
+        "disabled_legacy_duplicates": report.disabled_legacy_duplicates,
+    }
+
+
+def _format_text(report: CommandRegistrationReport) -> str:
+    lines = [_summary_line(report)]
+    lines.append("active command surface: commands package (authoritative)")
+    if report.disabled_legacy_count:
+        lines.append("disabled legacy command surfaces retained:")
         for source in SECONDARY_MODULES:
-            print(f"  {source.label}: {len(paths[source.label])} command(s)")
+            lines.append(f"  {source.label}: {len(report.paths[source.label])} command(s)")
     else:
-        print("disabled legacy command surfaces: none retained")
+        lines.append("disabled legacy command surfaces: none retained")
 
-    if grouped:
-        print("grouped command summary (statically detected):")
-        for group_name in sorted(grouped):
-            subcommands = grouped[group_name]
-            print(f"  /{group_name}: {len(subcommands)} subcommand(s)")
+    if report.grouped:
+        lines.append("grouped command summary (statically detected):")
+        for group_name in sorted(report.grouped):
+            subcommands = report.grouped[group_name]
+            lines.append(f"  /{group_name}: {len(subcommands)} subcommand(s)")
 
-    failed = False
-    if primary_count > PRIMARY_COMMAND_LIMIT:
-        print(
-            f"primary command limit exceeded: {primary_count}/{PRIMARY_COMMAND_LIMIT} "
+    if report.primary_count > PRIMARY_COMMAND_LIMIT:
+        lines.append(
+            f"primary command limit exceeded: {report.primary_count}/{PRIMARY_COMMAND_LIMIT} "
             "top-level application commands"
         )
-        failed = True
-    elif primary_count >= PRIMARY_COMMAND_WARNING_THRESHOLD:
-        print(
-            f"primary command limit warning: {primary_count}/{PRIMARY_COMMAND_LIMIT} "
+    elif report.primary_count >= PRIMARY_COMMAND_WARNING_THRESHOLD:
+        lines.append(
+            f"primary command limit warning: {report.primary_count}/{PRIMARY_COMMAND_LIMIT} "
             "top-level application commands"
         )
 
-    if not active_duplicates:
-        print("no active duplicate risks detected")
+    if report.unexpected_top_level:
+        lines.append("unexpected top-level command drift detected:")
+        for name in sorted(report.unexpected_top_level):
+            lines.append(f"  /{name}")
     else:
-        print("active duplicate risks detected:")
-        for name in sorted(active_duplicates):
-            print(f"  /{name}: {', '.join(active_duplicates[name])}")
+        lines.append("no unexpected top-level command drift detected")
 
-    if disabled_legacy_duplicates:
-        print("disabled legacy duplicates detected:")
-        for name in sorted(disabled_legacy_duplicates):
-            print(f"  /{name}: {', '.join(disabled_legacy_duplicates[name])}")
+    if report.missing_approved_top_level:
+        lines.append("approved top-level commands missing from current inventory:")
+        for name in sorted(report.missing_approved_top_level):
+            lines.append(f"  /{name}")
 
-    return 1 if failed else 0
+    if not report.active_duplicates:
+        lines.append("no active duplicate risks detected")
+    else:
+        lines.append("active duplicate risks detected:")
+        for name in sorted(report.active_duplicates):
+            lines.append(f"  /{name}: {', '.join(report.active_duplicates[name])}")
+
+    if report.disabled_legacy_duplicates:
+        lines.append("disabled legacy duplicates detected:")
+        for name in sorted(report.disabled_legacy_duplicates):
+            lines.append(f"  /{name}: {', '.join(report.disabled_legacy_duplicates[name])}")
+
+    return "\n".join(lines)
+
+
+def _format_json(report: CommandRegistrationReport) -> str:
+    return json.dumps(_report_payload(report), indent=2, sort_keys=True)
+
+
+def _format_markdown(report: CommandRegistrationReport) -> str:
+    lines = [
+        "# Command Registration Inventory",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Top-level commands | {report.primary_count} |",
+        f"| Grouped subcommands detected | {report.grouped_subcommand_detected_count} |",
+        f"| Disabled legacy declarations | {report.disabled_legacy_count} |",
+        f"| Unique top-level commands | {report.total_unique} |",
+        f"| Discord top-level limit | {PRIMARY_COMMAND_LIMIT} |",
+        f"| Remaining headroom | {report.headroom} |",
+        "",
+        "## Grouped Commands",
+        "",
+        "| Group | Subcommands |",
+        "|---|---:|",
+    ]
+    for group_name in sorted(report.grouped):
+        lines.append(f"| `/{group_name}` | {len(report.grouped[group_name])} |")
+
+    lines.extend(["", "## Top-Level Commands", ""])
+    for name in sorted(report.primary_names):
+        lines.append(f"- `/{name}`")
+
+    lines.extend(["", "## Drift Checks", ""])
+    if report.unexpected_top_level:
+        lines.append("Unexpected top-level commands:")
+        lines.extend(f"- `/{name}`" for name in sorted(report.unexpected_top_level))
+    else:
+        lines.append("- No unexpected top-level command drift detected.")
+    if report.missing_approved_top_level:
+        lines.append("- Approved top-level commands missing from current inventory:")
+        lines.extend(f"- `/{name}`" for name in sorted(report.missing_approved_top_level))
+    if report.active_duplicates:
+        lines.append("- Active duplicate risks detected:")
+        lines.extend(
+            f"- `/{name}`: {', '.join(report.active_duplicates[name])}"
+            for name in sorted(report.active_duplicates)
+        )
+    else:
+        lines.append("- No active duplicate risks detected.")
+    return "\n".join(lines)
+
+
+def _is_failed(report: CommandRegistrationReport) -> bool:
+    return (
+        report.primary_count > PRIMARY_COMMAND_LIMIT
+        or bool(report.unexpected_top_level)
+        or bool(report.missing_approved_top_level)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+        help="Output format for the command registration inventory.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the formatted inventory artifact.",
+    )
+    args = parser.parse_args([] if argv is None else argv)
+
+    report = _build_report()
+    if args.format == "json":
+        output = _format_json(report)
+    elif args.format == "markdown":
+        output = _format_markdown(report)
+    else:
+        output = _format_text(report)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output + "\n", encoding="utf-8")
+    print(output)
+
+    return 1 if _is_failed(report) else 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_command_governance_config.py
+++ b/tests/test_command_governance_config.py
@@ -16,7 +16,10 @@ def test_command_governance_workflow_runs_validator_and_focused_tests() -> None:
 
     assert "python scripts/validate_command_registration.py" in workflow
     assert "command-registration-inventory.md" in workflow
-    assert (
-        "python -m pytest -q tests/test_validate_command_registration.py "
-        "tests/test_command_inventory.py tests/test_command_registration_smoke.py"
-    ) in workflow
+    assert "Commands.py" in workflow
+    assert "DL_bot.py" in workflow
+    assert "tests/test_command_governance_config.py" in workflow
+    assert "python -m pytest -q" in workflow
+    assert "tests/test_validate_command_registration.py" in workflow
+    assert "tests/test_command_inventory.py" in workflow
+    assert "tests/test_command_registration_smoke.py" in workflow

--- a/tests/test_command_governance_config.py
+++ b/tests/test_command_governance_config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pre_commit_runs_command_registration_validator() -> None:
+    config = Path(".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "id: validate-command-registration" in config
+    assert "entry: python scripts/validate_command_registration.py" in config
+    assert "pass_filenames: false" in config
+
+
+def test_command_governance_workflow_runs_validator_and_focused_tests() -> None:
+    workflow = Path(".github/workflows/command-governance.yml").read_text(encoding="utf-8")
+
+    assert "python scripts/validate_command_registration.py" in workflow
+    assert "command-registration-inventory.md" in workflow
+    assert (
+        "python -m pytest -q tests/test_validate_command_registration.py "
+        "tests/test_command_inventory.py tests/test_command_registration_smoke.py"
+    ) in workflow

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from scripts import validate_command_registration as validator
@@ -204,6 +205,7 @@ def register_two(bot):
     )
 
     monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ping"}))
     monkeypatch.setattr(
         validator,
         "SECONDARY_MODULES",
@@ -224,7 +226,9 @@ def register_two(bot):
 
 def test_main_warns_when_primary_command_count_nears_limit(tmp_path, monkeypatch, capsys):
     command_lines = []
+    expected_names = set()
     for index in range(validator.PRIMARY_COMMAND_WARNING_THRESHOLD):
+        expected_names.add(f"cmd_{index}")
         command_lines.append(f"""
     @bot.slash_command(name="cmd_{index}", description="Command {index}")
     async def cmd_{index}(ctx):
@@ -238,6 +242,7 @@ def test_main_warns_when_primary_command_count_nears_limit(tmp_path, monkeypatch
     _write(tmp_path / "subscribe.py", "")
 
     monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset(expected_names))
     monkeypatch.setattr(
         validator,
         "SECONDARY_MODULES",
@@ -268,6 +273,7 @@ def register_sample(bot):
     )
 
     monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ping"}))
     monkeypatch.setattr(
         validator,
         "SECONDARY_MODULES",
@@ -312,6 +318,7 @@ class SummaryCommands(commands.Cog):
     _write(tmp_path / "subscribe.py", "")
 
     monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ping"}))
     monkeypatch.setattr(
         validator,
         "SECONDARY_MODULES",
@@ -330,3 +337,112 @@ class SummaryCommands(commands.Cog):
     assert "no active duplicate risks detected" in output
     assert "disabled legacy duplicates detected:" in output
     assert "/ping: cogs/commands.py (disabled legacy), commands package (authoritative)" in output
+
+
+def test_main_fails_on_unapproved_top_level_command(tmp_path, monkeypatch, capsys):
+    _write(
+        tmp_path / "commands" / "sample_cmds.py",
+        """
+def register_sample(bot):
+    @bot.slash_command(name="new_admin_tool", description="New admin tool")
+    async def new_admin_tool(ctx):
+        pass
+""",
+    )
+
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ping"}))
+    monkeypatch.setattr(
+        validator,
+        "SECONDARY_MODULES",
+        [
+            validator.CommandSource(
+                "cogs/commands.py (disabled legacy)", tmp_path / "cogs" / "commands.py"
+            ),
+            validator.CommandSource("subscribe.py (disabled legacy)", tmp_path / "subscribe.py"),
+        ],
+    )
+
+    assert validator.main() == 1
+
+    output = capsys.readouterr().out
+    assert "unexpected top-level command drift detected:" in output
+    assert "/new_admin_tool" in output
+    assert "approved top-level commands missing from current inventory:" in output
+    assert "/ping" in output
+
+
+def test_main_writes_json_inventory_artifact(tmp_path, monkeypatch, capsys):
+    _write(
+        tmp_path / "commands" / "sample_cmds.py",
+        """
+import discord
+
+
+def register_sample(bot):
+    group = discord.SlashCommandGroup("ops", "Ops")
+
+    @group.command(name="status", description="Status")
+    async def status(ctx):
+        pass
+
+    bot.add_application_command(group)
+""",
+    )
+    output_path = tmp_path / "artifacts" / "commands.json"
+
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ops"}))
+    monkeypatch.setattr(
+        validator,
+        "SECONDARY_MODULES",
+        [
+            validator.CommandSource(
+                "cogs/commands.py (disabled legacy)", tmp_path / "cogs" / "commands.py"
+            ),
+            validator.CommandSource("subscribe.py (disabled legacy)", tmp_path / "subscribe.py"),
+        ],
+    )
+
+    assert validator.main(["--format", "json", "--output", str(output_path)]) == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["primary"] == 1
+    assert payload["summary"]["grouped_subcommands_detected"] == 1
+    assert payload["top_level_commands"] == ["ops"]
+    assert payload["grouped_commands"] == {"ops": ["status"]}
+    assert json.loads(capsys.readouterr().out)["summary"]["headroom"] == 99
+
+
+def test_main_writes_markdown_inventory_artifact(tmp_path, monkeypatch):
+    _write(
+        tmp_path / "commands" / "sample_cmds.py",
+        """
+def register_sample(bot):
+    @bot.slash_command(name="ping", description="Ping")
+    async def ping(ctx):
+        pass
+""",
+    )
+    output_path = tmp_path / "artifacts" / "commands.md"
+
+    monkeypatch.setattr(validator, "ROOT", tmp_path)
+    monkeypatch.setattr(validator, "APPROVED_TOP_LEVEL_COMMANDS", frozenset({"ping"}))
+    monkeypatch.setattr(
+        validator,
+        "SECONDARY_MODULES",
+        [
+            validator.CommandSource(
+                "cogs/commands.py (disabled legacy)", tmp_path / "cogs" / "commands.py"
+            ),
+            validator.CommandSource("subscribe.py (disabled legacy)", tmp_path / "subscribe.py"),
+        ],
+    )
+
+    assert validator.main(["--format", "markdown", "--output", str(output_path)]) == 0
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "# Command Registration Inventory" in output
+    assert "| Top-level commands | 1 |" in output
+    assert "- `/ping`" in output
+    assert "No unexpected top-level command drift detected" in output

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -446,3 +446,47 @@ def register_sample(bot):
     assert "| Top-level commands | 1 |" in output
     assert "- `/ping`" in output
     assert "No unexpected top-level command drift detected" in output
+
+
+def test_markdown_inventory_nests_missing_and_duplicate_details() -> None:
+    report = validator.CommandRegistrationReport(
+        primary_names={"new_tool", "ping"},
+        grouped={},
+        primary_name_sources={"ping": ["commands/a.py", "commands/b.py"]},
+        paths={
+            validator.PRIMARY_COMMAND_SURFACE_LABEL: {"new_tool", "ping"},
+            "renamed secondary label": {"legacy_ping"},
+        },
+        active_duplicates={"ping": ["commands/a.py", "commands/b.py"]},
+        disabled_legacy_duplicates={},
+        unexpected_top_level={"new_tool"},
+        missing_approved_top_level={"ops"},
+    )
+
+    output = validator._format_markdown(report)
+
+    assert "- Approved top-level commands missing from current inventory:" in output
+    assert "  - `/ops`" in output
+    assert "- Active duplicate risks detected:" in output
+    assert "  - `/ping`: commands/a.py, commands/b.py" in output
+    assert "| Disabled legacy declarations | 1 |" in output
+
+
+def test_report_secondary_counts_tolerate_missing_or_extended_labels() -> None:
+    report = validator.CommandRegistrationReport(
+        primary_names={"ping"},
+        grouped={},
+        primary_name_sources={},
+        paths={
+            validator.PRIMARY_COMMAND_SURFACE_LABEL: {"ping"},
+            "custom secondary surface": {"legacy_ping", "legacy_subscribe"},
+        },
+        active_duplicates={},
+        disabled_legacy_duplicates={},
+        unexpected_top_level=set(),
+        missing_approved_top_level=set(),
+    )
+
+    assert report.secondary_cogs_count == 0
+    assert report.secondary_subscribe_count == 0
+    assert report.disabled_legacy_count == 2


### PR DESCRIPTION
## Summary

- Adds Phase 7 command-platform governance guardrails without moving, renaming, retiring, or adding slash commands.
- Enforces the approved top-level command baseline in `scripts/validate_command_registration.py`.
- Adds JSON/Markdown validator artifact output, pre-commit wiring, focused command-governance CI, and task/PR/promotion checklist updates.

## File Manifest

- `.github/workflows/command-governance.yml`
- `.github/pull_request_template.md`
- `.pre-commit-config.yaml`
- `scripts/validate_command_registration.py`
- `tests/test_validate_command_registration.py`
- `tests/test_command_governance_config.py`
- `docs/reference/canonical_command_reference.md`
- `docs/reference/K98 Bot - Coding Execution Guidelines.md`
- `docs/reference/Promotion Guide.md`
- `docs/reference/runbook_devops.md`
- `docs/reference/command_platform_audit.md`
- `docs/reference/command_surface_audit.md`
- `docs/reference/deferred_optimisations.md`
- `docs/task_packs/Codex Task Pack - Command Platform Phase 7 Governance And CI Guardrails.md`
- `docs/templates/Codex Task Pack Template.md`

## SQL Changes

- None.

## Helpers Reused

- Reused `commands/command_inventory.py` as the authoritative static inventory helper.
- Reused existing validator/test-selector/pre-commit patterns.

## Refactor Findings

- No command handlers, services, DAL, views, permissions, SQL, or runtime command behavior changed.
- No new direct SQL or interaction-layer business logic introduced.
- Existing command-limit drift deferred item is updated as resolved in progress by Phase 7 guardrails.

## Test Plan And Results

- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py` - passed.
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py` - passed.
- `.\.venv\Scripts\python.exe scripts\select_tests.py` - passed; recommended full tests because test files changed.
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py` - passed.
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py` - passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py tests\test_command_governance_config.py` - 18 passed.
- `.\.venv\Scripts\python.exe -m pre_commit run -a` - passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests` - 1627 passed, 2 skipped.
- `git diff --check` - passed.

## AI Review Gates

- Codex Security: skipped. This phase changes governance/docs/tooling only and does not alter permissions, command runtime behavior, Discord interactions, SQL/data access, file handling, secrets/config, network calls, user-controlled input parsing, or restart-sensitive persistence.

## Deployment / Rollback Notes

- Mirror PR only. No production promotion or bot-machine deployment in this phase.
- Rollback is a normal revert of this PR; it restores the previous validator behavior, removes the focused CI workflow, and removes the added checklist language.

## Deferred Optimisations

- Player self-service workflow redesign remains separate.
- Public calendar/KVK calendar redesign remains separate.
- No new deferred optimisation items added.

## Programme Closure Recommendation

- Recommend closing the Command Platform Audit & Optimisation Programme after this PR lands. Phase 7 provides the final guardrails needed to preserve the Phase 5A/6 command-count baseline.
