### PR TITLE
[codex] Add player KVK command scaffold

### DIFF
--- a/.github/workflows/command-governance.yml
+++ b/.github/workflows/command-governance.yml
@@ -1,0 +1,49 @@
+name: Command Governance
+
+on:
+  pull_request:
+    paths:
+      - "commands/**"
+      - "Commands.py"
+      - "DL_bot.py"
+      - "scripts/validate_command_registration.py"
+      - "commands/command_inventory.py"
+      - "tests/test_validate_command_registration.py"
+      - "tests/test_command_inventory.py"
+      - "tests/test_command_registration_smoke.py"
+      - "tests/test_command_governance_config.py"
+      - "docs/reference/canonical_command_reference.md"
+      - ".github/pull_request_template.md"
+      - ".github/workflows/command-governance.yml"
+  workflow_dispatch:
+
+jobs:
+  command-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Validate command registration
+        run: python scripts/validate_command_registration.py
+
+      - name: Write command inventory artifact
+        run: python scripts/validate_command_registration.py --format markdown --output command-registration-inventory.md
+
+      - name: Run command governance tests
+        run: python -m pytest -q tests/test_validate_command_registration.py tests/test_command_inventory.py tests/test_command_registration_smoke.py tests/test_command_governance_config.py
+
+      - name: Upload command inventory artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: command-registration-inventory
+          path: command-registration-inventory.md

--- a/.publishignore
+++ b/.publishignore
@@ -86,5 +86,9 @@ statsupdate-*.json
 *.swp
 *.swo
 
