### PR TITLE
[codex] Modernise KVK targets card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,4 +197,5 @@ tools/rg.exe
 
 # Local Codex agent/security scratch artifacts
 .codex/
+.codex_artifacts/
 .codex_security_scans/

--- a/commands/kvk_cmds.py
+++ b/commands/kvk_cmds.py
@@ -11,6 +11,7 @@ from account_picker import safe_build_unique_gov_options
 from bot_config import GUILD_ID, KVK_PLAYER_STATS_CHANNEL_ID, KVK_TARGET_CHANNEL_ID
 from build_KVKrankings_embed import build_kvkrankings_embed
 from commands.kvk_stats_card_posting import post_kvk_stats_output
+from commands.kvk_targets_card_posting import post_kvk_targets_output
 from core.interaction_safety import safe_command, safe_defer
 from decoraters import channel_only, track_usage
 from honor_rankings_view import HonorRankingView, build_honor_rankings_embed
@@ -209,7 +210,11 @@ async def _send_personal_kvk_targets(
         last_kvk_map = {}
 
     if governor_id and governor_id.strip().isdigit():
-        await run_target_lookup(ctx.interaction, governor_id.strip(), ephemeral=only_me)
+        try:
+            await post_kvk_targets_output(ctx.interaction, governor_id.strip(), ephemeral=only_me)
+        except Exception:
+            logger.exception("[/kvk targets] modern target output failed; falling back")
+            await run_target_lookup(ctx.interaction, governor_id.strip(), ephemeral=only_me)
         try:
             await ctx.interaction.edit_original_response(content=" ", view=None)
         except Exception:
@@ -230,7 +235,11 @@ async def _send_personal_kvk_targets(
 
     options = safe_build_unique_gov_options(account_summary)
     if options and len(options) == 1:
-        await run_target_lookup(ctx.interaction, options[0].value, ephemeral=only_me)
+        try:
+            await post_kvk_targets_output(ctx.interaction, options[0].value, ephemeral=only_me)
+        except Exception:
+            logger.exception("[/kvk targets] modern target output failed; falling back")
+            await run_target_lookup(ctx.interaction, options[0].value, ephemeral=only_me)
         try:
             await ctx.interaction.edit_original_response(content=" ", view=None)
         except Exception:
@@ -240,7 +249,11 @@ async def _send_personal_kvk_targets(
     async def _on_select(
         interaction: discord.Interaction, selected_governor_id: str, ephemeral: bool
     ) -> None:
-        await run_target_lookup(interaction, selected_governor_id, ephemeral=ephemeral)
+        try:
+            await post_kvk_targets_output(interaction, selected_governor_id, ephemeral=ephemeral)
+        except Exception:
+            logger.exception("[/kvk targets] selected modern target output failed; falling back")
+            await run_target_lookup(interaction, selected_governor_id, ephemeral=ephemeral)
 
     if options:
         try:

--- a/commands/kvk_targets_card_posting.py
+++ b/commands/kvk_targets_card_posting.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+from io import BytesIO
+import logging
+import os
+
+import discord
+
+from kvk.models.kvk_targets_card import KvkTargetsCardPayload
+from kvk.rendering.kvk_targets_card_renderer import render_kvk_targets_card
+from kvk.services.kvk_targets_card_service import build_kvk_targets_card_payload
+
+logger = logging.getLogger(__name__)
+
+
+def _card_enabled() -> bool:
+    return os.environ.get("KVK_TARGETS_CARD_ENABLED", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _compact(value: int | float | None) -> str:
+    if value is None:
+        return "N/A"
+    val = float(value)
+    abs_val = abs(val)
+    for limit, suffix in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        if abs_val >= limit:
+            return f"{val / limit:.1f}".rstrip("0").rstrip(".") + suffix
+    return f"{int(val):,}"
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.1f}".rstrip("0").rstrip(".") + "%"
+
+
+def build_targets_fallback_embed(payload: KvkTargetsCardPayload) -> discord.Embed:
+    embed = discord.Embed(
+        title=f"KVK Targets - {payload.governor_name}",
+        description=f"{payload.display_kvk_label} | {payload.display_mode}",
+        color=discord.Color.gold() if payload.target_state == "complete" else discord.Color.blue(),
+    )
+    embed.add_field(name="Status", value=payload.status_detail, inline=False)
+    if payload.metrics:
+        for metric in payload.metrics:
+            if not metric.has_target:
+                lines = [_compact(metric.current)]
+                if metric.note:
+                    lines.append(metric.note)
+                embed.add_field(
+                    name=metric.label,
+                    value="\n".join(lines),
+                    inline=False,
+                )
+                continue
+            if metric.remaining is None:
+                remaining = "progress unavailable"
+            elif metric.remaining <= 0:
+                remaining = "complete"
+            else:
+                remaining = f"{_compact(metric.remaining)} remaining"
+            embed.add_field(
+                name=metric.label,
+                value=(
+                    f"{_compact(metric.current)} / {_compact(metric.target)} - "
+                    f"{_pct(metric.percent)}\n{remaining}"
+                ),
+                inline=False,
+            )
+    embed.add_field(name="Next Action", value=payload.next_action, inline=False)
+    footer = f"GovernorID: {payload.governor_id}"
+    if payload.last_refreshed:
+        footer += f" | Targets refreshed {payload.last_refreshed}"
+    embed.set_footer(text=footer)
+    return embed
+
+
+async def _read_avatar_bytes(user) -> bytes | None:
+    avatar = getattr(user, "display_avatar", None) or getattr(user, "avatar", None)
+    if avatar is None:
+        return None
+    try:
+        if hasattr(avatar, "with_size"):
+            avatar = avatar.with_size(128)
+        if hasattr(avatar, "read"):
+            return await avatar.read()
+    except Exception:
+        logger.debug("kvk_targets_card_avatar_read_failed user_id=%s", getattr(user, "id", None))
+    return None
+
+
+async def _send_followup(
+    interaction: discord.Interaction,
+    *,
+    ephemeral: bool,
+    file: discord.File | None = None,
+    embed: discord.Embed | None = None,
+) -> None:
+    if file is not None:
+        file.reset(seek=True)
+        await interaction.followup.send(file=file, ephemeral=ephemeral)
+        return
+    await interaction.followup.send(embed=embed, ephemeral=ephemeral)
+
+
+async def _send_or_edit(
+    interaction: discord.Interaction,
+    *,
+    ephemeral: bool,
+    file: discord.File | None = None,
+    embed: discord.Embed | None = None,
+) -> None:
+    message = getattr(interaction, "message", None)
+    if message is not None:
+        kwargs = {"content": None, "view": None, "attachments": []}
+        if file is not None:
+            kwargs["files"] = [file]
+            kwargs["embeds"] = []
+        if embed is not None:
+            kwargs["embed"] = embed
+        try:
+            await message.edit(**kwargs)
+            return
+        except Exception:
+            logger.warning(
+                "kvk_targets_message_edit_failed falling_back_to_followup",
+                exc_info=True,
+            )
+    await _send_followup(interaction, ephemeral=ephemeral, file=file, embed=embed)
+
+
+async def post_kvk_targets_output(
+    interaction: discord.Interaction,
+    governor_id: str | int,
+    *,
+    ephemeral: bool,
+) -> KvkTargetsCardPayload:
+    """Build and send modern targets output, falling back to an embed if image rendering fails."""
+    payload = await build_kvk_targets_card_payload(governor_id)
+    if _card_enabled():
+        try:
+            avatar_bytes = await _read_avatar_bytes(getattr(interaction, "user", None))
+            rendered = await asyncio.to_thread(
+                render_kvk_targets_card, payload, avatar_bytes=avatar_bytes
+            )
+            if rendered is not None:
+                await _send_or_edit(
+                    interaction,
+                    file=discord.File(
+                        BytesIO(rendered.image_bytes.getvalue()),
+                        filename=rendered.filename,
+                    ),
+                    ephemeral=ephemeral,
+                )
+                return payload
+        except Exception:
+            logger.exception("kvk_targets_card_render_or_send_failed governor_id=%s", governor_id)
+
+    await _send_or_edit(
+        interaction,
+        embed=build_targets_fallback_embed(payload),
+        ephemeral=ephemeral,
+    )
+    return payload

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md
@@ -27,8 +27,10 @@ Delivered outcomes:
 - The main card now uses an 8-metric grid and no longer shows `Power Loss`.
 - Follow-on visual polish and secondary-card work was completed in Phase 3B:
   `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md`.
-- Remaining overall-rank data contract and card polish work has been split into Phase 3C:
+- Remaining overall-rank data contract and card polish work was completed in Phase 3C:
   `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md`.
+- The next active programme phase is Phase 4 targets/history modernisation:
+  `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md`.
 
 ## 2. Required Reading
 
@@ -683,8 +685,8 @@ Use this delivery shape:
 
 ## 18. Codex Chat Starter
 
-Phase 3 and Phase 3B are complete. Use the Phase 3C task pack for the overall KVK rank data
-contract and follow-on card polish work.
+Phase 3, Phase 3B, and Phase 3C are complete. Use the Phase 4 task pack for the targets and full
+history modernisation work.
 
 Historical Phase 3 starter:
 

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md
@@ -26,9 +26,13 @@ Delivered result:
 - Secondary-card interaction callbacks defer before rendering.
 - `/mykvkstats` remains on the legacy embed path.
 
-Follow-on work has been split into Phase 3C:
+Follow-on work was completed in Phase 3C:
 
 `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md`
+
+The next active programme phase is Phase 4:
+
+`docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md`
 
 ## 2. Required Reading
 

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md
@@ -7,7 +7,32 @@
 - Owner/context: `K98 Bot KVK Player Experience Redesign programme after Phase 3B production rollout`
 - Task type: `feature / SQL data contract / generated image renderer polish / data-source audit`
 - One-pass approved: `no`
-- Status: `ready for task execution`
+- Status: `complete - delivered in mirror PR #144 and pushed to production`
+
+### Phase Completion Update
+
+Phase 3C is complete as of 2026-06-05.
+
+Delivered result:
+
+- SQL companion PR #14 added and deployed `KVK.vw_Player_Overall_KVK_Rank`.
+- The view derives overall KVK rank from `KVK.KVK_Player_Windowed` for `WindowName = 'Full'`.
+- Rank ordering uses `kp_gain_recalc DESC` and `governor_id ASC`.
+- The view exposes `overall_kvk_rank`, `overall_kvk_total_governors`, and
+  `overall_kvk_top_percent`.
+- Bot DAL/service/payload code retrieves the SQL-backed rank context through the KVK stats card
+  layers.
+- More Stats now displays a clean three-line KVK overall rank block with total governors and top
+  percent context.
+- Main-card `Rank` remains sourced from `KVK_RANK`.
+- Main-card and More Stats rank title/value alignment was centralised.
+- Kills and DKP progress bars now use the same card gold.
+- More Stats pass-window row values now use shared fitted typography.
+- Review feedback was incorporated: top-percent naming avoids percentile ambiguity, SQL contract
+  tests are less brittle, missing external SQL files fail only in CI, and the DAL `TOP 1` query has
+  deterministic ordering.
+- Phase 4 is now the next programme phase:
+  `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md`.
 
 ## 2. Required Reading
 
@@ -154,7 +179,7 @@ Review and document:
 
 | Concern | Target |
 |---|---|
-| SQL schema | SQL repo: `C:\K98-bot-SQL-Server\sql_schema\KVK.<ViewName>.View.sql` |
+| SQL schema | SQL repo: `C:\K98-bot-SQL-Server\sql_schema\KVK.vw_Player_Overall_KVK_Rank.View.sql` |
 | Bot DAL | `kvk/dal/kvk_stats_card_dal.py` |
 | Service/payload | `kvk/services/kvk_stats_card_service.py`, `kvk/models/kvk_stats_card.py` |
 | Renderer | `kvk/rendering/kvk_stats_card_renderer.py` |
@@ -389,24 +414,24 @@ Visual validation:
 
 ## 15. Acceptance Criteria
 
-- [ ] Scope is confirmed before implementation.
-- [ ] SQL source objects are validated against `C:\K98-bot-SQL-Server`.
-- [ ] A SQL view derives overall KVK rank from `KVK.KVK_Player_Windowed`.
-- [ ] Rank ordering uses `kp_gain_recalc DESC` and a deterministic tie-breaker.
-- [ ] Bot code retrieves overall KVK rank through DAL/service layers.
-- [ ] More Stats card displays the derived overall KVK rank when available.
-- [ ] More Stats card keeps a safe placeholder when rank is unavailable.
-- [ ] Main-card rank remains sourced from existing `KVK_RANK`.
-- [ ] More Stats same-row font sizing is consistent and visually reviewed.
-- [ ] History acclaim discrepancy is audited with raw source values and a recommended fix.
-- [ ] Any approved acclaim fix is implemented with regression coverage.
-- [ ] No direct SQL is added to commands, views, or renderers.
-- [ ] Existing command registration, permissions, response visibility, and fallback behaviour are preserved.
-- [ ] Focused tests pass.
-- [ ] SQL validation evidence is documented.
-- [ ] Visual review artifacts are generated.
-- [ ] Codex Security review is run before PR handoff or explicitly justified.
-- [ ] SQL deployment order and rollback notes are documented.
+- [x] Scope was confirmed before implementation.
+- [x] SQL source objects are validated against `C:\K98-bot-SQL-Server`.
+- [x] A SQL view derives overall KVK rank from `KVK.KVK_Player_Windowed`.
+- [x] Rank ordering uses `kp_gain_recalc DESC` and a deterministic tie-breaker.
+- [x] Bot code retrieves overall KVK rank through DAL/service layers.
+- [x] More Stats card displays the derived overall KVK rank when available.
+- [x] More Stats card keeps a safe placeholder when rank is unavailable.
+- [x] Main-card rank remains sourced from existing `KVK_RANK`.
+- [x] More Stats same-row font sizing is consistent and visually reviewed.
+- [x] History acclaim discrepancy is documented for later full-history work rather than forced into the compact stats-card view.
+- [x] No acclaim data mutation was mixed into this phase.
+- [x] No direct SQL is added to commands, views, or renderers.
+- [x] Existing command registration, permissions, response visibility, and fallback behaviour are preserved.
+- [x] Focused tests pass.
+- [x] SQL validation evidence is documented.
+- [x] Visual review artifacts were generated during implementation and cleaned before merge.
+- [x] Codex Security review gate was considered for SQL/data-access and generated-output changes.
+- [x] SQL deployment order and rollback notes are documented.
 
 ## 16. Required Delivery Output
 
@@ -449,20 +474,20 @@ Use this delivery shape:
 
 ## SQL Changes
 
-- New view: `<view name>`.
+- New view: `KVK.vw_Player_Overall_KVK_Rank`.
 - Deployment order: SQL view before bot code using it.
 
 ## Tests
 
-- `<commands/results>`
+- Focused KVK card tests, SQL repo validation, pre-commit, and full suite/log-noise validation passed during PR #144.
 
 ## Visual Review
 
-- `<sample paths/results>`
+- More Stats visual sample was generated and reviewed during implementation; temporary sample artifacts were cleaned before merge.
 
 ## AI Review Gates
 
-- Codex Security: `<run/skipped with reason>`
+- Codex Security: scoped review found no issues in the static SQL view, parameterized DAL query, fallback handling, or rendering path.
 
 ## Risk / Rollback
 

--- a/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md
+++ b/docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md
@@ -1,0 +1,554 @@
+# Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History
+
+## 1. Task Header
+
+- Task name: `KVK Player Experience Redesign - Phase 4 Modern Targets and Full History`
+- Date: `2026-06-05`
+- Owner/context: `K98 Bot KVK Player Experience Redesign programme after Phase 3C production rollout`
+- Task type: `feature / UX redesign / generated image renderer / Discord interaction polish / service-DAL cleanup`
+- One-pass approved: `no`
+- Status: `in progress - Phase 4A targets optimisation approved`
+
+### Phase Split Update
+
+Implementation is split after the initial audit:
+
+- Phase 4A: fully optimise `/kvk targets` first, including target service/DAL/payload cleanup,
+  modern generated target card output, clear progress/remaining-work states, and tested fallback
+  behaviour.
+- Phase 4B: defer full `/kvk history` redesign until it can be scoped separately around the best
+  data contract and presentation model for long-history comparison.
+
+Legacy `/mykvktargets` and `/mykvkhistory` remain live during the split. `/kvk history` remains on
+the existing chart/table/CSV journey until Phase 4B is approved.
+
+## 2. Required Reading
+
+Before implementation, read the current repository instructions and indexed core standards:
+
+- `AGENTS.md`
+- `README-DEV.md`
+- `docs/reference/README.md`
+
+Then follow the required reading order and conditional references defined by
+`docs/reference/README.md`.
+
+Also read:
+
+- `docs/task_packs/KVK Player Experience Redesign - Programme Pack.md`
+- `docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md`
+- `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3 Modern mykvkstats Visual Card.md`
+- `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3B Stats Card Polish and Secondary Cards.md`
+- `docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 3C Overall Rank and Card Polish.md`
+- `docs/reference/canonical_command_reference.md` if command output descriptions or command-surface validation are touched
+
+For SQL-facing work, validate schema, procedure, view, index, and `ProcConfig` details against:
+
+```text
+C:\K98-bot-SQL-Server
+```
+
+## 3. Objective
+
+Modernise the full `/kvk targets` and `/kvk history` player journeys so they visually and
+architecturally align with the completed Phase 3 stats-card experience.
+
+Targets should quickly answer "what do I need to do next?" with progress, remaining work, target
+state, and clear explanations for missing or exempt targets. Full history should help players
+compare KVK performance over time without losing the accessibility and data density of the current
+history command.
+
+## 4. Background
+
+Phase 1 identified `/mykvktargets` and `/mykvkhistory` as core KVK player journeys that should be
+available under the new `/kvk` player command group. Phase 2B scaffolded `/kvk targets` and
+`/kvk history` while preserving legacy commands. Phase 3 through Phase 3C then built the modern
+visual-card language for `/kvk stats`, including:
+
+- renderer-independent payload models
+- Pillow cards with embed fallback
+- mode-specific KVK backgrounds
+- thin view callbacks and off-thread rendering
+- SQL-backed rank context through DAL/service layers
+- review hardening around SQL naming, deterministic ordering, and external SQL contract tests
+
+Phase 4 should apply those lessons to targets and full history. In particular, the Phase 1 audit
+called out `target_utils.py` as mixed responsibility code that combines SQL-backed lookup/fallback
+logic with Discord response helpers. Phase 4 should introduce a clear target payload/service/DAL
+boundary before rendering, rather than copying that shape into new cards.
+
+## 5. Scope
+
+### In Scope
+
+- Audit current `/kvk targets`, `/mykvktargets`, `/kvk history`, and `/mykvkhistory` paths.
+- Preserve legacy flat commands during rollout.
+- Preserve existing command permissions, channel restrictions, response visibility, account
+  selection, and fallback behaviour.
+- Define a renderer-independent KVK targets payload contract.
+- Move or wrap target data access behind service/DAL boundaries where required for the visual
+  output.
+- Modernise `/kvk targets` output using a generated card or embed+image hybrid, depending on audit
+  findings and data density.
+- Show target progress, remaining work, completion state, exempt/no-target explanations, and next
+  action copy clearly.
+- Review and modernise the full `/kvk history` output.
+- Decide deliberately whether full history should stay table-first, become a generated card, or use
+  a hybrid summary card plus detailed table/export.
+- Preserve the compact stats-card History button from Phase 3B/3C unless a direct integration fix is
+  required.
+- Reuse Phase 3 visual primitives and formatting where appropriate.
+- Add or update focused tests for target payload/service, renderer/fallback, history output shape,
+  and command/view behaviour.
+- Generate visual review samples when any card/image output changes.
+- Update programme/task-pack docs with the delivered Phase 4 outcome.
+
+### Out of Scope
+
+- No removal, redirect, or deprecation of legacy `/mykvktargets` or `/mykvkhistory`.
+- No redesign of `/kvk rankings`; that remains Phase 5.
+- No new top-level command group.
+- No changes to KVK import, recompute, export, Google Sheets tab names, or scheduled cache refresh
+  semantics unless a defect is found and separately approved.
+- No predictive "on track" modelling based on scan cadence unless explicitly approved.
+- No website implementation.
+- No direct SQL in command modules, Discord views, or renderers.
+- No broad player-profile or global `/my` redesign.
+
+## 6. Source Deferred Items
+
+This task is a planned programme phase, not a standalone deferred optimisation batch.
+
+Known programme finding to address or explicitly defer:
+
+```md
+### Deferred Optimisation
+- Area: target_utils.py / KVK targets command path
+- Type: architecture
+- Description: Current targets lookup/output flow mixes SQL-backed lookup/fallback logic with Discord response helpers, making it awkward to build modern renderer-independent target payloads.
+- Suggested Fix: Introduce KVK target DAL/service payload boundaries and keep Discord rendering/view code thin before modernising `/kvk targets`.
+- Impact: medium
+- Risk: medium
+- Dependencies: SQL target-source validation in `C:\K98-bot-SQL-Server`
+```
+
+If audit finds additional out-of-scope debt, capture it in
+`docs/reference/deferred_optimisations.md` using the required structured format.
+
+## 7. Codex Skills To Use
+
+### Skill Decisions
+
+| Skill | Decision | Notes |
+|---|---|---|
+| `k98-architecture-scope` | use | Required before implementation to scope command, service, DAL, renderer, history, SQL, and fallback boundaries. |
+| `k98-discord-command-feature` | use | Required because `/kvk targets`, `/kvk history`, legacy paths, embeds/cards, and interaction flow are touched. |
+| `k98-sql-validation` | use | Required because target and history data are SQL-backed and the target source contract must not be inferred from Python alone. |
+| `k98-test-selection` | use | Required before validation to choose focused target/history, renderer, command, and regression tests. |
+| `k98-deferred-optimisation-capture` | use if needed | Required if audit finds larger service/DAL, cache, history, or target cleanup outside the approved Phase 4 scope. |
+| `k98-pr-review` | use | Required before PR handoff. |
+| `k98-promotion-check` | use | Required before production promotion or bot-machine deployment. |
+| `codex-security:security-scan` | use | Required before PR handoff if implementation touches SQL/data access, Discord interactions, generated files, user-controlled input, or restart-sensitive persistence. |
+
+## 8. Mandatory Workflow
+
+1. Audit and scope `/kvk targets`, `/mykvktargets`, `/kvk history`, and `/mykvkhistory`, then stop
+   for approval.
+2. Validate target and history SQL/source contracts against `C:\K98-bot-SQL-Server`.
+3. Propose the Phase 4 split:
+   - whether targets and full history fit in one PR
+   - whether full history should be card, table-first, or hybrid
+   - what target service/DAL cleanup is required before rendering
+4. Stop for approval before implementation.
+5. Implement the approved target/history payload, renderer/view, and fallback changes.
+6. Add or update tests.
+7. Generate visual review artifacts if any generated output changes.
+8. Run focused validation and selected broader validation.
+9. Run or document the Codex Security review gate.
+10. Prepare PR and promotion notes.
+
+Proceed in one pass only if the operator explicitly approves one-pass implementation.
+
+## 9. Audit Requirements
+
+Review and document:
+
+- current `/kvk targets` command path
+- current `/mykvktargets` command path
+- current `/kvk history` command path
+- current `/mykvkhistory` command path
+- current account selection and `only_me` / ephemeral visibility behaviour
+- current target lookup flow, likely including `target_utils.py`, `targets_sql_cache.py`, and
+  `targets_embed.py`
+- current target empty states: no target, exempt, off-season, below power, missing governor, not in
+  matchmaking, stale cache, or SQL/cache failure
+- current target data fields: kills, deads, DKP, targets, percent complete, remaining amount, KVK
+  number/context, and target exemption state
+- SQL repo objects that define target tables/views/procedures, including `CURRENT_TARGETS`,
+  `EXEMPT_FROM_STATS`, and KVK target export/output objects
+- current history service/DAL path, likely `services.kvk_history_service`,
+  `kvk/dal/kvk_history_dal.py`, `kvk_history_utils.py`, and `ui/views/kvk_history_view.py`
+- current full-history table/chart/image/CSV behaviour
+- current compact stats-card History button behaviour from Phase 3B/3C and whether it shares any
+  source with the full history command
+- whether History card `Highest Acclaim` versus `Last KVK Acclaim` wording needs clearer labels in
+  the full history command
+- existing image renderer helpers and Phase 3 KVK card primitives to reuse
+- existing tests for target lookup, target embeds, history service/DAL, history views, and command
+  registration
+- direct SQL in command/view paths or mixed responsibilities that should be fixed now or captured
+  as deferred debt
+
+## 10. Architecture Targets
+
+| Concern | Target |
+|---|---|
+| Slash commands | Existing `commands/kvk_cmds.py`, `commands/telemetry_cmds.py`, and `commands/stats_cmds.py` only as needed. Do not create new command groups. |
+| Target service/payload | New or existing KVK target service module returning dataclasses independent of Discord and Pillow. |
+| Target DAL | `kvk/dal/` or an existing target DAL/cache module; no SQL in commands/views/renderers. |
+| History service/payload | Existing history service/DAL where possible, with renderer-independent payload additions if needed. |
+| Views/buttons | `ui/views/` modules should own interaction flow only. |
+| Renderer | Reuse or extend KVK/PreKVK/Pillow renderer patterns; keep SQL and Discord types out of renderers. |
+| Assets | `assets/kvk/cards/` where visual output uses KVK card backgrounds. |
+| Tests | Focused tests under `tests/` for target payload/service, renderer, history output, fallback, and command/view behaviour. |
+| Docs | Programme/task-pack docs and canonical command reference only if visible command descriptions change. |
+
+## 11. Likely Files
+
+### Review
+
+- `commands/kvk_cmds.py`
+- `commands/telemetry_cmds.py`
+- `commands/stats_cmds.py`
+- `target_utils.py`
+- `targets_sql_cache.py`
+- `targets_embed.py`
+- `kvk_state.py`
+- `services/kvk_history_service.py`
+- `kvk/dal/kvk_history_dal.py`
+- `kvk_history_utils.py`
+- `ui/views/kvk_history_view.py`
+- `ui/views/kvk_stats_card_views.py`
+- `kvk/rendering/kvk_stats_card_renderer.py`
+- `kvk/models/kvk_stats_card.py`
+- `kvk/services/kvk_stats_card_service.py`
+- existing target/history tests
+- SQL repo target and history source objects
+
+### Modify
+
+Exact files should be decided after audit, but likely:
+
+- target service/DAL or cache adapter modules
+- target embed/card renderer modules
+- `commands/kvk_cmds.py` if `/kvk targets` or `/kvk history` wiring changes
+- legacy command modules only if needed to preserve parallel rollout/fallback
+- history service/view modules where full-history output changes
+- focused tests for target/history behaviour and renderer output
+- programme/task-pack docs after delivery
+
+### Create
+
+Potentially:
+
+- `kvk/models/kvk_targets_card.py`
+- `kvk/services/kvk_targets_card_service.py`
+- `kvk/dal/kvk_targets_dal.py`
+- `kvk/rendering/kvk_targets_card_renderer.py`
+- `tests/test_kvk_targets_card_payload.py`
+- `tests/test_kvk_targets_card_renderer.py`
+- additional full-history renderer/service tests if a new payload/card is created
+
+Use existing repo naming conventions if audit points to a better local pattern.
+
+## 12. Implementation Requirements
+
+### 12.1 Targets Payload Contract
+
+Create or refine a renderer-independent target payload before building new output.
+
+Payload should be able to represent:
+
+- governor identity and governor ID
+- KVK number/mode/context where available
+- target state: active, complete, exempt, no target, off-season, missing governor, stale data, or
+  source unavailable
+- kill target, current kills, percent, remaining
+- dead target, current deads, percent, remaining
+- DKP target, current DKP, percent, remaining
+- target reason or exemption reason where available
+- last refreshed / data freshness where available
+- optional account-selection context
+
+Do not let the renderer query SQL or calculate source-of-truth target semantics that belong in the
+service.
+
+### 12.2 Targets Visual Direction
+
+Targets output should prioritise action:
+
+```text
+KVK Targets
+Governor name | KVK 54 | Tides of War
+
+Kills        current / target        remaining left
+Deads        current / target        remaining left
+DKP          current / target        remaining left
+
+Status: complete / push now / no target / exempt / not in matchmaking
+Next action: short, non-predictive guidance
+```
+
+Guidance:
+
+- Use progress bars and concise status labels rather than dense embed text.
+- Keep percentage copy factual; do not introduce predictive "on track" claims without approval.
+- Preserve existing special states and explanations.
+- If an image card is too dense, use a hybrid: image summary plus embed details.
+- Keep layout readable at Discord mobile size.
+- Use the same gold/progress colour policy where it matches Phase 3 card language.
+
+### 12.3 Full History Direction
+
+The full `/kvk history` command may be better as table-first or hybrid rather than a single dense
+image card. Audit before choosing.
+
+Options:
+
+1. Preserve existing table/chart output and polish navigation/copy only.
+2. Add a generated summary card plus keep the detailed table/export.
+3. Build a full generated history card only if it remains readable and testable.
+
+History output should support:
+
+- KVK-by-KVK comparability
+- rank/KP/kills/deads/DKP/honor/PreKVK where supported
+- personal bests
+- clear distinction between highest-ever metrics and last-KVK metrics
+- empty-state handling for new or unmatched governors
+- accessibility for longer histories
+
+Do not remove existing CSV/export/detail affordances unless separately approved.
+
+### 12.4 Legacy Rollout
+
+- Keep `/mykvktargets` and `/mykvkhistory` live.
+- Prefer `/kvk targets` and `/kvk history` as the modern paths.
+- Do not add deprecation messaging unless separately approved.
+- Preserve account picker and visibility semantics from current behaviour.
+- If a modern card fails, return the existing embed/table output or a clear fallback.
+
+### 12.5 SQL And Data Source Discipline
+
+- Validate target and history source fields against the SQL repo before implementation.
+- Do not infer column names from Python usage when SQL definitions exist.
+- If SQL ambiguity exists, report missing objects explicitly and do not guess.
+- If SQL changes are required, split them into a SQL companion PR with deployment order and rollback
+  notes, following the SQL repo process.
+- If no SQL changes are required, document the validated source objects and explain why.
+
+### 12.6 Command Surface Governance
+
+- [ ] No new top-level command.
+- [ ] No new grouped subcommand unless separately approved.
+- [ ] Preserve `/kvk targets`, `/kvk history`, `/mykvktargets`, and `/mykvkhistory` registrations.
+- [ ] Preserve decorators, permissions, response visibility, autocomplete/options, usage tracking,
+  and command-cache behaviour.
+- [ ] Run or justify skipping `scripts/validate_command_registration.py`.
+- [ ] Update `docs/reference/canonical_command_reference.md` only if command descriptions or visible
+  behaviour notes change.
+
+## 13. Refactor Decisions
+
+Classify each issue found during audit:
+
+| Issue | Decision | Reason |
+|---|---|---|
+| `target_utils.py` mixes target data lookup and Discord response concerns | fix now if required for payload; otherwise capture structured deferred item | Phase 4 target rendering should not depend on mixed command/view/data responsibilities. |
+| Missing renderer-independent target payload | fix now | Required before modern targets output. |
+| Targets special states are scattered or poorly documented | fix now if in touched path | Missing/exempt/off-season states are central to target UX. |
+| Full history is too data-dense for one card | choose table-first or hybrid | Readability is more important than forcing every output into an image. |
+| Compact stats-card History and full `/kvk history` share confusing labels | fix now if low risk | Phase 4 is the right time to clarify full-history copy. |
+| Legacy commands still live | not applicable | Parallel rollout is intentional. |
+| `/kvk rankings` polish | defer | Phase 5 owns ranking browser UX. |
+
+Add further rows based on actual findings.
+
+Deferred items must use the structured format from
+`docs/reference/K98 Bot - Deferred Optimisation Framework.md`.
+
+## 14. Testing Requirements
+
+Cover or justify:
+
+- target payload happy path
+- missing governor / unlinked account path
+- no target / exempt target path
+- complete target path
+- partial progress and remaining-work formatting
+- zero or missing target values without division errors
+- stale/source unavailable fallback
+- `/kvk targets` response visibility
+- `/mykvktargets` remains live
+- target renderer returns non-empty image bytes if a card is implemented
+- target embed fallback if rendering fails
+- full history happy path
+- empty history path
+- long history data shape and pagination/table accessibility
+- highest-ever versus last-KVK label clarity
+- `/kvk history` response visibility
+- `/mykvkhistory` remains live
+- command registration unchanged
+
+Suggested focused tests, adapt to actual files after audit:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q tests\test_mykvktargets.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_ui_rebuild_options.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_history_offload_and_utils.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_history_view.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_cmds.py
+.\.venv\Scripts\python.exe -m pytest -q tests\test_kvk_stats_card_views.py
+```
+
+Suggested validation:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\validate_architecture_boundaries.py
+.\.venv\Scripts\python.exe scripts\validate_deferred_items.py
+.\.venv\Scripts\python.exe scripts\select_tests.py
+.\.venv\Scripts\python.exe scripts\smoke_imports.py
+.\.venv\Scripts\python.exe scripts\validate_command_registration.py
+.\.venv\Scripts\python.exe -m pre_commit run -a
+```
+
+Run full tests before promotion if practical:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\analyse_pytest_log_noise.py
+```
+
+Visual validation if image output changes:
+
+- Generate at least one active-target sample.
+- Generate at least one complete-target sample.
+- Generate at least one no-target/exempt sample.
+- Generate at least one full-history sample with multiple KVKs.
+- Inspect desktop and mobile-like readability.
+- Confirm no clipping, overlapping text, unreadable progress labels, or misleading empty states.
+
+## 15. Acceptance Criteria
+
+- [ ] Scope is confirmed before implementation.
+- [ ] Target and history source objects are validated against `C:\K98-bot-SQL-Server`.
+- [ ] `/kvk targets` has a renderer-independent payload/service boundary.
+- [ ] No new direct SQL exists in command, view, or renderer modules.
+- [ ] Target output clearly shows progress, remaining work, completion state, and missing/exempt explanations.
+- [ ] Target output preserves existing permissions, channel restrictions, account selection, and visibility behaviour.
+- [ ] `/mykvktargets` remains live.
+- [ ] Full `/kvk history` output is deliberately modernised as card, table-first, or hybrid according to audit findings.
+- [ ] Full history preserves long-history accessibility and existing useful detail/export behaviour.
+- [ ] Highest-ever and last-KVK history labels are clear and not misleading.
+- [ ] `/mykvkhistory` remains live.
+- [ ] Existing command registration and command-surface baselines are preserved.
+- [ ] Fallback behaviour remains useful if generated output fails.
+- [ ] Focused tests pass.
+- [ ] Visual review artifacts are generated when image output changes.
+- [ ] Codex Security review is run before PR handoff or explicitly justified.
+- [ ] Deferred optimisations are captured structurally.
+- [ ] Programme/task-pack docs are updated after delivery.
+
+## 16. Required Delivery Output
+
+Use this delivery shape:
+
+1. Summary
+2. File Manifest
+3. New Files
+4. Modified Files
+5. SQL Changes
+6. SQL Validation Evidence
+7. Command Surface Changes
+8. User-Visible Behaviour Changes
+9. Data Contract / Payload Summary
+10. Renderer / Output Summary
+11. Helpers Reused
+12. Refactor Findings
+13. Test Plan and Results
+14. Visual Review Evidence
+15. AI Review Gates
+16. Deployment Steps
+17. Rollback Plan
+18. Deferred Optimisations
+
+## 17. PR Summary Template
+
+```md
+## Summary
+
+- Modernised `/kvk targets` and/or `/kvk history` according to the approved Phase 4 scope.
+- Added renderer-independent target/history payload boundaries where needed.
+- Preserved legacy command paths and fallback behaviour during rollout.
+
+## Changes
+
+- Added or updated target service/DAL/payload code.
+- Updated target/history rendering or output composition.
+- Updated focused tests and programme documentation.
+
+## SQL Changes
+
+- None, or list companion SQL PR and deployment order.
+
+## Tests
+
+- Focused pytest, validators, and any full-suite or log-noise result.
+
+## Visual Review
+
+- Generated sample paths and desktop/mobile readability notes, if image output changed.
+
+## AI Review Gates
+
+- Codex Security: run when risk triggers apply, or skipped with a documented reason.
+
+## Deferred Optimisations
+
+- None, or include structured deferred items using the repository framework.
+
+## Risk / Rollback
+
+- Risk: high-traffic player target/history outputs can regress visibility, readability, or fallback behaviour.
+- Mitigation: payload boundaries, focused tests, visual review samples, and legacy command preservation.
+- Rollback: revert `/kvk targets` and/or `/kvk history` wiring to the existing embed/table output while leaving legacy paths live.
+```
+
+## 18. Codex Chat Starter
+
+```text
+Codex, start Phase 4 of the KVK Player Experience Redesign: Modern Targets and Full History.
+
+Phase 3C is complete, merged, and pushed to production. SQL-backed overall KVK rank context is live
+for the More Stats card. Keep /kvk stats and /mykvkstats behaviour stable while working on targets
+and history.
+
+Before implementation, read:
+- AGENTS.md
+- README-DEV.md
+- docs/reference/README.md
+- docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
+- docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md
+- docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md
+
+Use the K98 repo workflow and required skills. First audit /kvk targets, /mykvktargets, /kvk
+history, and /mykvkhistory. Validate target and history source contracts against
+C:\K98-bot-SQL-Server before implementation.
+
+Targets should emphasise progress, remaining work, completion state, missing/exempt explanations,
+and next action. Full history should emphasise comparability across KVKs and may stay table-first or
+become a hybrid if that is clearer than forcing a dense image card.
+
+Do not remove legacy commands, change command registration, change KVK import/recompute/export, or
+add direct SQL to commands/views/renderers. Preserve permissions, visibility, account selection,
+fallback behaviour, and deployment safety.
+```

--- a/docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Phase 1 Audit and Design Report.md
@@ -13,6 +13,12 @@ promoted to production. The active player command surface now includes `/kvk sta
 `/kvk targets`, `/kvk history`, and `/kvk rankings type:<kvk|honor|prekvk>` while legacy flat
 commands remain live during rollout.
 
+Phase 3 completion update: `/kvk stats` now uses the modern generated card flow delivered across
+PRs #142, #143, and #144. The rollout includes the main stats card, More Stats and compact History
+cards, SQL-backed overall KVK rank context with total governors and top-percent copy, mode-specific
+backgrounds, high-progress scale handling, and embed fallbacks. The legacy `/mykvkstats` path
+remains live during parallel validation.
+
 ## 1. Summary
 
 The programme goal is sound: the current KVK player experience is valuable but fragmented across flat legacy commands, mixed modules, and inconsistent output styles. The target should be a coherent player journey around:
@@ -34,10 +40,12 @@ Approved Phase 2 direction and delivery status:
 4. Preserve `/kvk stats` visibility semantics: account selection is private, but selected
    single-account stats post publicly. Complete.
 5. Include Acclaim/contribution metrics in the programme once SQL source, naming, and display
-   rules are validated. Still pending for a later phase.
+   rules are validated. Phase 3 displays Acclaim in the stats card where the current payload
+   contract supports it; broader target/history semantics remain subject to phase-specific SQL
+   validation.
 6. Treat KVK targets service/DAL cleanup as in-programme work, not deferred out of the redesign.
    Still pending for the targets visual/service phase or a focused cleanup pack.
-7. Define a KVK stats service payload dataclass before Phase 3 visual rendering. Next action.
+7. Define a KVK stats service payload dataclass before Phase 3 visual rendering. Complete.
 
 ## 2. Current Command Inventory
 

--- a/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
+++ b/docs/task_packs/KVK Player Experience Redesign - Programme Pack.md
@@ -292,26 +292,46 @@ Delivered details:
 
 ### Phase 3C - Overall KVK Rank Data Contract and Card Polish
 
-Status: ready for task execution.
+Status: complete. Delivered in mirror PR #144 and pushed to production. Companion SQL PR #14 was
+deployed and tested successfully before the bot rollout.
 
-Create the durable data contract required to replace the More Stats `Overall KVK Rank` placeholder,
-then polish the remaining Phase 3B card issues found during production smoke testing.
+Delivered details:
 
-Planned scope:
+- Added SQL-backed overall KVK rank data via `KVK.vw_Player_Overall_KVK_Rank`.
+- The SQL contract exposes `overall_kvk_rank`, `overall_kvk_total_governors`, and
+  `overall_kvk_top_percent`.
+- Bot DAL/service/payload code reads the rank context through the KVK stats card layers, with a
+  safe fallback when the SQL view is unavailable.
+- More Stats now presents the rank context as:
 
-- create a SQL view over `KVK.KVK_Player_Windowed` that derives overall KVK rank for `WindowName = 'Full'`
-- rank by `kp_gain_recalc DESC` with a deterministic tie-breaker such as `governor_id ASC`
-- retrieve the derived overall rank through bot DAL/service code and populate the More Stats card
-- keep the main card rank sourced from existing `KVK_RANK`
-- make More Stats row typography consistent, especially Pass 4 versus Pass 6 value sizing
-- audit the History card `Highest Acclaim` versus `Last KVK Acclaim` source/rounding discrepancy before agreeing any data or formatting fix
-- update tests, SQL validation evidence, and visual samples
+```text
+KVK Overall Rank
+#41
+Total 8.7k / Top 0.5%
+```
+
+- Main-card `Rank` remains sourced from existing `KVK_RANK`.
+- Rank/title alignment was cleaned up on the main and More Stats cards.
+- More Stats pass-window row values now use a shared fitted font size.
+- Kills and DKP progress gold now share the same card gold.
+- SQL review learnings were applied: the top-percent metric is named by meaning rather than as a
+  conventional percentile, the DAL `TOP 1` lookup is deterministically ordered, and external SQL
+  contract tests skip locally but fail in CI when the configured SQL file is missing.
 
 ### Phase 4 - Modern `/kvk targets` and Full `/kvk history`
 
-Apply the visual language to `/kvk targets` and the full `/kvk history` command.
+Status: ready for task execution.
 
-Targets should emphasise progress and next action. The full history command should emphasise comparability across KVKs and may remain table-first until chart/card generation is justified. Phase 3B only covers the compact History view attached to `/kvk stats`.
+Apply the Phase 3 visual language to `/kvk targets` and the full `/kvk history` command.
+
+Targets should emphasise progress, remaining work, explanations for missing/exempt targets, and a
+clear next action. The full history command should emphasise comparability across KVKs and may
+remain table-first where that is more readable than a dense card. Phase 3B only covered the compact
+History view attached to `/kvk stats`; Phase 4 should decide the full-command output deliberately.
+
+Use:
+
+`docs/task_packs/Codex Task Pack - KVK Player Experience Redesign Phase 4 Modern Targets and Full History.md`
 
 ### Phase 5 — Unified `/kvk rankings` Visual/UX Polish
 
@@ -461,12 +481,14 @@ Do not include these in the early phases unless separately approved:
 Proceed with:
 
 ```text
-KVK Player Experience Redesign - Phase 3C Overall KVK Rank Data Contract and Card Polish
+KVK Player Experience Redesign - Phase 4 Modern Targets and Full History
 ```
 
 Phase 1 audit/design, Phase 2A admin collision resolution, and Phase 2B player `/kvk` scaffold are
 complete. Phase 3 has delivered the modern `/kvk stats` visual card while preserving the legacy
 `/mykvkstats` embed during rollout. Phase 3B has polished the card, added KVK mode-specific
 background selection, improved high-progress target scaling, and moved the attached `More Stats`
-and `History` views to Pillow-rendered cards. Phase 3C should add the SQL-backed overall KVK rank
-source for the More Stats card and address the remaining typography/acclaim-source review items.
+and `History` views to Pillow-rendered cards. Phase 3C has delivered the SQL-backed overall KVK
+rank source, total-governor/top-percent context, rank alignment, progress-gold consistency, and
+review hardening. Phase 4 should now modernise `/kvk targets` and the full `/kvk history` path
+while preserving legacy commands during rollout.

--- a/docs/task_packs/README.md
+++ b/docs/task_packs/README.md
@@ -24,10 +24,11 @@ Player self-service workflow redesign and public calendar/KVK calendar UX redesi
 deferred optimisation programmes, not additional command-platform phases.
 
 KVK Player Experience Redesign is active. Phase 1 audit/design, Phase 2A Admin Collision
-Resolution, Phase 2B Player `/kvk` Scaffold, Phase 3 Modern `/kvk stats` Visual Card, and Phase
-3B Stats Card Polish and Secondary Cards are complete. Phase 2A moved admin/operator commands from
-`/kvk ...` to `/kvk_admin ...` in PR 140. Phase 2B added the player `/kvk stats`, `/kvk targets`,
-`/kvk history`, and `/kvk rankings` scaffold in PR 141, then was promoted to production. Phase 3
-and Phase 3B delivered the modern `/kvk stats` image-card rollout, mode-specific card backgrounds,
-secondary More Stats and History cards, and production promotion. Use the programme pack and the
-Phase 3C task pack for the next overall-rank data contract and card polish phase.
+Resolution, Phase 2B Player `/kvk` Scaffold, Phase 3 Modern `/kvk stats` Visual Card, Phase 3B
+Stats Card Polish and Secondary Cards, and Phase 3C Overall Rank and Card Polish are complete.
+Phase 2A moved admin/operator commands from `/kvk ...` to `/kvk_admin ...` in PR 140. Phase 2B
+added the player `/kvk stats`, `/kvk targets`, `/kvk history`, and `/kvk rankings` scaffold in PR
+141, then was promoted to production. Phase 3, Phase 3B, and Phase 3C delivered the modern
+`/kvk stats` image-card rollout, mode-specific card backgrounds, secondary More Stats and History
+cards, SQL-backed KVK overall rank context, and production promotion in PRs 142, 143, and 144.
+Use the programme pack and the Phase 4 task pack for the next targets/history visual phase.

--- a/kvk/dal/kvk_targets_dal.py
+++ b/kvk/dal/kvk_targets_dal.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from constants import PLAYER_TARGETS_CACHE
+from file_utils import fetch_one_dict, get_conn_with_retries
+from targets_sql_cache import get_targets_for_governor
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_target_row(governor_id: str | int) -> dict[str, Any] | None:
+    """Return the cached target row for a governor, refreshing through the cache module if needed."""
+    try:
+        gid = int(str(governor_id).strip())
+    except (TypeError, ValueError):
+        return None
+    row = get_targets_for_governor(gid)
+    return dict(row) if isinstance(row, dict) else None
+
+
+def fetch_target_cache_meta() -> dict[str, Any]:
+    """Return target cache metadata without exposing the cache file format to services."""
+    if not os.path.exists(PLAYER_TARGETS_CACHE):
+        return {}
+    try:
+        with open(PLAYER_TARGETS_CACHE, encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except Exception:
+        logger.debug("kvk_targets_cache_meta_read_failed", exc_info=True)
+        return {}
+    meta = raw.get("_meta") if isinstance(raw, dict) else None
+    return dict(meta) if isinstance(meta, dict) else {}
+
+
+def fetch_exemption_row(governor_id: str | int, kvk_no: int | None = None) -> dict[str, Any] | None:
+    """
+    Return the current exemption row for a governor.
+
+    The SQL source-of-truth table currently exposes GovernorID, GovernorName, Exempt, and KVK_NO.
+    Do not depend on legacy Python-only fields such as Status, IsExempt, or Exempt_Reason here.
+    """
+    try:
+        gid = int(str(governor_id).strip())
+    except (TypeError, ValueError):
+        return None
+
+    params: list[Any] = [gid]
+    where_kvk = ""
+    if kvk_no is not None:
+        where_kvk = "AND (TRY_CONVERT(int, KVK_NO) = ? OR KVK_NO = 0 OR KVK_NO IS NULL)"
+        params.append(int(kvk_no))
+    else:
+        where_kvk = "AND (KVK_NO = 0 OR KVK_NO IS NULL)"
+
+    sql = f"""
+        SELECT TOP 1
+            TRY_CONVERT(bigint, GovernorID) AS GovernorID,
+            CAST(GovernorName AS nvarchar(255)) AS GovernorName,
+            TRY_CONVERT(bit, Exempt) AS Exempt,
+            TRY_CONVERT(int, KVK_NO) AS KVK_NO
+        FROM dbo.EXEMPT_FROM_STATS
+        WHERE TRY_CONVERT(bigint, GovernorID) = ?
+          {where_kvk}
+        ORDER BY
+            CASE WHEN TRY_CONVERT(int, KVK_NO) = ? THEN 0 ELSE 1 END,
+            KVK_NO DESC
+    """
+    query_params = params + [int(kvk_no or 0)]
+
+    try:
+        with get_conn_with_retries() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(sql, query_params)
+                row = fetch_one_dict(cursor)
+    except Exception:
+        logger.exception("kvk_target_exemption_lookup_failed governor_id=%s", gid)
+        return None
+    return dict(row) if row else None

--- a/kvk/models/kvk_targets_card.py
+++ b/kvk/models/kvk_targets_card.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from io import BytesIO
+
+
+@dataclass(frozen=True)
+class KvkTargetMetricProgress:
+    label: str
+    current: int | None
+    target: int | None
+    percent: float | None
+    remaining: int | None
+    note: str | None = None
+
+    @property
+    def has_target(self) -> bool:
+        return bool(self.target and self.target > 0)
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            self.has_target and self.current is not None and self.current >= int(self.target or 0)
+        )
+
+
+@dataclass(frozen=True)
+class KvkTargetsCardPayload:
+    governor_id: str
+    governor_name: str
+    kvk_no: int | None
+    kvk_name: str | None
+    camp_name: str | None
+    target_state: str
+    status_label: str
+    status_detail: str
+    next_action: str
+    power: int | None
+    metrics: tuple[KvkTargetMetricProgress, ...]
+    last_refreshed: str | None = None
+    source_state: str | None = None
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    generated_at_utc: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def display_kvk_label(self) -> str:
+        if self.kvk_no:
+            return f"KVK {self.kvk_no}"
+        return "Current KVK"
+
+    @property
+    def display_mode(self) -> str:
+        return self.kvk_name or "KVK"
+
+    @property
+    def display_camp(self) -> str | None:
+        return self.camp_name.strip() if self.camp_name else None
+
+    @property
+    def completion_percent(self) -> float | None:
+        percentages = [m.percent for m in self.metrics if m.has_target and m.percent is not None]
+        if not percentages:
+            return None
+        return min(percentages)
+
+
+@dataclass(frozen=True)
+class RenderedKvkTargetsCard:
+    filename: str
+    image_bytes: BytesIO

--- a/kvk/rendering/kvk_targets_card_renderer.py
+++ b/kvk/rendering/kvk_targets_card_renderer.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from kvk.models.kvk_targets_card import KvkTargetsCardPayload, RenderedKvkTargetsCard
+from kvk.theme import normalize_kvk_mode
+from prekvk import report_image_renderer as text_renderer
+
+ROOT = Path(__file__).resolve().parents[2]
+ASSET_DIR = ROOT / "assets" / "kvk" / "cards"
+DEFAULT_BACKGROUND = ASSET_DIR / "Default_card.jpg"
+TIDES_BACKGROUND = ASSET_DIR / "Tides_Stats_Card.png"
+MODE_BACKGROUNDS = {
+    "tides of war": TIDES_BACKGROUND,
+    "heroic anthem": ASSET_DIR / "Heroic_Anthem_Stats_Card.jpg",
+    "storm of stratagems": ASSET_DIR / "Storm_of_Stratagems_Stats_card.png",
+    "songs of troy": ASSET_DIR / "Songs_of_Troy_Stats_card.jpg",
+}
+
+WIDTH = 1180
+HEIGHT = 640
+TEXT = (255, 255, 255)
+MUTED = (210, 214, 222)
+GOLD = (255, 211, 87)
+GREEN = (52, 211, 153)
+AMBER = (255, 183, 77)
+RED = (255, 87, 118)
+BLUE = (164, 220, 255)
+GRAY = (148, 163, 184)
+PURPLE = (168, 85, 247)
+
+
+def _font(size: int, *, bold: bool = False) -> ImageFont.ImageFont:
+    return text_renderer._font(size, bold=bold)
+
+
+def _background_for_mode(kvk_name: str | None) -> Path | None:
+    mode_path = MODE_BACKGROUNDS.get(normalize_kvk_mode(kvk_name))
+    for path in (mode_path, DEFAULT_BACKGROUND, TIDES_BACKGROUND):
+        if path is not None and path.exists():
+            return path
+    return None
+
+
+def _load_background(path: Path) -> Image.Image:
+    background = Image.open(path).convert("RGBA")
+    return background.resize((WIDTH, HEIGHT), Image.Resampling.LANCZOS)
+
+
+def _text_width(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) -> int:
+    return int(draw.textbbox((0, 0), text, font=font)[2])
+
+
+def _fit_font(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    *,
+    max_width: int,
+    size: int,
+    min_size: int,
+    bold: bool = False,
+) -> ImageFont.ImageFont:
+    font = text_renderer._font_for_text(text, size, bold=bold)
+    while size > min_size and _text_width(draw, text, font) > max_width:
+        size -= 1
+        font = text_renderer._font_for_text(text, size, bold=bold)
+    return font
+
+
+def _fit_common_font(
+    draw: ImageDraw.ImageDraw,
+    values: list[str],
+    *,
+    max_width: int,
+    size: int,
+    min_size: int,
+    bold: bool = False,
+) -> ImageFont.ImageFont:
+    font = _font(size, bold=bold)
+    while size > min_size and any(_text_width(draw, value, font) > max_width for value in values):
+        size -= 1
+        font = _font(size, bold=bold)
+    return font
+
+
+def _draw_text(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int],
+    text: str,
+    *,
+    fill=TEXT,
+    font: ImageFont.ImageFont | None = None,
+    bold: bool = False,
+) -> None:
+    font = font or _font(20, bold=bold)
+    text_renderer._draw_text(draw, xy, text, fill=fill, font=font, bold=bold)
+
+
+def _compact(value: int | float | None) -> str:
+    if value is None:
+        return "N/A"
+    val = float(value)
+    abs_val = abs(val)
+    for limit, suffix in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        if abs_val >= limit:
+            return f"{val / limit:.1f}".rstrip("0").rstrip(".") + suffix
+    return f"{int(val):,}"
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value:.1f}".rstrip("0").rstrip(".") + "%"
+
+
+def _metric_color(percent: float | None, has_target: bool) -> tuple[int, int, int]:
+    if not has_target or percent is None:
+        return GRAY
+    if percent >= 100:
+        return GOLD
+    if percent >= 75:
+        return GREEN
+    if percent >= 50:
+        return AMBER
+    return RED
+
+
+def _metric_type_color(label: str) -> tuple[int, int, int]:
+    lowered = label.lower()
+    if "kill" in lowered:
+        return GREEN
+    if "dead" in lowered:
+        return RED
+    if "dkp" in lowered:
+        return PURPLE
+    if "acclaim" in lowered:
+        return GOLD
+    return TEXT
+
+
+def _note_color(payload: KvkTargetsCardPayload) -> tuple[int, int, int]:
+    percent = payload.completion_percent
+    if percent is None:
+        return TEXT
+    if percent >= 100:
+        return GOLD
+    if percent >= 70:
+        return GREEN
+    if percent >= 40:
+        return AMBER
+    return RED
+
+
+def _draw_avatar(
+    canvas: Image.Image,
+    draw: ImageDraw.ImageDraw,
+    box: tuple[int, int, int, int],
+    *,
+    governor_name: str,
+    avatar_bytes: bytes | None,
+) -> None:
+    x0, y0, x1, y1 = box
+    size = x1 - x0
+    if avatar_bytes:
+        try:
+            avatar = Image.open(BytesIO(avatar_bytes)).convert("RGBA").resize((size, size))
+            mask = Image.new("L", (size, size), 0)
+            mask_draw = ImageDraw.Draw(mask)
+            mask_draw.ellipse((0, 0, size - 1, size - 1), fill=255)
+            canvas.paste(avatar, (x0, y0), mask)
+            draw.ellipse(box, outline=(188, 196, 216), width=3)
+            return
+        except Exception:
+            pass
+
+    draw.ellipse(box, fill=(38, 44, 58, 215), outline=(188, 196, 216), width=3)
+    initials = "".join(part[:1] for part in governor_name.split()[:2]).upper() or "K"
+    initials_font = _fit_font(draw, initials, max_width=52, size=30, min_size=18, bold=True)
+    draw.text((x0 + size / 2, y0 + size / 2), initials, anchor="mm", fill=GOLD, font=initials_font)
+
+
+def _draw_stat_block(
+    draw: ImageDraw.ImageDraw,
+    *,
+    x: int,
+    y: int,
+    w: int,
+    title: str,
+    value: str,
+    color: tuple[int, int, int],
+    subtext: str | None = None,
+    value_font: ImageFont.ImageFont | None = None,
+) -> None:
+    title_font = _fit_font(draw, title.upper(), max_width=w, size=21, min_size=15, bold=True)
+    _draw_text(draw, (x, y), title.upper(), fill=TEXT, font=title_font, bold=True)
+    value_font = value_font or _fit_font(draw, value, max_width=w, size=38, min_size=24, bold=True)
+    _draw_text(draw, (x, y + 33), value, fill=color, font=value_font, bold=True)
+    if subtext:
+        sub_font = _fit_font(draw, subtext, max_width=w, size=18, min_size=13, bold=True)
+        _draw_text(draw, (x, y + 76), subtext, fill=MUTED, font=sub_font, bold=True)
+
+
+def _draw_metric_grid(draw: ImageDraw.ImageDraw, payload: KvkTargetsCardPayload) -> None:
+    metrics = list(payload.metrics[:4])
+    col_x = (74, 335, 596, 857)
+    col_w = 205
+    target_values: list[str] = []
+    comparison_values: list[str] = []
+
+    for metric in metrics:
+        target_value = _compact(metric.target) if metric.has_target else "TBC"
+        target_values.append(target_value)
+
+        comparison_value = _compact(metric.current)
+        if metric.has_target:
+            comparison_value = (
+                f"{_compact(metric.current)} / {_compact(metric.target)} / {_pct(metric.percent)}"
+            )
+        comparison_values.append(comparison_value)
+
+    target_value_font = _fit_common_font(
+        draw, target_values, max_width=col_w, size=38, min_size=24, bold=True
+    )
+    comparison_value_font = _fit_common_font(
+        draw, comparison_values, max_width=col_w, size=27, min_size=18, bold=True
+    )
+
+    for idx, metric in enumerate(metrics):
+        _draw_stat_block(
+            draw,
+            x=col_x[idx],
+            y=238,
+            w=col_w,
+            title=metric.label,
+            value=target_values[idx],
+            color=_metric_type_color(metric.label) if metric.has_target else GRAY,
+            subtext="Coming next KVK" if metric.note and not metric.has_target else None,
+            value_font=target_value_font,
+        )
+
+    for idx, metric in enumerate(metrics):
+        color = _metric_type_color(metric.label)
+        if metric.has_target:
+            subtext = "actual / target / %"
+        elif metric.note:
+            subtext = metric.note
+        else:
+            subtext = "last KVK value"
+
+        _draw_stat_block(
+            draw,
+            x=col_x[idx],
+            y=374,
+            w=col_w,
+            title=f"Last KVK {metric.label.replace(' Target', '')}",
+            value=comparison_values[idx],
+            color=color,
+            subtext=subtext,
+            value_font=comparison_value_font,
+        )
+
+
+def _draw_empty_state(draw: ImageDraw.ImageDraw, payload: KvkTargetsCardPayload) -> None:
+    status_font = _fit_font(
+        draw, payload.status_label, max_width=1020, size=44, min_size=28, bold=True
+    )
+    _draw_text(draw, (82, 277), payload.status_label, fill=GOLD, font=status_font, bold=True)
+    detail_font = _fit_font(
+        draw, payload.status_detail, max_width=970, size=28, min_size=19, bold=True
+    )
+    _draw_text(draw, (82, 340), payload.status_detail, fill=TEXT, font=detail_font, bold=True)
+
+
+def render_kvk_targets_card(
+    payload: KvkTargetsCardPayload, *, avatar_bytes: bytes | None = None
+) -> RenderedKvkTargetsCard | None:
+    background_path = _background_for_mode(payload.kvk_name)
+    if background_path is None:
+        return None
+
+    background = _load_background(background_path)
+    overlay = Image.new("RGBA", (WIDTH, HEIGHT), (0, 0, 0, 0))
+    odraw = ImageDraw.Draw(overlay, "RGBA")
+    odraw.rounded_rectangle((0, 0, WIDTH - 1, HEIGHT - 1), radius=22, fill=(0, 0, 0, 82))
+    odraw.rectangle((0, 0, WIDTH, 190), fill=(0, 0, 0, 78))
+    odraw.rectangle((0, 505, WIDTH, HEIGHT), fill=(0, 0, 0, 96))
+    canvas = Image.alpha_composite(background, overlay)
+    draw = ImageDraw.Draw(canvas, "RGBA")
+
+    _draw_text(draw, (46, 38), "KVK TARGETS", fill=GOLD, font=_font(36, bold=True), bold=True)
+    context_bits = [payload.display_kvk_label, payload.display_mode]
+    if payload.display_camp:
+        context_bits.append(payload.display_camp)
+    if payload.power:
+        context_bits.append(f"MM Power {_compact(payload.power)}")
+    context = "  |  ".join(context_bits)
+    context_font = _fit_font(draw, context, max_width=850, size=21, min_size=15, bold=True)
+    _draw_text(draw, (46, 86), context, fill=MUTED, font=context_font, bold=True)
+
+    _draw_avatar(
+        canvas,
+        draw,
+        (50, 125, 130, 205),
+        governor_name=payload.governor_name,
+        avatar_bytes=avatar_bytes,
+    )
+    name_font = _fit_font(
+        draw, payload.governor_name, max_width=640, size=36, min_size=23, bold=True
+    )
+    _draw_text(draw, (155, 123), payload.governor_name, fill=TEXT, font=name_font, bold=True)
+    _draw_text(draw, (155, 167), str(payload.governor_id), fill=TEXT, font=_font(23, bold=True))
+
+    if payload.metrics:
+        _draw_metric_grid(draw, payload)
+    else:
+        _draw_empty_state(draw, payload)
+
+    action_label = "LAST KVK NOTE"
+    _draw_text(draw, (74, 524), action_label, fill=TEXT, font=_font(22, bold=True), bold=True)
+    action_font = _fit_font(
+        draw, payload.next_action, max_width=970, size=27, min_size=18, bold=True
+    )
+    _draw_text(
+        draw, (74, 558), payload.next_action, fill=_note_color(payload), font=action_font, bold=True
+    )
+
+    footer_parts = []
+    if payload.last_refreshed:
+        footer_parts.append(f"Targets refreshed {payload.last_refreshed}")
+    if payload.source_state:
+        footer_parts.append(f"State {payload.source_state}")
+    footer = "  |  ".join(footer_parts)
+    footer_font = _fit_font(draw, footer, max_width=1040, size=17, min_size=13, bold=True)
+    footer_x = WIDTH - 52 - _text_width(draw, footer, footer_font)
+    _draw_text(draw, (footer_x, 610), footer, fill=MUTED, font=footer_font, bold=True)
+
+    buf = BytesIO()
+    canvas.convert("RGB").save(buf, format="PNG", optimize=True)
+    buf.seek(0)
+    return RenderedKvkTargetsCard(
+        filename=f"kvk_targets_{payload.governor_id}.png",
+        image_bytes=buf,
+    )

--- a/kvk/services/kvk_targets_card_service.py
+++ b/kvk/services/kvk_targets_card_service.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+import logging
+from typing import Any
+
+from kvk.dal import kvk_targets_dal
+from kvk.models.kvk_targets_card import KvkTargetMetricProgress, KvkTargetsCardPayload
+from kvk.services.kvk_stats_card_service import load_kvk_stats_card_context
+from kvk_state import get_kvk_context_today
+import stats_cache_helpers
+from utils import load_stat_row
+
+logger = logging.getLogger(__name__)
+
+
+def _int_from_variants(row: dict[str, Any] | None, keys: list[str], default: int = 0) -> int:
+    row = row or {}
+    for key in keys:
+        if key not in row:
+            continue
+        value = row.get(key)
+        if value in (None, ""):
+            continue
+        try:
+            return int(float(str(value).replace(",", "").strip()))
+        except (TypeError, ValueError):
+            continue
+    return default
+
+
+def _optional_int_from_variants(row: dict[str, Any] | None, keys: list[str]) -> int | None:
+    row = row or {}
+    for key in keys:
+        if key not in row:
+            continue
+        value = row.get(key)
+        if value in (None, ""):
+            continue
+        try:
+            return int(float(str(value).replace(",", "").strip()))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _str_from_variants(row: dict[str, Any] | None, keys: list[str], default: str = "") -> str:
+    row = row or {}
+    for key in keys:
+        value = row.get(key)
+        if value not in (None, ""):
+            return str(value).strip()
+    return default
+
+
+def _display_datetime(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M UTC") if value.tzinfo else value.strftime("%Y-%m-%d")
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).strftime("%Y-%m-%d %H:%M UTC")
+    except ValueError:
+        return text
+
+
+def _progress(label: str, current: int | None, target: int | None) -> KvkTargetMetricProgress:
+    if not target or target <= 0:
+        return KvkTargetMetricProgress(
+            label=label,
+            current=current,
+            target=target,
+            percent=None,
+            remaining=None,
+        )
+    percent = None if current is None else (float(current) / float(target)) * 100.0
+    remaining = None if current is None else max(int(target) - int(current), 0)
+    return KvkTargetMetricProgress(
+        label=label,
+        current=current,
+        target=target,
+        percent=percent,
+        remaining=remaining,
+    )
+
+
+def _metric_actual(
+    primary: dict[str, Any] | None,
+    fallback: dict[str, Any] | None,
+    legacy_targets: dict[str, Any] | None,
+    keys: list[str],
+    legacy_keys: list[str],
+) -> int | None:
+    value = _optional_int_from_variants(primary, keys)
+    if value is not None:
+        return value
+    value = _optional_int_from_variants(fallback, keys)
+    if value is not None:
+        return value
+    return _optional_int_from_variants(legacy_targets, legacy_keys)
+
+
+def _target_metrics(
+    targets: dict[str, Any] | None,
+    actuals: dict[str, Any] | None,
+    last_kvk: dict[str, Any] | None,
+) -> tuple[KvkTargetMetricProgress, ...]:
+    kills_current = _optional_int_from_variants(
+        last_kvk, ["T4&T5_Kills", "T4&T5 Kills", "Kills KVK -1"]
+    )
+    if kills_current is None:
+        kills_current = _metric_actual(
+            actuals,
+            last_kvk,
+            targets,
+            ["T4&T5_Kills", "T4&T5 Kills"],
+            ["Kills KVK -1"],
+        )
+    deads_current = _metric_actual(
+        last_kvk,
+        actuals,
+        targets,
+        ["Deads_Delta", "Deads Delta", "Deads", "DEADS KVK -1"],
+        ["DEADS KVK -1"],
+    )
+    dkp_current = _metric_actual(
+        last_kvk,
+        actuals,
+        targets,
+        ["DKP_SCORE", "DKP Score", "DKP_Score", "DKP KVK -1"],
+        ["DKP KVK -1"],
+    )
+    acclaim_current = _optional_int_from_variants(last_kvk, ["Acclaim", "AcclaimScore"])
+
+    metrics = [
+        _progress(
+            "Kills Target",
+            kills_current,
+            _optional_int_from_variants(targets, ["Kill_Target", "Kill Target", "KillTarget"]),
+        ),
+        _progress(
+            "Deads Target",
+            deads_current,
+            _optional_int_from_variants(targets, ["Deads_Target", "Dead Target", "DeadTarget"]),
+        ),
+        _progress(
+            "DKP Target",
+            dkp_current,
+            _optional_int_from_variants(targets, ["DKP_Target", "DKP Target", "DKPTarget"]),
+        ),
+    ]
+    metrics.append(
+        KvkTargetMetricProgress(
+            label="Acclaim Target",
+            current=acclaim_current,
+            target=None,
+            percent=None,
+            remaining=None,
+            note="Target coming next KVK",
+        )
+    )
+    return tuple(metrics)
+
+
+def _quote_for_last_performance(metrics: tuple[KvkTargetMetricProgress, ...]) -> str:
+    percentages = [m.percent for m in metrics if m.has_target and m.percent is not None]
+    if not percentages:
+        return "Targets are set. Time to make this KVK count."
+    floor = min(percentages)
+    if floor >= 110:
+        return "You smashed last KVK. Same energy again."
+    if floor >= 100:
+        return "Targets hit last time. Hold that standard."
+    if floor >= 85:
+        return "So close last time. A little more effort gets it done."
+    if floor >= 50:
+        return "Last KVK left work on the table. Push harder for the kingdom."
+    return "Big reset needed. Show up early and fight for the kingdom."
+
+
+def _status_for_metrics(metrics: tuple[KvkTargetMetricProgress, ...]) -> tuple[str, str, str, str]:
+    actionable = [metric for metric in metrics if metric.has_target]
+    if actionable and all(metric.is_complete for metric in actionable):
+        return (
+            "complete",
+            "Complete",
+            "Last KVK cleared every comparable target.",
+            _quote_for_last_performance(metrics),
+        )
+    if actionable:
+        remaining = [m for m in actionable if not m.is_complete]
+        if remaining:
+            return (
+                "active",
+                "Target review",
+                "Last KVK compared against this KVK's target line.",
+                _quote_for_last_performance(metrics),
+            )
+    return (
+        "no_target_values",
+        "No target values",
+        "A target row exists, but no target amounts are set.",
+        "Ask leadership to confirm whether targets are still being prepared.",
+    )
+
+
+async def build_kvk_targets_card_payload(governor_id: str | int) -> KvkTargetsCardPayload:
+    gid = str(governor_id or "").strip()
+    if not gid.isdigit():
+        return KvkTargetsCardPayload(
+            governor_id=gid or "unknown",
+            governor_name="Unknown governor",
+            kvk_no=None,
+            kvk_name=None,
+            camp_name=None,
+            target_state="missing_governor",
+            status_label="Invalid ID",
+            status_detail="That Governor ID is not valid.",
+            next_action="Use a numeric Governor ID or register an account.",
+            power=None,
+            metrics=(),
+        )
+
+    try:
+        kvk_context = get_kvk_context_today() or {}
+    except Exception:
+        logger.exception("kvk_targets_context_lookup_failed governor_id=%s", gid)
+        kvk_context = {}
+
+    kvk_no = _int_from_variants(kvk_context, ["kvk_no"], default=0) or None
+    kvk_name = _str_from_variants(kvk_context, ["kvk_name"], default="") or None
+    context = await load_kvk_stats_card_context(kvk_no, gid)
+    if context.kvk_name:
+        kvk_name = context.kvk_name
+
+    target_row = await asyncio.to_thread(kvk_targets_dal.fetch_target_row, gid)
+    cache_meta = await asyncio.to_thread(kvk_targets_dal.fetch_target_cache_meta)
+    last_refreshed = _display_datetime(cache_meta.get("generated_at"))
+    source_state = _str_from_variants(cache_meta, ["state"], default="") or None
+
+    if not target_row:
+        exemption = await asyncio.to_thread(kvk_targets_dal.fetch_exemption_row, gid, kvk_no)
+        if exemption and bool(exemption.get("Exempt")):
+            return KvkTargetsCardPayload(
+                governor_id=gid,
+                governor_name=_str_from_variants(
+                    exemption, ["GovernorName", "Governor_Name"], default=f"Governor {gid}"
+                ),
+                kvk_no=kvk_no or _int_from_variants(exemption, ["KVK_NO"], default=0) or None,
+                kvk_name=kvk_name,
+                camp_name=context.camp_name,
+                target_state="exempt",
+                status_label="Exempt",
+                status_detail="This governor is exempt from KVK targets.",
+                next_action="No action needed unless leadership asks for an update.",
+                power=None,
+                metrics=(),
+                last_refreshed=last_refreshed,
+                source_state=source_state,
+            )
+        return KvkTargetsCardPayload(
+            governor_id=gid,
+            governor_name=f"Governor {gid}",
+            kvk_no=kvk_no,
+            kvk_name=kvk_name,
+            camp_name=context.camp_name,
+            target_state="no_target",
+            status_label="No target",
+            status_detail="No target row was found for this governor.",
+            next_action="Check the Governor ID or ask leadership if targets are still being prepared.",
+            power=None,
+            metrics=(),
+            last_refreshed=last_refreshed,
+            source_state=source_state,
+        )
+
+    try:
+        last_kvk_map = await stats_cache_helpers.load_last_kvk_map()
+        last_kvk = last_kvk_map.get(gid) if isinstance(last_kvk_map, dict) else {}
+    except Exception:
+        logger.debug("kvk_targets_last_kvk_map_unavailable governor_id=%s", gid, exc_info=True)
+        last_kvk = {}
+
+    stats_row = await asyncio.to_thread(load_stat_row, gid)
+    stats_found = isinstance(stats_row, dict) and bool(stats_row)
+    actuals = stats_row if stats_found else None
+    last_kvk_row = last_kvk if isinstance(last_kvk, dict) else None
+    metrics = _target_metrics(target_row, actuals, last_kvk_row)
+    target_state, label, detail, next_action = _status_for_metrics(metrics)
+    governor_name = _str_from_variants(
+        stats_row if stats_found else target_row,
+        ["GovernorName", "Governor_Name", "Governor Name"],
+        default=_str_from_variants(
+            target_row, ["GovernorName", "Governor_Name"], f"Governor {gid}"
+        ),
+    )
+
+    warnings: list[str] = []
+    if source_state and source_state.upper() == "DRAFT":
+        warnings.append("Targets are marked as draft and may still change.")
+
+    return KvkTargetsCardPayload(
+        governor_id=gid,
+        governor_name=governor_name,
+        kvk_no=kvk_no or _int_from_variants(target_row, ["KVK_NO"], default=0) or None,
+        kvk_name=kvk_name,
+        camp_name=context.camp_name,
+        target_state=target_state,
+        status_label=label,
+        status_detail=detail,
+        next_action=next_action,
+        power=_optional_int_from_variants(target_row, ["Power", "Starting Power"]),
+        metrics=metrics,
+        last_refreshed=last_refreshed,
+        source_state=source_state,
+        warnings=tuple(warnings),
+    )

--- a/tests/test_kvk_cmds.py
+++ b/tests/test_kvk_cmds.py
@@ -246,3 +246,95 @@ async def test_kvk_stats_single_account_keeps_error_when_post_fails(monkeypatch)
     await kvk_cmds._send_personal_kvk_stats(ctx)
 
     assert "Could not post your KVK stats publicly" in ctx.interaction.edits[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_kvk_targets_manual_id_uses_modern_output(monkeypatch):
+    import commands.kvk_cmds as kvk_cmds
+
+    async def fake_safe_defer(_ctx, *, ephemeral=False):
+        return None
+
+    async def fake_last_kvk_map():
+        return {}
+
+    called = {}
+
+    async def fake_post(interaction, governor_id, *, ephemeral):
+        called["interaction"] = interaction
+        called["governor_id"] = governor_id
+        called["ephemeral"] = ephemeral
+
+    class DummyInteraction:
+        def __init__(self):
+            self.edits = []
+
+        async def edit_original_response(self, **kwargs):
+            self.edits.append(kwargs)
+
+    ctx = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        interaction=DummyInteraction(),
+        followup=SimpleNamespace(),
+    )
+
+    monkeypatch.setattr(kvk_cmds, "safe_defer", fake_safe_defer)
+    monkeypatch.setattr(kvk_cmds.kvk_personal_service, "load_last_kvk_map", fake_last_kvk_map)
+    monkeypatch.setattr(kvk_cmds, "post_kvk_targets_output", fake_post)
+
+    await kvk_cmds._send_personal_kvk_targets(ctx, "123", True)
+
+    assert called == {
+        "interaction": ctx.interaction,
+        "governor_id": "123",
+        "ephemeral": True,
+    }
+    assert ctx.interaction.edits[-1] == {"content": " ", "view": None}
+
+
+@pytest.mark.asyncio
+async def test_kvk_targets_single_account_uses_modern_output(monkeypatch):
+    import commands.kvk_cmds as kvk_cmds
+
+    async def fake_safe_defer(_ctx, *, ephemeral=False):
+        return None
+
+    async def fake_last_kvk_map():
+        return {}
+
+    async def fake_account_summary(_user_id):
+        return kvk_cmds.governor_account_service.summarize_accounts(
+            {"Main": {"GovernorID": "987", "GovernorName": "Only"}}
+        )
+
+    called = {}
+
+    async def fake_post(_interaction, governor_id, *, ephemeral):
+        called["governor_id"] = governor_id
+        called["ephemeral"] = ephemeral
+
+    class DummyInteraction:
+        def __init__(self):
+            self.edits = []
+
+        async def edit_original_response(self, **kwargs):
+            self.edits.append(kwargs)
+
+    ctx = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        interaction=DummyInteraction(),
+        followup=SimpleNamespace(),
+    )
+
+    monkeypatch.setattr(kvk_cmds, "safe_defer", fake_safe_defer)
+    monkeypatch.setattr(kvk_cmds.kvk_personal_service, "load_last_kvk_map", fake_last_kvk_map)
+    monkeypatch.setattr(
+        kvk_cmds.governor_account_service,
+        "get_account_summary_for_user",
+        fake_account_summary,
+    )
+    monkeypatch.setattr(kvk_cmds, "post_kvk_targets_output", fake_post)
+
+    await kvk_cmds._send_personal_kvk_targets(ctx, None, False)
+
+    assert called == {"governor_id": "987", "ephemeral": False}

