### PR TITLE
[codex] Polish KVK stats card ranks

### DIFF
--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md
@@ -25,8 +25,10 @@ Delivered outcomes:
 - KVK mode and camp are shown on the main card.
 - Discord avatar support is included with a fallback identity marker.
 - The main card now uses an 8-metric grid and no longer shows `Power Loss`.
-- Follow-on visual polish and secondary-card work has been split into Phase 3B:
+- Follow-on visual polish and secondary-card work was completed in Phase 3B:
   `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md`.
+- Remaining overall-rank data contract and card polish work has been split into Phase 3C:
+  `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md`.
 
 ## 2. Required Reading
 
@@ -681,7 +683,8 @@ Use this delivery shape:
 
 ## 18. Codex Chat Starter
 
-Phase 3 is complete. Use the Phase 3B task pack for follow-on card polish and secondary-card work.
+Phase 3 and Phase 3B are complete. Use the Phase 3C task pack for the overall KVK rank data
+contract and follow-on card polish work.
 
 Historical Phase 3 starter:
 

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md
@@ -7,6 +7,28 @@
 - Owner/context: `K98 Bot KVK Player Experience Redesign programme after Phase 3 visual card rollout`
 - Task type: `feature / UX polish / generated image renderer / Discord interaction polish`
 - One-pass approved: `no`