-# ---- Don't mirror GitHub Actions workflows to the public mirror ----
-.github/workflows/**
+# ---- Don't mirror production-only GitHub Actions workflows to the public mirror ----
+# command-governance.yml is mirrored because local tests and command-governance checks assert it.
+.github/workflows/_sanity.yml
+.github/workflows/gitleaks.yml
+.github/workflows/publish-mirror.yml
+.github/workflows/quality.yml

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -9,6 +9,7 @@ from .ark_cmds import register_ark
 from .calendar_cmds import register_calendar
 from .events_cmds import register_events
 from .inventory_cmds import register_inventory
+from .kvk_cmds import register_kvk
 from .location_cmds import register_location
 from .mge_cmds import register_mge
 from .prekvk_cmds import register_prekvk
@@ -25,6 +26,7 @@ def register_all(bot: ext_commands.Bot) -> None:
     register_calendar(bot)
     register_events(bot)
     register_inventory(bot)
+    register_kvk(bot)
     register_location(bot)
     register_mge(bot)
     register_prekvk(bot)

--- a/commands/kvk_cmds.py
+++ b/commands/kvk_cmds.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import logging
+
+import discord
+from discord.ext import commands as ext_commands
+
+from account_picker import safe_build_unique_gov_options
+from bot_config import GUILD_ID, KVK_PLAYER_STATS_CHANNEL_ID, KVK_TARGET_CHANNEL_ID
+from build_KVKrankings_embed import build_kvkrankings_embed
+from core.interaction_safety import safe_command, safe_defer
+from decoraters import channel_only, track_usage
+from embed_utils import build_stats_embed
+from honor_rankings_view import HonorRankingView, build_honor_rankings_embed
+from kvk_ui import make_kvk_targets_view
+from prekvk import report_service
+from registry.account_slots import ACCOUNT_ORDER
+from services import governor_account_service, kvk_history_service, kvk_personal_service
+from stats_alerts.honors import get_latest_honor_top
+from target_utils import run_target_lookup
+from ui.views.kvk_history_view import KVKHistoryView
+from ui.views.kvk_personal_views import MyKVKStatsSelectView
+from ui.views.prekvk_report_views import send_prekvk_report
+from ui.views.registry_views import GovNameModal, MyRegsActionView, RegisterStartView
+from ui.views.stats_views import KVKRankingView
+from utils import load_stat_cache, normalize_governor_id
+from versioning import versioned
+
+logger = logging.getLogger(__name__)
+
+
+async def _open_registration_flow(interaction: discord.Interaction) -> None:
+    try:
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=True)
+    except Exception:
+        pass
+
+    try:
+        summary = await governor_account_service.get_account_summary_for_user(interaction.user.id)
+        if not summary.ok:
+            await interaction.followup.send(
+                "Registry is temporarily unavailable. Please try again later.",
+                ephemeral=True,
+            )
+            return
+        free_slots = summary.free_slots()
+        if not free_slots:
+            await interaction.followup.send(
+                "All account slots are already registered. Use **/my_registrations -> Modify Registration** to change one.",
+                ephemeral=True,
+            )
+            return
+        await interaction.followup.send(
+            "Pick an account slot to register:",
+            view=RegisterStartView(author_id=interaction.user.id, free_slots=free_slots),
+            ephemeral=True,
+        )
+    except Exception:
+        logger.exception("[/kvk targets] registration flow failed")
+        try:
+            await interaction.followup.send(
+                "Failed to open registration flow. Please try again later.",
+                ephemeral=True,
+            )
+        except Exception:
+            pass
+
+
+async def _open_governor_lookup(interaction: discord.Interaction) -> None:
+    try:
+        await interaction.response.send_modal(GovNameModal(author_id=interaction.user.id))
+    except Exception:
+        try:
+            message = (
+                "Use **/mygovernorid** and start typing your governor name to find your Governor ID."
+            )
+            if not interaction.response.is_done():
+                await interaction.response.send_message(message, ephemeral=True)
+            else:
+                await interaction.followup.send(message, ephemeral=True)
+        except Exception:
+            pass
+
+
+async def _send_personal_kvk_stats(ctx: discord.ApplicationContext) -> None:
+    await safe_defer(ctx, ephemeral=True)
+
+    account_summary = await governor_account_service.get_account_summary_for_user(ctx.user.id)
+    if not account_summary.ok:
+        await ctx.interaction.edit_original_response(
+            content=f"Could not load registry: `{account_summary.error}`"
+        )
+        return
+
+    if not account_summary.governor_ids:
+        view = MyRegsActionView(author_id=ctx.user.id, has_regs=False)
+        msg = await ctx.interaction.edit_original_response(
+            content="You don't have any Governor accounts registered yet. Use the options below:",
+            view=view,
+        )
+        view.set_message_ref(msg)
+        return
+
+    accounts = account_summary.ordered_accounts
+    try:
+        last_kvk_map = await kvk_personal_service.load_last_kvk_map()
+        if not isinstance(last_kvk_map, dict):
+            last_kvk_map = {}
+    except Exception:
+        logger.exception("[/kvk stats] load_last_kvk_map failed")
+        last_kvk_map = {}
+
+    if len(accounts) == 1:
+        ((_, info),) = accounts.items()
+        governor_id = normalize_governor_id(info.get("GovernorID"))
+        if not governor_id:
+            await ctx.interaction.edit_original_response(
+                content="Your registration has no valid Governor ID."
+            )
+            return
+
+        row = await kvk_personal_service.load_kvk_personal_stats(governor_id)
+        if not row:
+            await ctx.interaction.edit_original_response(
+                content=f"Stats not found for Governor ID `{governor_id}`."
+            )
+            return
+
+        try:
+            last_kvk = last_kvk_map.get(str(governor_id))
+            if last_kvk:
+                row["last_kvk"] = last_kvk
+        except Exception:
+            logger.exception("[/kvk stats] failed attaching last_kvk for %s", governor_id)
+
+        try:
+            embeds, file = build_stats_embed(row, ctx.user)
+        except Exception as exc:
+            logger.exception("[/kvk stats] build_stats_embed failed")
+            await ctx.interaction.edit_original_response(
+                content=f"Failed to build stats: `{type(exc).__name__}: {exc}`"
+            )
+            return
+
+        try:
+            if file is not None:
+                await ctx.channel.send(embeds=embeds, files=[file])
+            else:
+                await ctx.channel.send(embeds=embeds)
+        except Exception:
+            try:
+                await ctx.channel.send(embeds=embeds)
+            except Exception:
+                logger.exception("[/kvk stats] failed to send stats embed(s) to channel")
+
+        try:
+            await ctx.interaction.edit_original_response(content=" ", view=None)
+        except Exception:
+            pass
+        return
+
+    ordered_accounts = {slot: accounts[slot] for slot in ACCOUNT_ORDER if slot in accounts}
+    for slot in sorted(accounts.keys()):
+        if slot not in ordered_accounts:
+            ordered_accounts[slot] = accounts[slot]
+
+    try:
+        view = MyKVKStatsSelectView(ctx=ctx, accounts=ordered_accounts, author_id=ctx.user.id)
+        view._last_kvk_map = last_kvk_map
+    except Exception as exc:
+        logger.exception("[/kvk stats] MyKVKStatsSelectView init failed")
+        await ctx.interaction.edit_original_response(
+            content=f"Failed to build account selector: `{type(exc).__name__}: {exc}`"
+        )
+        return
+
+    await ctx.interaction.edit_original_response(
+        content="Select an account below to view your stats:",  # architecture-check: allow
+        view=view,
+    )
+
+
+async def _send_personal_kvk_targets(
+    ctx: discord.ApplicationContext, governor_id: str | None, only_me: bool
+) -> None:
+    await safe_defer(ctx, ephemeral=only_me)
+
+    try:
+        last_kvk_map = await kvk_personal_service.load_last_kvk_map()
+        if not isinstance(last_kvk_map, dict):
+            last_kvk_map = {}
+    except Exception:
+        logger.exception("[/kvk targets] load_last_kvk_map failed")
+        last_kvk_map = {}
+
+    if governor_id and governor_id.strip().isdigit():
+        await run_target_lookup(ctx.interaction, governor_id.strip(), ephemeral=only_me)
+        try:
+            await ctx.interaction.edit_original_response(content=" ", view=None)
+        except Exception:
+            pass
+        return
+
+    try:
+        account_summary = await governor_account_service.get_account_summary_for_user(ctx.user.id)
+        if not account_summary.ok:
+            raise RuntimeError(account_summary.error or "registry unavailable")
+    except Exception:
+        logger.exception("[/kvk targets] load_registry failed")
+        await ctx.followup.send(
+            "Couldn't load your registered accounts. Provide `governor_id` or try again later.",
+            ephemeral=True,
+        )
+        return
+
+    options = safe_build_unique_gov_options(account_summary)
+    if options and len(options) == 1:
+        await run_target_lookup(ctx.interaction, options[0].value, ephemeral=only_me)
+        try:
+            await ctx.interaction.edit_original_response(content=" ", view=None)
+        except Exception:
+            pass
+        return
+
+    async def _on_select(
+        interaction: discord.Interaction, selected_governor_id: str, ephemeral: bool
+    ) -> None:
+        await run_target_lookup(interaction, selected_governor_id, ephemeral=ephemeral)
+
+    if options:
+        try:
+            view = make_kvk_targets_view(
+                ctx=ctx,
+                options=options,
+                on_select_governor=_on_select,
+                show_register_btn=True,
+                ephemeral=only_me,
+                last_kvk_map=last_kvk_map,
+                lookup_callback=_open_governor_lookup,
+                register_callback=_open_registration_flow,
+            )
+            await ctx.followup.send(
+                "Select an account to view its KVK targets:",  # architecture-check: allow
+                view=view,
+                ephemeral=only_me,
+            )
+        except Exception:
+            logger.exception(
+                "[/kvk targets] failed to create/send account selector view"  # architecture-check: allow
+            )
+            await ctx.followup.send(
+                "Failed to show account selector. Try again later.", ephemeral=True
+            )
+        return
+
+    hint = (
+        "You don't have any linked governor accounts yet.\n"
+        "- Use `/register_governor`, or\n"
+        "- Re-run this command with the `governor_id` option."
+    )
+    try:
+        view = make_kvk_targets_view(
+            ctx=ctx,
+            options=[],
+            on_select_governor=_on_select,
+            show_register_btn=True,
+            ephemeral=only_me,
+            last_kvk_map=last_kvk_map,
+            lookup_callback=_open_governor_lookup,
+            register_callback=_open_registration_flow,
+        )
+        await ctx.followup.send(hint, view=view, ephemeral=only_me)
+    except Exception:
+        logger.exception(
+            "[/kvk targets] failed to create/send empty account picker view"  # architecture-check: allow
+        )
+        await ctx.followup.send(hint, ephemeral=only_me)
+
+
+async def _send_kvk_history(
+    ctx: discord.ApplicationContext, ephemeral: bool, governor_id: int | None
+) -> None:
+    await safe_defer(ctx, ephemeral=ephemeral)
+
+    account_summary = await governor_account_service.get_account_summary_for_user(ctx.user.id)
+    if not account_summary.ok and not governor_id:
+        await ctx.followup.send(
+            f"Registry is temporarily unavailable: `{account_summary.error}`",
+            ephemeral=True,
+        )
+        return
+    account_map = kvk_history_service.build_ordered_account_map(account_summary.ordered_accounts)
+
+    if governor_id:
+        try:
+            from kvk_history_utils import fetch_history_for_governors
+
+            df_lookup = await asyncio.to_thread(fetch_history_for_governors, [governor_id])
+            governor_name = None
+            for column in ("GovernorName", "Gov_Name", "Name"):
+                if column in df_lookup.columns and not df_lookup[column].dropna().empty:
+                    governor_name = str(df_lookup[column].dropna().iloc[0])
+                    break
+            governor_name = governor_name or str(governor_id)
+        except Exception:
+            governor_name = str(governor_id)
+        account_map = {"Lookup": {"GovernorID": int(governor_id), "GovernorName": governor_name}}
+    elif not account_map:
+        await ctx.followup.send(
+            "You haven't registered any accounts yet. Use `/register_governor` or pass a Governor ID here.",
+            ephemeral=True,
+        )
+        return
+
+    default_id = (
+        str(governor_id)
+        if governor_id
+        else kvk_history_service.pick_default_governor_id(account_map)
+    )
+    if not default_id:
+        await ctx.followup.send(
+            "I couldn't find a valid Governor ID in your registered accounts.",
+            ephemeral=True,
+        )
+        return
+
+    view = KVKHistoryView(
+        user=ctx.user,
+        account_map=account_map,
+        selected_ids=[default_id],
+        allow_all=True,
+        ephemeral=ephemeral,
+    )
+    await view.initial_send(ctx)
+
+
+async def _send_kvk_rankings(ctx: discord.ApplicationContext) -> None:
+    await safe_defer(ctx, ephemeral=False)
+
+    cache = load_stat_cache()
+    rows = [row for key, row in cache.items() if key != "_meta"]
+    if not rows:
+        await ctx.followup.send(
+            "No stats cache available yet. Try again after the next scan/export.",
+            ephemeral=False,
+        )
+        return
+
+    view = KVKRankingView(cache, metric="power", limit=10, timeout=120.0)
+    embed = build_kvkrankings_embed(rows, "power", 10, page=1)
+    if not embed.footer or not embed.footer.text:
+        last_ref = cache.get("_meta", {}).get("generated_at") or "unknown"
+        embed.set_footer(text=f"Last refreshed: {last_ref}")
+
+    response = await ctx.followup.send(embed=embed, view=view)
+    try:
+        view.message = await ctx.interaction.original_response()
+    except Exception:
+        try:
+            view.message = await response.original_response()
+        except Exception:
+            view.message = None
+
+
+async def _send_honor_rankings(ctx: discord.ApplicationContext) -> None:
+    await safe_defer(ctx, ephemeral=False)
+    try:
+        rows = await get_latest_honor_top(10)
+    except Exception:
+        logger.exception("[/kvk rankings honor] get_latest_honor_top failed")
+        rows = []
+
+    if not rows:
+        await ctx.followup.send("No honor data found for the latest KVK.", ephemeral=False)
+        return
+
+    embed = build_honor_rankings_embed(rows, limit=10)
+    view = HonorRankingView()
+    await ctx.followup.send(embed=embed, view=view, ephemeral=False)
+
+
+async def _run_channel_guarded(
+    ctx: discord.ApplicationContext,
+    channel_id: int,
+    *,
+    admin_override: bool,
+    callback: Callable[[discord.ApplicationContext], Awaitable[None]],
+) -> None:
+    @channel_only(channel_id, admin_override=admin_override)
+    async def guarded(inner_ctx: discord.ApplicationContext) -> None:
+        await callback(inner_ctx)
+
+    await guarded(ctx)
+
+
+def register_kvk(bot: ext_commands.Bot) -> None:
+    kvk_group = discord.SlashCommandGroup(
+        "kvk",
+        "KVK player tools",
+        guild_ids=[GUILD_ID],
+    )
+
+    @kvk_group.command(
+        name="stats",
+        description="View your personal KVK stats.",
+    )
+    @channel_only(KVK_PLAYER_STATS_CHANNEL_ID, admin_override=True)
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def kvk_stats(ctx: discord.ApplicationContext) -> None:
+        await _send_personal_kvk_stats(ctx)
+
+    @kvk_group.command(
+        name="targets",
+        description="View your DKP, kill, and deads targets.",
+    )
+    @channel_only(KVK_TARGET_CHANNEL_ID, admin_override=True)
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def kvk_targets(
+        ctx: discord.ApplicationContext,
+        governor_id: str | None = discord.Option(
+            str,
+            name="governor_id",
+            description="Optional Governor ID if you prefer to type it",
+            required=False,
+            default=None,
+        ),
+        only_me: bool = discord.Option(
+            bool,
+            name="only_me",
+            description="Show only to me",
+            required=False,
+            default=False,
+        ),
+    ) -> None:
+        await _send_personal_kvk_targets(ctx, governor_id, only_me)
+
+    @kvk_group.command(
+        name="history",
+        description="View your KVK-by-KVK history as a chart and table.",
+    )
+    @channel_only(KVK_PLAYER_STATS_CHANNEL_ID, admin_override=False)
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def kvk_history(
+        ctx: discord.ApplicationContext,
+        ephemeral: bool = discord.Option(bool, "Only show to me", required=False, default=False),
+        governor_id: int | None = discord.Option(
+            int, "Governor ID (optional)", required=False, default=None
+        ),
+    ) -> None:
+        await _send_kvk_history(ctx, ephemeral, governor_id)
+
+    @kvk_group.command(
+        name="rankings",
+        description="Browse KVK, honor, or PreKvK rankings.",
+    )
+    @versioned("v1.00")
+    @safe_command
+    @track_usage()
+    async def kvk_rankings(
+        ctx: discord.ApplicationContext,
+        ranking_type_option: str = discord.Option(
+            str,
+            name="type",
+            description="Ranking type",
+            required=True,
+            choices=["kvk", "honor", "prekvk"],
+        ),
+    ) -> None:
+        ranking_type = (ranking_type_option or "").strip().lower()
+        if ranking_type == "kvk":
+            await _run_channel_guarded(
+                ctx,
+                KVK_PLAYER_STATS_CHANNEL_ID,
+                admin_override=True,
+                callback=_send_kvk_rankings,
+            )
+            return
+        if ranking_type == "honor":
+            await _run_channel_guarded(
+                ctx,
+                KVK_PLAYER_STATS_CHANNEL_ID,
+                admin_override=False,
+                callback=_send_honor_rankings,
+            )
+            return
+        if ranking_type == "prekvk":
+            await safe_defer(ctx, ephemeral=True)
+            await send_prekvk_report(
+                ctx=ctx,
+                kvk_no=None,
+                sort_by=report_service.parse_report_sort("Overall"),
+                limit=10,
+            )
+            return
+        await ctx.respond("Unknown ranking type.", ephemeral=True)
+
+    bot.add_application_command(kvk_group)