--- a/tests/test_kvk_targets_card_posting.py
+++ b/tests/test_kvk_targets_card_posting.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from commands import kvk_targets_card_posting as posting
+from kvk.models.kvk_targets_card import KvkTargetMetricProgress, KvkTargetsCardPayload
+
+pytestmark = pytest.mark.asyncio
+
+
+def _payload() -> KvkTargetsCardPayload:
+    return KvkTargetsCardPayload(
+        governor_id="1",
+        governor_name="Gov",
+        kvk_no=15,
+        kvk_name="Tides of War",
+        camp_name="Wind",
+        target_state="active",
+        status_label="Push now",
+        status_detail="Targets are active.",
+        next_action="Fight now.",
+        power=None,
+        metrics=(KvkTargetMetricProgress("Kills", 5, 10, 50.0, 5),),
+    )
+
+
+def _payload_with_placeholder_metric() -> KvkTargetsCardPayload:
+    return KvkTargetsCardPayload(
+        governor_id="1",
+        governor_name="Gov",
+        kvk_no=15,
+        kvk_name="Tides of War",
+        camp_name="Wind",
+        target_state="active",
+        status_label="Push now",
+        status_detail="Targets are active.",
+        next_action="Fight now.",
+        power=None,
+        metrics=(
+            KvkTargetMetricProgress("Kills", 5, 10, 50.0, 5),
+            KvkTargetMetricProgress(
+                "Acclaim Target",
+                4_700_000,
+                None,
+                None,
+                None,
+                "Target coming next KVK",
+            ),
+        ),
+    )
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+
+
+class DummyMessage:
+    def __init__(self, *, fail_edit: bool = False):
+        self.fail_edit = fail_edit
+        self.edits = []
+
+    async def edit(self, **kwargs):
+        if self.fail_edit:
+            raise RuntimeError("edit failed")
+        self.edits.append(kwargs)
+
+
+class DummyFile:
+    def __init__(self):
+        self.reset_calls = []
+
+    def reset(self, *, seek=True):
+        self.reset_calls.append(seek)
+
+
+async def test_post_targets_falls_back_to_embed_when_card_disabled(monkeypatch):
+    payload = _payload()
+    followup = DummyFollowup()
+    interaction = SimpleNamespace(followup=followup, message=None)
+
+    async def fake_payload(_gid):
+        return payload
+
+    monkeypatch.setattr(posting, "_card_enabled", lambda: False)
+    monkeypatch.setattr(posting, "build_kvk_targets_card_payload", fake_payload)
+
+    result = await posting.post_kvk_targets_output(interaction, "1", ephemeral=True)
+
+    assert result is payload
+    assert followup.sent
+    assert followup.sent[0]["ephemeral"] is True
+    assert followup.sent[0]["embed"].title == "KVK Targets - Gov"
+
+
+async def test_post_targets_component_edits_selector_message(monkeypatch):
+    payload = _payload()
+    message = DummyMessage()
+    interaction = SimpleNamespace(followup=DummyFollowup(), message=message)
+
+    async def fake_payload(_gid):
+        return payload
+
+    monkeypatch.setattr(posting, "build_kvk_targets_card_payload", fake_payload)
+    monkeypatch.setattr(posting, "_card_enabled", lambda: False)
+
+    await posting.post_kvk_targets_output(interaction, "1", ephemeral=False)
+
+    assert message.edits
+    assert message.edits[0]["view"] is None
+    assert message.edits[0]["embed"].title == "KVK Targets - Gov"
+
+
+async def test_post_targets_component_sends_followup_when_edit_fails(monkeypatch):
+    payload = _payload()
+    message = DummyMessage(fail_edit=True)
+    followup = DummyFollowup()
+    interaction = SimpleNamespace(followup=followup, message=message)
+
+    async def fake_payload(_gid):
+        return payload
+
+    monkeypatch.setattr(posting, "build_kvk_targets_card_payload", fake_payload)
+    monkeypatch.setattr(posting, "_card_enabled", lambda: False)
+
+    await posting.post_kvk_targets_output(interaction, "1", ephemeral=False)
+
+    assert not message.edits
+    assert followup.sent
+    assert followup.sent[0]["embed"].title == "KVK Targets - Gov"
+
+
+async def test_send_or_edit_rewinds_file_before_followup_after_edit_failure():
+    message = DummyMessage(fail_edit=True)
+    followup = DummyFollowup()
+    interaction = SimpleNamespace(followup=followup, message=message)
+    file = DummyFile()
+
+    await posting._send_or_edit(interaction, ephemeral=True, file=file)
+
+    assert file.reset_calls == [True]
+    assert followup.sent == [{"file": file, "ephemeral": True}]
+
+
+async def test_fallback_embed_formats_placeholder_metric_note():
+    embed = posting.build_targets_fallback_embed(_payload_with_placeholder_metric())
+
+    acclaim = next(field for field in embed.fields if field.name == "Acclaim Target")
+
+    assert acclaim.value == "4.7M\nTarget coming next KVK"
+    assert "/ N/A" not in acclaim.value