+- Status: `complete - delivered in mirror PR #143 and promoted to production`
+
+### Phase Completion Update
+
+Phase 3B is complete as of 2026-06-05.
+
+Delivered result:
+
+- Main-card compact values use one-decimal formatting.
+- KVK mode card backgrounds are selected through shared mode normalization and asset fallback logic.
+- Main-card rank displays the existing `KVK_RANK` value from the stats payload.
+- More Stats top-right `Overall KVK Rank` is intentionally shown as `TBC` until Phase 3C adds the durable SQL-backed rank source.
+- More Stats and History are Pillow-rendered secondary cards attached to `/kvk stats`.
+- More Stats includes pass-window kills/deads, Pre-KVK rank/points, Honor rank/points, and DKP progress.
+- History includes Autarch, KVK Played, Highest Acclaim, personal bests, and last KVK summary metrics; matchmaking snapshot data is intentionally excluded.
+- Dynamic progress scales support high performers, including values around `225%`.
+- Secondary-card interaction callbacks defer before rendering.
+- `/mykvkstats` remains on the legacy embed path.
+
+Follow-on work has been split into Phase 3C:
+
+`docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md`
 
 ## 2. Required Reading
 

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md
@@ -1,0 +1,505 @@
+# Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish
+
+## 1. Task Header
+
+- Task name: `KVK Player Experience Redesign - Phase 3C Overall Rank and Card Polish`
+- Date: `2026-06-05`
+- Owner/context: `K98 Bot KVK Player Experience Redesign programme after Phase 3B production rollout`
+- Task type: `feature / SQL data contract / generated image renderer polish / data-source audit`
+- One-pass approved: `no`
+- Status: `ready for task execution`
+
+## 2. Required Reading
+
+Before implementation, read the current repository instructions and indexed core standards:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+
+Then follow the required reading order and conditional references defined by `docs/reference/README.md`.
+
+Also read:
+
+- `docs/task_packs/KVK Player Experience Redesign - Programme Pack.md`
+- `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md`
+- `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md`
+- `docs/reference/canonical_command_reference.md` if command output descriptions or command-surface validation are touched
+
+For SQL-facing work, validate schema, procedure, view, index, and `ProcConfig` details against:
+
+```text
+C:\K98-bot-SQL-Server
+```
+
+## 3. Objective
+
+Replace the More Stats card's temporary `Overall KVK Rank: TBC` placeholder with a durable SQL-backed rank derived from `KVK.KVK_Player_Windowed`, then polish the remaining Phase 3B visual issues.
+
+This phase should add the missing overall-rank data contract in the SQL repo, retrieve that value through the bot DAL/service layers, populate the More Stats card, make More Stats typography consistent, and audit the History card acclaim discrepancy before agreeing any data or formatting fix.
+
+## 4. Background
+
+Phase 3B delivered the modern More Stats and History Pillow cards. During final production review, the rank semantics were clarified:
+
+- Main-card `Rank` should use existing `KVK_RANK`; this is the KVK rank for our kingdom.
+- More Stats needs an `Overall KVK Rank`, but no direct DB column currently exists.
+- The desired overall rank can be derived from `KVK.KVK_Player_Windowed` for the current KVK where `WindowName = 'Full'`, ordered by `kp_gain_recalc DESC`.
+- Phase 3B therefore shipped `Overall KVK Rank` as `TBC` and split durable data work into this Phase 3C task.
+
+Two additional visual/data issues were observed from production screenshots:
+
+- More Stats values use inconsistent fitted font sizes in the same row, especially Pass 4 versus Pass 6.
+- History card `Highest Acclaim` and `Last KVK Acclaim` can display different rounded values even when the last KVK acclaim appears to be the governor's highest acclaim. Example: GovernorID `4677418` has `STATS_FOR_UPLOAD.HighestAcclaim = 4744606`, which should display as `4.7M`, while the screenshot shows `Last KVK Acclaim = 4.6M`.
+
+## 5. Scope
+
+### In Scope
+
+- Audit the current Phase 3B `/kvk stats` card payload, renderer, DAL, and cache/source flow.
+- Create a SQL view in `C:\K98-bot-SQL-Server` that derives overall KVK rank from `KVK.KVK_Player_Windowed`.
+- Use `WindowName = 'Full'` for overall rank.
+- Rank by `kp_gain_recalc DESC` and use a deterministic tie-breaker such as `governor_id ASC`.
+- Retrieve the overall rank through bot DAL/service code; do not query SQL from commands, views, or renderers.
+- Add an optional payload field for overall KVK rank.
+- Populate the More Stats card top-right `Overall KVK Rank` value when available.
+- Preserve the Phase 3B `TBC` or clear fallback when the view/value is missing.
+- Keep main-card `Rank` sourced from existing `KVK_RANK`.
+- Make More Stats card row typography consistent, especially pass-window values.
+- Audit and document the `Highest Acclaim` versus `Last KVK Acclaim` data-source discrepancy.
+- Implement an acclaim fix only if the audit identifies a low-risk source/formatting correction and the operator approves it.
+- Add or update SQL, DAL/service, renderer, and view tests as appropriate.
+- Generate updated visual review samples for main, More Stats, and History where relevant.
+
+### Out of Scope
+
+- No new slash commands or command groups.
+- No removal or deprecation of `/mykvkstats` or other legacy paths.
+- No changes to KVK import/recompute/export semantics unless explicitly required for the approved SQL view.
+- No mutation of `KVK.KVK_Player_Windowed` table shape unless the SQL audit proves a view is insufficient and the operator separately approves table changes.
+- No broad History card redesign or full `/kvk history` redesign.
+- No website implementation.
+- No predictive "on track" modelling.
+- No direct SQL in command modules, Discord views, or renderers.
+
+## 6. Source Deferred Items
+
+This task is a planned programme sub-phase, not a deferred optimisation batch.
+
+If audit finds out-of-scope debt, capture it in `docs/reference/deferred_optimisations.md` using the required structure:
+
+```md
+### Deferred Optimisation
+- Area:
+- Type: performance | architecture | cleanup | refactor | consistency
+- Description:
+- Suggested Fix:
+- Impact: low | medium | high
+- Risk: low | medium | high
+- Dependencies:
+```
+
+## 7. Codex Skills To Use
+
+### Skill Decisions
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | use | Required before implementation to keep SQL, DAL, service, renderer, and tests properly layered. |
+| `k98-discord-command-feature` | use | Required because `/kvk stats` button-attached cards and user-visible Discord output are touched. |
+| `k98-sql-validation` | use | Required because this phase creates a SQL view and changes the bot's SQL-backed card payload contract. |
+| `k98-test-selection` | use | Required before validation to select SQL contract, payload, renderer, and view tests. |
+| `k98-deferred-optimisation-capture` | use if needed | Required if audit finds broader renderer, cache, SQL, or history-source debt. |
+| `k98-pr-review` | use | Required before PR handoff. |
+| `k98-promotion-check` | use | Required before SQL/bot production promotion or bot-machine deployment. |
+| `codex-security:security-scan` | use | Required before PR handoff because SQL/data access, Discord interactions, and generated image output are touched. |
+
+## 8. Mandatory Workflow
+
+1. Audit and scope the Phase 3C work, then stop for approval.
+2. Validate SQL source objects in `C:\K98-bot-SQL-Server`.
+3. Propose the SQL view name, columns, indexes/dependencies, and deployment order, then stop for approval.
+4. Propose the bot DAL/service/payload/renderer implementation plan, then stop for approval.
+5. Implement the approved SQL view and bot code.
+6. Add/update tests.
+7. Generate visual review artifacts.
+8. Run focused validation and selected broader validation.
+9. Run Codex Security review before PR handoff.
+10. Prepare promotion notes that cover SQL deployment order before bot rollout.
+
+Proceed in one pass only if the operator explicitly approves one-pass implementation.
+
+## 9. Audit Requirements
+
+Review and document:
+
+- current `/kvk stats` posting path
+- current Phase 3B payload fields for `kvk_rank`, `kingdom_rank`, and More Stats rank display
+- current SQL source for `KVK.KVK_Player_Windowed`
+- whether `kp_gain_recalc` is the approved ranking metric for overall KVK rank
+- whether `WindowName = 'Full'` is unique enough for one row per `KVK_NO`/`governor_id`
+- how ties should be handled for stable rank output
+- whether `KVK_NO` should be passed from the current stats row or resolved from `ProcConfig`
+- current data freshness behaviour for `KVK_Player_Windowed` versus `STATS_FOR_UPLOAD`
+- current `kvk_stats_card_dal.fetch_kvk_stats_card_context` query pattern
+- current `KvkStatsCardPayload` and renderer fallback behaviour
+- current More Stats font fitting behaviour and why same-row values use inconsistent sizes
+- current History card `Highest Acclaim` source from `STATS_FOR_UPLOAD`
+- current `last_kvk_summary` source, likely `player_stats_cache.lastkvk` built from `EXCEL_FOR_KVK_<N>`
+- raw acclaim values for GovernorID `4677418` across `STATS_FOR_UPLOAD`, the last KVK cache/source table, and any view/procedure used by history summaries
+- whether the acclaim discrepancy is a rounding issue, stale/source mismatch, or legitimately different source value
+- existing renderer tests and visual artifact patterns
+
+## 10. Architecture Targets
+
+| Concern | Target |
+|---|---|
+| SQL schema | SQL repo: `C:\K98-bot-SQL-Server\sql_schema\KVK.<ViewName>.View.sql` |
+| Bot DAL | `kvk/dal/kvk_stats_card_dal.py` |
+| Service/payload | `kvk/services/kvk_stats_card_service.py`, `kvk/models/kvk_stats_card.py` |
+| Renderer | `kvk/rendering/kvk_stats_card_renderer.py` |
+| Views/buttons | Existing `ui/views/kvk_stats_card_views.py` only if fallback output changes |
+| Commands | No command changes expected |
+| Tests | Existing KVK stats card tests under `tests/` plus SQL/DAL-focused tests where practical |
+| Docs | Programme/task-pack updates only unless command output descriptions change |
+
+## 11. Likely Files
+
+### Review
+
+- `commands/kvk_stats_card_posting.py`
+- `commands/kvk_cmds.py`
+- `kvk/dal/kvk_stats_card_dal.py`
+- `kvk/models/kvk_stats_card.py`
+- `kvk/services/kvk_stats_card_service.py`
+- `kvk/rendering/kvk_stats_card_renderer.py`
+- `ui/views/kvk_stats_card_views.py`
+- `player_stats_cache.py`
+- `stats_cache_helpers.py`
+- `utils.py`
+- SQL repo: `sql_schema/KVK.KVK_Player_Windowed.Table.sql`
+- SQL repo: `sql_schema/KVK.sp_KVK_Recompute_Windows.StoredProcedure.sql`
+- SQL repo objects for `STATS_FOR_UPLOAD`, `SP_Stats_for_Upload`, and `EXCEL_FOR_KVK_<N>`
+
+### Modify
+
+- SQL repo: add `sql_schema/KVK.vw_Player_Overall_KVK_Rank.View.sql` or an approved equivalent name
+- `kvk/dal/kvk_stats_card_dal.py`
+- `kvk/models/kvk_stats_card.py`
+- `kvk/services/kvk_stats_card_service.py`
+- `kvk/rendering/kvk_stats_card_renderer.py`
+- focused KVK stats card tests
+- programme/task-pack docs if implementation changes the approved plan
+
+### Create
+
+- SQL repo view file for the overall KVK rank.
+- Optional bot test file only if existing KVK stats card test files become crowded.
+
+## 12. Implementation Requirements
+
+### 12.1 Overall KVK Rank SQL View
+
+Create a SQL view rather than adding a physical column to `KVK.KVK_Player_Windowed` unless audit proves a view is unsuitable.
+
+Proposed view shape:
+
+```sql
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE OR ALTER VIEW [KVK].[vw_Player_Overall_KVK_Rank]
+AS
+SELECT
+    p.KVK_NO,
+    p.WindowName,
+    p.governor_id,
+    p.name,
+    p.kingdom,
+    p.campid,
+    p.kp_gain_recalc,
+    ROW_NUMBER() OVER (
+        PARTITION BY p.KVK_NO, p.WindowName
+        ORDER BY p.kp_gain_recalc DESC, p.governor_id ASC
+    ) AS overall_kvk_rank,
+    p.last_scan_id,
+    p.computed_at_utc
+FROM KVK.KVK_Player_Windowed AS p
+WHERE p.WindowName = N'Full';
+```
+
+Audit before finalising:
+
+- whether `kp_gain_recalc` can be null and should sort last
+- whether `governor_id ASC` is the approved tie-breaker
+- whether the view should filter `WindowName = N'Full'` internally or expose all windows
+- whether duplicate rows can exist for one `KVK_NO`/`WindowName`/`governor_id`
+- whether an index already supports `KVK_NO`, `WindowName`, `kp_gain_recalc`, and `governor_id`
+
+### 12.2 Bot Retrieval And Payload
+
+- Add a DAL helper or extend `fetch_kvk_stats_card_context` to retrieve `overall_kvk_rank`.
+- Query by `KVK_NO`, `governor_id`, and `WindowName = 'Full'`.
+- Do not add SQL to commands, views, or renderers.
+- Add `overall_kvk_rank: int | str | None` to the stats card context/payload as appropriate.
+- Preserve existing `kvk_rank` from `KVK_RANK`; this remains the main-card rank.
+- Preserve `kingdom_rank`/`Rank` only if it is still useful elsewhere; do not use it for either card rank unless separately approved.
+- If the view or value is unavailable, keep More Stats display safe with `TBC` or `N/A` according to the approved copy.
+
+### 12.3 More Stats Card Rank Display
+
+- Replace the Phase 3B top-right placeholder with the SQL-backed overall rank when available.
+- Keep the label clear, for example `Overall KVK Rank`.
+- Keep trophy/rank styling consistent with the main card.
+- If no value exists, display `TBC` rather than a misleading fallback to `KVK_RANK` or `Rank`.
+
+### 12.4 More Stats Font Consistency
+
+Audit and fix inconsistent row typography on the More Stats card.
+
+Observed issue:
+
+- Pass 4 value `14.3M / 1.1M` and Pass 6 value `4.6M / 0` can render with visibly different font sizes in the same row.
+
+Requirements:
+
+- Same-row metric values should use consistent typography unless a value would otherwise clip.
+- Prefer a row-level fitted font size for pass-window values instead of fitting each metric independently.
+- Keep labels, values, and sublabels readable at Discord desktop and mobile-like sizes.
+- Add a focused renderer/helper test where practical and include visual sample review.
+
+### 12.5 History Acclaim Discrepancy Audit
+
+Audit before changing behaviour.
+
+Known example:
+
+- GovernorID: `4677418`
+- `dbo.STATS_FOR_UPLOAD.HighestAcclaim`: `4744606`
+- Expected compact display for that raw value: `4.7M`
+- Production screenshot shows `Highest Acclaim = 4.7M` and `Last KVK Acclaim = 4.6M`, even though the last KVK appears to be the highest acclaim event for this governor.
+
+Audit questions:
+
+- What raw source populates `history_summary["Highest Acclaim"]`?
+- What raw source populates `last_kvk_summary["Acclaim"]`?
+- Is the last KVK source the prior `EXCEL_FOR_KVK_<N>` table, `v_EXCEL_FOR_KVK_All`, `player_stats_cache.lastkvk`, or another cached/derived object?
+- Are the two raw values actually different?
+- If different, is that expected because current highest acclaim is from current KVK, last finished KVK, or a different KVK?
+- If the raw values match, is a formatter discrepancy causing one-decimal display drift?
+- Should History card display `Last KVK Acclaim`, `Highest Acclaim`, or both with clearer labels?
+
+Do not silently force the last KVK acclaim value from `HighestAcclaim`. Produce the source analysis and recommended fix first.
+
+### 12.6 Command Surface Governance
+
+- [ ] No new top-level command.
+- [ ] No new grouped subcommand.
+- [ ] Preserve `/kvk stats` registration and legacy `/mykvkstats`.
+- [ ] Preserve decorators, permissions, response visibility, usage tracking, and command-cache behaviour.
+- [ ] Run or justify skipping `scripts/validate_command_registration.py`.
+
+## 13. Refactor Decisions
+
+Classify each issue found during audit:
+
+| Issue | Decision | Reason |
+|---|---|---|
+| Overall KVK Rank missing from SQL output contract | fix now | Required to replace the More Stats `TBC` placeholder without guessing in Python. |
+| Physical rank column on `KVK_Player_Windowed` | defer unless view is insufficient | A view is lower impact and avoids table-shape downstream risk. |
+| More Stats same-row font inconsistency | fix now | Visible production polish issue. |
+| History acclaim source discrepancy | audit first | Need source-of-truth evidence before changing display or data logic. |
+| Main-card `Rank` semantics | not applicable | Phase 3B clarified and fixed this to use existing `KVK_RANK`. |
+| Broader `/kvk history` redesign | defer | Phase 3C only audits the compact History card discrepancy. |
+
+Add further rows based on actual findings.
+
+## 14. Testing Requirements
+
+Cover or justify:
+
+- SQL view returns one row per `KVK_NO`/`WindowName = Full`/`governor_id`
+- SQL view ranks by `kp_gain_recalc DESC`
+- SQL view rank tie-breaker is deterministic
+- DAL returns `overall_kvk_rank` for a known row
+- DAL handles missing view/value safely
+- payload includes `overall_kvk_rank`
+- main-card rank still uses `KVK_RANK`
+- More Stats card displays SQL-backed overall rank when present
+- More Stats card displays `TBC` or approved fallback when rank is missing
+- More Stats pass-window typography is visually consistent
+- History acclaim source audit has documented raw values for GovernorID `4677418`
+- any approved acclaim fix has regression tests
+- command registration unchanged
+
+Suggested focused tests, adapt to actual files:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_stats_card_payload.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_stats_card_renderer.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_stats_card_views.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_stats_card_posting.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_theme.py
+```
+
+Suggested validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+.\.venv\Scripts\python.exe -m pytest -q tests
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+SQL validation in `C:\K98-bot-SQL-Server`:
+
+```powershell
+rg "KVK_Player_Windowed|kp_gain_recalc|WindowName" C:\K98-bot-SQL-Server\sql_schema
+rg "vw_Player_Overall_KVK_Rank" C:\K98-bot-SQL-Server\sql_schema
+```
+
+Example DB verification query after SQL deployment:
+
+```sql
+SELECT TOP (20)
+    KVK_NO,
+    WindowName,
+    governor_id,
+    name,
+    kingdom,
+    kp_gain_recalc,
+    overall_kvk_rank
+FROM KVK.vw_Player_Overall_KVK_Rank
+WHERE KVK_NO = 15
+ORDER BY overall_kvk_rank ASC;
+```
+
+Visual validation:
+
+- Generate updated `More Stats` sample showing a real overall rank.
+- Generate updated `More Stats` sample with missing rank fallback.
+- Generate updated `History` sample for GovernorID `4677418` if test data permits.
+- Inspect Discord desktop and mobile-like sizes for label clipping, font mismatch, and value readability.
+
+## 15. Acceptance Criteria
+
+- [ ] Scope is confirmed before implementation.
+- [ ] SQL source objects are validated against `C:\K98-bot-SQL-Server`.
+- [ ] A SQL view derives overall KVK rank from `KVK.KVK_Player_Windowed`.
+- [ ] Rank ordering uses `kp_gain_recalc DESC` and a deterministic tie-breaker.
+- [ ] Bot code retrieves overall KVK rank through DAL/service layers.
+- [ ] More Stats card displays the derived overall KVK rank when available.
+- [ ] More Stats card keeps a safe placeholder when rank is unavailable.
+- [ ] Main-card rank remains sourced from existing `KVK_RANK`.
+- [ ] More Stats same-row font sizing is consistent and visually reviewed.
+- [ ] History acclaim discrepancy is audited with raw source values and a recommended fix.
+- [ ] Any approved acclaim fix is implemented with regression coverage.
+- [ ] No direct SQL is added to commands, views, or renderers.
+- [ ] Existing command registration, permissions, response visibility, and fallback behaviour are preserved.
+- [ ] Focused tests pass.
+- [ ] SQL validation evidence is documented.
+- [ ] Visual review artifacts are generated.
+- [ ] Codex Security review is run before PR handoff or explicitly justified.
+- [ ] SQL deployment order and rollback notes are documented.
+
+## 16. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. New Files
+4. Modified Files
+5. SQL Changes
+6. SQL Validation Evidence
+7. Command Surface Changes
+8. User-Visible Behaviour Changes
+9. Data Contract / Payload Summary
+10. Renderer Summary
+11. Helpers Reused
+12. Refactor Findings
+13. Test Plan and Results
+14. Visual Review Evidence
+15. AI Review Gates
+16. Deployment Steps
+17. Rollback Plan
+18. Deferred Optimisations
+
+## 17. PR Summary Template
+
+```md
+## Summary
+
+- Added SQL-backed overall KVK rank support for the More Stats card.
+- Polished More Stats typography consistency.
+- Audited the History card acclaim source discrepancy and implemented the approved fix, if applicable.
+
+## Changes
+
+- Added `KVK.vw_Player_Overall_KVK_Rank` in the SQL repo.
+- Added DAL/service/payload support for overall KVK rank.
+- Updated More Stats rendering to show the derived overall rank.
+- Updated renderer tests and visual samples.
+
+## SQL Changes
+
+- New view: `<view name>`.
+- Deployment order: SQL view before bot code using it.
+
+## Tests
+
+- `<commands/results>`
+
+## Visual Review
+
+- `<sample paths/results>`
+
+## AI Review Gates
+
+- Codex Security: `<run/skipped with reason>`
+
+## Risk / Rollback
+
+- Risk: SQL view or rank semantics mismatch could show misleading overall rank.
+- Mitigation: SQL validation, deterministic ordering, fallback display, focused renderer/payload tests.
+- Rollback: deploy previous bot code or keep More Stats fallback as `TBC`; SQL view can remain unused or be dropped if necessary.
+```
+
+## 18. Codex Chat Starter
+
+```text
+Codex, start Phase 3C of the KVK Player Experience Redesign: Overall Rank and Card Polish.
+
+Phase 3B is complete, merged, and promoted to production. The More Stats card currently shows Overall KVK Rank as TBC because no durable SQL-backed source existed in Phase 3B.
+
+Before implementation, read:
+- AGENTS.md
+- README-DEV.md
+- docs/reference/README.md
+- docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
+- docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md
+- this Phase 3C task pack
+
+Use the K98 repo workflow and required skills. First audit the SQL source and propose the view contract before coding.
+
+Overall rank requirement:
+- create a SQL view over KVK.KVK_Player_Windowed
+- use KVK_NO for the current KVK
+- use WindowName = Full
+- rank by kp_gain_recalc DESC with deterministic tie-breaker
+- retrieve the value through bot DAL/service code
+- populate the More Stats card Overall KVK Rank
+- keep main card Rank sourced from KVK_RANK
+
+Card polish requirements:
+- make More Stats same-row font sizes consistent, especially Pass 4 vs Pass 6 values
+- audit the History Highest Acclaim vs Last KVK Acclaim discrepancy for GovernorID 4677418 before agreeing the fix
+
+Do not add direct SQL to commands, views, or renderers. Do not change KVK import/recompute/export semantics or legacy command rollout behaviour unless separately approved.
+```

--- a/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
@@ -273,21 +273,39 @@ Delivered details:
 
 ### Phase 3B - Stats Card Polish and Secondary Cards
 
+Status: complete. Delivered in mirror PR #143 and promoted to production.
+
+Polished the delivered `/kvk stats` main card and extended the Phase 3 visual language to the
+attached `More Stats` and `History` views.
+
+Delivered details:
+
+- Main-card compact stat values now use one decimal place.
+- Card backgrounds are selected by KVK mode from `KVK_NAME`, with fallback/default handling.
+- `Tides of War`, `Heroic Anthem`, `Storm of Stratagems`, and `Songs of Troy` card backgrounds are supported where assets exist.
+- The main card rank marker uses the existing `KVK_RANK` value from the stats payload.
+- The More Stats card shows `Overall KVK Rank` as `TBC` until Phase 3C provides a durable SQL-backed source.
+- Kills and DKP progress ticks scale dynamically for high performers, including values around `225%`.
+- `More Stats` and compact `History` are now Pillow-rendered secondary cards attached to `/kvk stats`.
+- Matchmaking snapshot data is intentionally excluded from the compact History card.
+- `/mykvkstats` remains legacy during parallel validation.
+
+### Phase 3C - Overall KVK Rank Data Contract and Card Polish
+
 Status: ready for task execution.
 
-Polish the delivered `/kvk stats` main card and extend the Phase 3 visual language to the attached
-`More Stats` and `History` views.
+Create the durable data contract required to replace the More Stats `Overall KVK Rank` placeholder,
+then polish the remaining Phase 3B card issues found during production smoke testing.
 
 Planned scope:
 
-- reduce main-card compact stat values to one decimal place
-- select card background by KVK mode from `KVK_NAME`
-- support `Tides of War` and `Heroic Anthem` card backgrounds
-- add trophy/rank visual polish
-- make kills target progress ticks scale dynamically for high performers, including around `225%`
-- review and improve `More Stats` and `History` information order
-- build Pillow-rendered `More Stats` and `History` cards if the audit confirms they fit in one PR
-- keep `/mykvkstats` legacy during parallel validation
+- create a SQL view over `KVK.KVK_Player_Windowed` that derives overall KVK rank for `WindowName = 'Full'`
+- rank by `kp_gain_recalc DESC` with a deterministic tie-breaker such as `governor_id ASC`
+- retrieve the derived overall rank through bot DAL/service code and populate the More Stats card
+- keep the main card rank sourced from existing `KVK_RANK`
+- make More Stats row typography consistent, especially Pass 4 versus Pass 6 value sizing
+- audit the History card `Highest Acclaim` versus `Last KVK Acclaim` source/rounding discrepancy before agreeing any data or formatting fix
+- update tests, SQL validation evidence, and visual samples
 
 ### Phase 4 - Modern `/kvk targets` and Full `/kvk history`
 
@@ -443,11 +461,12 @@ Do not include these in the early phases unless separately approved:
 Proceed with:
 
 ```text