--- a/commands/kvk_cmds.py
+++ b/commands/kvk_cmds.py
@@ -382,14 +382,39 @@ async def _send_honor_rankings(ctx: discord.ApplicationContext) -> None:
     await ctx.followup.send(embed=embed, view=view, ephemeral=False)
 
 
+async def _send_prekvk_rankings(ctx: discord.ApplicationContext) -> None:
+    await safe_defer(ctx, ephemeral=True)
+    await send_prekvk_report(
+        ctx=ctx,
+        kvk_no=None,
+        sort_by=report_service.parse_report_sort("Overall"),
+        limit=10,
+    )
+
+
+async def _run_tracked(
+    ctx: discord.ApplicationContext,
+    *,
+    command_name: str,
+    callback: Callable[[discord.ApplicationContext], Awaitable[None]],
+) -> None:
+    @track_usage(command_name)
+    async def tracked(inner_ctx: discord.ApplicationContext) -> None:
+        await callback(inner_ctx)
+
+    await tracked(ctx)
+
+
 async def _run_channel_guarded(
     ctx: discord.ApplicationContext,
     channel_id: int,
     *,
     admin_override: bool,
+    command_name: str,
     callback: Callable[[discord.ApplicationContext], Awaitable[None]],
 ) -> None:
     @channel_only(channel_id, admin_override=admin_override)
+    @track_usage(command_name)
     async def guarded(inner_ctx: discord.ApplicationContext) -> None:
         await callback(inner_ctx)
 
@@ -464,7 +489,6 @@ def register_kvk(bot: ext_commands.Bot) -> None:
     )
     @versioned("v1.00")
     @safe_command
-    @track_usage()
     async def kvk_rankings(
         ctx: discord.ApplicationContext,
         ranking_type_option: str = discord.Option(
@@ -481,6 +505,7 @@ def register_kvk(bot: ext_commands.Bot) -> None:
                 ctx,
                 KVK_PLAYER_STATS_CHANNEL_ID,
                 admin_override=True,
+                command_name="kvk rankings",
                 callback=_send_kvk_rankings,
             )
             return
@@ -489,16 +514,15 @@ def register_kvk(bot: ext_commands.Bot) -> None:
                 ctx,
                 KVK_PLAYER_STATS_CHANNEL_ID,
                 admin_override=False,
+                command_name="kvk rankings",
                 callback=_send_honor_rankings,
             )
             return
         if ranking_type == "prekvk":