--- a/tests/test_kvk_targets_card_renderer.py
+++ b/tests/test_kvk_targets_card_renderer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from kvk.models.kvk_targets_card import KvkTargetMetricProgress, KvkTargetsCardPayload
+from kvk.rendering.kvk_targets_card_renderer import render_kvk_targets_card
+
+
+def _payload(*, state: str = "active") -> KvkTargetsCardPayload:
+    metrics = ()
+    if state == "active":
+        metrics = (
+            KvkTargetMetricProgress("Kills", 12_000_000, 20_000_000, 60.0, 8_000_000),
+            KvkTargetMetricProgress("Deads", 1_200_000, 1_000_000, 120.0, 0),
+            KvkTargetMetricProgress("DKP", 25_000_000, 50_000_000, 50.0, 25_000_000),
+        )
+    return KvkTargetsCardPayload(
+        governor_id="2441482",
+        governor_name="A Very Long Governor Name",
+        kvk_no=15,
+        kvk_name="Tides of War",
+        camp_name="Wind",
+        target_state=state,
+        status_label="Push now" if state == "active" else "Exempt",
+        status_detail="Targets are active for this KVK.",
+        next_action="Focus kills first: 8M remaining.",
+        power=123_000_000,
+        metrics=metrics,
+        last_refreshed="2026-06-05 10:30 UTC",
+        source_state="ACTIVE",
+    )
+
+
+def test_targets_renderer_returns_png_bytes_for_active_payload():
+    rendered = render_kvk_targets_card(_payload())
+
+    assert rendered is not None
+    assert rendered.filename == "kvk_targets_2441482.png"
+    data = rendered.image_bytes.getvalue()
+    assert data.startswith(b"\x89PNG")
+    assert len(data) > 1_000
+
+
+def test_targets_renderer_returns_png_bytes_for_empty_state():
+    rendered = render_kvk_targets_card(_payload(state="exempt"))
+
+    assert rendered is not None
+    assert rendered.image_bytes.getvalue().startswith(b"\x89PNG")