-KVK Player Experience Redesign - Phase 3B Stats Card Polish and Secondary Cards
+KVK Player Experience Redesign - Phase 3C Overall KVK Rank Data Contract and Card Polish
 ```
 
 Phase 1 audit/design, Phase 2A admin collision resolution, and Phase 2B player `/kvk` scaffold are
 complete. Phase 3 has delivered the modern `/kvk stats` visual card while preserving the legacy
-`/mykvkstats` embed during rollout. Phase 3B should polish the delivered card, add KVK mode-specific
-background selection, improve high-progress target scaling, and move the attached `More Stats` and
-`History` views toward Pillow-rendered cards.
+`/mykvkstats` embed during rollout. Phase 3B has polished the card, added KVK mode-specific
+background selection, improved high-progress target scaling, and moved the attached `More Stats`
+and `History` views to Pillow-rendered cards. Phase 3C should add the SQL-backed overall KVK rank
+source for the More Stats card and address the remaining typography/acclaim-source review items.

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -24,7 +24,10 @@ Player self-service workflow redesign and public calendar/KVK calendar UX redesi
 deferred optimisation programmes, not additional command-platform phases.
 
 KVK Player Experience Redesign is active. Phase 1 audit/design, Phase 2A Admin Collision
-Resolution, and Phase 2B Player `/kvk` Scaffold are complete. Phase 2A moved admin/operator
-commands from `/kvk ...` to `/kvk_admin ...` in PR 140. Phase 2B added the player `/kvk stats`,
-`/kvk targets`, `/kvk history`, and `/kvk rankings` scaffold in PR 141, then was promoted to
-production. Use the programme pack to scope Phase 3, the modern `/kvk stats` visual card.
+Resolution, Phase 2B Player `/kvk` Scaffold, Phase 3 Modern `/kvk stats` Visual Card, and Phase
+3B Stats Card Polish and Secondary Cards are complete. Phase 2A moved admin/operator commands from
+`/kvk ...` to `/kvk_admin ...` in PR 140. Phase 2B added the player `/kvk stats`, `/kvk targets`,
+`/kvk history`, and `/kvk rankings` scaffold in PR 141, then was promoted to production. Phase 3
+and Phase 3B delivered the modern `/kvk stats` image-card rollout, mode-specific card backgrounds,
+secondary More Stats and History cards, and production promotion. Use the programme pack and the
+Phase 3C task pack for the next overall-rank data contract and card polish phase.

--- a/kvk/dal/kvk_stats_card_dal.py
+++ b/kvk/dal/kvk_stats_card_dal.py
@@ -60,4 +60,31 @@ def fetch_kvk_stats_card_context(kvk_no: int | None, governor_id: str) -> dict[s
             context["kingdom"] = data.get("kingdom")
             context["camp_id"] = data.get("campid")
             context["camp_name"] = data.get("camp_name")
+
+        try:
+            cur.execute(
+                """
+                SELECT TOP 1
+                    overall_kvk_rank,
+                    overall_kvk_total_governors,
+                    overall_kvk_percentile
+                FROM KVK.vw_Player_Overall_KVK_Rank
+                WHERE KVK_NO = ?
+                  AND governor_id = ?
+                """,
+                (int(kvk_no), gov_int),
+            )
+            row = cur.fetchone()
+            if row:
+                data = cursor_row_to_dict(cur, row)
+                context["overall_kvk_rank"] = data.get("overall_kvk_rank")
+                context["overall_kvk_total_governors"] = data.get("overall_kvk_total_governors")
+                context["overall_kvk_percentile"] = data.get("overall_kvk_percentile")
+        except Exception:
+            logger.warning(
+                "kvk_stats_card_overall_rank_unavailable kvk_no=%s governor_id=%s",
+                kvk_no,
+                governor_id,
+                exc_info=True,
+            )
     return context

--- a/kvk/dal/kvk_stats_card_dal.py
+++ b/kvk/dal/kvk_stats_card_dal.py
@@ -71,6 +71,7 @@ def fetch_kvk_stats_card_context(kvk_no: int | None, governor_id: str) -> dict[s
                 FROM KVK.vw_Player_Overall_KVK_Rank
                 WHERE KVK_NO = ?
                   AND governor_id = ?
+                ORDER BY overall_kvk_rank ASC
                 """,
                 (int(kvk_no), gov_int),
             )

--- a/kvk/dal/kvk_stats_card_dal.py
+++ b/kvk/dal/kvk_stats_card_dal.py
@@ -67,7 +67,7 @@ def fetch_kvk_stats_card_context(kvk_no: int | None, governor_id: str) -> dict[s
                 SELECT TOP 1
                     overall_kvk_rank,
                     overall_kvk_total_governors,
-                    overall_kvk_percentile
+                    overall_kvk_top_percent
                 FROM KVK.vw_Player_Overall_KVK_Rank
                 WHERE KVK_NO = ?
                   AND governor_id = ?
@@ -79,7 +79,7 @@ def fetch_kvk_stats_card_context(kvk_no: int | None, governor_id: str) -> dict[s
                 data = cursor_row_to_dict(cur, row)
                 context["overall_kvk_rank"] = data.get("overall_kvk_rank")
                 context["overall_kvk_total_governors"] = data.get("overall_kvk_total_governors")
-                context["overall_kvk_percentile"] = data.get("overall_kvk_percentile")
+                context["overall_kvk_top_percent"] = data.get("overall_kvk_top_percent")
         except Exception:
             logger.warning(
                 "kvk_stats_card_overall_rank_unavailable kvk_no=%s governor_id=%s",

--- a/kvk/models/kvk_stats_card.py
+++ b/kvk/models/kvk_stats_card.py
@@ -11,6 +11,9 @@ class KvkStatsCardContext:
     kingdom: int | None = None
     camp_id: int | None = None
     camp_name: str | None = None
+    overall_kvk_rank: int | None = None
+    overall_kvk_total_governors: int | None = None
+    overall_kvk_percentile: float | None = None
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,9 @@ class KvkStatsCardPayload:
     dkp_target: int
     dkp_target_percent: float | None
     kingdom_rank: int | str | None = None
+    overall_kvk_rank: int | None = None
+    overall_kvk_total_governors: int | None = None
+    overall_kvk_percentile: float | None = None
     pass_stats: dict[str, int] = field(default_factory=dict)
     prekvk_rank: int | None = None
     prekvk_points: int | None = None

--- a/kvk/models/kvk_stats_card.py
+++ b/kvk/models/kvk_stats_card.py
@@ -13,7 +13,7 @@ class KvkStatsCardContext:
     camp_name: str | None = None
     overall_kvk_rank: int | None = None
     overall_kvk_total_governors: int | None = None
-    overall_kvk_percentile: float | None = None
+    overall_kvk_top_percent: float | None = None
 
 
 @dataclass(frozen=True)
@@ -57,7 +57,7 @@ class KvkStatsCardPayload:
     kingdom_rank: int | str | None = None
     overall_kvk_rank: int | None = None
     overall_kvk_total_governors: int | None = None
-    overall_kvk_percentile: float | None = None
+    overall_kvk_top_percent: float | None = None
     pass_stats: dict[str, int] = field(default_factory=dict)
     prekvk_rank: int | None = None
     prekvk_points: int | None = None

--- a/kvk/rendering/kvk_stats_card_renderer.py
+++ b/kvk/rendering/kvk_stats_card_renderer.py
@@ -115,6 +115,23 @@ def _fit_font(
     return font
 
 
+def _fit_shared_font(
+    draw: ImageDraw.ImageDraw,
+    values: list[str],
+    *,
+    max_width: int,
+    size: int,
+    min_size: int,
+    bold: bool = False,
+) -> ImageFont.ImageFont:
+    text = max(values or [""], key=len)
+    font = text_renderer._font_for_text(text, size, bold=bold)
+    while size > min_size and any(_text_width(draw, value, font) > max_width for value in values):
+        size -= 1
+        font = text_renderer._font_for_text(text, size, bold=bold)
+    return font
+
+
 def _draw_text(
     draw: ImageDraw.ImageDraw,
     xy: tuple[int, int],
@@ -128,6 +145,21 @@ def _draw_text(
     text_renderer._draw_text(draw, xy, text, fill=fill, font=font, bold=bold)
 
 
+def _draw_centered_text(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center_x: int,
+    y: int,
+    text: str,
+    fill=TEXT,
+    font: ImageFont.ImageFont | None = None,
+    bold: bool = False,
+) -> None:
+    font = font or _font(20, bold=bold)
+    x = center_x - (_text_width(draw, text, font) // 2)
+    _draw_text(draw, (x, y), text, fill=fill, font=font, bold=bold)
+
+
 def _metric(
     draw: ImageDraw.ImageDraw,
     *,
@@ -138,9 +170,10 @@ def _metric(
     value: str,
     color: tuple[int, int, int],
     sub: str | None = None,
+    value_font: ImageFont.ImageFont | None = None,
 ) -> None:
     _draw_text(draw, (x, y), title.upper(), fill=TEXT, font=_font(21, bold=True), bold=True)
-    value_font = _fit_font(draw, value, max_width=w, size=44, min_size=29, bold=True)
+    value_font = value_font or _fit_font(draw, value, max_width=w, size=44, min_size=29, bold=True)
     _draw_text(draw, (x, y + 34), value, fill=color, font=value_font, bold=True)
     if sub:
         sub_font = _fit_font(draw, sub, max_width=w, size=18, min_size=13, bold=True)
@@ -234,8 +267,23 @@ def _main_rank_value(payload: KvkStatsCardPayload) -> str:
     return _rank_value(payload.kvk_rank)
 
 
-def _overall_kvk_rank_value() -> str:
-    return "TBC"
+def _overall_kvk_rank_value(payload: KvkStatsCardPayload) -> str:
+    if payload.overall_kvk_rank in (None, 0):
+        return "TBC"
+    return _rank_value(payload.overall_kvk_rank)
+
+
+def _overall_kvk_rank_context(payload: KvkStatsCardPayload) -> str | None:
+    if payload.overall_kvk_rank in (None, 0):
+        return None
+    parts: list[str] = []
+    if payload.overall_kvk_total_governors:
+        parts.append(f"Total {_compact(payload.overall_kvk_total_governors).lower()}")
+    if payload.overall_kvk_percentile is not None:
+        parts.append(f"Top {_pct(payload.overall_kvk_percentile)}")
+    if not parts:
+        return None
+    return " / ".join(parts)
 
 
 def _pass_window(payload: KvkStatsCardPayload, pass_no: int) -> tuple[int, int]:
@@ -373,12 +421,26 @@ def render_kvk_stats_card(
     _draw_text(draw, (155, 135), payload.governor_name, fill=TEXT, font=name_font, bold=True)
     _draw_text(draw, (155, 183), str(payload.governor_id), fill=TEXT, font=_font(24, bold=True))
 
-    rank_x = 940
-    _draw_text(
-        draw, (rank_x, 56), "\U0001f3c6 RANK", fill=TEXT, font=_font(25, bold=True), bold=True
+    rank_center_x = 995
+    _draw_centered_text(
+        draw,
+        center_x=rank_center_x,
+        y=56,
+        text="\U0001f3c6 RANK",
+        fill=TEXT,
+        font=_font(25, bold=True),
+        bold=True,
     )
     rank_value = _main_rank_value(payload)
-    _draw_text(draw, (rank_x, 88), rank_value, fill=TEXT, font=_font(50, bold=True), bold=True)
+    _draw_centered_text(
+        draw,
+        center_x=rank_center_x,
+        y=88,
+        text=rank_value,
+        fill=TEXT,
+        font=_font(50, bold=True),
+        bold=True,
+    )
 
     col_w = 230
     col_x = (45, 315, 585, 855)
@@ -493,23 +555,57 @@ def render_kvk_more_stats_card(payload: KvkStatsCardPayload) -> RenderedKvkStats
 
     _draw_card_header(draw, payload, title="More KVK Stats")
 
-    rank_x = 930
-    rank_label_x = 875
-    rank_label = "\U0001f3c6 OVERALL KVK RANK"
+    rank_center_x = 1008
+    rank_label = "KVK OVERALL RANK"
     rank_font = _fit_font(draw, rank_label, max_width=265, size=22, min_size=16, bold=True)
-    _draw_text(draw, (rank_label_x, 50), rank_label, fill=TEXT, font=rank_font, bold=True)
-    _draw_text(
+    _draw_centered_text(
         draw,
-        (rank_x, 82),
-        _overall_kvk_rank_value(),
+        center_x=rank_center_x,
+        y=50,
+        text=rank_label,
         fill=TEXT,
-        font=_font(46, bold=True),
+        font=rank_font,
         bold=True,
     )
+    _draw_centered_text(
+        draw,
+        center_x=rank_center_x,
+        y=82,
+        text=_overall_kvk_rank_value(payload),
+        fill=TEXT,
+        font=_fit_font(
+            draw,
+            _overall_kvk_rank_value(payload),
+            max_width=160,
+            size=46,
+            min_size=30,
+            bold=True,
+        ),
+        bold=True,
+    )
+    rank_context = _overall_kvk_rank_context(payload)
+    if rank_context:
+        _draw_centered_text(
+            draw,
+            center_x=rank_center_x,
+            y=128,
+            text=rank_context,
+            fill=GOLD,
+            font=_fit_font(draw, rank_context, max_width=280, size=20, min_size=15, bold=True),
+            bold=True,
+        )
 
     col_w = 230
     col_x = (45, 315, 585, 855)
     pass_y = 205
+    pass_values = [
+        f"{_compact(kills)} / {_compact(deads)}"
+        for pass_no in (4, 6, 7, 8)
+        for kills, deads in [_pass_window(payload, pass_no)]
+    ]
+    pass_value_font = _fit_shared_font(
+        draw, pass_values, max_width=col_w, size=44, min_size=29, bold=True
+    )
     for idx, pass_no in enumerate((4, 6, 7, 8)):
         kills, deads = _pass_window(payload, pass_no)
         _metric(
@@ -521,6 +617,7 @@ def render_kvk_more_stats_card(payload: KvkStatsCardPayload) -> RenderedKvkStats
             value=f"{_compact(kills)} / {_compact(deads)}",
             color=GREEN if kills else MUTED,
             sub="Kills / Deads",
+            value_font=pass_value_font,
         )
 
     row2_y = 345

--- a/kvk/rendering/kvk_stats_card_renderer.py
+++ b/kvk/rendering/kvk_stats_card_renderer.py
@@ -279,8 +279,8 @@ def _overall_kvk_rank_context(payload: KvkStatsCardPayload) -> str | None:
     parts: list[str] = []
     if payload.overall_kvk_total_governors:
         parts.append(f"Total {_compact(payload.overall_kvk_total_governors).lower()}")
-    if payload.overall_kvk_percentile is not None:
-        parts.append(f"Top {_pct(payload.overall_kvk_percentile)}")
+    if payload.overall_kvk_top_percent is not None:
+        parts.append(f"Top {_pct(payload.overall_kvk_top_percent)}")
     if not parts:
         return None
     return " / ".join(parts)

--- a/kvk/services/kvk_stats_card_service.py
+++ b/kvk/services/kvk_stats_card_service.py
@@ -14,6 +14,8 @@ from kvk.models.kvk_stats_card import (
 
 logger = logging.getLogger(__name__)
 
+PROGRESS_GOLD_HEX = "#FFD357"
+
 PASS_KEYS = (
     "Pass 4 Kills",
     "Pass 6 Kills",
@@ -87,7 +89,7 @@ def kill_progress_policy(percent: float | None, *, is_exempt: bool = False) -> t
         return "#666666", "No targets assigned this KVK"
     value = float(percent or 0.0)
     if value >= 100:
-        return "#FFD700", "Smashed it! Don't stop!!"
+        return PROGRESS_GOLD_HEX, "Smashed it! Don't stop!!"
     if value >= 85:
         return "#006400", "So close, push now!"
     if value >= 70:
@@ -134,6 +136,15 @@ def _build_context(raw: dict[str, Any] | None) -> KvkStatsCardContext:
         kingdom=_int_from_variants(raw, ["kingdom", "Kingdom"], default=0) or None,
         camp_id=_int_from_variants(raw, ["camp_id", "campid", "CampID"], default=0) or None,
         camp_name=_str_from_variants(raw, ["camp_name", "CampName"], default="") or None,
+        overall_kvk_rank=_int_from_variants(raw, ["overall_kvk_rank", "OverallKvkRank"], default=0)
+        or None,
+        overall_kvk_total_governors=_int_from_variants(
+            raw, ["overall_kvk_total_governors", "OverallKvkTotalGovernors"], default=0
+        )
+        or None,
+        overall_kvk_percentile=_float_from_variants(
+            raw, ["overall_kvk_percentile", "OverallKvkPercentile"]
+        ),
     )
 
 
@@ -246,6 +257,9 @@ async def build_kvk_stats_card_payload(
         dkp=dkp,
         dkp_target=dkp_target,
         dkp_target_percent=dkp_target_percent,
+        overall_kvk_rank=context.overall_kvk_rank,
+        overall_kvk_total_governors=context.overall_kvk_total_governors,
+        overall_kvk_percentile=context.overall_kvk_percentile,
         pass_stats=pass_stats,
         prekvk_rank=_int_from_variants(row, ["PreKvk_Rank", "PreKvk Rank"], default=0) or None,
         prekvk_points=_int_from_variants(row, ["Max_PreKvk_Points", "Max PreKvk Points"], default=0)

--- a/kvk/services/kvk_stats_card_service.py
+++ b/kvk/services/kvk_stats_card_service.py
@@ -142,8 +142,8 @@ def _build_context(raw: dict[str, Any] | None) -> KvkStatsCardContext:
             raw, ["overall_kvk_total_governors", "OverallKvkTotalGovernors"], default=0
         )
         or None,
-        overall_kvk_percentile=_float_from_variants(
-            raw, ["overall_kvk_percentile", "OverallKvkPercentile"]
+        overall_kvk_top_percent=_float_from_variants(
+            raw, ["overall_kvk_top_percent", "OverallKvkTopPercent"]
         ),
     )
 
@@ -259,7 +259,7 @@ async def build_kvk_stats_card_payload(
         dkp_target_percent=dkp_target_percent,
         overall_kvk_rank=context.overall_kvk_rank,
         overall_kvk_total_governors=context.overall_kvk_total_governors,
-        overall_kvk_percentile=context.overall_kvk_percentile,
+        overall_kvk_top_percent=context.overall_kvk_top_percent,
         pass_stats=pass_stats,
         prekvk_rank=_int_from_variants(row, ["PreKvk_Rank", "PreKvk Rank"], default=0) or None,
         prekvk_points=_int_from_variants(row, ["Max_PreKvk_Points", "Max PreKvk Points"], default=0)

--- a/tests/test_kvk_stats_card_dal.py
+++ b/tests/test_kvk_stats_card_dal.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from kvk.dal import kvk_stats_card_dal
+
+
+class _Cursor:
+    def __init__(self, rows: list[dict], *, fail_rank_query: bool = False):
+        self._rows = rows
+        self._index = 0
+        self._fail_rank_query = fail_rank_query
+        self.executed: list[tuple[str, object]] = []
+
+    def execute(self, sql: str, params=None):
+        self.executed.append((sql, params))
+        if self._fail_rank_query and "vw_Player_Overall_KVK_Rank" in sql:
+            raise RuntimeError("view missing")
+        return None
+
+    def fetchone(self):
+        if self._index >= len(self._rows):
+            return None
+        row = self._rows[self._index]
+        self._index += 1
+        return row
+
+
+class _Connection:
+    def __init__(self, cursor: _Cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_fetch_context_includes_overall_kvk_rank(monkeypatch):
+    cursor = _Cursor(
+        [
+            {"KVK_NAME": "Tides of War"},
+            {"kingdom": 1978, "campid": 2, "camp_name": "Wind"},
+            {
+                "overall_kvk_rank": 41,
+                "overall_kvk_total_governors": 8734,
+                "overall_kvk_percentile": 0.47,
+            },
+        ]
+    )
+    monkeypatch.setattr(kvk_stats_card_dal, "get_conn_with_retries", lambda: _Connection(cursor))
+    monkeypatch.setattr(kvk_stats_card_dal, "cursor_row_to_dict", lambda _cur, row: row)
+
+    context = kvk_stats_card_dal.fetch_kvk_stats_card_context(54, "58744139")
+
+    assert context["kvk_name"] == "Tides of War"
+    assert context["kingdom"] == 1978
+    assert context["camp_id"] == 2
+    assert context["camp_name"] == "Wind"
+    assert context["overall_kvk_rank"] == 41
+    assert context["overall_kvk_total_governors"] == 8734
+    assert context["overall_kvk_percentile"] == 0.47
+    assert any("vw_Player_Overall_KVK_Rank" in sql for sql, _params in cursor.executed)
+
+
+def test_fetch_context_preserves_existing_context_when_rank_view_missing(monkeypatch, caplog):
+    cursor = _Cursor(
+        [
+            {"KVK_NAME": "Tides of War"},
+            {"kingdom": 1978, "campid": 2, "camp_name": "Wind"},
+        ],
+        fail_rank_query=True,
+    )
+    monkeypatch.setattr(kvk_stats_card_dal, "get_conn_with_retries", lambda: _Connection(cursor))
+    monkeypatch.setattr(kvk_stats_card_dal, "cursor_row_to_dict", lambda _cur, row: row)
+
+    context = kvk_stats_card_dal.fetch_kvk_stats_card_context(54, "58744139")
+
+    assert context["kvk_name"] == "Tides of War"
+    assert context["camp_name"] == "Wind"
+    assert "overall_kvk_rank" not in context
+    assert "kvk_stats_card_overall_rank_unavailable" in caplog.text

--- a/tests/test_kvk_stats_card_dal.py
+++ b/tests/test_kvk_stats_card_dal.py
@@ -62,7 +62,10 @@ def test_fetch_context_includes_overall_kvk_rank(monkeypatch):
     assert context["overall_kvk_rank"] == 41
     assert context["overall_kvk_total_governors"] == 8734
     assert context["overall_kvk_top_percent"] == 0.47
-    assert any("vw_Player_Overall_KVK_Rank" in sql for sql, _params in cursor.executed)
+    rank_query = next(
+        sql for sql, _params in cursor.executed if "vw_Player_Overall_KVK_Rank" in sql
+    )
+    assert "ORDER BY overall_kvk_rank ASC" in rank_query
 
 
 def test_fetch_context_preserves_existing_context_when_rank_view_missing(monkeypatch, caplog):

--- a/tests/test_kvk_stats_card_dal.py
+++ b/tests/test_kvk_stats_card_dal.py
@@ -46,7 +46,7 @@ def test_fetch_context_includes_overall_kvk_rank(monkeypatch):
             {
                 "overall_kvk_rank": 41,
                 "overall_kvk_total_governors": 8734,
-                "overall_kvk_percentile": 0.47,
+                "overall_kvk_top_percent": 0.47,
             },
         ]
     )
@@ -61,7 +61,7 @@ def test_fetch_context_includes_overall_kvk_rank(monkeypatch):
     assert context["camp_name"] == "Wind"
     assert context["overall_kvk_rank"] == 41
     assert context["overall_kvk_total_governors"] == 8734
-    assert context["overall_kvk_percentile"] == 0.47
+    assert context["overall_kvk_top_percent"] == 0.47
     assert any("vw_Player_Overall_KVK_Rank" in sql for sql, _params in cursor.executed)
 
 

--- a/tests/test_kvk_stats_card_payload.py
+++ b/tests/test_kvk_stats_card_payload.py
@@ -32,7 +32,14 @@ async def test_build_payload_includes_kvk_mode_and_camp():
         "KvKPlayed": 8,
         "MostKvKKill": 1_200_000_000,
     }
-    context = KvkStatsCardContext(kvk_name="Tides of War", kingdom=1978, camp_name="Wind")
+    context = KvkStatsCardContext(
+        kvk_name="Tides of War",
+        kingdom=1978,
+        camp_name="Wind",
+        overall_kvk_rank=41,
+        overall_kvk_total_governors=8_734,
+        overall_kvk_percentile=0.47,
+    )
 
     payload = await build_kvk_stats_card_payload(row, context=context)
 
@@ -41,6 +48,9 @@ async def test_build_payload_includes_kvk_mode_and_camp():
     assert payload.display_camp == "Wind"
     assert payload.kingdom_rank == 8
     assert payload.kvk_rank == 23
+    assert payload.overall_kvk_rank == 41
+    assert payload.overall_kvk_total_governors == 8_734
+    assert payload.overall_kvk_percentile == pytest.approx(0.47)
     assert payload.kp_loss == 639_013_000
     assert payload.playstyle == "Sniping Kills"
     assert payload.kill_progress.percent == pytest.approx(95.5512)
@@ -83,7 +93,7 @@ async def test_build_payload_preserves_zero_healed_value():
 
 
 def test_kill_progress_policy_preserves_existing_threshold_quotes():
-    assert kill_progress_policy(101) == ("#FFD700", "Smashed it! Don't stop!!")
+    assert kill_progress_policy(101) == ("#FFD357", "Smashed it! Don't stop!!")
     assert kill_progress_policy(86) == ("#006400", "So close, push now!")
     assert kill_progress_policy(10) == ("#8B0000", "FIGHT NOW!!")
     assert kill_progress_policy(None, is_exempt=True) == (

--- a/tests/test_kvk_stats_card_payload.py
+++ b/tests/test_kvk_stats_card_payload.py
@@ -38,7 +38,7 @@ async def test_build_payload_includes_kvk_mode_and_camp():
         camp_name="Wind",
         overall_kvk_rank=41,
         overall_kvk_total_governors=8_734,
-        overall_kvk_percentile=0.47,
+        overall_kvk_top_percent=0.47,
     )
 
     payload = await build_kvk_stats_card_payload(row, context=context)
@@ -50,7 +50,7 @@ async def test_build_payload_includes_kvk_mode_and_camp():
     assert payload.kvk_rank == 23
     assert payload.overall_kvk_rank == 41
     assert payload.overall_kvk_total_governors == 8_734
-    assert payload.overall_kvk_percentile == pytest.approx(0.47)
+    assert payload.overall_kvk_top_percent == pytest.approx(0.47)
     assert payload.kp_loss == 639_013_000
     assert payload.playstyle == "Sniping Kills"
     assert payload.kill_progress.percent == pytest.approx(95.5512)

--- a/tests/test_kvk_stats_card_renderer.py
+++ b/tests/test_kvk_stats_card_renderer.py
@@ -164,7 +164,7 @@ def test_overall_kvk_rank_formats_population_context():
         _payload(),
         overall_kvk_rank=41,
         overall_kvk_total_governors=8_734,
-        overall_kvk_percentile=0.47,
+        overall_kvk_top_percent=0.47,
     )
 
     assert _overall_kvk_rank_value(payload) == "#41"

--- a/tests/test_kvk_stats_card_renderer.py
+++ b/tests/test_kvk_stats_card_renderer.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 from dataclasses import replace
 from io import BytesIO
 
-from PIL import Image
+from PIL import Image, ImageDraw
 
 from kvk.models.kvk_stats_card import (
     KvkStatsCardPayload,
     KvkTargetProgress,
 )
 from kvk.rendering.kvk_stats_card_renderer import (
+    GOLD,
     _background_for_mode,
     _compact,
+    _fit_shared_font,
+    _hex_color,
     _history_background,
     _main_rank_value,
+    _overall_kvk_rank_context,
     _overall_kvk_rank_value,
     _pct,
     _progress_scale,
@@ -147,8 +151,38 @@ def test_main_rank_does_not_fall_back_to_power_rank():
     assert _main_rank_value(payload) == "N/A"
 
 
-def test_overall_kvk_rank_is_placeholder_until_phase_3c_data_contract():
-    assert _overall_kvk_rank_value() == "TBC"
+def test_overall_kvk_rank_uses_placeholder_when_missing():
+    assert _overall_kvk_rank_value(replace(_payload(), overall_kvk_rank=None)) == "TBC"
+
+
+def test_overall_kvk_rank_formats_payload_rank():
+    assert _overall_kvk_rank_value(replace(_payload(), overall_kvk_rank=41)) == "#41"
+
+
+def test_overall_kvk_rank_formats_population_context():
+    payload = replace(
+        _payload(),
+        overall_kvk_rank=41,
+        overall_kvk_total_governors=8_734,
+        overall_kvk_percentile=0.47,
+    )
+
+    assert _overall_kvk_rank_value(payload) == "#41"
+    assert _overall_kvk_rank_context(payload) == "Total 8.7k / Top 0.5%"
+
+
+def test_progress_gold_is_shared_between_payload_and_renderer():
+    assert _hex_color("#FFD357") == GOLD
+
+
+def test_shared_font_fits_all_pass_values_to_one_size():
+    image = Image.new("RGB", (400, 120), "black")
+    draw = ImageDraw.Draw(image)
+    values = ["14.3M / 1.1M", "4.6M / 0", "123.4M / 12.2M"]
+
+    font = _fit_shared_font(draw, values, max_width=230, size=44, min_size=29, bold=True)
+
+    assert all(draw.textbbox((0, 0), value, font=font)[2] <= 230 for value in values)
 
 
 def test_history_background_uses_history_card_asset():

--- a/tests/test_kvk_stats_card_sql_contract.py
+++ b/tests/test_kvk_stats_card_sql_contract.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+
+import pytest
+
+
+SQL_REPO = Path(os.environ.get("K98_SQL_REPO", r"C:\K98-bot-SQL-Server"))
+SQL_SCHEMA = SQL_REPO / "sql_schema"
+
+
+def _normalise_sql(sql: str) -> str:
+    return re.sub(r"\s+", " ", sql).strip().lower()
+
+
+def _read_sql_file(name: str) -> str:
+    path = SQL_SCHEMA / name
+    if not path.exists():
+        if "K98_SQL_REPO" in os.environ:
+            pytest.fail(f"SQL repo file not available: {path}")
+        pytest.skip(f"SQL repo file not available: {path}")
+    return path.read_text(encoding="utf-8-sig")
+
+
+def test_overall_kvk_rank_view_contract():
+    sql = _normalise_sql(_read_sql_file("KVK.vw_Player_Overall_KVK_Rank.View.sql"))
+
+    assert "create or alter view [kvk].[vw_player_overall_kvk_rank]" in sql
+    assert "from kvk.kvk_player_windowed as p" in sql
+    assert "where p.windowname = n'full'" in sql
+    assert "row_number() over" in sql
+    assert "partition by p.kvk_no, p.windowname" in sql
+    assert "order by p.kp_gain_recalc desc, p.governor_id asc" in sql
+    assert "as overall_kvk_rank" in sql
+    assert "as overall_kvk_total_governors" in sql
+    assert "as overall_kvk_percentile" in sql

--- a/tests/test_kvk_stats_card_sql_contract.py
+++ b/tests/test_kvk_stats_card_sql_contract.py
@@ -6,13 +6,14 @@ import re
 
 import pytest
 
-
 SQL_REPO = Path(os.environ.get("K98_SQL_REPO", r"C:\K98-bot-SQL-Server"))
 SQL_SCHEMA = SQL_REPO / "sql_schema"
 
 
 def _normalise_sql(sql: str) -> str:
-    return re.sub(r"\s+", " ", sql).strip().lower()
+    sql = sql.lower().replace("[", "").replace("]", "")
+    sql = re.sub(r"\bn'", "'", sql)
+    return re.sub(r"\s+", " ", sql).strip()
 
 
 def _read_sql_file(name: str) -> str:
@@ -27,12 +28,17 @@ def _read_sql_file(name: str) -> str:
 def test_overall_kvk_rank_view_contract():
     sql = _normalise_sql(_read_sql_file("KVK.vw_Player_Overall_KVK_Rank.View.sql"))
 
-    assert "create or alter view [kvk].[vw_player_overall_kvk_rank]" in sql
-    assert "from kvk.kvk_player_windowed as p" in sql
-    assert "where p.windowname = n'full'" in sql
-    assert "row_number() over" in sql
-    assert "partition by p.kvk_no, p.windowname" in sql
-    assert "order by p.kp_gain_recalc desc, p.governor_id asc" in sql
-    assert "as overall_kvk_rank" in sql
-    assert "as overall_kvk_total_governors" in sql
-    assert "as overall_kvk_percentile" in sql
+    assert re.search(r"\bcreate\s+or\s+alter\s+view\s+kvk\.vw_player_overall_kvk_rank\b", sql)
+    assert re.search(r"\bfrom\s+kvk\.kvk_player_windowed\s+(?:as\s+)?p\b", sql)
+    assert re.search(r"\bwhere\s+p\.windowname\s*=\s*'full'", sql)
+    assert re.search(
+        r"\brow_number\(\)\s+over\s*\([^)]*partition\s+by\s+p\.kvk_no\s*,\s*p\.windowname",
+        sql,
+    )
+    assert re.search(
+        r"\border\s+by\s+p\.kp_gain_recalc\s+desc\s*,\s*p\.governor_id\s+asc",
+        sql,
+    )
+    assert re.search(r"\bas\s+overall_kvk_rank\b", sql)
+    assert re.search(r"\bas\s+overall_kvk_total_governors\b", sql)
+    assert re.search(r"\bas\s+overall_kvk_top_percent\b", sql)

--- a/tests/test_kvk_stats_card_sql_contract.py
+++ b/tests/test_kvk_stats_card_sql_contract.py
@@ -6,8 +6,15 @@ import re
 
 import pytest
 
-SQL_REPO = Path(os.environ.get("K98_SQL_REPO", r"C:\K98-bot-SQL-Server"))
+K98_SQL_REPO_ENV = os.environ.get("K98_SQL_REPO")
+SQL_REPO = Path(K98_SQL_REPO_ENV) if K98_SQL_REPO_ENV else Path(r"C:\K98-bot-SQL-Server")
 SQL_SCHEMA = SQL_REPO / "sql_schema"
+
+
+def _running_in_ci() -> bool:
+    return any(
+        os.environ.get(name) for name in ("CI", "GITHUB_ACTIONS", "BUILD_BUILDID", "TF_BUILD")
+    )
 
 
 def _normalise_sql(sql: str) -> str:
@@ -19,8 +26,13 @@ def _normalise_sql(sql: str) -> str:
 def _read_sql_file(name: str) -> str:
     path = SQL_SCHEMA / name
     if not path.exists():
-        if "K98_SQL_REPO" in os.environ:
-            pytest.fail(f"SQL repo file not available: {path}")
+        if not K98_SQL_REPO_ENV:
+            pytest.skip(
+                "SQL contract tests require the external SQL repository; "
+                f"set K98_SQL_REPO to enable them. Missing expected file: {path}"
+            )
+        if _running_in_ci():
+            pytest.fail(f"SQL repo file not available in CI: {path}")
         pytest.skip(f"SQL repo file not available: {path}")
     return path.read_text(encoding="utf-8-sig")
 

--- a/tests/test_kvk_stats_card_views.py
+++ b/tests/test_kvk_stats_card_views.py
@@ -50,7 +50,7 @@ def _payload() -> KvkStatsCardPayload:
         dkp_target_percent=50.0,
         overall_kvk_rank=42,
         overall_kvk_total_governors=8_734,
-        overall_kvk_percentile=0.48,
+        overall_kvk_top_percent=0.48,
         pass_stats={"Pass 4 Kills": 1_000},
         prekvk_rank=7,
         prekvk_points=123_456,

--- a/tests/test_kvk_stats_card_views.py
+++ b/tests/test_kvk_stats_card_views.py
@@ -48,6 +48,9 @@ def _payload() -> KvkStatsCardPayload:
         dkp=25_000_000,
         dkp_target=50_000_000,
         dkp_target_percent=50.0,
+        overall_kvk_rank=42,
+        overall_kvk_total_governors=8_734,
+        overall_kvk_percentile=0.48,
         pass_stats={"Pass 4 Kills": 1_000},
         prekvk_rank=7,
         prekvk_points=123_456,
@@ -78,6 +81,8 @@ def test_more_stats_embed_uses_payload_context():
 
     assert embed.title == "More KVK Stats - Card Tester"
     assert embed.description == "KVK 54 | Tides of War"
+    assert embed.fields[0].name == "KVK Overall Rank"
+    assert embed.fields[0].value == "#42\nTotal 8.7k / Top 0.5%"
     assert any(field.name == "Passes" for field in embed.fields)
 
 

--- a/ui/views/kvk_stats_card_views.py
+++ b/ui/views/kvk_stats_card_views.py
@@ -43,8 +43,8 @@ def _overall_rank_text(payload: KvkStatsCardPayload) -> str:
     context: list[str] = []
     if payload.overall_kvk_total_governors:
         context.append(f"Total {_compact(payload.overall_kvk_total_governors).lower()}")
-    if payload.overall_kvk_percentile is not None:
-        context.append(f"Top {_pct(payload.overall_kvk_percentile)}")
+    if payload.overall_kvk_top_percent is not None:
+        context.append(f"Top {_pct(payload.overall_kvk_top_percent)}")
     if context:
         value = f"{value}\n{' / '.join(context)}"
     return value

--- a/ui/views/kvk_stats_card_views.py
+++ b/ui/views/kvk_stats_card_views.py
@@ -36,6 +36,20 @@ def _line(label: str, value: str) -> str:
     return f"**{label}:** {value}"
 
 
+def _overall_rank_text(payload: KvkStatsCardPayload) -> str:
+    if not payload.overall_kvk_rank:
+        return "TBC"
+    value = f"#{payload.overall_kvk_rank}"
+    context: list[str] = []
+    if payload.overall_kvk_total_governors:
+        context.append(f"Total {_compact(payload.overall_kvk_total_governors).lower()}")
+    if payload.overall_kvk_percentile is not None:
+        context.append(f"Top {_pct(payload.overall_kvk_percentile)}")
+    if context:
+        value = f"{value}\n{' / '.join(context)}"
+    return value
+
+
 def _nonzero_items(values: dict) -> list[tuple[str, int | float | str]]:
     return [(label, value) for label, value in values.items() if value not in (None, "", 0, 0.0)]
 
@@ -45,6 +59,11 @@ def build_more_stats_embed(payload: KvkStatsCardPayload) -> discord.Embed:
         title=f"More KVK Stats - {payload.governor_name}",
         description=f"{payload.display_kvk_label} | {payload.display_mode}",
         color=discord.Color.blurple(),
+    )
+    embed.add_field(
+        name="KVK Overall Rank",
+        value=_overall_rank_text(payload),
+        inline=False,
     )
     embed.add_field(
         name="DKP",


### PR DESCRIPTION
## Summary
- Implement Phase 3C KVK stats-card polish, including centered Rank / KVK Overall Rank title-value alignment.
- Add SQL-backed Overall KVK Rank context to the card payload: rank, total governors, and percentile.
- Render the More Stats rank block as:
  - `KVK Overall Rank`
  - `#41`
  - `Total 8.7k / Top 0.5%`