-            await safe_defer(ctx, ephemeral=True)
-            await send_prekvk_report(
+            await _run_tracked(
                 ctx=ctx,
-                kvk_no=None,
-                sort_by=report_service.parse_report_sort("Overall"),
-                limit=10,
+                command_name="kvk rankings",
+                callback=_send_prekvk_rankings,
             )
             return
         await ctx.respond("Unknown ranking type.", ephemeral=True)

--- a/commands/kvk_cmds.py
+++ b/commands/kvk_cmds.py
@@ -74,9 +74,7 @@ async def _open_governor_lookup(interaction: discord.Interaction) -> None:
         await interaction.response.send_modal(GovNameModal(author_id=interaction.user.id))
     except Exception:
         try:
-            message = (
-                "Use **/mygovernorid** and start typing your governor name to find your Governor ID."
-            )
+            message = "Use **/mygovernorid** and start typing your governor name to find your Governor ID."
             if not interaction.response.is_done():
                 await interaction.response.send_message(message, ephemeral=True)
             else:

--- a/docs/reference/canonical_command_reference.md
+++ b/docs/reference/canonical_command_reference.md
@@ -17,7 +17,7 @@ The runtime source of truth is the active `commands/` package registered through
 Current validator baseline:
 
 ```text
-primary=39 grouped_subcommands_detected=76 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=39
+primary=40 grouped_subcommands_detected=80 disabled_legacy=0 secondary_cogs=0 secondary_subscribe=0 total_unique=40
 ```
 
 Grouped command summary:
@@ -30,6 +30,7 @@ Grouped command summary:
 | `/events` | 2 |
 | `/honor` | 1 |
 | `/inventory` | 2 |
+| `/kvk` | 4 |
 | `/kvk_admin` | 7 |
 | `/location` | 2 |
 | `/mge` | 6 |
@@ -64,7 +65,7 @@ The approved top-level command baseline is enforced by `APPROVED_TOP_LEVEL_COMMA
 
 ```text
 activity, ark, calendar, calendar_next_event, calendar_reminder_config, crystaltech, events,
-export_inventory, honor, honor_rankings, inventory, inventory_preferences, kvk_admin, kvk_rankings,
+export_inventory, honor, honor_rankings, inventory, inventory_preferences, kvk, kvk_admin, kvk_rankings,
 location, mge, modify_registration, modify_subscription, my_registrations, my_stats,
 my_stats_export, mygovernorid, myinventory, mykvkcrystaltech, mykvkhistory, mykvkstats,
 mykvktargets, next_kvk_event, next_kvk_fight, ops, ping, player_profile, prekvk,
@@ -160,6 +161,10 @@ Legend:
 | Ops | `/ops test_embed` | `commands/admin_cmds.py` | Grouped | Admin notify-channel decorator | Ephemeral | Standard | Preserve | Test embed dispatch. |
 | Ops | `/ops usage` | `commands/admin_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Usage analytics summary. |
 | Ops | `/ops usage_detail` | `commands/admin_cmds.py` | Grouped | Admin or leadership decorator | Ephemeral | Standard | Preserve | Usage analytics detail. |
+| Player/KVK | `/kvk stats` | `commands/kvk_cmds.py` | Grouped | KVK stats channel decorator with admin override | Private selector; selected single-account stats post public | Standard | New Phase 2B player scaffold; legacy `/mykvkstats` remains live | Player KVK stats journey. |
+| Player/KVK | `/kvk targets` | `commands/kvk_cmds.py` | Grouped | KVK target channel decorator with admin override | User-selectable | Standard | New Phase 2B player scaffold; legacy `/mykvktargets` remains live | Player KVK targets journey. |
+| Player/KVK | `/kvk history` | `commands/kvk_cmds.py` | Grouped | KVK stats channel decorator | User-selectable | Standard | New Phase 2B player scaffold; legacy `/mykvkhistory` remains live | Player KVK history chart/table journey. |
+| Player/KVK | `/kvk rankings` | `commands/kvk_cmds.py` | Grouped | Mode-specific legacy gates: KVK stats channel with admin override for `kvk`, KVK stats channel without admin override for `honor`, public command-level access for `prekvk` | Public for KVK/honor; PreKvK posts report with private acknowledgement | Standard | New Phase 2B player scaffold; legacy ranking commands remain live | Required `type` option supports `kvk`, `honor`, and `prekvk`. |
 | Player/KVK | `/mykvktargets` | `commands/telemetry_cmds.py` | Flat | KVK target channel decorator with admin override | User-selectable | Standard | Defer player self-service redesign | Player target lookup. |
 | Player/KVK | `/mygovernorid` | `commands/telemetry_cmds.py` | Flat | Public command-level access | Ephemeral | Standard | Defer player self-service redesign | Governor ID lookup. |
 | Player/KVK | `/player_profile` | `commands/telemetry_cmds.py` | Flat | Admin or leadership in allowed channels | Ephemeral | Standard | Defer profile workflow review | Leadership profile lookup. |
@@ -206,6 +211,8 @@ Legend:
   `/stats`, and `/subscriptions`.
 - KVK Player Experience Redesign Phase 2A moved KVK admin/operator commands from `/kvk` to
   `/kvk_admin`, leaving `/kvk` available for the player KVK scaffold.
+- KVK Player Experience Redesign Phase 2B added the player `/kvk` group with `stats`, `targets`,
+  `history`, and `rankings` subcommands in parallel with the legacy flat player commands.
 - Player self-service paths remain flat pending a dedicated workflow redesign.
 - Public calendar and KVK calendar paths remain flat pending a dedicated UX redesign.
 - `/ping` remains flat for simple health/debug discoverability.

--- a/docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md
@@ -4,6 +4,10 @@ Date: 2026-06-03
 
 Scope: audit/design only. No runtime code, SQL, command registration, or output behaviour changed.
 
+Phase 2A completion update: admin/operator KVK commands have now moved from `/kvk ...` to
+`/kvk_admin ...` in PR #140. The collision identified by this audit is resolved, and `/kvk`
+is available for the Phase 2B player scaffold.
+
 ## 1. Summary
 
 The programme goal is sound: the current KVK player experience is valuable but fragmented across flat legacy commands, mixed modules, and inconsistent output styles. The target should be a coherent player journey around:
@@ -13,7 +17,7 @@ The programme goal is sound: the current KVK player experience is valuable but f
 - `/kvk history`
 - `/kvk rankings`
 
-The key design correction from the initial programme pack is that `/kvk` already exists today as an admin/operator command group in `commands/stats_cmds.py`, with subcommands such as `export_all`, `recompute`, `list_scans`, `refresh_stats_cache`, `test_export`, `test_embed`, and `window_preview`. Phase 2 cannot simply add player subcommands under the current `/kvk` group without mixing player and operator journeys. The recommended path is to reserve `/kvk` for players and migrate current `/kvk` admin/operator commands to a later approved admin surface before or during the player scaffold rollout.
+The key design correction from the initial programme pack was that `/kvk` already existed as an admin/operator command group in `commands/stats_cmds.py`, with subcommands such as `export_all`, `recompute`, `list_scans`, `refresh_stats_cache`, `test_export`, `test_embed`, and `window_preview`. Phase 2 could not simply add player subcommands under that `/kvk` group without mixing player and operator journeys. Phase 2A has now delivered the recommended path: `/kvk` is reserved for players, and the admin/operator commands live under `/kvk_admin`.
 
 Approved Phase 2 direction:
 
@@ -44,7 +48,7 @@ Approved Phase 2 direction:
 
 ## 3. Admin/Operator Command Audit
 
-Current `/kvk` is an admin/operator group in `commands/stats_cmds.py`:
+Historical finding before Phase 2A: `/kvk` was an admin/operator group in `commands/stats_cmds.py`:
 
 - `/kvk test_export`
 - `/kvk refresh_stats_cache`
@@ -56,18 +60,17 @@ Current `/kvk` is an admin/operator group in `commands/stats_cmds.py`:
 
 These commands use `@is_admin_and_notify_channel()`, `@safe_command`, `@versioned()`, and `@track_usage()`. They are operational, SQL/data/export-facing, and should not share the final player `/kvk` group.
 
-Recommended admin separation:
+Delivered admin separation:
 
-- Preferred: move current operator commands to `/kvk_admin ...` in Phase 6 or an approved prerequisite phase.
-- Alternative: move high-risk operational commands under existing `/ops kvk_*` names to avoid adding a new top-level group.
-- Do not mix player `/kvk stats` with admin `/kvk recompute` in the same group unless explicitly approved as a temporary compatibility compromise.
+- Current operator commands moved to `/kvk_admin ...` in Phase 2A.
+- Old `/kvk ...` admin paths were removed from the active command surface by approval.
+- Player `/kvk stats` and admin `/kvk_admin recompute` are now separated before the Phase 2B scaffold.
 
 Command-surface governance:
 
-- `/kvk` already exists, so keeping the same top-level group does not increase top-level count.
-- Repurposing `/kvk` from admin to player does change grouped subcommand ownership and command-cache expectations.
-- A new `/kvk_admin` top-level group would require `APPROVED_TOP_LEVEL_COMMANDS`, canonical command reference, command inventory, smoke tests, and operator approval.
-- If admin commands move to `/ops`, no new top-level group is needed, but qualified command paths and docs/tests still change.
+- `/kvk` remains reserved for the player group.
+- `/kvk_admin` is now an approved top-level command group.
+- `APPROVED_TOP_LEVEL_COMMANDS`, the canonical command reference, command inventory expectations, smoke tests, and operator rollout notes were updated in Phase 2A.
 
 ## 4. Player Journey Audit
 
@@ -209,7 +212,7 @@ Recommended player group:
 /kvk rankings [type: kvk|honor|prekvk] [sort?] [limit?]
 ```
 
-Recommended admin/operator model:
+Delivered admin/operator model:
 
 ```text
 /kvk_admin export_all
@@ -221,26 +224,14 @@ Recommended admin/operator model:
 /kvk_admin test_embed
 ```
 
-Alternative if avoiding a new top-level group:
-
-```text
-/ops kvk_export_all
-/ops kvk_recompute
-/ops kvk_list_scans
-/ops kvk_refresh_stats_cache
-/ops kvk_window_preview
-/ops kvk_test_export
-/ops kvk_test_embed
-```
-
-Phase 2A should choose and implement one admin model before Phase 2B modifies `/kvk`.
+Phase 2A chose and implemented `/kvk_admin` before Phase 2B modifies `/kvk`.
 
 ## 10. Migration and Deprecation Plan
 
-1. Approve command-surface ownership: player `/kvk` plus either `/kvk_admin` or `/ops kvk_*`.
-2. Move/scaffold admin command paths only if needed to free `/kvk`; keep old paths live or redirect during an agreed compatibility window.
-3. Add player `/kvk` subcommands with parity output and old-command reuse.
-4. Update command registration validation, canonical command reference, command inventory tests, and smoke tests.
+1. Complete: command-surface ownership approved as player `/kvk` plus admin `/kvk_admin`.
+2. Complete: admin command paths moved to `/kvk_admin`; old `/kvk ...` admin paths removed by approval.
+3. Complete: command registration validation, canonical command reference, command inventory tests, and smoke tests updated for `/kvk_admin`.
+4. Add player `/kvk` subcommands with parity output and old-command reuse.
 5. Soft-launch with player announcement listing old and new paths.
 6. Monitor usage through command usage logs.
 7. Deprecate flat commands with redirect/help responses after approval.
@@ -259,11 +250,11 @@ Legacy commands to keep live through at least Phase 5:
 
 Phase 2 is split:
 
-Phase 2A: admin collision resolution.
+Phase 2A: admin collision resolution. Complete in PR #140.
 
-- Move current admin/operator `/kvk` commands away from the player `/kvk` surface.
-- Preserve permissions, channel restrictions, usage tracking, command cache behaviour, and existing service/DAL ownership.
-- Keep legacy compatibility or clear rollout notes for old operator paths.
+- Moved current admin/operator `/kvk` commands away from the player `/kvk` surface.
+- Preserved permissions, channel restrictions, usage tracking, command cache behaviour, and existing service/DAL ownership.
+- Documented that old `/kvk ...` operator paths were removed from the active command surface.
 
 Phase 2B: player `/kvk` scaffold.
 
@@ -334,16 +325,14 @@ Codex Security:
 | SQL result-shape drift | High | Validate object contracts against SQL repo before each implementation phase. |
 | View restart/persistence assumptions | Medium | Keep Phase 2 views non-persistent unless explicitly designed; test timeout/stale interactions. |
 
-## 14. Deferred Optimisations
+## 14. Resolved Finding And Remaining Programme Work
 
-### Deferred Optimisation
+Resolved Phase 2A finding:
+
 - Area: `commands/stats_cmds.py` `/kvk` admin group and future KVK player commands
 - Type: architecture
-- Description: The `/kvk` top-level group currently contains admin/operator commands, but the target KVK player redesign wants `/kvk` to be the player-facing surface. Mixing both would weaken discoverability and increase permission-regression risk.
-- Suggested Fix: Scope and approve an admin command-surface migration to `/kvk_admin` or `/ops kvk_*` before or as part of the player `/kvk` scaffold. Update command registration validation, canonical command reference, smoke tests, and operator docs.
-- Impact: high
-- Risk: medium
-- Dependencies: Operator approval for the final admin command path and compatibility/announcement plan.
+- Resolution: Admin/operator commands moved from `/kvk ...` to `/kvk_admin ...` in PR #140.
+- Result: The player `/kvk` surface is available for Phase 2B, and command registration validation, canonical command reference, smoke tests, and operator documentation now reflect `/kvk_admin`.
 
 The previous targets and personal stats payload findings are now programme work rather than deferred optimisations:
 
@@ -352,6 +341,6 @@ The previous targets and personal stats payload findings are now programme work 
 
 ## 15. Approval Questions
 
-1. Should Phase 2A use `/kvk_admin ...` or `/ops kvk_*` for the admin/operator commands?
+1. Resolved: Phase 2A uses `/kvk_admin ...` for the admin/operator commands.
 2. For Acclaim/contribution, which exact SQL output object should be treated as the player-card source of truth?
 3. Should Phase 2B expose ranking type as a required slash option, a defaulted slash option, or an interactive select after `/kvk rankings`?

--- a/docs/task_packs/KVK Player Experience Redesign - Phase 2 New KVK Player Command Group Scaffold Task Pack - Draft.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Phase 2 New KVK Player Command Group Scaffold Task Pack - Draft.md
@@ -1,6 +1,6 @@
 # KVK Player Experience Redesign — Phase 2 New `/kvk` Player Command Group Scaffold Task Pack Draft
 
-> Superseded: this combined Phase 2 draft is replaced by the approved split into Phase 2A admin collision resolution and Phase 2B player `/kvk` scaffold. Keep this file only as historical planning context unless it is archived or removed later.
+> Superseded: this combined Phase 2 draft is replaced by the approved split into Phase 2A admin collision resolution and Phase 2B player `/kvk` scaffold. Phase 2A has now delivered `/kvk_admin` in PR #140; use the Phase 2B task pack for current scaffold work. Keep this file only as historical planning context unless it is archived or removed later.
 
 ## 1. Task Header
 
@@ -9,7 +9,7 @@
 - Owner/context: K98 Bot KVK player command migration programme
 - Task type: `feature / command-surface refactor / UX migration scaffold`
 - One-pass approved: `no`
-- Status: `draft — do not start until Phase 1 audit/design is complete and approved`
+- Status: `superseded - Phase 2A complete; use the Phase 2B task pack for current work`
 
 ## 2. Required Reading
 
@@ -86,7 +86,7 @@ The purpose of Phase 2 is not to modernise the visual output yet. It is to creat
 - No generated image implementation.
 - No old command removal.
 - No old command redirect/deprecation behaviour unless explicitly approved as a tiny help-only addition.
-- No `/kvk_admin` implementation.
+- No further `/kvk_admin` implementation in this superseded combined scaffold draft; Phase 2A delivered the active `/kvk_admin` surface separately.
 - No SQL schema/procedure/view/function changes.
 - No KVK import/recompute/export changes.
 - No Google Sheets output contract changes.

--- a/docs/task_packs/KVK Player Experience Redesign - Phase 2A Admin Collision Resolution Task Pack - Draft.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Phase 2A Admin Collision Resolution Task Pack - Draft.md
@@ -1,27 +1,28 @@
-# KVK Player Experience Redesign - Phase 2A Admin Collision Resolution Task Pack Draft
+# KVK Player Experience Redesign - Phase 2A Admin Collision Resolution Task Pack
 
 ## 1. Task Header
 
 - Task name: `KVK Player Experience Redesign - Phase 2A Admin Collision Resolution`
 - Date: `2026-06-03`
+- Completed: `2026-06-04`
 - Task type: `command-surface refactor / admin migration`
 - One-pass approved: `no`
-- Status: `approved for /kvk_admin implementation`
+- Status: `complete - delivered and merged in PR #140`
 
 ## 2. Objective
 
-Resolve the current `/kvk` command collision before the player `/kvk` scaffold is implemented.
+Resolve the former `/kvk` command collision before the player `/kvk` scaffold is implemented.
 
-Current `/kvk` is an admin/operator group in `commands/stats_cmds.py`. The programme target reserves `/kvk` for player journeys, so the existing admin/operator commands must move to an approved admin surface first.
+Delivered result: the existing admin/operator commands were moved from `/kvk ...` to `/kvk_admin ...` in `commands/stats_cmds.py`. The `/kvk` top-level group is now available for the Phase 2B player scaffold.
 
 ## 3. Scope
 
 In scope:
 
-- Move or wrap current admin/operator `/kvk` commands under the approved admin surface.
+- Move current admin/operator `/kvk` commands under the approved admin surface.
 - Preserve permissions, channel restrictions, usage tracking, versioning, safe command handling, logging, command-cache behaviour, and service/DAL ownership.
 - Update command registration validation, canonical command reference, command inventory tests, smoke tests, and operator rollout notes.
-- Keep old operator command paths live or provide approved compatibility/help behaviour if needed.
+- Document legacy operator path behaviour.
 
 Out of scope:
 
@@ -30,9 +31,9 @@ Out of scope:
 - No SQL schema, procedure, view, function, import, recompute, export, or Google Sheets behaviour changes.
 - No legacy player command removal.
 
-## 4. Commands To Move
+## 4. Commands Moved
 
-Current admin/operator commands:
+Former admin/operator commands:
 
 ```text
 /kvk test_export
@@ -44,7 +45,7 @@ Current admin/operator commands:
 /kvk window_preview
 ```
 
-Approved target:
+Delivered admin target:
 
 ```text
 /kvk_admin test_export
@@ -68,16 +69,22 @@ Rejected alternative for this task:
 /ops kvk_window_preview
 ```
 
-## 5. Architecture Direction
+Legacy compatibility behaviour:
+
+- Old `/kvk ...` admin/operator paths were removed from the active command surface.
+- No compatibility wrappers were retained, by approval, so the player `/kvk` group can be scaffolded cleanly in Phase 2B.
+
+## 5. Delivered Architecture
 
 - Commands remain thin and call `kvk.services.kvk_admin_service` or existing export/test helpers.
-- DAL stays in `kvk/dal/` or current approved data-access modules.
-- No direct SQL should be added to command/view layers.
-- If compatibility wrappers are used, they should delegate to the new command/service path and avoid duplicated logic.
+- DAL remains in `kvk/dal/` or current approved data-access modules.
+- No direct SQL was added to command/view layers.
+- No SQL/import/recompute/export, Google Sheets, service, or DAL semantics changed.
+- The command registration baseline, smoke tests, focused command tests, and canonical command reference now use `/kvk_admin`.
 
 ## 6. Testing And Validation
 
-Run or justify:
+Completed validation:
 
 ```powershell
 .\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
@@ -86,19 +93,20 @@ Run or justify:
 .\.venv\Scripts\python.exe scripts\validate_command_registration.py
 .\.venv\Scripts\python.exe scripts\smoke_imports.py
 .\.venv\Scripts\python.exe -m pytest -q tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py tests\test_stats_cmds.py tests\test_kvk_admin_service.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_command_governance_config.py tests\test_validate_command_registration.py tests\test_command_inventory.py tests\test_command_registration_smoke.py
 ```
 
-Run Codex Security before PR handoff because command permissions, Discord interactions, and SQL/export-facing operator commands are touched.
+Codex Security review was considered for PR handoff because command permissions, Discord interactions, and SQL/export-facing operator commands were touched. The delivered code change was a command-surface rename with existing permission decorators and service/DAL behaviour preserved.
 
 ## 7. Acceptance Criteria
 
-- [ ] Approved admin target surface is documented.
-- [ ] Current admin/operator `/kvk` commands no longer block the player `/kvk` scaffold.
-- [ ] Permissions and channel restrictions are preserved.
-- [ ] Command registration validation passes.
-- [ ] Canonical command reference is updated.
-- [ ] Legacy compatibility behaviour is documented.
-- [ ] No SQL/import/recompute/export semantics changed.
+- [x] Approved admin target surface is documented.
+- [x] Current admin/operator `/kvk` commands no longer block the player `/kvk` scaffold.
+- [x] Permissions and channel restrictions are preserved.
+- [x] Command registration validation passes.
+- [x] Canonical command reference is updated.
+- [x] Legacy compatibility behaviour is documented.
+- [x] No SQL/import/recompute/export semantics changed.
 
 ## 8. Approval Decision
 

--- a/docs/task_packs/KVK Player Experience Redesign - Phase 2B Player KVK Scaffold Task Pack.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Phase 2B Player KVK Scaffold Task Pack.md
@@ -1,4 +1,4 @@
-# KVK Player Experience Redesign - Phase 2B Player KVK Scaffold Task Pack Draft
+# KVK Player Experience Redesign - Phase 2B Player KVK Scaffold Task Pack
 
 ## 1. Task Header
 
@@ -6,11 +6,13 @@
 - Date: `2026-06-03`
 - Task type: `feature / command-surface migration scaffold`
 - One-pass approved: `no`
-- Status: `draft`
+- Status: `ready for implementation`
 
 ## 2. Objective
 
-Create the player-facing `/kvk` command group after Phase 2A resolves the admin collision.
+Create the player-facing `/kvk` command group after Phase 2A resolved the admin collision.
+
+Prerequisite status: Phase 2A is complete in PR #140. Admin/operator KVK commands now live under `/kvk_admin ...`, and the old `/kvk ...` admin paths are no longer active.
 
 Initial player subcommands:
 
@@ -20,8 +22,7 @@ Initial player subcommands:
 /kvk history
 /kvk rankings
 ```
-
-Legacy commands remain live.
+Legacy commands must remain live.
 
 ## 3. Approved Behaviour
 
@@ -40,7 +41,7 @@ In scope:
 - Preserve legacy flat commands unchanged.
 - Preserve current permissions and visibility unless this task explicitly changes them.
 - Add tests for command registration, permissions, delegation, ranking modes, and old-command preservation.
-- Update canonical command reference and command inventory expectations.
+- Update canonical command reference, approved top-level command baseline, and command inventory expectations for the new player `/kvk` group.
 - Begin targets service/DAL payload cleanup only where needed to keep `/kvk targets` thin and testable.
 
 Out of scope:
@@ -53,8 +54,10 @@ Out of scope:
 
 ## 5. Architecture Direction
 
-- New command module target: `commands/kvk_cmds.py`, unless Phase 2A establishes a better local pattern.
+- New player command module target: `commands/kvk_cmds.py`.
+- Existing admin/operator handlers remain in `commands/stats_cmds.py` under `/kvk_admin`.
 - Commands validate, defer safely, preserve permission checks, and call services/views.
+- Command registration governance should add `/kvk` as the player top-level group while keeping `/kvk_admin` as the operator top-level group.
 - KVK targets should move toward `kvk/services/` and `kvk/dal/` ownership for payload construction.
 - Ranking mode adapters should not duplicate ranking calculations.
 - PreKvK image/report rendering remains in `prekvk/` and `ui/views/prekvk_report_views.py`; `/kvk rankings type:prekvk` should delegate.
@@ -100,7 +103,7 @@ Requirements:
 - Preserve current KVK ranking calculations and pagination.
 - Preserve current honor ranking calculations and pagination.
 - Preserve current PreKvK report payload, sort, limit, and generated PNG behaviour by delegation.
-- Decide whether `type` is a required slash option, defaulted slash option, or interactive select before implementation.
+- Use `type` as a required slash option for the scaffold, with choices `kvk`, `honor`, and `prekvk`.
 
 ## 10. Testing And Validation
 
@@ -121,9 +124,10 @@ Run Codex Security before PR handoff because user-facing commands, permissions, 
 
 ## 11. Acceptance Criteria
 
-- [ ] Phase 2A is complete or explicitly accounted for.
+- [x] Phase 2A is complete; `/kvk` is available for the player scaffold.
 - [ ] `/kvk stats`, `/kvk targets`, `/kvk history`, and `/kvk rankings` are registered.
 - [ ] `/kvk rankings` supports `kvk`, `honor`, and `prekvk` modes.
+- [ ] `/kvk rankings type` is implemented as a required slash option.
 - [ ] `/kvk stats` preserves private selection and public selected stat output.
 - [ ] Legacy commands remain live.
 - [ ] No generated card work is mixed into this scaffold.

--- a/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
@@ -51,18 +51,19 @@ Optional later expansion after the core group is stable:
 
 ### Admin/operator command group
 
-Target later admin command group:
+Delivered Phase 2A admin command group:
 
 ```text
+/kvk_admin test_export
+/kvk_admin refresh_stats_cache
 /kvk_admin recompute
 /kvk_admin export_all
 /kvk_admin list_scans
 /kvk_admin window_preview
-/kvk_admin refresh_stats_cache
-/kvk_admin diagnostics
+/kvk_admin test_embed
 ```
 
-The admin group is intentionally separated from the player `/kvk` group so player journeys remain clean and admin/operator tools do not clutter the public command surface.
+The admin group is intentionally separated from the player `/kvk` group so player journeys remain clean and admin/operator tools do not clutter the public command surface. Phase 2A delivered this split in PR #140; `/kvk` is now reserved for the player scaffold.
 
 ## 5. Target User Journeys
 
@@ -208,31 +209,20 @@ No code changes.
 
 ### Phase 2A — Admin `/kvk` Collision Resolution
 
-Move or duplicate current admin/operator `/kvk` commands away from the player `/kvk` surface before the player scaffold is introduced.
+Status: complete. Delivered and merged in PR #140.
 
-Potential target admin surfaces:
+The former admin/operator `/kvk ...` commands were moved to `/kvk_admin ...` before the player scaffold was introduced:
 
 ```text
+/kvk_admin test_export
+/kvk_admin refresh_stats_cache
 /kvk_admin recompute
 /kvk_admin export_all
 /kvk_admin list_scans
 /kvk_admin window_preview
-/kvk_admin refresh_stats_cache
-/kvk_admin diagnostics
 ```
 
-or, if avoiding a new top-level admin group:
-
-```text
-/ops kvk_recompute
-/ops kvk_export_all
-/ops kvk_list_scans
-/ops kvk_window_preview
-/ops kvk_refresh_cache
-/ops kvk_diagnostics
-```
-
-Preserve permissions, channel restrictions, logging, usage tracking, service/DAL ownership, command-cache behaviour, and operator rollout notes.
+Old `/kvk ...` admin paths were intentionally removed from the active command surface. Permissions, channel restrictions, logging, usage tracking, service/DAL ownership, command-cache governance, and operator reference documentation were updated without changing SQL, import, recompute, export, or Google Sheets behaviour.
 
 ### Phase 2B — New `/kvk` Player Command Group Scaffold
 
@@ -280,7 +270,7 @@ Support dropdowns/buttons for ranking type and pagination. Keep image output opt
 
 ### Phase 6 — Admin Command Hardening And Legacy Operator Cleanup
 
-Harden the approved admin/operator KVK command surface after Phase 2A.
+Harden the delivered `/kvk_admin` operator command surface after Phase 2A.
 
 This phase should preserve all permissions, channel restrictions, logging, and existing service/DAL ownership.
 
@@ -417,10 +407,10 @@ Do not include these in the early phases unless separately approved:
 
 ## 14. Suggested Next Action
 
-Start with:
+Proceed with:
 
 ```text
-KVK Player Experience Redesign — Phase 1 Audit and Design Only
+KVK Player Experience Redesign - Phase 2B Player /kvk Scaffold
 ```
 
-Do not implement until Phase 1 has produced and agreed the target command model, visual architecture, migration plan, and risk controls.
+Phase 1 audit/design and Phase 2A admin collision resolution are complete. Phase 2B can now scaffold the player `/kvk` group while preserving the legacy flat player commands.

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -22,3 +22,8 @@ material.
 
 Player self-service workflow redesign and public calendar/KVK calendar UX redesign remain separate
 deferred optimisation programmes, not additional command-platform phases.
+
+KVK Player Experience Redesign is active. Phase 1 audit/design is complete, and Phase 2A Admin
+Collision Resolution was delivered in PR 140 by moving admin/operator commands from `/kvk ...` to
+`/kvk_admin ...`. Use the Phase 2B Player `/kvk` Scaffold task pack for the next implementation
+step.

--- a/scripts/validate_command_registration.py
+++ b/scripts/validate_command_registration.py
@@ -48,6 +48,7 @@ APPROVED_TOP_LEVEL_COMMANDS = frozenset(
         "honor_rankings",
         "inventory",
         "inventory_preferences",
+        "kvk",
         "kvk_admin",
         "kvk_rankings",
         "location",

--- a/tests/test_command_registration_smoke.py
+++ b/tests/test_command_registration_smoke.py
@@ -49,7 +49,7 @@ def test_register_commands_smoke(monkeypatch):
     assert "honor" in registered_top_level
     assert "inventory" in registered_top_level
     assert "kvk_admin" in registered_top_level
-    assert "kvk" not in registered_top_level
+    assert "kvk" in registered_top_level
     assert "location" in registered_top_level
     assert "ops" in registered_top_level
     assert "mge" in registered_top_level

--- a/tests/test_kvk_cmds.py
+++ b/tests/test_kvk_cmds.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeGroup:
+    def __init__(self, name, description=None, guild_ids=None):
+        self.name = name
+        self.description = description
+        self.guild_ids = guild_ids
+        self.commands = {}
+
+    def command(self, *, name, description=None, guild_ids=None):
+        def decorator(fn):
+            self.commands[name] = fn
+            return fn
+
+        return decorator
+
+
+def _unwrap(fn):
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+def _register_kvk(monkeypatch):
+    import commands.kvk_cmds as kvk_cmds
+
+    created = {}
+
+    def fake_group(*args, **kwargs):
+        group = _FakeGroup(*args, **kwargs)
+        created["group"] = group
+        return group
+
+    bot = SimpleNamespace(added=[])
+    bot.add_application_command = lambda command: bot.added.append(command)
+    monkeypatch.setattr(kvk_cmds.discord, "SlashCommandGroup", fake_group)
+
+    kvk_cmds.register_kvk(bot)
+    return kvk_cmds, created["group"], bot
+
+
+def test_register_kvk_declares_player_group(monkeypatch):
+    _module, group, bot = _register_kvk(monkeypatch)
+
+    assert group.name == "kvk"
+    assert set(group.commands) == {"stats", "targets", "history", "rankings"}
+    assert bot.added == [group]
+
+
+def test_kvk_rankings_type_option_is_required():
+    import commands.kvk_cmds as kvk_cmds
+
+    source = inspect.getsource(kvk_cmds.register_kvk)
+
+    assert 'name="type"' in source
+    assert "required=True" in source
+    assert 'choices=["kvk", "honor", "prekvk"]' in source
+
+
+@pytest.mark.asyncio
+async def test_kvk_rankings_routes_all_modes(monkeypatch):
+    kvk_cmds, group, _bot = _register_kvk(monkeypatch)
+    handler = _unwrap(group.commands["rankings"])
+    ctx = SimpleNamespace(responded=[])
+
+    calls = []
+
+    async def fake_kvk(ctx_arg):
+        calls.append(("kvk", ctx_arg))
+
+    async def fake_honor(ctx_arg):
+        calls.append(("honor", ctx_arg))
+
+    async def fake_defer(ctx_arg, *, ephemeral=False):
+        calls.append(("defer", ephemeral, ctx_arg))
+
+    async def fake_prekvk_report(**kwargs):
+        calls.append(("prekvk", kwargs))
+
+    async def fake_channel_guarded(ctx_arg, channel_id, *, admin_override, callback):
+        calls.append(("guard", channel_id, admin_override, callback.__name__))
+        await callback(ctx_arg)
+
+    async def fake_respond(message, *, ephemeral=False):
+        ctx.responded.append((message, ephemeral))
+
+    ctx.respond = fake_respond
+    monkeypatch.setattr(kvk_cmds, "_send_kvk_rankings", fake_kvk)
+    monkeypatch.setattr(kvk_cmds, "_send_honor_rankings", fake_honor)
+    monkeypatch.setattr(kvk_cmds, "_run_channel_guarded", fake_channel_guarded)
+    monkeypatch.setattr(kvk_cmds, "safe_defer", fake_defer)
+    monkeypatch.setattr(kvk_cmds, "send_prekvk_report", fake_prekvk_report)
+    monkeypatch.setattr(
+        kvk_cmds.report_service,
+        "parse_report_sort",
+        lambda value: f"parsed:{value}",
+    )
+
+    await handler(ctx, "kvk")
+    await handler(ctx, "honor")
+    await handler(ctx, "prekvk")
+    await handler(ctx, "bad")
+
+    assert calls[0][0:3] == ("guard", kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID, True)
+    assert calls[1] == ("kvk", ctx)
+    assert calls[2][0:3] == ("guard", kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID, False)
+    assert calls[3] == ("honor", ctx)
+    assert calls[4] == ("defer", True, ctx)
+    assert calls[5][0] == "prekvk"
+    assert calls[5][1]["ctx"] is ctx
+    assert calls[5][1]["sort_by"] == "parsed:Overall"
+    assert calls[5][1]["limit"] == 10
+    assert ctx.responded == [("Unknown ranking type.", True)]

--- a/tests/test_kvk_cmds.py
+++ b/tests/test_kvk_cmds.py
@@ -83,9 +83,13 @@ async def test_kvk_rankings_routes_all_modes(monkeypatch):
     async def fake_prekvk_report(**kwargs):
         calls.append(("prekvk", kwargs))
 
-    async def fake_channel_guarded(ctx_arg, channel_id, *, admin_override, callback):
-        calls.append(("guard", channel_id, admin_override, callback.__name__))
+    async def fake_channel_guarded(ctx_arg, channel_id, *, admin_override, command_name, callback):
+        calls.append(("guard", channel_id, admin_override, command_name, callback.__name__))
         await callback(ctx_arg)
+
+    async def fake_tracked(ctx=None, *, command_name, callback):
+        calls.append(("tracked", command_name, callback.__name__))
+        await callback(ctx)
 
     async def fake_respond(message, *, ephemeral=False):
         ctx.responded.append((message, ephemeral))
@@ -94,6 +98,7 @@ async def test_kvk_rankings_routes_all_modes(monkeypatch):
     monkeypatch.setattr(kvk_cmds, "_send_kvk_rankings", fake_kvk)
     monkeypatch.setattr(kvk_cmds, "_send_honor_rankings", fake_honor)
     monkeypatch.setattr(kvk_cmds, "_run_channel_guarded", fake_channel_guarded)
+    monkeypatch.setattr(kvk_cmds, "_run_tracked", fake_tracked)
     monkeypatch.setattr(kvk_cmds, "safe_defer", fake_defer)
     monkeypatch.setattr(kvk_cmds, "send_prekvk_report", fake_prekvk_report)
     monkeypatch.setattr(
@@ -107,13 +112,19 @@ async def test_kvk_rankings_routes_all_modes(monkeypatch):
     await handler(ctx, "prekvk")
     await handler(ctx, "bad")
 
-    assert calls[0][0:3] == ("guard", kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID, True)
+    assert calls[0][0:4] == ("guard", kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID, True, "kvk rankings")
     assert calls[1] == ("kvk", ctx)
-    assert calls[2][0:3] == ("guard", kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID, False)
+    assert calls[2][0:4] == (
+        "guard",
+        kvk_cmds.KVK_PLAYER_STATS_CHANNEL_ID,
+        False,
+        "kvk rankings",
+    )
     assert calls[3] == ("honor", ctx)
-    assert calls[4] == ("defer", True, ctx)
-    assert calls[5][0] == "prekvk"
-    assert calls[5][1]["ctx"] is ctx
-    assert calls[5][1]["sort_by"] == "parsed:Overall"
-    assert calls[5][1]["limit"] == 10
+    assert calls[4] == ("tracked", "kvk rankings", "_send_prekvk_rankings")
+    assert calls[5] == ("defer", True, ctx)
+    assert calls[6][0] == "prekvk"
+    assert calls[6][1]["ctx"] is ctx
+    assert calls[6][1]["sort_by"] == "parsed:Overall"
+    assert calls[6][1]["limit"] == 10
     assert ctx.responded == [("Unknown ranking type.", True)]

--- a/tests/test_validate_command_registration.py
+++ b/tests/test_validate_command_registration.py
@@ -156,9 +156,10 @@ def test_current_command_surface_reflects_phase5a_admin_grouping():
         "activity": {"activity_top": "top"},
     }
 
-    assert len(names) == 39
+    assert len(names) == 40
+    assert "kvk" in names
     assert "kvk_admin" in names
-    assert "kvk" not in names
+    assert {"stats", "targets", "history", "rankings"}.issubset(grouped["kvk"])
     assert moved_to_ops.isdisjoint(names)
     assert moved_to_ops.issubset(grouped["ops"])
     assert set(moved_to_ark).isdisjoint(names)
@@ -168,7 +169,7 @@ def test_current_command_surface_reflects_phase5a_admin_grouping():
         assert set(mapping.values()).issubset(grouped[group_name])
     assert len(grouped["ops"]) == 25
     assert len(grouped["ark"]) == 14
-    assert sum(len(commands) for commands in grouped.values()) == 76
+    assert sum(len(commands) for commands in grouped.values()) == 80
     assert "calendar" in names
     assert "honor_rankings" in names
     assert "player_profile" in names


### PR DESCRIPTION
## Summary

- Added the new player-facing `/kvk` command group with `stats`, `targets`, `history`, and `rankings` subcommands.
- Preserved legacy flat KVK commands while routing the new scaffold through existing stats, targets, history, KVK rankings, honor rankings, and PreKvK report behavior.
- Updated command governance docs, validator baseline, task-pack docs, and focused registration tests for the new `/kvk` group.

## Command Surface

- New `/kvk rankings` requires `type` with choices `kvk`, `honor`, and `prekvk`.
- KVK and honor ranking modes preserve their legacy channel gates separately.
- PreKvK mode delegates to the existing report sender and keeps the private acknowledgement/public report behavior.

## Validation

- `\.\.venv\Scripts\python.exe scripts\validate_command_registration.py` passed.
- `\.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py` passed.
- `\.\.venv\Scripts\python.exe scripts\validate_deferred_items.py` passed.
- `\.\.venv\Scripts\python.exe scripts\smoke_imports.py` passed.
- `\.\.venv\Scripts\python.exe -m ruff check commands\kvk_cmds.py tests\test_kvk_cmds.py` passed.
- Focused KVK suite passed: `114 passed`.
- Command governance focused suite passed: `21 passed`.

## Known Validation Gap

- Full `pytest -q tests` was run and produced `1631 passed, 2 skipped, 1 failed`.
- The failure is unrelated to this PR: `tests/test_command_governance_config.py` expects missing file `.github/workflows/command-governance.yml` in this worktree.

## AI Review Gates

- Diff-focused security review performed locally; it identified and fixed a rankings permission drift before commit.
- Full Codex Security artifact scan still recommended before marking ready for review because this touches Discord command interactions and SQL-backed output paths.

## Rollout Notes

- This is a parallel scaffold only. No legacy KVK player commands are removed or deprecated in this PR.
- No SQL schema, import, export, recompute, Google Sheets, or visual card behavior changed.