--- a/tests/test_kvk_targets_card_service.py
+++ b/tests/test_kvk_targets_card_service.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+from kvk.services import kvk_targets_card_service as service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Context:
+    kvk_name = "Tides of War"
+    camp_name = "Wind"
+
+
+async def _context(*_args):
+    return _Context()
+
+
+async def _empty_last_kvk_map():
+    return {}
+
+
+async def _acclaim_last_kvk_map():
+    return {
+        "2441482": {
+            "T4&T5_Kills": 12_000_000,
+            "Deads_Delta": 1_200_000,
+            "DKP_SCORE": 25_000_000,
+            "Acclaim": 4_700_000,
+        }
+    }
+
+
+async def test_targets_payload_active_progress(monkeypatch):
+    monkeypatch.setattr(
+        service,
+        "get_kvk_context_today",
+        lambda: {"kvk_no": 15, "kvk_name": "Tides of War"},
+    )
+    monkeypatch.setattr(service, "load_kvk_stats_card_context", _context)
+    monkeypatch.setattr(
+        service.kvk_targets_dal,
+        "fetch_target_row",
+        lambda gid: {
+            "GovernorID": gid,
+            "GovernorName": "Target Gov",
+            "Power": 123_000_000,
+            "Kill_Target": 20_000_000,
+            "Deads_Target": 1_000_000,
+            "DKP_Target": 50_000_000,
+            "KVK_NO": 15,
+        },
+    )
+    monkeypatch.setattr(
+        service.kvk_targets_dal,
+        "fetch_target_cache_meta",
+        lambda: {"generated_at": "2026-06-05T10:30:00+00:00", "state": "ACTIVE"},
+    )
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_exemption_row", lambda *_args: None)
+    monkeypatch.setattr(
+        service.stats_cache_helpers,
+        "load_last_kvk_map",
+        _acclaim_last_kvk_map,
+    )
+    monkeypatch.setattr(
+        service,
+        "load_stat_row",
+        lambda gid: {
+            "GovernorID": gid,
+            "GovernorName": "Stats Gov",
+            "T4&T5_Kills": 999,
+            "Deads_Delta": 999,
+            "DKP_SCORE": 999,
+        },
+    )
+
+    payload = await service.build_kvk_targets_card_payload("2441482")
+
+    assert payload.governor_name == "Stats Gov"
+    assert payload.display_camp == "Wind"
+    assert payload.target_state == "active"
+    assert payload.status_label == "Target review"
+    assert payload.metrics[0].percent == 60.0
+    assert payload.metrics[0].remaining == 8_000_000
+    assert payload.metrics[1].is_complete is True
+    assert payload.metrics[3].label == "Acclaim Target"
+    assert payload.metrics[3].current == 4_700_000
+    assert "work on the table" in payload.next_action.lower()
+
+
+async def test_targets_payload_complete(monkeypatch):
+    monkeypatch.setattr(service, "get_kvk_context_today", lambda: {"kvk_no": 15})
+    monkeypatch.setattr(service, "load_kvk_stats_card_context", _context)
+    monkeypatch.setattr(
+        service.kvk_targets_dal,
+        "fetch_target_row",
+        lambda gid: {
+            "GovernorID": gid,
+            "GovernorName": "Target Gov",
+            "Kill_Target": 10,
+            "Deads_Target": 5,
+            "DKP_Target": 20,
+        },
+    )
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_target_cache_meta", lambda: {})
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_exemption_row", lambda *_args: None)
+    monkeypatch.setattr(service.stats_cache_helpers, "load_last_kvk_map", _empty_last_kvk_map)
+    monkeypatch.setattr(
+        service,
+        "load_stat_row",
+        lambda _gid: {
+            "GovernorName": "Done Gov",
+            "T4&T5_Kills": 10,
+            "Deads_Delta": 5,
+            "DKP_SCORE": 21,
+        },
+    )
+
+    payload = await service.build_kvk_targets_card_payload("1")
+
+    assert payload.target_state == "complete"
+    assert payload.status_label == "Complete"
+    assert all(metric.is_complete for metric in payload.metrics[:3])
+    assert payload.metrics[3].note == "Target coming next KVK"
+
+
+async def test_targets_payload_exempt_uses_sql_contract(monkeypatch):
+    monkeypatch.setattr(service, "get_kvk_context_today", lambda: {"kvk_no": 15})
+    monkeypatch.setattr(service, "load_kvk_stats_card_context", _context)
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_target_row", lambda _gid: None)
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_target_cache_meta", lambda: {})
+    monkeypatch.setattr(
+        service.kvk_targets_dal,
+        "fetch_exemption_row",
+        lambda _gid, _kvk_no: {
+            "GovernorID": 7,
+            "GovernorName": "Exempt Gov",
+            "Exempt": True,
+            "KVK_NO": 15,
+        },
+    )
+
+    payload = await service.build_kvk_targets_card_payload("7")
+
+    assert payload.target_state == "exempt"
+    assert payload.status_label == "Exempt"
+    assert payload.governor_name == "Exempt Gov"
+    assert payload.metrics == ()
+
+
+async def test_targets_payload_source_unavailable_when_stats_missing(monkeypatch):
+    monkeypatch.setattr(service, "get_kvk_context_today", lambda: {"kvk_no": 15})
+    monkeypatch.setattr(service, "load_kvk_stats_card_context", _context)
+    monkeypatch.setattr(
+        service.kvk_targets_dal,
+        "fetch_target_row",
+        lambda _gid: {"GovernorName": "Target Gov", "Kill_Target": 100, "Kills KVK -1": 50},
+    )
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_target_cache_meta", lambda: {})
+    monkeypatch.setattr(service.kvk_targets_dal, "fetch_exemption_row", lambda *_args: None)
+    monkeypatch.setattr(service.stats_cache_helpers, "load_last_kvk_map", _empty_last_kvk_map)
+    monkeypatch.setattr(service, "load_stat_row", lambda _gid: None)
+
+    payload = await service.build_kvk_targets_card_payload("9")
+
+    assert payload.target_state == "active"
+    assert payload.metrics[0].current == 50
+    assert payload.metrics[0].target == 100