- Align kills/DKP progress gold and normalize pass-row value sizing.
- Include the Phase 3C task pack plus updated programme/task-pack docs.

## SQL Dependency
- Companion SQL PR: https://github.com/cwatts6/K98-bot-SQL-Server/pull/14
- Deploy the SQL PR first so `KVK.vw_Player_Overall_KVK_Rank` exists before this bot change is promoted.
- Bot behavior is fallback-safe if the view is unavailable; Overall KVK Rank remains `TBC` and logs a warning.

## Validation
- `.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py`: passed
- `.\.venv\Scripts\python.exe scripts\validate_deferred_items.py`: passed
- `.\.venv\Scripts\python.exe scripts\select_tests.py`: completed
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_kvk_stats_card_payload.py tests/test_kvk_stats_card_renderer.py tests/test_kvk_stats_card_views.py tests/test_kvk_stats_card_dal.py tests/test_kvk_stats_card_sql_contract.py`: 30 passed
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_ui_imports.py`: 1 passed
- `.\.venv\Scripts\python.exe scripts\smoke_imports.py`: passed
- `.\.venv\Scripts\python.exe scripts\validate_command_registration.py`: passed
- `.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py`: 1668 passed, 2 skipped; production operational logs unchanged
- `.\.venv\Scripts\python.exe -m pre_commit run -a`: passed
- `.\deploy\Validate-SqlRepo.ps1 -RepoPath C:\K98-bot-SQL-Server`: passed

## Security Review
- Scoped security review found no issues: the SQL view is static, the DAL read uses parameterized queries, rollback is included, and the rendering path only formats payload values.