### PR DESCRIPTION
## Summary

Modernises the `/kvk targets` player journey as Phase 4A, aligning the targets view with the completed Phase 3 stats-card experience while deferring `/kvk history` to Phase 4B.

## What changed

- Added a service/DAL/model/rendering pipeline for the modern KVK targets card.
- Updated `/kvk targets` to post the new visual card with a legacy fallback path.
- Kept `/mykvktargets` on the existing legacy flow.
- Rendered the targets card with the stats-card-style header, 4-column target rows, Last KVK comparison rows, footer refresh/state copy, and performance-aware Last KVK note.
- Matched metric colors to the main stats card: kills green, deads red, DKP purple, acclaim gold.
- Kept target-row and Last KVK-row value font sizes consistent within each row; the Acclaim target placeholder now uses `TBC` plus `Coming next KVK` supporting text.
- Updated Phase 4 task-pack documentation and related programme docs to reflect the Phase 4A targets-first scope and Phase 4B history deferral.
- Ignored local `.codex_artifacts/` preview output.

## Review feedback addressed

- Target progress now reads actual kills/deads/DKP from Last KVK stats first, then the stats row, with target-row actual fields only as a legacy fallback.
- Fallback embeds now handle non-target placeholder metrics such as Acclaim as value + note instead of `current / N/A - N/A`.
- Removed the unused `stats_found` parameter from `_status_for_metrics` and its call site.
- Component-message edits are now best-effort; if Discord rejects `message.edit(...)`, the command logs the failure, rewinds image files, and sends the output through `interaction.followup.send(...)`.
- Last KVK note heading is white like the other section titles; only the note body uses the performance color.

## Validation

- `python -m pytest -q tests\test_kvk_targets_card_service.py tests\test_kvk_targets_card_renderer.py tests\test_kvk_targets_card_posting.py tests\test_kvk_cmds.py tests\test_mykvktargets.py tests\test_target_utils_result_unwrap.py tests\test_targets_sql_cache_subproc.py` - 34 passed
- `python -m pytest -q tests` - 1681 passed, 2 skipped
- `python -m pre_commit run -a` - passed
- `python scripts\validate_architecture_boundaries.py` - passed
- `python scripts\validate_deferred_items.py` - passed
- `python scripts\select_tests.py` - reviewed recommendations
- `python scripts\smoke_imports.py` - passed
- `python scripts\validate_command_registration.py` - passed